### PR TITLE
Switch to proprietary license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,5 @@
-MIT License
+Copyright (c) 2024 print2. All rights reserved.
 
-Copyright (c) 2024 print2
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+This software and its associated documentation are proprietary and confidential.
+No part of this software may be copied, modified, distributed, or used without
+explicit written permission from the copyright holder.


### PR DESCRIPTION
## Summary
- replace MIT License with proprietary notice

## Testing
- `npm test` in `backend`
- `npm install` in `backend/hunyuan_server` *(fails: No matching version found for multer@^1.4.5)*

------
https://chatgpt.com/codex/tasks/task_e_684099732a1c832d85da79f4ed6fa8a3