### PR TITLE
Add missing test for create-order unknown job

### DIFF
--- a/backend/tests/additionalApi.test.js
+++ b/backend/tests/additionalApi.test.js
@@ -209,9 +209,15 @@ test('SSE progress endpoint streams updates', async () => {
   const req = request(app).get('/api/progress/job1');
   setTimeout(() => {
     progressEmitter.emit('progress', { jobId: 'job1', progress: 100 });
-  }, 10);
+  }, 50);
   const res = await req;
   expect(res.text).toContain('data: {"jobId":"job1","progress":100}');
+});
+
+test('POST /api/create-order rejects unknown job', async () => {
+  db.query.mockResolvedValueOnce({ rows: [] });
+  const res = await request(app).post('/api/create-order').send({ jobId: 'bad' });
+  expect(res.status).toBe(404);
 });
 
 test('GET /api/shared/:slug returns data', async () => {


### PR DESCRIPTION
## Summary
- add missing API test to ensure `/api/create-order` returns 404 for unknown jobs
- tweak SSE progress test timing for reliability

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842000ec104832da5689291eaa6fccb