### PR TITLE
Add front-end prompt validation

### DIFF
--- a/index.html
+++ b/index.html
@@ -220,6 +220,7 @@
 
           <div class="flex items-center w-full gap-4">
             <div
+              id="prompt-wrapper"
               class="flex-1 bg-[#2A2A2E] border border-white/10 rounded-3xl px-5 py-2 flex items-center"
             >
               <textarea

--- a/js/index.js
+++ b/js/index.js
@@ -18,6 +18,7 @@ const refs = {
   demoNote: $("demo-note"),
   demoClose: $("demo-note-close"),
   promptInput: $("promptInput"),
+  promptWrapper: $("prompt-wrapper"),
   submitBtn: $("submit-button"),
   submitIcon: $("submit-icon"),
   uploadInput: $("uploadInput"),
@@ -47,6 +48,24 @@ const hideDemo = () => {
   document.documentElement.classList.add("has-generated");
 };
 
+function showError(msg) {
+  document.getElementById("gen-error").textContent = msg;
+}
+
+function validatePrompt(p) {
+  if (!p && uploadedFiles.length === 0) {
+    showError("Enter a prompt or upload images");
+    refs.promptWrapper.classList.add("border-red-500");
+    return false;
+  }
+  if (p && p.length < 5) {
+    showError("Prompt must be at least 5 characters");
+    refs.promptWrapper.classList.add("border-red-500");
+    return false;
+  }
+  return true;
+}
+
 refs.demoClose?.addEventListener("click", () => {
   hideDemo();
   localStorage.setItem("demoDismissed", "true");
@@ -58,6 +77,8 @@ refs.promptInput.addEventListener("input", () => {
   const lh = parseFloat(getComputedStyle(el).lineHeight);
   el.style.height = Math.min(el.scrollHeight, lh * 9) + "px";
   el.style.overflowY = el.scrollHeight > lh * 9 ? "auto" : "hidden";
+  document.getElementById("gen-error").textContent = "";
+  refs.promptWrapper.classList.remove("border-red-500");
 });
 
 refs.promptInput.addEventListener("keydown", (e) => {
@@ -154,7 +175,9 @@ async function fetchGlb(prompt, files) {
 
 refs.submitBtn.addEventListener("click", async () => {
   const prompt = refs.promptInput.value.trim();
-  if (!prompt && uploadedFiles.length === 0) return;
+  if (!validatePrompt(prompt)) return;
+  showError("");
+  refs.promptWrapper.classList.remove("border-red-500");
   refs.checkoutBtn.classList.add("hidden");
   refs.submitIcon.classList.replace("fa-arrow-up", "fa-stop");
   showLoader();


### PR DESCRIPTION
## Summary
- validate the prompt on the index page
- highlight the input border and show inline error messages when invalid
- add id to prompt wrapper for styling hook

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_6841c29c5340832d970283420a0311b9