### PR TITLE
Add unauthenticated check for competition entry

### DIFF
--- a/backend/tests/additionalApi.test.js
+++ b/backend/tests/additionalApi.test.js
@@ -185,6 +185,12 @@ test('POST /api/competitions/:id/enter requires auth', async () => {
   expect(res.status).toBe(401);
 });
 
+test('POST /api/competitions/:id/enter rejects unauthenticated user', async () => {
+  const res = await request(app).post('/api/competitions/5/enter').send({ modelId: 'm1' });
+  expect(res.status).toBe(401);
+  expect(res.body.error).toBe('Unauthorized');
+});
+
 test('POST /api/competitions/:id/enter prevents duplicate', async () => {
   db.query.mockResolvedValueOnce({});
   const token = jwt.sign({ id: 'u1' }, 'secret');


### PR DESCRIPTION
## Summary
- verify `/api/competitions/:id/enter` rejects unauthenticated users

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684200023384832d91d7aa0ee2319d45