### PR TITLE
Update README with profile APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,21 @@ python -m http.server
 Then navigate to `http://localhost:8080/index.html` or
 `http://localhost:8080/payment.html`.
 
+## User Profiles API
+
+Two new routes expose profile information:
+
+- `GET /api/profile` – retrieve the currently authenticated user's profile.
+- `GET /api/users/:username/profile` – fetch a public profile for any user.
+
+Profiles are stored in the `user_profiles` table. After pulling the latest code
+run the migration to create this table:
+
+```bash
+cd backend
+npm run migrate
+```
+
 ## Contributing
 
 We welcome pull requests! Please fork the repo and create a topic branch. Ensure `npm test` runs clean before submitting.


### PR DESCRIPTION
## Summary
- document new `/api/profile` and `/api/users/:username/profile` routes
- mention `user_profiles` table and migration command

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684189a57428832d9342708fb7898273