### PR TITLE
Fix back button outline on community page

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -35,7 +35,7 @@
     <header class="relative flex items-center justify-between py-4 px-6">
       <a
         href="index.html"
-        class="relative z-10 flex items-center bg-[#2A2A2E] px-4 py-2 rounded-3xl hover:bg-[#3A3A3E] transition-shape"
+        class="relative z-10 flex items-center bg-[#2A2A2E] border border-white/10 px-4 py-2 rounded-3xl hover:bg-[#3A3A3E] transition-shape"
       >
         <i class="fas fa-arrow-left text-xl text-white mr-2"></i>
         <span class="text-white font-medium">Back</span>


### PR DESCRIPTION
## Summary
- ensure Community Creations back button uses the same light border style as other controls

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842d9882e7c832d8865b919035cac07