### PR TITLE
Implement share route and DB table

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -3,6 +3,33 @@ require("dotenv").config();
 const { Pool } = require("pg");
 const { dbUrl } = require("./config");
 const pool = new Pool({ connectionString: dbUrl });
+
+function query(text, params) {
+  return pool.query(text, params);
+}
+
+async function insertShare(jobId, userId, slug) {
+  return query(
+    "INSERT INTO shares(job_id, user_id, slug) VALUES($1,$2,$3) RETURNING *",
+    [jobId, userId, slug],
+  ).then((res) => res.rows[0]);
+}
+
+async function getShareBySlug(slug) {
+  return query("SELECT * FROM shares WHERE slug=$1", [slug]).then(
+    (res) => res.rows[0],
+  );
+}
+
+async function getShareByJobId(jobId) {
+  return query("SELECT * FROM shares WHERE job_id=$1", [jobId]).then(
+    (res) => res.rows[0],
+  );
+}
+
 module.exports = {
-  query: (text, params) => pool.query(text, params),
+  query,
+  insertShare,
+  getShareBySlug,
+  getShareByJobId,
 };

--- a/backend/migrations/011_create_shares.sql
+++ b/backend/migrations/011_create_shares.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS shares (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  job_id UUID REFERENCES jobs(job_id) ON DELETE CASCADE,
+  user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+  slug TEXT UNIQUE NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS shares_slug_idx ON shares(slug);
+
+CREATE TRIGGER shares_set_updated
+BEFORE UPDATE ON shares
+FOR EACH ROW EXECUTE PROCEDURE set_updated_at();

--- a/backend/server.js
+++ b/backend/server.js
@@ -325,6 +325,18 @@ app.post("/api/models/:id/like", authRequired, async (req, res) => {
   }
 });
 
+app.post("/api/models/:id/share", authRequired, async (req, res) => {
+  const jobId = req.params.id;
+  try {
+    const slug = uuidv4();
+    await db.insertShare(jobId, req.user.id, slug);
+    res.json({ slug });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: "Failed to create share" });
+  }
+});
+
 // Submit a generated model to the community gallery
 app.post("/api/community", authRequired, async (req, res) => {
   const { jobId, title, category } = req.body;

--- a/docs/List of tasks to complete
+++ b/docs/List of tasks to complete
@@ -76,6 +76,7 @@ Note: the lightweight Hunyuan3D API server files were moved from `img/` to `back
   - Display them near the checkout button.
 - Let users share a generated model to the community or social media with one click.
   - Provide Open Graph meta tags for previews.
+  - Implement GET /api/shared/:slug endpoint to fetch shared model metadata.
 - Provide tooltips or a short tutorial overlay explaining each step.
   - Design tooltip copy and dismiss logic.
   - Allow users to skip the tutorial.


### PR DESCRIPTION
## Summary
- add migration for `shares` table
- support inserting and fetching shares in db helper
- expose `POST /api/models/:id/share` route
- note follow-up GET shared link endpoint in task list

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68418a3c5ce8832db5ddf44465332f12