### PR TITLE
Add past winners to competitions

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -387,6 +387,22 @@ app.get('/api/competitions/active', async (req, res) => {
   }
 });
 
+app.get('/api/competitions/past', async (req, res) => {
+  try {
+    const { rows } = await db.query(
+      `SELECT c.id, c.name, c.end_date, j.model_url
+       FROM competitions c
+       LEFT JOIN jobs j ON c.winner_model_id=j.job_id
+       WHERE c.end_date < CURRENT_DATE AND c.winner_model_id IS NOT NULL
+       ORDER BY c.end_date DESC LIMIT 5`
+    );
+    res.json(rows);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to fetch past competitions' });
+  }
+});
+
 app.get('/api/competitions/:id/entries', async (req, res) => {
   try {
     const { rows } = await db.query(

--- a/backend/tests/additionalApi.test.js
+++ b/backend/tests/additionalApi.test.js
@@ -143,6 +143,20 @@ test('GET /api/competitions/active upcoming', async () => {
   expect(db.query).toHaveBeenCalledWith(expect.stringContaining('end_date >= CURRENT_DATE'));
 });
 
+test('GET /api/competitions/past', async () => {
+  db.query.mockResolvedValueOnce({ rows: [] });
+  const res = await request(app).get('/api/competitions/past');
+  expect(res.status).toBe(200);
+});
+
+test('GET /api/competitions/past ordering', async () => {
+  db.query.mockResolvedValueOnce({ rows: [] });
+  await request(app).get('/api/competitions/past');
+  expect(db.query).toHaveBeenCalledWith(
+    expect.stringContaining('ORDER BY c.end_date DESC LIMIT 5')
+  );
+});
+
 test('GET /api/competitions/:id/entries', async () => {
   db.query.mockResolvedValueOnce({ rows: [{ model_id: 'm1', likes: 3 }] });
   const res = await request(app).get('/api/competitions/5/entries');

--- a/competitions.html
+++ b/competitions.html
@@ -34,6 +34,8 @@
       </section>
       <h2 class="text-2xl">Active Competitions</h2>
       <div id="list" class="space-y-4"></div>
+      <h2 class="text-2xl mt-8">Past Winners</h2>
+      <div id="past" class="space-y-4"></div>
     </main>
     <script type="module" src="js/competitions.js"></script>
     <script type="module">

--- a/js/competitions.js
+++ b/js/competitions.js
@@ -75,4 +75,29 @@ async function enter(id) {
   alert('Submitted');
 }
 
-document.addEventListener('DOMContentLoaded', load);
+async function loadPast() {
+  const res = await fetch('/api/competitions/past');
+  const container = document.getElementById('past');
+  if (!res.ok) {
+    container.textContent = 'Failed to load winners';
+    return;
+  }
+  const comps = await res.json();
+  if (comps.length === 0) {
+    container.innerHTML =
+      '<p class="text-center text-white/80">No past competitions yet.</p>';
+    return;
+  }
+  comps.forEach((c) => {
+    const div = document.createElement('div');
+    div.className = 'bg-[#2A2A2E] p-4 rounded-xl space-y-2 text-center';
+    div.innerHTML = `<h3 class="text-lg">${c.name}</h3>
+      <img src="${c.model_url}" alt="Winning model" class="w-32 h-32 object-contain mx-auto" />`;
+    container.appendChild(div);
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  load();
+  loadPast();
+});


### PR DESCRIPTION
## Summary
- show past winners on the competitions page
- expose `/api/competitions/past` to fetch previous competitions
- test the new endpoint ordering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841fc4eb0c8832d9daf8ba45fb3eb38