### PR TITLE
Add print queue integration

### DIFF
--- a/backend/queue/printQueue.js
+++ b/backend/queue/printQueue.js
@@ -1,0 +1,14 @@
+const queue = [];
+
+function enqueuePrint(jobId) {
+  // In a real system, this would push to a message broker
+  if (jobId) {
+    queue.push(jobId);
+  }
+}
+
+function _getQueue() {
+  return queue;
+}
+
+module.exports = { enqueuePrint, _getQueue };


### PR DESCRIPTION
## Summary
- implement a simple in-memory print queue
- invoke `enqueuePrint` in the Stripe webhook handler
- test that print queue is triggered on `checkout.session.completed`

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_6840827304a0832dad73c28a6986df78