### PR TITLE
Restore astronaut placeholder

### DIFF
--- a/index.html
+++ b/index.html
@@ -385,6 +385,10 @@
       });
 
       window.addEventListener("DOMContentLoaded", () => {
+        // ensure astronaut placeholder is visible on first load
+        refs.viewer.src = FALLBACK_GLB;
+        refs.viewer.style.display = "block";
+
         const prompt = localStorage.getItem("print2Prompt");
         const model = localStorage.getItem("print2Model");
         const has = localStorage.getItem("hasGenerated") === "true";


### PR DESCRIPTION
## Summary
- keep the astronaut model visible at page load

## Testing
- `npm test --prefix backend` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6840569420d4832da375e8609c029361