### PR TITLE
Add auth test for competition entry endpoint

### DIFF
--- a/backend/tests/additionalApi.test.js
+++ b/backend/tests/additionalApi.test.js
@@ -149,6 +149,13 @@ test("POST /api/competitions/:id/enter", async () => {
   expect(res.status).toBe(201);
 });
 
+test("POST /api/competitions/:id/enter requires auth", async () => {
+  const res = await request(app)
+    .post("/api/competitions/5/enter")
+    .send({ modelId: "m1" });
+  expect(res.status).toBe(401);
+});
+
 test("DELETE /api/admin/competitions/:id", async () => {
   db.query.mockResolvedValueOnce({});
   const res = await request(app)


### PR DESCRIPTION
## Summary
- add missing test for unauthorized competition entries
- format code with Prettier

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841c28d48a4832daaaf8d7a123d3be4