### PR TITLE
Add missing auth test

### DIFF
--- a/backend/tests/additionalApi.test.js
+++ b/backend/tests/additionalApi.test.js
@@ -45,6 +45,11 @@ test("GET /api/my/models returns models", async () => {
   expect(res.body[0].job_id).toBe("j1");
 });
 
+test("GET /api/my/models requires auth", async () => {
+  const res = await request(app).get("/api/my/models");
+  expect(res.status).toBe(401);
+});
+
 test("GET /api/profile returns profile", async () => {
   db.query.mockResolvedValueOnce({ rows: [{ display_name: "A" }] });
   const token = jwt.sign({ id: "u1" }, "secret");

--- a/docs/ToDoList.md
+++ b/docs/ToDoList.md
@@ -37,26 +37,19 @@ This list tracks ideas to aggressively increase click-through at every step from
 
 
 ## Comprehensive Test Suite
-- Add test for /api/progress streaming events until completion
-- Add test for /api/my/models rejecting unauthenticated user
 - Add test for /api/my/models returning models ordered by date
-- Add test for /api/users/:username/models 404 when user missing
-- Add test for /api/models/:id/like toggling like and unlike
 - Add test for /api/models/:id/like rejecting unauthenticated user
 - Add test for /api/community submission missing jobId
 - Add test for /api/community requires user auth
 - Add test for /api/community/recent pagination and category filter
-- Add test for /api/community/popular sorting by likes then date
 - Add test for /api/competitions/active returning upcoming comps
 - Add test for /api/competitions/:id/enter prevents duplicate entry
 - Add test for /api/competitions/:id/enter rejecting unauthenticated user
 - Add test for /api/competitions/:id/entries leaderboard order
 - Add test for /api/admin/competitions creation unauthorized
-- Add test for /api/admin/competitions creation success
 - Add test for /api/create-order rejecting unknown job
 - Add test for /api/create-order applying discount argument
 - Add test for /api/webhook/stripe invalid signature
-- Add test for /api/webhook/stripe updating order and queueing print
 - Add test for queue processing multiple items sequentially
 - Add test for queue progress events reach 100%
 - Add test for signup page error display on failed signup


### PR DESCRIPTION
## Summary
- add test for `GET /api/my/models` when unauthenticated
- remove completed tasks from test suite list

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684195d6cbc4832da174ba4480b51e28