### PR TITLE
Align Community Creations filters

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -87,11 +87,10 @@
     <!-- Content -->
     <main class="flex-1 px-6 py-8 space-y-12">
       <div class="mb-6 flex flex-wrap items-center gap-2">
-        <label for="category" class="font-medium">Filter:</label>
         <select
           id="category"
           aria-label="Category filter"
-          class="bg-[#2A2A2E] border border-white/20 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#4A4A4E]"
+          class="bg-[#2A2A2E] border border-white/20 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#4A4A4E] h-10"
         >
           <option value="">All</option>
           <option value="sculpture">Sculpture</option>
@@ -110,7 +109,7 @@
         <select
           id="sort"
           aria-label="Sort order"
-          class="bg-[#2A2A2E] border border-white/20 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#4A4A4E]"
+          class="bg-[#2A2A2E] border border-white/20 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#4A4A4E] h-10"
         >
           <option value="desc">Newest</option>
           <option value="asc">Oldest</option>


### PR DESCRIPTION
## Summary
- remove the visible "Filter" label but keep the dropdown
- make the category and sort boxes the same height as the search bar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841c8323fc8832d9e68f6be918d3bb4