### PR TITLE
Add /api/community/recent filter test

### DIFF
--- a/backend/tests/additionalApi.test.js
+++ b/backend/tests/additionalApi.test.js
@@ -120,6 +120,12 @@ test('POST /api/models/:id/like requires auth', async () => {
   expect(res.status).toBe(401);
 });
 
+test('GET /api/community/recent pagination and category', async () => {
+  db.query.mockResolvedValueOnce({ rows: [] });
+  await request(app).get('/api/community/recent?limit=5&offset=2&category=art');
+  expect(db.query).toHaveBeenCalledWith(expect.any(String), [5, 2, 'art', null]);
+});
+
 test('GET /api/community/popular uses correct ordering', async () => {
   db.query.mockResolvedValueOnce({ rows: [] });
   await request(app).get('/api/community/popular?limit=1&offset=0');


### PR DESCRIPTION
## Summary
- add a missing test for `/api/community/recent` checking pagination and category arguments

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841fff03f3c832da27c2e0617841e18