### PR TITLE
Enable sharing of generated models

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,15 @@ cd backend
 npm run migrate
 ```
 
+## Sharing API
+
+Models can be shared publicly via unique slugs.
+
+- `POST /api/models/:id/share` – create a share link for a model.
+- `GET /api/shared/:slug` – retrieve metadata for a shared model.
+- Visiting `/shared/:slug` returns an HTML page with Open Graph meta tags that
+  redirect to `share.html` for viewing.
+
 ## Contributing
 
 We welcome pull requests! Please fork the repo and create a topic branch. Ensure `npm test` runs clean before submitting.

--- a/backend/server.js
+++ b/backend/server.js
@@ -308,6 +308,54 @@ app.post('/api/models/:id/share', authRequired, async (req, res) => {
   }
 });
 
+app.get('/api/shared/:slug', async (req, res) => {
+  try {
+    const share = await db.getShareBySlug(req.params.slug);
+    if (!share) return res.status(404).json({ error: 'Share not found' });
+    const { rows } = await db.query('SELECT prompt, model_url FROM jobs WHERE job_id=$1', [
+      share.job_id,
+    ]);
+    if (!rows.length) return res.status(404).json({ error: 'Share not found' });
+    res.json({
+      jobId: share.job_id,
+      slug: share.slug,
+      model_url: rows[0].model_url,
+      prompt: rows[0].prompt,
+    });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to fetch share' });
+  }
+});
+
+app.get('/shared/:slug', async (req, res) => {
+  try {
+    const share = await db.getShareBySlug(req.params.slug);
+    if (!share) return res.status(404).send('Not found');
+    const { rows } = await db.query('SELECT prompt, model_url FROM jobs WHERE job_id=$1', [
+      share.job_id,
+    ]);
+    const prompt = rows[0]?.prompt || 'Shared model';
+    const ogImage = `${req.protocol}://${req.get('host')}/img/boxlogo.png`;
+    res.send(`<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta property="og:title" content="print3 shared model" />
+    <meta property="og:description" content="${prompt.replace(/"/g, '&quot;')}" />
+    <meta property="og:image" content="${ogImage}" />
+    <meta property="og:url" content="${req.protocol}://${req.get('host')}/shared/${share.slug}" />
+  </head>
+  <body>
+    <script>window.location='/share.html?slug=${share.slug}'</script>
+  </body>
+</html>`);
+  } catch (err) {
+    console.error(err);
+    res.status(500).send('Server error');
+  }
+});
+
 // Submit a generated model to the community gallery
 app.post('/api/community', authRequired, async (req, res) => {
   const { jobId, title, category } = req.body;

--- a/backend/tests/additionalApi.test.js
+++ b/backend/tests/additionalApi.test.js
@@ -199,3 +199,17 @@ test('SSE progress endpoint streams updates', async () => {
   const res = await req;
   expect(res.text).toContain('data: {"jobId":"job1","progress":100}');
 });
+
+test('GET /api/shared/:slug returns data', async () => {
+  db.getShareBySlug = jest.fn().mockResolvedValue({ job_id: 'j1', slug: 's1' });
+  db.query.mockResolvedValueOnce({ rows: [{ prompt: 'p', model_url: '/m.glb' }] });
+  const res = await request(app).get('/api/shared/s1');
+  expect(res.status).toBe(200);
+  expect(res.body.model_url).toBe('/m.glb');
+});
+
+test('GET /api/shared/:slug 404 when missing', async () => {
+  db.getShareBySlug = jest.fn().mockResolvedValue(null);
+  const res = await request(app).get('/api/shared/bad');
+  expect(res.status).toBe(404);
+});

--- a/js/sharedModel.js
+++ b/js/sharedModel.js
@@ -1,0 +1,20 @@
+import { shareOn } from './share.js';
+window.shareOn = shareOn;
+
+document.addEventListener('DOMContentLoaded', async () => {
+  const params = new URLSearchParams(window.location.search);
+  const slug = params.get('slug');
+  if (!slug) {
+    document.getElementById('error').textContent = 'Missing share link';
+    return;
+  }
+  try {
+    const res = await fetch(`/api/shared/${slug}`);
+    if (!res.ok) throw new Error('bad');
+    const data = await res.json();
+    const viewer = document.getElementById('viewer');
+    viewer.src = data.model_url;
+  } catch (err) {
+    document.getElementById('error').textContent = 'Failed to load model';
+  }
+});

--- a/share.html
+++ b/share.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Shared Model</title>
+    <meta property="og:title" content="Shared Model – print3" />
+    <meta property="og:description" content="View a 3D model shared on print3." />
+    <meta property="og:image" content="img/boxlogo.png" />
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css"
+    />
+    <script
+      type="module"
+      src="https://cdn.jsdelivr.net/npm/@google/model-viewer@1.12.0/dist/model-viewer.min.js"
+    ></script>
+    <script type="module" src="js/sharedModel.js"></script>
+    <script type="module">
+      import { shareOn } from './js/share.js';
+      window.shareOn = shareOn;
+    </script>
+  </head>
+  <body class="bg-[#1A1A1D] text-white font-sans flex flex-col min-h-screen">
+    <header class="p-4 flex justify-between items-center">
+      <a
+        href="index.html"
+        class="flex items-center bg-[#2A2A2E] px-3 py-1 rounded-xl hover:bg-[#3A3A3E] transition"
+      >
+        <i class="fas fa-arrow-left mr-2"></i>Back
+      </a>
+      <div class="flex space-x-2">
+        <button
+          onclick="shareOn('twitter')"
+          aria-label="Share on Twitter"
+          class="w-8 h-8 flex items-center justify-center bg-[#1A1A1D] border border-white/10 rounded hover:bg-[#3A3A3E]"
+        >
+          <i class="fab fa-twitter"></i>
+        </button>
+        <button
+          onclick="shareOn('facebook')"
+          aria-label="Share on Facebook"
+          class="w-8 h-8 flex items-center justify-center bg-[#1A1A1D] border border-white/10 rounded hover:bg-[#3A3A3E]"
+        >
+          <i class="fab fa-facebook-f"></i>
+        </button>
+      </div>
+    </header>
+    <main class="flex-1 flex items-center justify-center p-4">
+      <div class="w-full max-w-md h-80 relative">
+        <model-viewer
+          id="viewer"
+          src=""
+          environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
+          camera-controls
+          style="width: 100%; height: 100%; display: block"
+        ></model-viewer>
+        <p id="error" class="absolute bottom-2 left-0 w-full text-center text-red-400"></p>
+      </div>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- implement `GET /api/shared/:slug` API
- serve `/shared/:slug` page with Open Graph tags
- create `share.html` with viewer UI
- add `js/sharedModel.js` for loading shared models
- document Sharing API in README
- test coverage for share endpoint

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841fde80584832da445d4dd8ebc8a07