### PR TITLE
Add generation progress bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -183,12 +183,18 @@
         <!-- centred loader -->
         <div
           id="loader"
-          class="absolute inset-0 flex items-center justify-center bg-[#2A2A2E]/80"
+          class="absolute inset-0 flex flex-col items-center justify-center bg-[#2A2A2E]/80"
           style="display: none"
         >
           <div
-            class="h-10 w-10 border-4 border-white border-t-transparent rounded-full animate-spin"
+            class="h-10 w-10 border-4 border-white border-t-transparent rounded-full animate-spin mb-6"
           ></div>
+          <div id="progress-wrapper" class="w-3/4 max-w-xs" style="display: none">
+            <div class="w-full h-2 bg-gray-700 rounded">
+              <div id="progress-bar" class="h-full bg-cyan-400 rounded" style="width: 0%"></div>
+            </div>
+            <div id="progress-text" class="text-center text-sm text-white mt-2"></div>
+          </div>
         </div>
 
         <!-- checkout button (hidden by default) -->

--- a/js/index.js
+++ b/js/index.js
@@ -16,6 +16,9 @@ const refs = {
   previewImg: $('preview-img'),
   loader: $('loader'),
   viewer: $('viewer'),
+  progressBar: $('progress-bar'),
+  progressWrapper: $('progress-wrapper'),
+  progressText: $('progress-text'),
   demoNote: $('demo-note'),
   demoClose: $('demo-note-close'),
   promptInput: $('promptInput'),
@@ -48,6 +51,34 @@ function setStep(name) {
 window.shareOn = shareOn;
 let uploadedFiles = [];
 let lastJobId = null;
+let progressInterval = null;
+
+function startProgress(estimateMs = 20000) {
+  if (!refs.progressWrapper) return;
+  const start = Date.now();
+  refs.progressBar.style.width = '0%';
+  refs.progressWrapper.style.display = 'block';
+  const tick = () => {
+    const elapsed = Date.now() - start;
+    const pct = Math.min((elapsed / estimateMs) * 100, 99);
+    refs.progressBar.style.width = pct + '%';
+    const remaining = Math.max(estimateMs - elapsed, 0);
+    refs.progressText.textContent = `~${Math.ceil(remaining / 1000)}s remaining`;
+  };
+  tick();
+  clearInterval(progressInterval);
+  progressInterval = setInterval(tick, 500);
+}
+
+function stopProgress() {
+  if (!refs.progressWrapper) return;
+  clearInterval(progressInterval);
+  refs.progressBar.style.width = '100%';
+  refs.progressText.textContent = '';
+  setTimeout(() => {
+    refs.progressWrapper.style.display = 'none';
+  }, 300);
+}
 
 const hideAll = () => {
   refs.previewImg.style.display = 'none';
@@ -57,10 +88,12 @@ const hideAll = () => {
 const showLoader = () => {
   hideAll();
   refs.loader.style.display = 'flex';
+  startProgress();
 };
 const showModel = () => {
   hideAll();
   refs.viewer.style.display = 'block';
+  stopProgress();
 };
 const hideDemo = () => {
   refs.demoNote && (refs.demoNote.style.display = 'none');


### PR DESCRIPTION
## Summary
- integrate a progress bar into the loader overlay
- show estimated wait time while a model is generating
- update JS logic to control progress bar visibility and timing

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841fdc2e070832db35ab296887c4d6a