### PR TITLE
Fix Node CI workflow

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -13,10 +13,18 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'
-      - run: npm install
+          node-version: '16'
+      - name: Show Node and npm versions
+        run: |
+          node --version
+          npm --version
         working-directory: backend
-      - run: npm test
+      - name: Copy environment variables
+        run: cp ../.env.example .env
+        working-directory: backend
+      - run: npm ci
+        working-directory: backend
+      - run: npm run test-ci
         working-directory: backend
       - run: npx prettier --check "**/*.{js,jsx,json,md,html}"
         working-directory: backend


### PR DESCRIPTION
## Summary
- pin Node 16
- show Node/NPM versions during workflow
- copy `.env.example` to avoid missing env errors
- use `npm ci` then `npm run test-ci`

## Testing
- `npm ci`
- `npm test`
- `npx prettier --check "**/*.{js,jsx,json,md,html}"`

------
https://chatgpt.com/codex/tasks/task_e_6842ecc638a4832da9e24ec0b99dd2c3