### PR TITLE
Remove progress indicator text

### DIFF
--- a/docs/task_list.md
+++ b/docs/task_list.md
@@ -24,8 +24,6 @@ This consolidated list merges all outstanding tasks from the previous to-do docu
 - Provide tooltips or a short tutorial overlay explaining each step.
   - Design tooltip copy and dismiss logic.
   - Allow users to skip the tutorial.
-- Add a progress indicator at the top summarizing "Prompt → Model → Buy."
-  - Display the current step at all times.
 
 ## Purchase & Checkout
 - Present a 3D viewer with clear "Buy Now" and "Edit" options once generation completes.

--- a/index.html
+++ b/index.html
@@ -150,19 +150,6 @@
       </div>
     </header>
 
-    <nav
-      id="progress"
-      aria-label="Progress"
-      class="w-full flex justify-center mb-4 text-sm"
-    >
-      <ol class="flex space-x-2">
-        <li id="step-prompt" class="font-semibold">Prompt</li>
-        <li>→</li>
-        <li id="step-model" class="text-gray-400">Model</li>
-        <li>→</li>
-        <li id="step-buy" class="text-gray-400">Buy</li>
-      </ol>
-    </nav>
 
     <main
       class="flex-1 flex flex-col items-center justify-start gap-8 px-4 lg:px-16"


### PR DESCRIPTION
## Summary
- remove the `Prompt → Model → Buy` progress text from the index page
- delete the associated progress indicator task from task list

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841c60d87d0832d977d675f79897d60