### PR TITLE
Add like button to model cards

### DIFF
--- a/js/community.js
+++ b/js/community.js
@@ -62,7 +62,11 @@ function createCard(model) {
     'model-card relative h-32 bg-[#2A2A2E] border border-white/10 rounded-xl hover:bg-[#3A3A3E] transition-shape flex items-center justify-center cursor-pointer';
   div.dataset.model = model.model_url;
   div.dataset.job = model.job_id;
-  div.innerHTML = `\n      <img src="${model.snapshot || ''}" alt="Model" class="w-full h-full object-contain pointer-events-none" />\n      <span class="sr-only">${model.title || 'Model'}</span>\n      <span class="absolute bottom-1 right-1 text-xs bg-black/50 px-1 rounded" id="likes-${model.id}">${model.likes}</span>\n      <button class="purchase absolute bottom-1 left-1 text-xs bg-blue-600 px-1 rounded">Buy</button>`;
+  div.innerHTML = `\n      <img src="${model.snapshot || ''}" alt="Model" class="w-full h-full object-contain pointer-events-none" />\n      <span class="sr-only">${model.title || 'Model'}</span>\n      <button class="like absolute bottom-1 right-1 text-xs bg-red-600 px-1 rounded">❤️ <span id="likes-${model.id}">${model.likes}</span></button>\n      <button class="purchase absolute bottom-1 left-1 text-xs bg-blue-600 px-1 rounded">Buy</button>`;
+  div.querySelector('.like').addEventListener('click', (e) => {
+    e.stopPropagation();
+    like(model.id);
+  });
   div.querySelector('.purchase').addEventListener('click', (e) => {
     e.stopPropagation();
     localStorage.setItem('print3Model', model.model_url);


### PR DESCRIPTION
## Summary
- add a like button on model cards
- wire the button to call the existing `like()` function so the count updates

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842c3033ae4832d91c9073643996a4c