### PR TITLE
Add leaderboard ordering test

### DIFF
--- a/backend/tests/additionalApi.test.js
+++ b/backend/tests/additionalApi.test.js
@@ -170,6 +170,19 @@ test('GET /api/competitions/:id/entries order', async () => {
   expect(db.query).toHaveBeenCalledWith(expect.stringContaining('ORDER BY likes DESC'), ['5']);
 });
 
+test('GET /api/competitions/:id/entries leaderboard order', async () => {
+  db.query.mockResolvedValueOnce({
+    rows: [
+      { model_id: 'm2', likes: 10 },
+      { model_id: 'm1', likes: 5 },
+      { model_id: 'm3', likes: 1 },
+    ],
+  });
+  const res = await request(app).get('/api/competitions/5/entries');
+  expect(res.status).toBe(200);
+  expect(res.body.map((e) => e.likes)).toEqual([10, 5, 1]);
+});
+
 test('POST /api/competitions/:id/enter', async () => {
   db.query.mockResolvedValueOnce({});
   const token = jwt.sign({ id: 'u1' }, 'secret');


### PR DESCRIPTION
## Summary
- test that competition entry leaderboard comes back sorted

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684200069518832db53078151251e8a4