### PR TITLE
Align payment form beside model viewer

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -64,47 +64,68 @@
         <a href="profile.html" class="underline">View profile</a>
       </div>
       <div id="cancel" class="hidden text-red-400 text-center">Payment cancelled.</div>
-      <!-- Model Preview -->
-      <section
-        id="preview-wrapper"
-        class="relative w-full max-w-lg h-80 bg-[#2A2A2E] border border-white/10 rounded-3xl overflow-visible"
-      >
-
-        <!-- fallback still-image (hidden)  -->
-
-        <img
-          id="preview-img"
-          src="https://placehold.co/600x400/2A2A2E/2A2A2E?text="
-          class="object-contain h-full w-full"
-          style="display: none"
-          alt="Preview image"
-        />
-
-
-        <!-- The astronaut now loads eagerly and is always visible  -->
-
-        <model-viewer
-          id="viewer"
-          src="https://modelviewer.dev/shared-assets/models/Astronaut.glb"
-          alt="3D astronaut"
-          environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
-          camera-controls
-          auto-rotate
-          loading="eager"
-          style="width: 100%; height: 100%; display: block"
-        ></model-viewer>
-
-        <!-- centred loader -->
-        <div
-          id="loader"
-          class="absolute inset-0 flex items-center justify-center bg-[#2A2A2E]/80"
-          style="display: none"
+      <div class="flex flex-col md:flex-row items-start justify-center w-full max-w-4xl gap-8">
+        <!-- Model Preview -->
+        <section
+          id="preview-wrapper"
+          class="relative w-full md:w-1/2 max-w-lg h-80 bg-[#2A2A2E] border border-white/10 rounded-3xl overflow-visible"
         >
+          <!-- fallback still-image (hidden)  -->
+
+          <img
+            id="preview-img"
+            src="https://placehold.co/600x400/2A2A2E/2A2A2E?text="
+            class="object-contain h-full w-full"
+            style="display: none"
+            alt="Preview image"
+          />
+
+          <!-- The astronaut now loads eagerly and is always visible  -->
+
+          <model-viewer
+            id="viewer"
+            src="https://modelviewer.dev/shared-assets/models/Astronaut.glb"
+            alt="3D astronaut"
+            environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
+            camera-controls
+            auto-rotate
+            loading="eager"
+            style="width: 100%; height: 100%; display: block"
+          ></model-viewer>
+
+          <!-- centred loader -->
           <div
-            class="h-10 w-10 border-4 border-white border-t-transparent rounded-full animate-spin"
-          ></div>
+            id="loader"
+            class="absolute inset-0 flex items-center justify-center bg-[#2A2A2E]/80"
+            style="display: none"
+          >
+            <div
+              class="h-10 w-10 border-4 border-white border-t-transparent rounded-full animate-spin"
+            ></div>
+          </div>
+        </section>
+
+        <!-- Checkout Form -->
+        <div class="w-full md:w-1/2 max-w-md bg-[#2A2A2E] border border-white/10 rounded-3xl p-6">
+          <h2 class="text-2xl font-semibold mb-4 text-center">Checkout</h2>
+
+          <div id="payment-element" class="mb-6 text-center text-gray-400">
+            [Stripe payment form will go here]
+          </div>
+
+          <button
+            id="submit-payment"
+            class="w-full bg-[#30D5C8] text-[#1A1A1D] py-3 rounded-xl font-semibold hover:bg-[#28b7a8] transition"
+          >
+            Pay Now
+          </button>
+          <p class="mt-2 text-xs text-red-300 text-center">Limited print slots available</p>
+          <div class="flex justify-center gap-4 mt-4 text-2xl text-white">
+            <i class="fas fa-lock" aria-label="Secure checkout"></i>
+            <i class="fas fa-shield-alt" aria-label="Money-back guarantee"></i>
+          </div>
         </div>
-      </section>
+      </div>
 
       <!-- delivery notice -->
       <p class="text-center text-sm text-gray-400/75">
@@ -117,27 +138,6 @@
         ✅︎ If you don’t love it, we’ll refund you – no questions asked:<br />
         <span class="text-white">enquiries@domain.com</span>
       </p>
-
-      <!-- Checkout Form -->
-      <div class="w-full max-w-md bg-[#2A2A2E] border border-white/10 rounded-3xl p-6">
-        <h2 class="text-2xl font-semibold mb-4 text-center">Checkout</h2>
-
-        <div id="payment-element" class="mb-6 text-center text-gray-400">
-          [Stripe payment form will go here]
-        </div>
-
-        <button
-          id="submit-payment"
-          class="w-full bg-[#30D5C8] text-[#1A1A1D] py-3 rounded-xl font-semibold hover:bg-[#28b7a8] transition"
-        >
-          Pay Now
-        </button>
-        <p class="mt-2 text-xs text-red-300 text-center">Limited print slots available</p>
-        <div class="flex justify-center gap-4 mt-4 text-2xl text-white">
-          <i class="fas fa-lock" aria-label="Secure checkout"></i>
-          <i class="fas fa-shield-alt" aria-label="Money-back guarantee"></i>
-        </div>
-      </div>
     </main>
 
     <!-- ─────────── Init -->


### PR DESCRIPTION
## Summary
- rearrange payment page layout so the model viewer and checkout form share a row
- keep delivery and refund notices below the new container

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_6841fb43dd8c832db52abfe6215e27ce