### PR TITLE
Add rules link placeholder to competition cards

### DIFF
--- a/competitions.html
+++ b/competitions.html
@@ -31,6 +31,7 @@
           and win free prints.
         </p>
         <p>Sign up or log in to submit your best designs.</p>
+        <a class="text-sm underline" href="#" id="rules-link">Rules</a>
       </section>
       <h2 class="text-2xl">Active Competitions</h2>
       <div id="list" class="space-y-4"></div>

--- a/js/competitions.js
+++ b/js/competitions.js
@@ -21,6 +21,7 @@ async function load() {
         <button data-id="${c.id}" class="enter bg-[#30D5C8] text-[#1A1A1D] px-3 py-1 rounded">Enter</button>
         <button onclick="shareOn('twitter')" aria-label="Share on Twitter" class="w-8 h-8 flex items-center justify-center bg-[#1A1A1D] border border-white/10 rounded hover:bg-[#3A3A3E]"><i class="fab fa-twitter"></i></button>
       </div>
+      <a class="text-sm underline" href="#" id="rules-link">Rules</a>
       <table class="leaderboard w-full mt-4 text-sm"></table>`;
     list.appendChild(div);
     const table = div.querySelector('.leaderboard');


### PR DESCRIPTION
## Summary
- add a placeholder rules link in the competitions page intro
- include the same link in each dynamically generated competition card

## Testing
- `npm test` *(fails: A worker process failed to exit)*

------
https://chatgpt.com/codex/tasks/task_e_6842c346e3a0832dac24c87decb82094