### PR TITLE
Move sort dropdown before search input

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -105,13 +105,6 @@
           <option value="miniatures">Miniatures</option>
           <option value="props">Props</option>
         </select>
-        <input
-          type="text"
-          id="search"
-          placeholder="Search..."
-          aria-label="Search creations"
-          class="bg-[#2A2A2E] border border-white/20 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#4A4A4E] flex-1 min-w-[10rem] h-11"
-        />
         <select
           id="sort"
           aria-label="Sort order"
@@ -120,6 +113,13 @@
           <option value="desc">Newest</option>
           <option value="asc">Oldest</option>
         </select>
+        <input
+          type="text"
+          id="search"
+          placeholder="Search..."
+          aria-label="Search creations"
+          class="bg-[#2A2A2E] border border-white/20 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#4A4A4E] flex-1 min-w-[10rem] h-11"
+        />
       </div>
       <!-- Popular Creations -->
       <section class="mb-12">


### PR DESCRIPTION
## Summary
- re-order the sort dropdown to appear between the category filter and the search field on the Community Creations page

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6842fccbb7a0832db61e8c3ceaf5d990