### PR TITLE
Add login prompt for entering competitions

### DIFF
--- a/js/competitions.js
+++ b/js/competitions.js
@@ -61,7 +61,10 @@ function startCountdown(el) {
 
 async function enter(id) {
   const token = localStorage.getItem('token');
-  if (!token) return alert('Login required');
+  if (!token) {
+    alert('Please log in to enter.');
+    return;
+  }
   const modelId = prompt('Model ID to submit');
   if (!modelId) return;
   await fetch(`/api/competitions/${id}/enter`, {


### PR DESCRIPTION
## Summary
- show login reminder when entering a competition without auth token

## Testing
- `npm --prefix backend install`
- `npm --prefix backend test` *(fails: Test Suites: 1 failed, 12 passed, 13 total)*

------
https://chatgpt.com/codex/tasks/task_e_6842c32dd4a4832da2e49c46c7d002c0