### PR TITLE
Implement profile-based checkout prefill

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -141,6 +141,11 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (ship.address) document.getElementById('ship-address').value = ship.address;
         if (ship.city) document.getElementById('ship-city').value = ship.city;
         if (ship.zip) document.getElementById('ship-zip').value = ship.zip;
+        const pay = profile.payment_info || {};
+        if (pay.name) document.getElementById('pay-name').value = pay.name;
+        if (pay.number) document.getElementById('pay-number').value = pay.number;
+        if (pay.exp) document.getElementById('pay-exp').value = pay.exp;
+        if (pay.cvc) document.getElementById('pay-cvc').value = pay.cvc;
       }
     } catch {
       /* ignore profile errors */

--- a/payment.html
+++ b/payment.html
@@ -158,6 +158,41 @@
               />
             </div>
 
+            <div>
+              <input
+                id="pay-name"
+                class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10"
+                placeholder="Name on Card"
+                autocomplete="cc-name"
+                aria-label="Name on card"
+              />
+            </div>
+            <div>
+              <input
+                id="pay-number"
+                class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10"
+                placeholder="Card Number"
+                autocomplete="cc-number"
+                aria-label="Card number"
+              />
+            </div>
+            <div class="flex gap-2">
+              <input
+                id="pay-exp"
+                class="flex-1 p-2 rounded-md bg-[#1A1A1D] border border-white/10"
+                placeholder="MM/YY"
+                autocomplete="cc-exp"
+                aria-label="Expiration"
+              />
+              <input
+                id="pay-cvc"
+                class="w-28 p-2 rounded-md bg-[#1A1A1D] border border-white/10"
+                placeholder="CVC"
+                autocomplete="cc-csc"
+                aria-label="CVC"
+              />
+            </div>
+
             <div id="payment-element" class="text-center text-gray-400">
               [Stripe payment form will go here]
             </div>


### PR DESCRIPTION
## Summary
- add card info inputs on payment page
- prepopulate checkout fields from the user's profile

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684223c8b07c832d82ea1721b8c0b3a6