### PR TITLE
Add script loading task

### DIFF
--- a/docs/task_list.md
+++ b/docs/task_list.md
@@ -13,6 +13,16 @@ This consolidated list merges all outstanding tasks from the previous to-do docu
 - Provide a few example prompts to inspire new visitors.
 - Prefill the prompt box with the last prompt or a suggested one.
 
+- Offer subreddit-specific landing pages for Reddit ads.
+  - Accept an `sr` query parameter indicating the subreddit.
+  - Place a dedicated .glb placeholder for each subreddit in `/models/`.
+  - Create `js/subredditLanding.js` with a mapping from subreddit to placeholder and quote.
+  - Parse `sr` on page load to choose the correct .glb and quote.
+  - Insert the quote into a new element with id `sr-quote`.
+  - Include `<script src="js/subredditLanding.js"></script>` on the landing page.
+  - Fallback to the default astronaut and generic quote when `sr` is missing or unknown.
+  - Generate ad links with the `?sr=<subreddit>` parameter.
+
 ## Prompting & Generation
 
 - Validate prompts client-side to prevent submission errors.


### PR DESCRIPTION
## Summary
- extend Reddit-specific landing page tasks

## Testing
- `npm test --silent` in `backend` *(fails: jest not found)*
- `npm test --silent` in `backend/hunyuan_server` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842e901310c832dad74e94a5dbc3b89