### PR TITLE
Add user profile endpoint

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -263,6 +263,23 @@ app.get("/api/users/:username/models", async (req, res) => {
   }
 });
 
+app.get("/api/users/:username/profile", async (req, res) => {
+  try {
+    const { rows } = await db.query(
+      `SELECT p.display_name, p.avatar_url
+       FROM users u
+       JOIN user_profiles p ON u.username=p.username
+       WHERE u.username=$1`,
+      [req.params.username],
+    );
+    if (!rows.length) return res.status(404).json({ error: "User not found" });
+    res.json(rows[0]);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: "Failed to fetch profile" });
+  }
+});
+
 app.post("/api/models/:id/like", authRequired, async (req, res) => {
   const modelId = req.params.id;
   try {

--- a/backend/tests/api.test.js
+++ b/backend/tests/api.test.js
@@ -266,3 +266,19 @@ test("/api/status/:id returns 404 when missing", async () => {
   const res = await request(app).get("/api/status/bad");
   expect(res.status).toBe(404);
 });
+
+test("GET /api/users/:username/profile returns profile", async () => {
+  db.query.mockResolvedValueOnce({
+    rows: [{ display_name: "Alice", avatar_url: "a.png" }],
+  });
+  const res = await request(app).get("/api/users/alice/profile");
+  expect(res.status).toBe(200);
+  expect(res.body.display_name).toBe("Alice");
+  expect(res.body.avatar_url).toBe("a.png");
+});
+
+test("GET /api/users/:username/profile 404 when missing", async () => {
+  db.query.mockResolvedValueOnce({ rows: [] });
+  const res = await request(app).get("/api/users/none/profile");
+  expect(res.status).toBe(404);
+});


### PR DESCRIPTION
## Summary
- add new endpoint to fetch public user profile information
- test profile endpoint

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684189a3d454832d983c23ea2d3cda6b