### PR TITLE
Add entry modal for competitions

### DIFF
--- a/competitions.html
+++ b/competitions.html
@@ -40,6 +40,8 @@
     <div
       id="entry-modal"
       class="fixed inset-0 bg-black/80 flex items-center justify-center hidden z-50"
+      role="dialog"
+      aria-modal="true"
     >
       <div class="bg-[#2A2A2E] p-4 rounded-lg w-11/12 max-w-md space-y-4">
         <select

--- a/competitions.html
+++ b/competitions.html
@@ -37,6 +37,29 @@
       <h2 class="text-2xl mt-8">Past Winners</h2>
       <div id="past" class="space-y-4"></div>
     </main>
+    <div
+      id="entry-modal"
+      class="fixed inset-0 bg-black/80 flex items-center justify-center hidden z-50"
+    >
+      <div class="bg-[#2A2A2E] p-4 rounded-lg w-11/12 max-w-md space-y-4">
+        <select
+          id="model-select"
+          class="w-full bg-[#2A2A2E] border border-white/20 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#4A4A4E]"
+        ></select>
+        <div class="text-right space-x-2">
+          <button id="entry-cancel" class="px-4 py-2 bg-gray-500 text-white rounded" type="button">
+            Cancel
+          </button>
+          <button
+            id="entry-submit"
+            class="px-4 py-2 bg-[#30D5C8] text-[#1A1A1D] rounded hover:bg-[#28b7a8] transition"
+            type="button"
+          >
+            Submit
+          </button>
+        </div>
+      </div>
+    </div>
     <script type="module" src="js/competitions.js"></script>
     <script type="module">
       import { shareOn } from './js/share.js';

--- a/js/competitions.js
+++ b/js/competitions.js
@@ -147,6 +147,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const modal = document.getElementById('entry-modal');
   document.getElementById('entry-cancel').addEventListener('click', closeModal);
   document.getElementById('entry-submit').addEventListener('click', submitEntry);
+  modal.addEventListener('click', (e) => {
+    if (e.target === modal) closeModal();
+  });
   document.addEventListener('keydown', (e) => {
     if (e.key === 'Escape' && !modal.classList.contains('hidden')) closeModal();
   });


### PR DESCRIPTION
## Summary
- add hidden entry modal markup to `competitions.html`
- replace prompt with modal-based model selection in `js/competitions.js`
- wire up modal close and submit logic

## Testing
- `npm test --prefix backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842c34492c4832dab99de92ade7dd35