### PR TITLE
Add test for invalid Stripe webhook

### DIFF
--- a/backend/tests/additionalApi.test.js
+++ b/backend/tests/additionalApi.test.js
@@ -239,4 +239,5 @@ test('Stripe webhook invalid signature', async () => {
     .set('Content-Type', 'application/json')
     .send(payload);
   expect(res.status).toBe(400);
+  expect(res.text).toContain('Webhook Error: bad sig');
 });

--- a/backend/tests/additionalApi.test.js
+++ b/backend/tests/additionalApi.test.js
@@ -240,4 +240,5 @@ test('Stripe webhook invalid signature', async () => {
     .send(payload);
   expect(res.status).toBe(400);
   expect(res.text).toContain('Webhook Error: bad sig');
+  expect(stripeMock.webhooks.constructEvent).toHaveBeenCalled();
 });

--- a/backend/tests/additionalApi.test.js
+++ b/backend/tests/additionalApi.test.js
@@ -227,3 +227,17 @@ test('GET /api/shared/:slug 404 when missing', async () => {
   const res = await request(app).get('/api/shared/bad');
   expect(res.status).toBe(404);
 });
+
+
+test('Stripe webhook invalid signature', async () => {
+  stripeMock.webhooks.constructEvent.mockImplementation(() => {
+    throw new Error('bad sig');
+  });
+  const payload = JSON.stringify({});
+  const res = await request(app)
+    .post('/api/webhook/stripe')
+    .set('stripe-signature', 'bad')
+    .set('Content-Type', 'application/json')
+    .send(payload);
+  expect(res.status).toBe(400);
+});

--- a/backend/tests/additionalApi.test.js
+++ b/backend/tests/additionalApi.test.js
@@ -228,7 +228,6 @@ test('GET /api/shared/:slug 404 when missing', async () => {
   expect(res.status).toBe(404);
 });
 
-
 test('Stripe webhook invalid signature', async () => {
   stripeMock.webhooks.constructEvent.mockImplementation(() => {
     throw new Error('bad sig');

--- a/competitions.html
+++ b/competitions.html
@@ -27,8 +27,8 @@
     <main class="flex-1 p-4 space-y-6">
       <section class="bg-[#2A2A2E] p-4 rounded-xl">
         <p class="mb-2">
-          Put your modelling skills to the test! Enter our themed contests,
-          climb the leaderboard and win free prints.
+          Put your modelling skills to the test! Enter our themed contests, climb the leaderboard
+          and win free prints.
         </p>
         <p>Sign up or log in to submit your best designs.</p>
       </section>

--- a/index.html
+++ b/index.html
@@ -218,7 +218,9 @@
           id="buy-now-button"
           class="hidden absolute bottom-4 right-32 font-bold py-3 px-5 rounded-full shadow-md transition"
           style="background-color: #5ec2c5; color: #1f3b65"
-        >Buy Now</button>
+        >
+          Buy Now
+        </button>
         <div
           id="gen-error"
           class="absolute bottom-2 left-0 w-full text-center text-red-400 pointer-events-none"

--- a/js/competitions.js
+++ b/js/competitions.js
@@ -84,8 +84,7 @@ async function loadPast() {
   }
   const comps = await res.json();
   if (comps.length === 0) {
-    container.innerHTML =
-      '<p class="text-center text-white/80">No past competitions yet.</p>';
+    container.innerHTML = '<p class="text-center text-white/80">No past competitions yet.</p>';
     return;
   }
   comps.forEach((c) => {

--- a/js/index.js
+++ b/js/index.js
@@ -86,7 +86,6 @@ function stopProgress() {
   }, 300);
 }
 
-
 const hideAll = () => {
   refs.previewImg.style.display = 'none';
   refs.loader.style.display = 'none';


### PR DESCRIPTION
## Summary
- cover invalid signature for `/api/webhook/stripe` in additional tests

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_684200124184832daf287d458c746054