### PR TITLE
Add live competition entry thumbnails

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -515,8 +515,9 @@ app.get('/api/competitions/past', async (req, res) => {
 app.get('/api/competitions/:id/entries', async (req, res) => {
   try {
     const { rows } = await db.query(
-      `SELECT e.model_id, COALESCE(l.count,0) as likes
+      `SELECT e.model_id, j.model_url, COALESCE(l.count,0) as likes
        FROM competition_entries e
+       JOIN jobs j ON e.model_id=j.job_id
        LEFT JOIN (SELECT model_id, COUNT(*) as count FROM likes GROUP BY model_id) l
        ON e.model_id=l.model_id
        WHERE e.competition_id=$1

--- a/competitions.html
+++ b/competitions.html
@@ -12,6 +12,15 @@
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css"
     />
+    <!-- Google <model-viewer> -->
+    <script
+      type="module"
+      src="https://cdn.jsdelivr.net/npm/@google/model-viewer@1.12.0/dist/model-viewer.min.js"
+    ></script>
+    <script
+      nomodule
+      src="https://cdn.jsdelivr.net/npm/@google/model-viewer@1.12.0/dist/model-viewer-legacy.js"
+    ></script>
   </head>
   <body class="bg-[#1A1A1D] text-white font-sans flex flex-col min-h-screen">
     <header class="relative flex items-center justify-between py-4 px-6">

--- a/js/competitions.js
+++ b/js/competitions.js
@@ -1,3 +1,48 @@
+function like(id) {
+  const token = localStorage.getItem('token');
+  if (!token) {
+    alert('Login required');
+    return;
+  }
+  fetch(`/api/models/${id}/like`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}` },
+  })
+    .then((r) => r.json())
+    .then((d) => {
+      const span = document.querySelector(`#likes-${id}`);
+      if (span) span.textContent = d.likes;
+    });
+}
+
+async function captureSnapshots(container) {
+  const cards = container.querySelectorAll('.entry-card');
+  for (const card of cards) {
+    const img = card.querySelector('img');
+    if (img && img.src) continue;
+    const glbUrl = card.dataset.model;
+    const viewer = document.createElement('model-viewer');
+    viewer.src = glbUrl;
+    viewer.setAttribute(
+      'environment-image',
+      'https://modelviewer.dev/shared-assets/environments/neutral.hdr'
+    );
+    viewer.style.position = 'fixed';
+    viewer.style.left = '-10000px';
+    viewer.style.width = '300px';
+    viewer.style.height = '300px';
+    document.body.appendChild(viewer);
+    try {
+      await viewer.updateComplete;
+      img.src = await viewer.toDataURL('image/png');
+    } catch (err) {
+      console.error('Failed to capture snapshot', err);
+    } finally {
+      viewer.remove();
+    }
+  }
+}
+
 async function load() {
   const res = await fetch('/api/competitions/active');
   const list = document.getElementById('list');
@@ -21,24 +66,43 @@ async function load() {
         <button data-id="${c.id}" class="enter bg-[#30D5C8] text-[#1A1A1D] px-3 py-1 rounded">Enter</button>
         <button onclick="shareOn('twitter')" aria-label="Share on Twitter" class="w-9 h-9 flex items-center justify-center bg-[#1A1A1D] border border-white/10 rounded hover:bg-[#3A3A3E]"><i class="fab fa-twitter"></i></button>
       </div>
-      <table class="leaderboard w-full mt-4 text-sm"></table>`;
+      <table class="leaderboard w-full mt-4 text-sm"></table>
+      <div class="entries-grid grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-2 mt-4"></div>`;
     list.appendChild(div);
     const table = div.querySelector('.leaderboard');
-    loadLeaderboard(c.id, table);
-    setInterval(() => loadLeaderboard(c.id, table), 30000);
+    const grid = div.querySelector('.entries-grid');
+    loadLeaderboard(c.id, table, grid);
+    setInterval(() => loadLeaderboard(c.id, table, grid), 30000);
     div.querySelector('.enter').addEventListener('click', () => enter(c.id));
     const timer = div.querySelector('.countdown');
     startCountdown(timer);
   });
 }
 
-async function loadLeaderboard(id, table) {
+async function loadLeaderboard(id, table, grid) {
   const res = await fetch(`/api/competitions/${id}/entries`);
   if (!res.ok) return;
   const rows = await res.json();
   table.innerHTML = rows
     .map((r, i) => `<tr><td>${i + 1}</td><td>${r.model_id}</td><td>${r.likes}</td></tr>`)
     .join('');
+  if (grid) {
+    grid.innerHTML = '';
+    rows.forEach((r) => {
+      const card = document.createElement('div');
+      card.className =
+        'entry-card relative h-32 bg-[#2A2A2E] border border-white/10 rounded-xl flex items-center justify-center';
+      card.dataset.model = r.model_url;
+      card.dataset.job = r.model_id;
+      card.innerHTML = `<img src="" alt="Model" class="w-full h-full object-contain pointer-events-none" />\n      <button class="like absolute bottom-1 left-1 text-xs bg-red-600 px-1 rounded">\u2665</button>\n      <span class="absolute bottom-1 right-1 text-xs bg-black/50 px-1 rounded" id="likes-${r.model_id}">${r.likes}</span>`;
+      card.querySelector('.like').addEventListener('click', (e) => {
+        e.stopPropagation();
+        like(r.model_id);
+      });
+      grid.appendChild(card);
+    });
+    captureSnapshots(grid);
+  }
 }
 
 function zeroPad(num) {


### PR DESCRIPTION
## Summary
- show model thumbnails for competition entries
- allow liking entries directly
- include model URLs in `/api/competitions/:id/entries`
- poll leaderboards with new likes in near real time

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842fd30689c832da5ae34518fea4d28