### PR TITLE
Adjust shipping notice layout on payment page

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -103,6 +103,19 @@
               class="h-10 w-10 border-4 border-white border-t-transparent rounded-full animate-spin"
             ></div>
           </div>
+          <!-- delivery notice -->
+          <div class="mt-4 text-center text-sm text-gray-400/75">
+            <p>
+              Due to incredibly high demand, delivery may take 3+ weeks.<br />
+              Please allow for this. –
+              <span class="text-white">The print2 team: Jia and Matthew</span>
+            </p>
+
+            <p class="mt-2">
+              ✅︎ If you don’t love it, we’ll refund you – no questions asked:<br />
+              <span class="text-white">enquiries@domain.com</span>
+            </p>
+          </div>
         </section>
 
         <!-- Checkout Form -->
@@ -126,18 +139,6 @@
           </div>
         </div>
       </div>
-
-      <!-- delivery notice -->
-      <p class="text-center text-sm text-gray-400/75">
-        Due to incredibly high demand, delivery may take 3+ weeks.<br />
-        Please allow for this. –
-        <span class="text-white">The print2 team: Jia and Matthew</span>
-      </p>
-
-      <p class="text-center text-sm text-gray-400/75">
-        ✅︎ If you don’t love it, we’ll refund you – no questions asked:<br />
-        <span class="text-white">enquiries@domain.com</span>
-      </p>
     </main>
 
     <!-- ─────────── Init -->


### PR DESCRIPTION
## Summary
- move delivery notice paragraphs inside the model viewer section so they appear right under the 3D viewer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841fc86478c832d8ca05e460688afb1