### PR TITLE
Remove UV finish option

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -132,10 +132,6 @@
             class="w-full mt-1 bg-[#1A1A1D] border border-white/10 rounded-md p-2"
           />
         </label>
-        <label class="inline-flex items-center mb-2">
-          <input id="uv-finish" type="checkbox" class="mr-2" />
-          Add UV finish for $5
-        </label>
         <label class="inline-flex items-center mb-4">
           <input id="opt-out" type="checkbox" class="mr-2" />
           Don't share my design in Community Creations


### PR DESCRIPTION
## Summary
- remove the unused UV finish checkbox from the payment form

## Testing
- `npm --prefix backend install`
- `npm --prefix backend test`

------
https://chatgpt.com/codex/tasks/task_e_6841d515cf5c832d8ac8bc13ee02c739