### PR TITLE
Fix remote CSS links in index test

### DIFF
--- a/backend/tests/frontend/community.test.js
+++ b/backend/tests/frontend/community.test.js
@@ -1,0 +1,26 @@
+/** @jest-environment node */
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+describe('community like', () => {
+  test('sends like request with auth header', async () => {
+    const dom = new JSDOM('<span id="likes-1"></span>', { url: 'http://localhost/' });
+    global.window = dom.window;
+    global.document = dom.window.document;
+    global.localStorage = dom.window.localStorage;
+    localStorage.setItem('token', 'abc');
+    const scriptSrc = fs
+      .readFileSync(path.join(__dirname, '../../../js/community.js'), 'utf8')
+      .replace(/export\s+\{[^}]+\};?/, '') + '\nwindow.like = like;';
+    const fetchMock = jest.fn(() => Promise.resolve({ json: () => Promise.resolve({ likes: 3 }) }));
+    dom.window.fetch = fetchMock;
+    global.fetch = fetchMock;
+    dom.window.eval(scriptSrc);
+    dom.window.like(1);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(fetchMock).toHaveBeenCalledWith('/api/models/1/like', expect.objectContaining({ headers: { Authorization: 'Bearer abc' } }));
+    expect(dom.window.document.querySelector('#likes-1').textContent).toBe('3');
+    dom.window.close();
+  });
+});

--- a/backend/tests/frontend/competitions.test.js
+++ b/backend/tests/frontend/competitions.test.js
@@ -1,0 +1,23 @@
+/** @jest-environment node */
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+let html = '<div id="list"></div>';
+
+describe('competitions page', () => {
+  test('displays message when no competitions', async () => {
+    const dom = new JSDOM(html, { runScripts: 'dangerously', resources: 'usable', url: 'http://localhost/' });
+    global.window = dom.window;
+    global.document = dom.window.document;
+    const scriptSrc = fs.readFileSync(path.join(__dirname, '../../../js/competitions.js'), 'utf8');
+    const fetchMock = jest.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve([]) }));
+    dom.window.fetch = fetchMock;
+    global.fetch = fetchMock;
+    dom.window.eval(scriptSrc);
+    dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(dom.window.document.getElementById('list').textContent).toContain('No active competitions');
+    dom.window.close();
+  });
+});

--- a/backend/tests/frontend/index.test.js
+++ b/backend/tests/frontend/index.test.js
@@ -1,0 +1,39 @@
+/** @jest-environment node */
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+let html = fs.readFileSync(path.join(__dirname, '../../../index.html'), 'utf8');
+html = html
+  .replace(/<script[^>]*src="https?:\/\/[^"']+"[^>]*>\s*<\/script>/g, '')
+  .replace(/<link[^>]*href="https?:\/\/[^"']+"[^>]*>/g, '')
+  .replace(/<script[^>]*src="js\/index.js"[^>]*>\s*<\/script>/, '');
+
+describe('index page', () => {
+  test('adds has-generated class when localStorage flag set', () => {
+    const dom = new JSDOM(html, { runScripts: 'dangerously', resources: 'usable', url: 'http://localhost/' });
+    global.window = dom.window;
+    global.document = dom.window.document;
+    dom.window.localStorage.setItem('hasGenerated', 'true');
+    const scriptSrc = fs
+      .readFileSync(path.join(__dirname, '../../../js/index.js'), 'utf8')
+      .replace(/import[^\n]+share.js';?/, 'const shareOn = () => {};');
+    dom.window.eval(scriptSrc);
+    expect(dom.window.document.documentElement.classList.contains('has-generated')).toBe(true);
+    dom.window.close();
+  });
+
+  test('sets prompt placeholder when no saved prompt', () => {
+    const dom = new JSDOM(html, { runScripts: 'dangerously', resources: 'usable', url: 'http://localhost/' });
+    global.window = dom.window;
+    global.document = dom.window.document;
+    const scriptSrc = fs
+      .readFileSync(path.join(__dirname, '../../../js/index.js'), 'utf8')
+      .replace(/import[^\n]+share.js';?/, 'const shareOn = () => {};');
+    dom.window.eval(scriptSrc);
+    dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
+    const placeholder = dom.window.document.getElementById('promptInput').placeholder;
+    expect(placeholder.length).toBeGreaterThan(0);
+    dom.window.close();
+  });
+});

--- a/backend/tests/frontend/profile.test.js
+++ b/backend/tests/frontend/profile.test.js
@@ -1,0 +1,24 @@
+/** @jest-environment node */
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+let html = fs.readFileSync(path.join(__dirname, '../../../profile.html'), 'utf8');
+html = html
+  .replace(/<script[^>]*src="https?:\/\/[^"']+"[^>]*>\s*<\/script>/g, '')
+  .replace(/<script[^>]*src="js\/profile.js"[^>]*>\s*<\/script>/, '');
+
+describe('profile page', () => {
+  test('redirects to login when no token', () => {
+    const dom = new JSDOM(html, { runScripts: 'dangerously', resources: 'usable', url: 'http://localhost/profile.html' });
+    global.window = dom.window;
+    global.document = dom.window.document;
+    const scriptSrc = fs
+      .readFileSync(path.join(__dirname, '../../../js/profile.js'), 'utf8')
+      .replace("window.location.href = 'login.html';", "window._testRedirect = 'login.html';");
+    dom.window.eval(scriptSrc);
+    dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
+    expect(dom.window._testRedirect).toBe('login.html');
+    dom.window.close();
+  });
+});

--- a/backend/tests/frontend/share.test.js
+++ b/backend/tests/frontend/share.test.js
@@ -1,1 +1,26 @@
-test.skip('share functions', () => {});
+/** @jest-environment node */
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+const scriptSrc = fs
+  .readFileSync(path.join(__dirname, '../../../js/share.js'), 'utf8')
+  .replace(/export\s+\{[^}]+\};?/, '') + '\nwindow.shareOn = shareOn;';
+
+describe('shareOn', () => {
+  test('opens twitter share url', () => {
+    const dom = new JSDOM('', { url: 'http://example.com' });
+    global.window = dom.window;
+    global.document = dom.window.document;
+    const openMock = jest.fn();
+    dom.window.open = openMock;
+    dom.window.eval(scriptSrc);
+    dom.window.shareOn('twitter');
+    expect(openMock).toHaveBeenCalledWith(
+      expect.stringContaining('twitter.com/intent/tweet'),
+      '_blank',
+      'noopener'
+    );
+    dom.window.close();
+  });
+});


### PR DESCRIPTION
## Summary
- strip external `<link>` tags when testing `index.js` to avoid jsdom network errors
- close `JSDOM` windows in frontend tests to prevent lingering timers

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841fdfb69a4832d8932b69b77ffd0ae