### PR TITLE
Enhance competitions page with engagement features

### DIFF
--- a/competitions.html
+++ b/competitions.html
@@ -36,5 +36,9 @@
       <div id="list" class="space-y-4"></div>
     </main>
     <script type="module" src="js/competitions.js"></script>
+    <script type="module">
+      import { shareOn } from './js/share.js';
+      window.shareOn = shareOn;
+    </script>
   </body>
 </html>

--- a/js/competitions.js
+++ b/js/competitions.js
@@ -13,14 +13,22 @@ async function load() {
   }
   comps.forEach((c) => {
     const div = document.createElement('div');
-    div.className = 'bg-[#2A2A2E] p-4 rounded-xl';
-    div.innerHTML = `<h2 class="text-xl mb-2">${c.name}</h2>
-      <p class="mb-2">${c.prize_description || ''}</p>
-      <button data-id="${c.id}" class="enter bg-[#30D5C8] text-[#1A1A1D] px-3 py-1 rounded">Enter</button>
+    div.className = 'bg-[#2A2A2E] p-4 rounded-xl space-y-2';
+    div.innerHTML = `<h2 class="text-xl">${c.name}</h2>
+      <p>${c.prize_description || ''}</p>
+      <p class="text-sm"><span class="countdown" data-end="${c.end_date}"></span> left</p>
+      <div class="flex space-x-2">
+        <button data-id="${c.id}" class="enter bg-[#30D5C8] text-[#1A1A1D] px-3 py-1 rounded">Enter</button>
+        <button onclick="shareOn('twitter')" aria-label="Share on Twitter" class="w-8 h-8 flex items-center justify-center bg-[#1A1A1D] border border-white/10 rounded hover:bg-[#3A3A3E]"><i class="fab fa-twitter"></i></button>
+      </div>
       <table class="leaderboard w-full mt-4 text-sm"></table>`;
     list.appendChild(div);
-    loadLeaderboard(c.id, div.querySelector('.leaderboard'));
+    const table = div.querySelector('.leaderboard');
+    loadLeaderboard(c.id, table);
+    setInterval(() => loadLeaderboard(c.id, table), 30000);
     div.querySelector('.enter').addEventListener('click', () => enter(c.id));
+    const timer = div.querySelector('.countdown');
+    startCountdown(timer);
   });
 }
 
@@ -31,6 +39,24 @@ async function loadLeaderboard(id, table) {
   table.innerHTML = rows
     .map((r, i) => `<tr><td>${i + 1}</td><td>${r.model_id}</td><td>${r.likes}</td></tr>`)
     .join('');
+}
+
+function startCountdown(el) {
+  const end = new Date(el.dataset.end + 'T23:59:59');
+  function update() {
+    const diff = end - new Date();
+    if (diff <= 0) {
+      el.textContent = 'Closed';
+      clearInterval(timer);
+      return;
+    }
+    const d = Math.floor(diff / 86400000);
+    const h = Math.floor((diff % 86400000) / 3600000);
+    const m = Math.floor((diff % 3600000) / 60000);
+    el.textContent = `${d}d ${h}h ${m}m`;
+  }
+  update();
+  const timer = setInterval(update, 60000);
 }
 
 async function enter(id) {


### PR DESCRIPTION
## Summary
- add countdown timers, Twitter share buttons, and auto-updating leaderboards
- expose share helper to the competitions page

## Testing
- `npm --prefix backend install`
- `npm --prefix backend test`

------
https://chatgpt.com/codex/tasks/task_e_6841f871b30c832da683602bb3c20866