### PR TITLE
Update Print3 branding to print2

### DIFF
--- a/READ-ME/List of tasks to complete
+++ b/READ-ME/List of tasks to complete
@@ -15,7 +15,7 @@ backend file
 
 (optional for now, but certainly do these long-term)
 - Configure the 'recent' and 'popular' pages on the Community Creations page
-- add in a 'print3 discount' for customers who purchase 3 prints.
+- add in a 'print2 discount' for customers who purchase 3 prints.
 - add in an 'opt-out' button at the purchase page for adding the design to the 'Community Creations' page:
 we want this to be opt-out to encourage as much sharing as possible, to build up the catalogue and 
 encourage the community 

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1.0, viewport-fit=cover"
     />
-    <title>Print3 Assistant</title>
+    <title>print2 Assistant</title>
 
     <!-- Tailwind CSS -->
     <script src="https://cdn.tailwindcss.com"></script>
@@ -84,7 +84,7 @@
   <body class="bg-[#1A1A1D] text-white font-sans flex flex-col">
     <header class="flex items-center justify-between py-4 px-6">
       <div class="flex flex-col items-start">
-        <img src="img/textlogo.png" alt="Print3" class="h-10 w-auto" />
+        <img src="img/textlogo.png" alt="print2" class="h-10 w-auto" />
         <div class="mt-1 flex flex-col text-sm text-gray-400 opacity-75">
           <p>5400+ prints</p>
           <p>delivered already</p>
@@ -163,7 +163,7 @@
         <div class="flex flex-col items-center text-center">
           <img
             src="img/boxlogo.png"
-            alt="Print3 cube"
+            alt="print2 cube"
             class="w-32 h-auto mb-8"
           />
           <h1 class="text-3xl font-semibold mb-8">Make your world.</h1>
@@ -297,7 +297,7 @@
           btn.onclick = () => {
             arr.splice(i, 1);
             uploadedFiles.splice(i, 1);
-            localStorage.setItem("print3Images", JSON.stringify(arr));
+            localStorage.setItem("print2Images", JSON.stringify(arr));
             renderThumbnails(arr);
           };
           wrap.appendChild(btn);
@@ -336,7 +336,7 @@
           )
         );
 
-        localStorage.setItem("print3Images", JSON.stringify(thumbs));
+        localStorage.setItem("print2Images", JSON.stringify(thumbs));
         renderThumbnails(thumbs);
       });
 
@@ -363,11 +363,11 @@
         refs.submitIcon.classList.replace("fa-arrow-up", "fa-stop");
         showLoader();
 
-        localStorage.setItem("print3Prompt", prompt);
+        localStorage.setItem("print2Prompt", prompt);
         localStorage.setItem("hasGenerated", "true");
 
         const url = await fetchGlb(prompt, uploadedFiles);
-        localStorage.setItem("print3Model", url);
+        localStorage.setItem("print2Model", url);
 
         refs.viewer.src = url;
         await refs.viewer.updateComplete;
@@ -379,11 +379,11 @@
       });
 
       window.addEventListener("DOMContentLoaded", () => {
-        const prompt = localStorage.getItem("print3Prompt");
-        const model = localStorage.getItem("print3Model");
+        const prompt = localStorage.getItem("print2Prompt");
+        const model = localStorage.getItem("print2Model");
         const has = localStorage.getItem("hasGenerated") === "true";
         const thumbs = JSON.parse(
-          localStorage.getItem("print3Images") || "[]"
+          localStorage.getItem("print2Images") || "[]"
         );
         if (prompt) {
           refs.promptInput.value = prompt;

--- a/payment.html
+++ b/payment.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Checkout - Print3</title>
+    <title>Checkout - print2</title>
 
     <!-- Tailwind CSS -->
     <script src="https://cdn.tailwindcss.com"></script>
@@ -123,7 +123,7 @@
     <!-- Initialization Script -->
     <script>
       document.addEventListener('DOMContentLoaded', () => {
-        const storedUrl = localStorage.getItem('print3Model');
+        const storedUrl = localStorage.getItem('print2Model');
         if (!storedUrl) return;
 
         const previewImg = document.getElementById('preview-img');


### PR DESCRIPTION
## Summary
- rename all `print3` references to `print2`
- update titles and alt text in index and payment pages
- switch localStorage keys from `print3*` to `print2*`
- update docs with new brand name

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6840559f0450832da7fe854ffeea626c