### PR TITLE
Update README with optional Hunyuan URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This repository contains the early MVP code for print2's website and backend.
    - `STRIPE_WEBHOOK_SECRET` – signing secret for Stripe webhooks.
    - `HUNYUAN_API_KEY` – key for the Hunyuan3D API.
    - Optional: `PORT` and `HUNYUAN_PORT` to override the default ports.
+   - Optional: `HUNYUAN_SERVER_URL` if your Hunyuan API runs on a custom URL.
 
 2. Install dependencies for both servers:
 


### PR DESCRIPTION
## Summary
- clarify that the HUNYUAN_SERVER_URL env var can be used to point to a custom service

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841b12fa220832d81852a342cf7c247