### PR TITLE
Keep layout static when generation fails

### DIFF
--- a/index.html
+++ b/index.html
@@ -202,14 +202,13 @@
           style="background-color: #1f3b65; color: #5ec2c5"
           onmouseover="this.style.opacity='0.85'"
           onmouseout="this.style.opacity='1'"
-          >Checkout</a
-        >
+          >Checkout</a>
+        <div
+          id="gen-error"
+          class="absolute bottom-2 left-0 w-full text-center text-red-400 pointer-events-none"
+          aria-live="assertive"
+        ></div>
       </section>
-      <div
-        id="gen-error"
-        class="text-red-400 text-center mt-2"
-        aria-live="assertive"
-      ></div>
 
       <!-- Prompt / upload area ------------------------------------------- -->
       <section class="w-full max-w-xl">


### PR DESCRIPTION
## Summary
- show the generation error inside the preview wrapper
- absolutely position the error text so it no longer pushes the rest of the page down

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684160fc3684832db4050bd509494bd7