### PR TITLE
Keep layout static when generation fails

### DIFF
--- a/index.html
+++ b/index.html
@@ -206,7 +206,7 @@
         </section>
         <div
           id="gen-error"
-          class="text-red-400 text-center mt-2 h-6 pointer-events-none"
+          class="absolute left-0 top-full mt-2 w-full text-center text-red-400 pointer-events-none"
           aria-live="assertive"
         ></div>
 

--- a/index.html
+++ b/index.html
@@ -203,12 +203,13 @@
           onmouseover="this.style.opacity='0.85'"
           onmouseout="this.style.opacity='1'"
           >Checkout</a>
-        </section>
+
         <div
           id="gen-error"
           class="absolute left-0 top-full mt-2 w-full text-center text-red-400 pointer-events-none"
           aria-live="assertive"
         ></div>
+        </section>
 
       <!-- Prompt / upload area ------------------------------------------- -->
       <section class="w-full max-w-xl">

--- a/index.html
+++ b/index.html
@@ -204,12 +204,12 @@
           onmouseout="this.style.opacity='1'"
           >Checkout</a>
 
-        <div
-          id="gen-error"
-          class="absolute left-0 top-full mt-2 w-full text-center text-red-400 pointer-events-none"
-          aria-live="assertive"
-        ></div>
         </section>
+      <div
+        id="gen-error"
+        class="h-6 mt-2 text-center text-red-400 pointer-events-none"
+        aria-live="assertive"
+      ></div>
 
       <!-- Prompt / upload area ------------------------------------------- -->
       <section class="w-full max-w-xl">

--- a/index.html
+++ b/index.html
@@ -202,14 +202,13 @@
           style="background-color: #1f3b65; color: #5ec2c5"
           onmouseover="this.style.opacity='0.85'"
           onmouseout="this.style.opacity='1'"
-          >Checkout</a
-        >
-      </section>
-      <div
-        id="gen-error"
-        class="text-red-400 text-center mt-2"
-        aria-live="assertive"
-      ></div>
+          >Checkout</a>
+        </section>
+        <div
+          id="gen-error"
+          class="text-red-400 text-center mt-2 h-6 pointer-events-none"
+          aria-live="assertive"
+        ></div>
 
       <!-- Prompt / upload area ------------------------------------------- -->
       <section class="w-full max-w-xl">


### PR DESCRIPTION
## Summary
- show the generation error just below the preview section again
- give the error element a fixed height so layout stays static

## Testing
- `npm test --silent` *(fails: cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684160fc3684832db4050bd509494bd7