### PR TITLE
Restore astronaut placeholder on startup

### DIFF
--- a/index.html
+++ b/index.html
@@ -390,8 +390,6 @@
         refs.viewer.style.display = "block";
 
         const prompt = localStorage.getItem("print2Prompt");
-        const model = localStorage.getItem("print2Model");
-        const has = localStorage.getItem("hasGenerated") === "true";
         const thumbs = JSON.parse(
           localStorage.getItem("print2Images") || "[]"
         );
@@ -400,13 +398,7 @@
           refs.promptInput.dispatchEvent(new Event("input"));
         }
         if (thumbs.length) renderThumbnails(thumbs);
-        if (has && model) {
-          hideAll();
-          refs.viewer.src = model;
-          refs.viewer.style.display = "block";
-          refs.checkoutBtn.classList.remove("hidden");
-          hideDemo();
-        }
+        // always show astronaut placeholder on load; do not auto-load prior model
       });
     </script>
   </body>


### PR DESCRIPTION
## Summary
- revert removal of astronaut placeholder on index page
- always show the astronaut model when the page first loads

## Testing
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_6840713f1fb8832db5b40d07c8d1eddf