### PR TITLE
Display other users' models on profile

### DIFF
--- a/js/profile.js
+++ b/js/profile.js
@@ -1,3 +1,54 @@
+function createCard(model) {
+  const div = document.createElement('div');
+  div.className =
+    'model-card relative h-32 bg-[#2A2A2E] border border-white/10 rounded-xl hover:bg-[#3A3A3E] flex items-center justify-center cursor-pointer';
+  div.dataset.model = model.model_url;
+  div.dataset.job = model.job_id;
+  div.innerHTML = `\n    <img src="${model.snapshot || ''}" alt="Model" class="w-full h-full object-contain pointer-events-none" />\n    <span class="sr-only">${model.prompt || 'Model'}</span>\n    <button class="purchase absolute bottom-1 left-1 text-xs bg-blue-600 px-1 rounded">Buy</button>`;
+  div.querySelector('.purchase').addEventListener('click', (e) => {
+    e.stopPropagation();
+    localStorage.setItem('print3Model', model.model_url);
+    localStorage.setItem('print3JobId', model.job_id);
+    window.location.href = 'payment.html';
+  });
+  div.addEventListener('click', () => {
+    const modal = document.getElementById('model-modal');
+    const viewer = modal.querySelector('model-viewer');
+    viewer.src = model.model_url;
+    modal.classList.remove('hidden');
+    document.body.classList.add('overflow-hidden');
+  });
+  return div;
+}
+
+async function captureSnapshots(container) {
+  const cards = container.querySelectorAll('.model-card');
+  for (const card of cards) {
+    const img = card.querySelector('img');
+    if (img && img.src) continue;
+    const glbUrl = card.dataset.model;
+    const viewer = document.createElement('model-viewer');
+    viewer.src = glbUrl;
+    viewer.setAttribute(
+      'environment-image',
+      'https://modelviewer.dev/shared-assets/environments/neutral.hdr'
+    );
+    viewer.style.position = 'fixed';
+    viewer.style.left = '-10000px';
+    viewer.style.width = '300px';
+    viewer.style.height = '300px';
+    document.body.appendChild(viewer);
+    try {
+      await viewer.updateComplete;
+      img.src = await viewer.toDataURL('image/png');
+    } catch (err) {
+      console.error('Failed to capture snapshot', err);
+    } finally {
+      viewer.remove();
+    }
+  }
+}
+
 async function load() {
   const token = localStorage.getItem('token');
   if (!token) {
@@ -14,12 +65,33 @@ async function load() {
   const models = await res.json();
   const container = document.getElementById('models');
   container.innerHTML = '';
-  models.forEach((m) => {
-    const div = document.createElement('div');
-    div.className = 'bg-[#2A2A2E] border border-white/10 rounded-3xl p-4 flex justify-between';
-    div.innerHTML = `<span>${m.prompt} - ${m.model_url || ''}</span><span>${m.likes} ❤️</span>`;
-    container.appendChild(div);
-  });
+  models.forEach((m) => container.appendChild(createCard(m)));
+  await captureSnapshots(container);
+
+  if (user) {
+    try {
+      const r = await fetch(`/api/users/${encodeURIComponent(user)}/profile`);
+      if (r.ok) {
+        const d = await r.json();
+        const el = document.getElementById('profile-name');
+        el.textContent = d.display_name || user;
+      }
+    } catch {
+      /* ignore */
+    }
+  }
 }
 
-document.addEventListener('DOMContentLoaded', load);
+document.addEventListener('DOMContentLoaded', () => {
+  const modal = document.getElementById('model-modal');
+  const closeBtn = document.getElementById('close-modal');
+  function close() {
+    modal.classList.add('hidden');
+    document.body.classList.remove('overflow-hidden');
+  }
+  closeBtn.addEventListener('click', close);
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') close();
+  });
+  load();
+});

--- a/profile.html
+++ b/profile.html
@@ -8,9 +8,59 @@
     <meta property="og:description" content="View your generated models and past orders." />
     <meta property="og:image" content="img/boxlogo.png" />
     <script src="https://cdn.tailwindcss.com"></script>
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@google/model-viewer@1.12.0/dist/model-viewer.min.js"></script>
   </head>
-  <body class="bg-[#1A1A1D] text-white font-sans min-h-screen">
-    <div id="models" class="p-4 grid grid-cols-1 gap-4"></div>
+  <body class="bg-[#1A1A1D] text-white font-sans flex flex-col min-h-screen">
+    <header class="relative flex items-center justify-between py-4 px-6">
+      <a
+        href="index.html"
+        class="relative z-10 flex items-center bg-[#2A2A2E] px-4 py-2 rounded-3xl hover:bg-[#3A3A3E] transition-shape"
+      >
+        <i class="fas fa-arrow-left text-xl text-white mr-2"></i>
+        <span class="text-white font-medium">Back</span>
+      </a>
+      <h1 id="profile-name" class="absolute inset-x-0 top-1/2 -translate-y-1/2 text-center text-2xl font-semibold">
+        Profile
+      </h1>
+      <span class="w-16"></span>
+    </header>
+    <main class="flex-1 px-6 py-4">
+      <div id="models" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4"></div>
+    </main>
+    <div
+      id="model-modal"
+      class="fixed inset-0 bg-black/80 flex items-center justify-center hidden z-50"
+    >
+      <div class="relative w-11/12 max-w-3xl">
+        <button
+          id="close-modal"
+          class="absolute -top-4 -right-4 w-[4.5rem] h-[4.5rem] rounded-full bg-white text-black flex items-center justify-center z-50"
+          type="button"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            class="w-10 h-10"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="3"
+            stroke-linecap="round"
+          >
+            <line x1="6" y1="6" x2="18" y2="18" />
+            <line x1="6" y1="18" x2="18" y2="6" />
+          </svg>
+          <span class="sr-only">Close</span>
+        </button>
+        <model-viewer
+          src=""
+          alt="3D model preview"
+          environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
+          camera-controls
+          auto-rotate
+          class="w-full h-96 bg-[#2A2A2E] rounded-xl"
+        ></model-viewer>
+      </div>
+    </div>
     <script type="module" src="js/profile.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add <model-viewer> and modal to the profile page
- show profile header and grid of models
- implement model cards with snapshots and purchase buttons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684223e00634832d91050994863c5a4b