### PR TITLE
Enable cross-origin for thumbnails

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -150,6 +150,7 @@
           environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
           camera-controls
           auto-rotate
+          crossorigin="anonymous"
           class="w-full h-96 bg-[#2A2A2E] rounded-xl"
         ></model-viewer>
       </div>

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ python -m http.server
 
 Then navigate to `http://localhost:8080/index.html` or
 `http://localhost:8080/payment.html`.
+If you capture thumbnails using model-viewer, make sure your server sends
+`Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp`.
+The backend server already sets these headers.
 
 ## User Profiles API
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -30,6 +30,11 @@ const app = express();
 app.use(morgan("dev"));
 app.use(compression());
 app.use(cors());
+app.use((req, res, next) => {
+  res.setHeader("Cross-Origin-Opener-Policy", "same-origin");
+  res.setHeader("Cross-Origin-Embedder-Policy", "require-corp");
+  next();
+});
 app.use(bodyParser.json());
 app.use(express.static(path.join(__dirname, "..")));
 const uploadsDir = path.join(__dirname, "..", "uploads");

--- a/docs/List of tasks to complete
+++ b/docs/List of tasks to complete
@@ -20,6 +20,15 @@ Note: the lightweight Hunyuan3D API server files were moved from `img/` to `back
 - Expand the category list with additional options (e.g., Fashion, Miniatures, Props).
 - Arrange filter controls in a responsive toolbar with sorting options.
 
+- Add CORS headers for GLB and HDR assets served by Express.
+- Set `Cross-Origin-Opener-Policy` and `Cross-Origin-Embedder-Policy` response headers so `model-viewer.toDataURL()` can read pixels.
+- Mark all `<model-viewer>` elements as `crossorigin="anonymous"` including the modal viewer and temporary viewers in `captureSnapshots()`.
+- Show a fallback thumbnail if snapshot capture fails.
+- Pre-generate thumbnails server-side when a model is submitted to the community gallery.
+- Include the thumbnail URL in `/api/community/*` responses.
+- Cache captured thumbnails in `localStorage` to avoid repeated conversions.
+- Test snapshot rendering in multiple browsers.
+- Document the cross-origin setup in `README`.
 ## Testing & CI
 
 - Add unit tests for frontend scripts.

--- a/js/community.js
+++ b/js/community.js
@@ -69,6 +69,7 @@ async function captureSnapshots(container) {
     if (img && img.src) continue;
     const glbUrl = card.dataset.model;
     const viewer = document.createElement("model-viewer");
+    viewer.setAttribute("crossorigin", "anonymous");
     viewer.src = glbUrl;
     viewer.setAttribute(
       "environment-image",


### PR DESCRIPTION
## Summary
- document cross-origin tasks in to-do list
- add cross-origin isolation headers in `server.js`
- mark modal and temporary model-viewers as `crossorigin="anonymous"`
- mention the headers in README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684198414398832dbec70a9d0c9c1226