### PR TITLE
Add user profiles migration

### DIFF
--- a/backend/migrations/010_create_user_profiles.sql
+++ b/backend/migrations/010_create_user_profiles.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS user_profiles (
+  user_id UUID PRIMARY KEY REFERENCES users(id),
+  display_name TEXT,
+  avatar_url TEXT,
+  shipping_info JSONB,
+  payment_info JSONB,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TRIGGER user_profiles_set_updated
+BEFORE UPDATE ON user_profiles
+FOR EACH ROW EXECUTE PROCEDURE set_updated_at();


### PR DESCRIPTION
## Summary
- add migration for `user_profiles` table with timestamp trigger

## Testing
- `npm test`
- `npm run migrate` *(fails: connect ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_684189a17ee0832dae3fb41fd561d24e