### PR TITLE
Fix search bar height

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -102,7 +102,7 @@
           id="search"
           placeholder="Search..."
           aria-label="Search creations"
-          class="bg-[#2A2A2E] border border-white/20 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#4A4A4E] flex-1 min-w-[10rem]"
+          class="bg-[#2A2A2E] border border-white/20 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#4A4A4E] flex-1 min-w-[10rem] h-11"
         />
         <select
           id="sort"


### PR DESCRIPTION
## Summary
- match search bar height to dropdown height on the community creations page

## Testing
- `npx prettier CommunityCreations.html --check`
- `npx prettier --check "**/*.{js,jsx,json,md,html}"` *(fails: Code style issues found in 3 files)*
- `npm test --prefix backend` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842eac4f250832da0b83b11b329e941