### PR TITLE
Fix button order on index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,12 +96,6 @@
       </div>
       <div class="flex items-center space-x-4">
         <a
-          href="competitions.html"
-          class="bg-[#2A2A2E] border border-white/10 rounded-3xl px-4 py-2 text-sm hover:bg-[#3A3A3E] transition-shape"
-        >
-          Competitions
-        </a>
-        <a
           href="profile.html"
           class="bg-[#2A2A2E] border border-white/10 rounded-3xl px-4 py-2 text-sm hover:bg-[#3A3A3E] transition-shape"
         >
@@ -112,6 +106,12 @@
           class="bg-[#2A2A2E] border border-white/10 rounded-3xl px-4 py-2 text-sm hover:bg-[#3A3A3E] transition-shape"
         >
           Community
+        </a>
+        <a
+          href="competitions.html"
+          class="bg-[#2A2A2E] border border-white/10 rounded-3xl px-4 py-2 text-sm hover:bg-[#3A3A3E] transition-shape"
+        >
+          Competitions
         </a>
         <div class="flex space-x-2">
           <button


### PR DESCRIPTION
## Summary
- reorder the navigation buttons so they display `Profile`, `Community`, then `Competitions` on the homepage

## Testing
- `npm run format` in `backend/`
- `npm test` in `backend/`


------
https://chatgpt.com/codex/tasks/task_e_6841f0befc08832dbba54ef203339301