### PR TITLE
Add drag-and-drop image cropping

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,13 @@
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css"
     />
 
+    <!-- Cropper.js -->
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/cropperjs@1.6.2/dist/cropper.min.css"
+    />
+    <script src="https://cdn.jsdelivr.net/npm/cropperjs@1.6.2/dist/cropper.min.js"></script>
+
     <!-- Google <model-viewer>  -->
     <!--  Use a CDN versioned URL so the module is served with CORS headers and the browser can actually download it.  -->
     <script
@@ -236,15 +243,16 @@
             </button>
           </div>
 
-          <div class="mt-4 w-full flex items-start gap-4">
+          <div class="mt-4 w-full flex flex-col gap-4">
             <input type="file" id="uploadInput" accept="image/*" multiple class="hidden" />
-            <label
-              for="uploadInput"
+            <div
+              id="drop-zone"
               aria-label="Upload Images"
-              class="inline-flex items-center justify-start flex-shrink-0 bg-[#2A2A2E] border border-white/10 rounded-3xl px-5 py-2 leading-[1.75rem] text-lg whitespace-nowrap cursor-pointer hover:bg-[#3A3A3E] transition-shape"
+              class="flex items-center justify-center bg-[#2A2A2E] border border-dashed border-white/10 rounded-3xl px-5 py-6 text-gray-400 cursor-pointer hover:bg-[#3A3A3E] transition-shape"
             >
-              Upload Images
-            </label>
+              Drag & drop images or
+              <label for="uploadInput" class="underline ml-1 cursor-pointer">browse</label>
+            </div>
             <div
               id="image-preview-area"
               class="hidden grid grid-cols-4 gap-3 bg-[#2A2A2E] border border-white/10 rounded-3xl min-h-[6rem] max-h-56 px-4 py-3 overflow-visible"
@@ -253,6 +261,21 @@
         </div>
       </section>
     </main>
+
+    <div
+      id="crop-modal"
+      class="fixed inset-0 bg-black/70 flex items-center justify-center hidden z-50"
+    >
+      <div class="bg-[#2A2A2E] p-4 rounded-lg">
+        <img id="crop-image" class="max-w-[80vw] max-h-[80vh]" />
+        <div class="mt-2 text-right">
+          <button id="crop-cancel" class="px-4 py-2 bg-gray-500 text-white rounded mr-2">
+            Cancel
+          </button>
+          <button id="crop-confirm" class="px-4 py-2 bg-blue-600 text-white rounded">Crop</button>
+        </div>
+      </div>
+    </div>
 
     <!--  Application logic ----------------------------------------------- -->
     <script type="module" src="js/index.js"></script>

--- a/js/index.js
+++ b/js/index.js
@@ -25,6 +25,10 @@ const refs = {
   uploadInput: $('uploadInput'),
   imagePreviewArea: $('image-preview-area'),
   dropZone: $('drop-zone'),
+  cropModal: $('crop-modal'),
+  cropImage: $('crop-image'),
+  cropConfirm: $('crop-confirm'),
+  cropCancel: $('crop-cancel'),
   examples: $('prompt-examples'),
   checkoutBtn: $('checkout-button'),
   stepPrompt: $('step-prompt'),
@@ -138,35 +142,58 @@ function renderThumbnails(arr) {
   });
 }
 
+function getThumbnail(file) {
+  return new Promise((res) => {
+    const R = new FileReader();
+    R.onload = () => {
+      const im = new Image();
+      im.onload = () => {
+        let [w, h] = [im.width, im.height],
+          max = 200,
+          r = Math.min(max / w, max / h, 1);
+        w *= r;
+        h *= r;
+        const c = document.createElement('canvas');
+        c.width = w;
+        c.height = h;
+        c.getContext('2d').drawImage(im, 0, 0, w, h);
+        res(c.toDataURL('image/png', 0.7));
+      };
+      im.src = R.result;
+    };
+    R.readAsDataURL(file);
+  });
+}
+
+function openCropper(file) {
+  return new Promise((resolve) => {
+    refs.cropImage.src = URL.createObjectURL(file);
+    refs.cropModal.classList.remove('hidden');
+    const cropper = new Cropper(refs.cropImage, { aspectRatio: 1, viewMode: 1 });
+    const done = (result) => {
+      cropper.destroy();
+      refs.cropModal.classList.add('hidden');
+      resolve(result);
+    };
+    refs.cropConfirm.onclick = () => {
+      const canvas = cropper.getCroppedCanvas({ width: 512, height: 512 });
+      canvas.toBlob((b) => {
+        done(new File([b], file.name, { type: 'image/png' }));
+      }, 'image/png');
+    };
+    refs.cropCancel.onclick = () => done(null);
+  });
+}
+
 async function processFiles(files) {
   if (!files.length) return;
-  uploadedFiles = files;
-  const thumbs = await Promise.all(
-    files.map(
-      (file) =>
-        new Promise((res) => {
-          const R = new FileReader();
-          R.onload = () => {
-            const im = new Image();
-            im.onload = () => {
-              let [w, h] = [im.width, im.height],
-                max = 200,
-                r = Math.min(max / w, max / h, 1);
-              w *= r;
-              h *= r;
-              const c = document.createElement('canvas');
-              c.width = w;
-              c.height = h;
-              c.getContext('2d').drawImage(im, 0, 0, w, h);
-              res(c.toDataURL('image/png', 0.7));
-            };
-            im.src = R.result;
-          };
-          R.readAsDataURL(file);
-        })
-    )
-  );
-
+  const processed = [];
+  for (const f of files) {
+    const c = await openCropper(f);
+    if (c) processed.push(c);
+  }
+  uploadedFiles = processed;
+  const thumbs = await Promise.all(processed.map((f) => getThumbnail(f)));
   localStorage.setItem('print3Images', JSON.stringify(thumbs));
   renderThumbnails(thumbs);
 }
@@ -176,6 +203,7 @@ refs.uploadInput.addEventListener('change', (e) => {
 });
 
 if (refs.dropZone) {
+  refs.dropZone.addEventListener('click', () => refs.uploadInput.click());
   ['dragover', 'dragenter'].forEach((ev) => {
     refs.dropZone.addEventListener(ev, (e) => {
       e.preventDefault();


### PR DESCRIPTION
## Summary
- support drag-and-drop uploads with cropping modal on index page
- integrate Cropper.js for client side cropping

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841fdf4e490832db48397307b952979