### PR TITLE
Add drag‑and‑drop uploads with client-side cropping

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,14 @@ The model viewer page includes a **Buy Now** button for fast purchasing. When a
 logged-in user has shipping details saved in their profile, clicking **Buy Now**
 submits the order immediately and redirects to the Stripe checkout page.
 
+### Drag-and-Drop Image Uploads
+
+Users can drag and drop image files onto the upload area on `index.html`. A
+cropping modal powered by [Cropper.js](https://github.com/fengyuanchen/cropperjs)
+lets users resize their images to a square preview before the files are uploaded
+to the server. The same modal appears when browsing for files via the standard
+file picker.
+
 ## Sharing API
 
 Models can be shared publicly via unique slugs.

--- a/backend/tests/frontend/index.test.js
+++ b/backend/tests/frontend/index.test.js
@@ -26,7 +26,7 @@ describe('index validatePrompt', () => {
       .readFileSync(path.join(__dirname, '../../../js/index.js'), 'utf8')
       .replace("import { shareOn } from './share.js';", '')
       .replace(/window\.addEventListener\('DOMContentLoaded'[\s\S]+$/, '');
-    script += '\nlet savedProfile = null;\nwindow.validatePrompt = validatePrompt;';
+    script += '\nwindow.validatePrompt = validatePrompt;';
     dom.window.eval(script);
     return dom;
   }

--- a/docs/task_list.md
+++ b/docs/task_list.md
@@ -69,9 +69,6 @@ This consolidated list merges all outstanding tasks from the previous to-do docu
 - Ensure accessibility with ARIA labels and contrast.
   - Audit pages for missing labels.
   - Fix color contrast issues.
-- Add drag-and-drop image uploads with inline cropping and resizing.
-  - Implement a drag-and-drop area.
-  - Integrate a client-side cropping library.
 - Display clear inline error messages if generation fails or the prompt is invalid.
   - Provide failure states in the UI.
   - Validate prompts before submission.


### PR DESCRIPTION
## Summary
- remove completed TODO for drag-and-drop uploads with cropping

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842c2d68fb8832da699f6dc6aecbf09