### PR TITLE
Align competition cards

### DIFF
--- a/competitions.html
+++ b/competitions.html
@@ -24,8 +24,8 @@
       <h1 class="text-xl font-semibold">Competitions</h1>
       <div></div>
     </header>
-    <main class="flex-1 p-4 space-y-6">
-      <section class="bg-[#2A2A2E] p-4 rounded-xl">
+    <main class="flex-1 p-4 space-y-6 flex flex-col items-center">
+      <section class="bg-[#2A2A2E] p-4 rounded-xl w-full max-w-xl">
         <p class="mb-2">
           Put your modelling skills to the test! Enter our themed contests, climb the leaderboard
           and win free prints.
@@ -33,9 +33,9 @@
         <p>Sign up or log in to submit your best designs.</p>
       </section>
       <h2 class="text-2xl">Active Competitions</h2>
-      <div id="list" class="space-y-4"></div>
+      <div id="list" class="space-y-4 w-full max-w-xl"></div>
       <h2 class="text-2xl mt-8">Past Winners</h2>
-      <div id="past" class="space-y-4"></div>
+      <div id="past" class="space-y-4 w-full max-w-xl"></div>
     </main>
     <script type="module" src="js/competitions.js"></script>
     <script type="module">

--- a/js/competitions.js
+++ b/js/competitions.js
@@ -13,7 +13,7 @@ async function load() {
   }
   comps.forEach((c) => {
     const div = document.createElement('div');
-    div.className = 'bg-[#2A2A2E] p-4 rounded-xl space-y-2';
+    div.className = 'bg-[#2A2A2E] border border-white/10 p-5 rounded-xl space-y-3 w-full';
     div.innerHTML = `<h2 class="text-xl">${c.name}</h2>
       <p>${c.prize_description || ''}</p>
       <p class="text-sm"><span class="countdown" data-end="${c.end_date}"></span> left</p>
@@ -89,7 +89,8 @@ async function loadPast() {
   }
   comps.forEach((c) => {
     const div = document.createElement('div');
-    div.className = 'bg-[#2A2A2E] p-4 rounded-xl space-y-2 text-center';
+    div.className =
+      'bg-[#2A2A2E] border border-white/10 p-5 rounded-xl space-y-3 text-center w-full';
     div.innerHTML = `<h3 class="text-lg">${c.name}</h3>
       <img src="${c.model_url}" alt="Winning model" class="w-32 h-32 object-contain mx-auto" />`;
     container.appendChild(div);


### PR DESCRIPTION
## Summary
- center competition sections
- make competition cards full-width with consistent padding and borders

## Testing
- `npm test` *(fails: 1 failed, 12 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6842c33ca794832db90d76447d06fca3