### PR TITLE
Update competition countdown format

### DIFF
--- a/backend/tests/additionalApi.test.js
+++ b/backend/tests/additionalApi.test.js
@@ -134,9 +134,6 @@ test('POST /api/models/:id/like requires auth', async () => {
   expect(res.status).toBe(401);
 });
 
-
-
-
 test('POST /api/models/:id/public updates flag', async () => {
   db.query.mockResolvedValueOnce({ rows: [{ is_public: true }] });
   const token = jwt.sign({ id: 'u1' }, 'secret');
@@ -161,8 +158,6 @@ test('POST /api/models/:id/public requires boolean', async () => {
     .send({});
   expect(res.status).toBe(400);
 });
-
-
 
 test('GET /api/community/recent pagination and category', async () => {
   db.query.mockResolvedValueOnce({ rows: [] });

--- a/backend/tests/frontend/competitions.test.js
+++ b/backend/tests/frontend/competitions.test.js
@@ -18,3 +18,27 @@ test('startCountdown closes past competitions', () => {
   dom.window.startCountdown(el);
   expect(el.textContent).toBe('Closed');
 });
+
+test('startCountdown formats remaining time', () => {
+  const dom = new JSDOM('<span id="t"></span>', { runScripts: 'dangerously' });
+  global.window = dom.window;
+  global.document = dom.window.document;
+  let script = fs
+    .readFileSync(path.join(__dirname, '../../../js/competitions.js'), 'utf8')
+    .replace(/document\.addEventListener\('DOMContentLoaded'[\s\S]+$/, '')
+    .replace(/const timer = setInterval/, 'var timer = setInterval');
+  script += '\nwindow.startCountdown = startCountdown;';
+  dom.window.eval(script);
+  const el = dom.window.document.getElementById('t');
+  const future = new Date(Date.now() + 2 * 86400000);
+  el.dataset.end = future.toISOString().slice(0, 10);
+  const now = new Date();
+  const end = new Date(el.dataset.end + 'T23:59:59');
+  const diff = end - now;
+  const d = Math.floor(diff / 86400000);
+  const h = Math.floor((diff % 86400000) / 3600000);
+  const m = Math.floor((diff % 3600000) / 60000);
+  const expected = `${d}d ${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+  dom.window.startCountdown(el);
+  expect(el.textContent).toBe(expected);
+});

--- a/backend/tests/frontend/competitions.test.js
+++ b/backend/tests/frontend/competitions.test.js
@@ -9,8 +9,7 @@ test('startCountdown closes past competitions', () => {
   global.document = dom.window.document;
   let script = fs
     .readFileSync(path.join(__dirname, '../../../js/competitions.js'), 'utf8')
-    .replace(/document\.addEventListener\('DOMContentLoaded'[\s\S]+$/, '')
-    .replace(/const timer = setInterval/, 'var timer = setInterval');
+    .replace(/document\.addEventListener\('DOMContentLoaded'[\s\S]+$/, '');
   script += '\nwindow.startCountdown = startCountdown;';
   dom.window.eval(script);
   const el = dom.window.document.getElementById('t');
@@ -25,8 +24,7 @@ test('startCountdown formats remaining time', () => {
   global.document = dom.window.document;
   let script = fs
     .readFileSync(path.join(__dirname, '../../../js/competitions.js'), 'utf8')
-    .replace(/document\.addEventListener\('DOMContentLoaded'[\s\S]+$/, '')
-    .replace(/const timer = setInterval/, 'var timer = setInterval');
+    .replace(/document\.addEventListener\('DOMContentLoaded'[\s\S]+$/, '');
   script += '\nwindow.startCountdown = startCountdown;';
   dom.window.eval(script);
   const el = dom.window.document.getElementById('t');

--- a/backend/tests/frontend/index.test.js
+++ b/backend/tests/frontend/index.test.js
@@ -26,7 +26,7 @@ describe('index validatePrompt', () => {
       .readFileSync(path.join(__dirname, '../../../js/index.js'), 'utf8')
       .replace("import { shareOn } from './share.js';", '')
       .replace(/window\.addEventListener\('DOMContentLoaded'[\s\S]+$/, '');
-    script += '\nlet savedProfile = null;\nwindow.validatePrompt = validatePrompt;';
+    script += '\nwindow.validatePrompt = validatePrompt;';
     dom.window.eval(script);
     return dom;
   }

--- a/js/competitions.js
+++ b/js/competitions.js
@@ -47,6 +47,7 @@ function zeroPad(num) {
 
 function startCountdown(el) {
   const end = new Date(el.dataset.end + 'T23:59:59');
+  let timer;
   function update() {
     const diff = end - new Date();
     if (diff <= 0) {
@@ -60,7 +61,7 @@ function startCountdown(el) {
     el.textContent = `${d}d ${zeroPad(h)}:${zeroPad(m)}`;
   }
   update();
-  const timer = setInterval(update, 60000);
+  timer = setInterval(update, 60000);
 }
 
 async function enter(id) {

--- a/js/competitions.js
+++ b/js/competitions.js
@@ -41,6 +41,10 @@ async function loadLeaderboard(id, table) {
     .join('');
 }
 
+function zeroPad(num) {
+  return String(num).padStart(2, '0');
+}
+
 function startCountdown(el) {
   const end = new Date(el.dataset.end + 'T23:59:59');
   function update() {
@@ -53,7 +57,7 @@ function startCountdown(el) {
     const d = Math.floor(diff / 86400000);
     const h = Math.floor((diff % 86400000) / 3600000);
     const m = Math.floor((diff % 3600000) / 60000);
-    el.textContent = `${d}d ${h}h ${m}m`;
+    el.textContent = `${d}d ${zeroPad(h)}:${zeroPad(m)}`;
   }
   update();
   const timer = setInterval(update, 60000);

--- a/js/index.js
+++ b/js/index.js
@@ -58,10 +58,8 @@ let uploadedFiles = [];
 let lastJobId = null;
 let savedProfile = null;
 
-
 // Track when the prompt or images have been modified after a generation
 let editsPending = false;
-
 
 let progressInterval = null;
 let progressStart = null;
@@ -373,7 +371,6 @@ refs.submitBtn.addEventListener('click', async () => {
 });
 
 window.addEventListener('DOMContentLoaded', () => {
-
   setStep('prompt');
   showModel();
   refs.viewer.src = FALLBACK_GLB;
@@ -391,7 +388,6 @@ window.addEventListener('DOMContentLoaded', () => {
         stopProgress();
       }
     });
-
   }
   fetchProfile().then(() => {
     if (savedProfile && refs.buyNowBtn) {

--- a/js/profile.js
+++ b/js/profile.js
@@ -93,7 +93,6 @@ async function load() {
     }
     container.appendChild(div);
   });
-
 }
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/profile.html
+++ b/profile.html
@@ -8,7 +8,10 @@
     <meta property="og:description" content="View your generated models and past orders." />
     <meta property="og:image" content="img/boxlogo.png" />
     <script src="https://cdn.tailwindcss.com"></script>
-    <script type="module" src="https://cdn.jsdelivr.net/npm/@google/model-viewer@1.12.0/dist/model-viewer.min.js"></script>
+    <script
+      type="module"
+      src="https://cdn.jsdelivr.net/npm/@google/model-viewer@1.12.0/dist/model-viewer.min.js"
+    ></script>
   </head>
   <body class="bg-[#1A1A1D] text-white font-sans flex flex-col min-h-screen">
     <header class="relative flex items-center justify-between py-4 px-6">
@@ -19,7 +22,10 @@
         <i class="fas fa-arrow-left text-xl text-white mr-2"></i>
         <span class="text-white font-medium">Back</span>
       </a>
-      <h1 id="profile-name" class="absolute inset-x-0 top-1/2 -translate-y-1/2 text-center text-2xl font-semibold">
+      <h1
+        id="profile-name"
+        class="absolute inset-x-0 top-1/2 -translate-y-1/2 text-center text-2xl font-semibold"
+      >
         Profile
       </h1>
       <span class="w-16"></span>


### PR DESCRIPTION
## Summary
- display competition countdown timers as `Xd HH:MM`
- unit test to cover new countdown format
- fix index page test helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842c335c6b0832db5bf7055f35a073e