### PR TITLE
Remove login requirement for purchasing

### DIFF
--- a/docs/ToDoList.md
+++ b/docs/ToDoList.md
@@ -28,3 +28,9 @@ This list tracks ideas to aggressively increase click-through at every step from
 - Automatically calculate and display shipping cost and delivery ETA before checkout.
 - Send a reminder email if a user generates a model but doesn't purchase.
 - Provide incentives like discounts or credits for the first order.
+
+## Community Prints
+- Add a "Purchase Print" button on every item in the Community Creations gallery.
+- Surface other users' models on profile pages with an option to buy prints.
+- Let creators mark their models as publicly sellable or private.
+- Record each purchase in the buyer's order history for reordering and tracking.


### PR DESCRIPTION
## Summary
- edit Community Prints tasks to avoid requiring login before purchases

## Testing
- `npm test` *(fails: could not find package.json)*


------
https://chatgpt.com/codex/tasks/task_e_6841645c9ed8832d8160b709c87673e7