### PR TITLE
Add tests for hunyuan3d server

### DIFF
--- a/backend/hunyuan_server/package.json
+++ b/backend/hunyuan_server/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "jest"
   },
   "dependencies": {
     "express": "^4.18.2",
@@ -13,5 +14,9 @@
     "obj2gltf": "^6.0.1",
     "uuid": "^9.0.0",
     "tencentcloud-sdk-nodejs": "^4.0.259"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "supertest": "^7.1.1"
   }
 }

--- a/backend/hunyuan_server/server.js
+++ b/backend/hunyuan_server/server.js
@@ -51,6 +51,11 @@ app.post('/generate', upload.single('image'), async (req, res) => {
 });
 
 const PORT = process.env.HUNYUAN_PORT || 4000;
-app.listen(PORT, () => {
-  console.log(`Hunyuan3D server listening on http://localhost:${PORT}`);
-});
+
+if (require.main === module) {
+  app.listen(PORT, () => {
+    console.log(`Hunyuan3D server listening on http://localhost:${PORT}`);
+  });
+}
+
+module.exports = app;

--- a/backend/hunyuan_server/tests/generate.test.js
+++ b/backend/hunyuan_server/tests/generate.test.js
@@ -1,0 +1,32 @@
+process.env.HUNYUAN_API_KEY = 'test';
+
+jest.mock('axios');
+const axios = require('axios');
+
+jest.mock('obj2gltf');
+const obj2gltf = require('obj2gltf');
+
+jest.mock('fs');
+const fs = require('fs');
+
+jest.mock('uuid', () => ({ v4: jest.fn() }));
+const { v4: uuidv4 } = require('uuid');
+
+const request = require('supertest');
+const app = require('../server');
+
+beforeEach(() => {
+  axios.post.mockResolvedValue({ data: { obj_url: 'http://example.com/model.obj' } });
+  axios.get.mockResolvedValue({ data: Buffer.from('obj-data') });
+  obj2gltf.mockResolvedValue({});
+  fs.promises = { mkdir: jest.fn().mockResolvedValue() };
+  fs.writeFileSync = jest.fn();
+  uuidv4.mockReset();
+  uuidv4.mockReturnValueOnce('obj-uuid').mockReturnValueOnce('glb-uuid');
+});
+
+test('POST /generate returns glb url', async () => {
+  const res = await request(app).post('/generate').field('prompt', 'hello');
+  expect(res.status).toBe(200);
+  expect(res.body.glb_url).toBe('/models/glb-uuid.glb');
+});


### PR DESCRIPTION
## Summary
- export express app from Hunyuan server
- add jest and supertest setup
- test OBJ→glTF conversion route with mocks

## Testing
- `npm test` in `backend/hunyuan_server` *(fails: jest not found)*
- `npm test` in `backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68408270e680832db1e013bd5b5772f3