### PR TITLE
Fix Stripe webhook parsing

### DIFF
--- a/backend/tests/api.test.js
+++ b/backend/tests/api.test.js
@@ -50,10 +50,16 @@ test('Stripe create-order flow', async () => {
 
 test('Stripe webhook updates order', async () => {
   db.query.mockResolvedValueOnce({});
-  const payload = JSON.stringify({});
+  const payload = Buffer.from(JSON.stringify({}));
   const res = await request(app)
     .post('/api/webhook/stripe')
     .set('stripe-signature', 'sig')
+    .set('Content-Type', 'application/json')
     .send(payload);
   expect(res.status).toBe(200);
+  expect(stripeMock.webhooks.constructEvent).toHaveBeenCalledWith(
+    expect.any(Buffer),
+    'sig',
+    process.env.STRIPE_WEBHOOK_SECRET
+  );
 });


### PR DESCRIPTION
## Summary
- register raw body parser for Stripe webhooks before enabling JSON parser
- move `bodyParser.json()` after the webhook handler
- ensure tests send raw buffer payloads for Stripe webhooks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6840826b1658832db9912cadb0da8d1b