### PR TITLE
Remove opt-out choice on payment page

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -30,7 +30,6 @@ document.addEventListener('DOMContentLoaded', async () => {
   const loader = document.getElementById('loader');
   const viewer = document.getElementById('viewer');
   const qtyInput = document.getElementById('qty');
-  const optOut = document.getElementById('opt-out');
   const successMsg = document.getElementById('success');
   const cancelMsg = document.getElementById('cancel');
   const flashBanner = document.getElementById('flash-banner');
@@ -118,7 +117,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   document.getElementById('submit-payment').addEventListener('click', async () => {
     const qty = parseInt(qtyInput.value) || 1;
-    let discount = qty >= 3 && !optOut.checked ? 200 : 0;
+    let discount = qty >= 3 ? 200 : 0;
     const end = parseInt(localStorage.getItem('flashDiscountEnd'), 10) || 0;
     if (end && end > Date.now()) {
       discount += Math.round(qty * PRICE * 0.05);

--- a/payment.html
+++ b/payment.html
@@ -136,10 +136,6 @@
           <input id="uv-finish" type="checkbox" class="mr-2" />
           Add UV finish for $5
         </label>
-        <label class="inline-flex items-center mb-4">
-          <input id="opt-out" type="checkbox" class="mr-2" />
-          Don't share my design in Community Creations
-        </label>
         <p class="mb-4 text-center text-sm text-[#30D5C8]">
           Order 3 or more prints to get a discount!
         </p>


### PR DESCRIPTION
## Summary
- remove the 'Don't share my design in Community Creations' checkbox from `payment.html`
- adjust payment discount logic after checkbox removal

## Testing
- `npm run format`
- `npm test` *(fails: jest not found)*
- `npm run test-ci` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d502e67c832da6fe31525a337c76