### PR TITLE
Improve modal accessibility

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -165,16 +165,22 @@
     <script type="module">
       import { shareOn } from './js/share.js';
       import { init } from './js/community.js';
+      import { trapFocus } from './js/focus-trap.js';
       window.shareOn = shareOn;
 
       document.addEventListener('DOMContentLoaded', () => {
         const modal = document.getElementById('model-modal');
         const viewer = modal.querySelector('model-viewer');
         const closeBtn = document.getElementById('close-modal');
+        let releaseFocus;
 
         function close() {
           modal.classList.add('hidden');
           document.body.classList.remove('overflow-hidden');
+          if (releaseFocus) {
+            releaseFocus();
+            releaseFocus = null;
+          }
         }
 
         document.addEventListener('click', (e) => {
@@ -183,6 +189,7 @@
             viewer.src = card.dataset.model;
             modal.classList.remove('hidden');
             document.body.classList.add('overflow-hidden');
+            releaseFocus = trapFocus(modal);
           }
         });
 

--- a/js/focus-trap.js
+++ b/js/focus-trap.js
@@ -1,0 +1,43 @@
+export function trapFocus(modal) {
+  const previouslyFocused = document.activeElement;
+  const selectors = [
+    'a[href]',
+    'area[href]',
+    'input:not([disabled])',
+    'select:not([disabled])',
+    'textarea:not([disabled])',
+    'button:not([disabled])',
+    'iframe',
+    'object',
+    'embed',
+    '[contenteditable]',
+    '[tabindex]:not([tabindex="-1"])',
+  ].join(',');
+  let focusables = Array.from(modal.querySelectorAll(selectors));
+  if (focusables.length === 0) {
+    modal.setAttribute('tabindex', '-1');
+    focusables = [modal];
+  }
+  const first = focusables[0];
+  const last = focusables[focusables.length - 1];
+  function handle(e) {
+    if (e.key !== 'Tab') return;
+    if (e.shiftKey) {
+      if (document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      }
+    } else {
+      if (document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+  }
+  modal.addEventListener('keydown', handle);
+  first.focus();
+  return () => {
+    modal.removeEventListener('keydown', handle);
+    previouslyFocused && previouslyFocused.focus && previouslyFocused.focus();
+  };
+}

--- a/js/index.js
+++ b/js/index.js
@@ -1,5 +1,6 @@
 'use strict';
 import { shareOn } from './share.js';
+import { trapFocus } from './focus-trap.js';
 
 if (
   localStorage.getItem('hasGenerated') === 'true' ||
@@ -267,10 +268,12 @@ function openCropper(file) {
   return new Promise((resolve) => {
     refs.cropImage.src = URL.createObjectURL(file);
     refs.cropModal.classList.remove('hidden');
+    const releaseFocus = trapFocus(refs.cropModal);
     const cropper = new Cropper(refs.cropImage, { aspectRatio: 1, viewMode: 1 });
     const done = (result) => {
       cropper.destroy();
       refs.cropModal.classList.add('hidden');
+      releaseFocus();
       resolve(result);
     };
     refs.cropConfirm.onclick = () => {

--- a/js/profile.js
+++ b/js/profile.js
@@ -1,3 +1,7 @@
+import { trapFocus } from './focus-trap.js';
+
+let releaseFocus = null;
+
 function createCard(model) {
   const div = document.createElement('div');
   div.className =
@@ -17,6 +21,7 @@ function createCard(model) {
     viewer.src = model.model_url;
     modal.classList.remove('hidden');
     document.body.classList.add('overflow-hidden');
+    releaseFocus = trapFocus(modal);
   });
   return div;
 }
@@ -102,6 +107,10 @@ document.addEventListener('DOMContentLoaded', () => {
   function close() {
     modal.classList.add('hidden');
     document.body.classList.remove('overflow-hidden');
+    if (releaseFocus) {
+      releaseFocus();
+      releaseFocus = null;
+    }
   }
   closeBtn.addEventListener('click', close);
   document.addEventListener('keydown', (e) => {


### PR DESCRIPTION
## Summary
- trap keyboard focus inside modal dialogs
- restore focus when modals close
- use new shared `trapFocus` helper

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842c31f2378832db91ddc79b481d219