### PR TITLE
Implement login error test and update ToDo list

### DIFF
--- a/backend/tests/frontend/login.test.js
+++ b/backend/tests/frontend/login.test.js
@@ -1,3 +1,4 @@
+/** @jest-environment node */
 const fs = require("fs");
 const path = require("path");
 const { JSDOM } = require("jsdom");
@@ -6,27 +7,35 @@ let html = fs.readFileSync(path.join(__dirname, "../../../login.html"), "utf8");
 html = html.replace(/<script[^>]+tailwind[^>]*><\/script>/, "");
 
 describe("login form", () => {
-  test.skip("shows error on failed login", async () => {
+  test("shows error on failed login", async () => {
     const dom = new JSDOM(html, {
       runScripts: "dangerously",
       resources: "usable",
+      url: "http://localhost/login.html",
     });
     dom.window.document
-      .querySelectorAll("script[src]")
+      .querySelectorAll('script[src*="tailwind"]')
       .forEach((s) => s.remove());
-    await new Promise((r) =>
-      dom.window.document.addEventListener("DOMContentLoaded", r),
+    global.window = dom.window;
+    global.document = dom.window.document;
+    const scriptSrc = fs.readFileSync(
+      path.join(__dirname, "../../../js/login.js"),
+      "utf8",
     );
+    dom.window.eval(scriptSrc);
+    // DOMContentLoaded has already fired in JSDOM when using runScripts,
+    // so no need to wait for it here.
     const fetchMock = jest.fn(() =>
       Promise.resolve({ json: () => ({ error: "fail" }) }),
     );
     dom.window.fetch = fetchMock;
+    global.fetch = fetchMock;
     dom.window.document.getElementById("li-name").value = "u";
     dom.window.document.getElementById("li-pass").value = "p";
     dom.window.document
       .getElementById("loginForm")
       .dispatchEvent(new dom.window.Event("submit"));
-    await Promise.resolve();
+    await new Promise((r) => setTimeout(r, 0));
     expect(dom.window.document.getElementById("error").textContent).toBe(
       "fail",
     );

--- a/docs/ToDoList.md
+++ b/docs/ToDoList.md
@@ -35,16 +35,6 @@ This list tracks ideas to aggressively increase click-through at every step from
 - Let creators mark their models as publicly sellable or private.
 - Record each purchase in the buyer's order history for reordering and tracking.
 
-## Payment Countdown Discount
-- [x] Insert a new `<p id="flash-discount">` element in `payment.html` below the existing quantity discount text.
-- [x] Style the countdown message so it matches other notice text.
-- [x] In `js/payment.js`, check `localStorage` for a `flashDiscountEnd` value on page load.
-- [x] If none exists or it's expired, set `flashDiscountEnd` to five minutes from the current time.
-- [x] Start a timer that updates the remaining time in `#flash-discount` every second.
-- [x] When the timer reaches zero, remove the message and delete `flashDiscountEnd` from `localStorage`.
-- [x] Apply a 5% discount during checkout while the timer is active.
-- [x] Pass this discount along with the quantity discount to `createCheckout`.
-- [x] Add a developer-only button or method to reset the timer for testing.
 
 ## Comprehensive Test Suite
 - Add test for /api/progress streaming events until completion
@@ -69,6 +59,5 @@ This list tracks ideas to aggressively increase click-through at every step from
 - Add test for /api/webhook/stripe updating order and queueing print
 - Add test for queue processing multiple items sequentially
 - Add test for queue progress events reach 100%
-- Add test for login page error display on failed login
 - Add test for signup page error display on failed signup
 - Add test for payment countdown timer expiration logic


### PR DESCRIPTION
## Summary
- add JSDOM based test verifying login page error handling
- clean completed Payment Countdown Discount section from ToDoList
- remove done item for login error test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68418fa50280832da8499dd0080b10de