### PR TITLE
Add infinite scroll for community page

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -117,14 +117,14 @@
       <section class="mb-12">
         <h2 class="text-xl font-semibold mb-4">Popular Now</h2>
         <div id="popular-grid" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4"></div>
-        <button id="popular-load" class="mt-4 px-4 py-2 bg-[#2A2A2E] rounded">Load More</button>
+        <div id="popular-sentinel" class="h-8"></div>
       </section>
 
       <!-- Recent Creations -->
       <section>
         <h2 class="text-xl font-semibold mb-4">Recent</h2>
         <div id="recent-grid" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4"></div>
-        <button id="recent-load" class="mt-4 px-4 py-2 bg-[#2A2A2E] rounded">Load More</button>
+        <div id="recent-sentinel" class="h-8"></div>
       </section>
     </main>
 


### PR DESCRIPTION
## Summary
- remove manual Load More buttons
- fetch more items when a sentinel div becomes visible
- reuse the same observer when filters change

## Testing
- `npm test` *(fails: index validatePrompt tests)*

------
https://chatgpt.com/codex/tasks/task_e_6842c3092eb8832d8de6255302be4104