### PR TITLE
Fix modal close button overlay and size

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -159,7 +159,7 @@
       <div class="relative w-11/12 max-w-3xl">
         <button
           id="close-modal"
-          class="absolute -top-4 -right-4 w-9 h-9 rounded-full bg-white text-black flex items-center justify-center"
+          class="absolute -top-4 -right-4 w-[4.5rem] h-[4.5rem] rounded-full bg-white text-black text-4xl flex items-center justify-center z-50"
         >
           &times;
         </button>


### PR DESCRIPTION
## Summary
- enlarge the close button in CommunityCreations modal
- ensure the close button sits above model viewer controls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684098721de0832d99d202c356cba294