### PR TITLE
Fix spacing between preview and logo

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,7 +157,7 @@
     </header>
 
     <main
-      class="flex-1 flex flex-col items-center justify-start gap-16 px-4 lg:px-16"
+      class="flex-1 flex flex-col items-center justify-start gap-8 px-4 lg:px-16"
     >
       <!-- 3‑D preview ------------------------------------------------------ -->
       <section


### PR DESCRIPTION
## Summary
- tighten the spacing between the 3D model preview and the prompt/logo section

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68415d7091a4832d953bb8035af4e2c0