### PR TITLE
Add consistent environment lighting

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -144,6 +144,7 @@
         <model-viewer
           src=""
           alt="3D model preview"
+          environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
           camera-controls
           auto-rotate
           class="w-full h-96 bg-[#2A2A2E] rounded-xl"

--- a/index.html
+++ b/index.html
@@ -171,6 +171,7 @@
           id="viewer"
           src="https://modelviewer.dev/shared-assets/models/Astronaut.glb"
           alt="3D astronaut"
+          environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
           camera-controls
           auto-rotate
           loading="eager"

--- a/js/community.js
+++ b/js/community.js
@@ -70,6 +70,10 @@ async function captureSnapshots(container) {
     const glbUrl = card.dataset.model;
     const viewer = document.createElement("model-viewer");
     viewer.src = glbUrl;
+    viewer.setAttribute(
+      "environment-image",
+      "https://modelviewer.dev/shared-assets/environments/neutral.hdr"
+    );
     viewer.style.position = "fixed";
     viewer.style.left = "-10000px";
     viewer.style.width = "300px";

--- a/payment.html
+++ b/payment.html
@@ -72,6 +72,7 @@
         <!-- viewer is always present -->
         <model-viewer
           id="viewer"
+          environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
           camera-controls
           auto-rotate
           crossorigin="anonymous"


### PR DESCRIPTION
## Summary
- use a neutral HDR environment on all `<model-viewer>` elements
- apply the same environment in dynamically-created viewers

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841881c2bb4832db71ee471e65d807a