### PR TITLE
Improve README with local server instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,19 @@ This repository contains the early MVP code for print2's website and backend.
    cd hunyuan_server && npm start  # inside backend/hunyuan_server/
    ```
 
+
+## Serving the Frontend Locally
+
+`index.html` and `payment.html` use ES module scripts. When opened directly from
+the filesystem (e.g. with a `file://` URL) the browser blocks these modules and
+nothing loads. Run a lightweight web server in the repository root and open the
+pages through `http://localhost` to avoid this issue. Two easy options are:
+
+```bash
+npx http-server      # Node.js
+# or
+python -m http.server
+```
+
+Then navigate to `http://localhost:8080/index.html` or
+`http://localhost:8080/payment.html`.


### PR DESCRIPTION
## Summary
- document how to serve `index.html` and `payment.html` via a local web server

## Testing
- `npm test` *(fails: Cannot find module 'obj2gltf')*

------
https://chatgpt.com/codex/tasks/task_e_68408eb4c8e0832d913f8aa886c9ded1