### PR TITLE
Add competition notification emails

### DIFF
--- a/backend/mail.js
+++ b/backend/mail.js
@@ -1,0 +1,7 @@
+async function sendMail(to, subject, text) {
+  // Placeholder mail utility - integrate with real email service in production
+  console.log(`Sending mail to ${to}: ${subject}`);
+  return Promise.resolve();
+}
+
+module.exports = { sendMail };

--- a/backend/migrations/014_add_competition_notify.sql
+++ b/backend/migrations/014_add_competition_notify.sql
@@ -1,0 +1,2 @@
+ALTER TABLE user_profiles
+  ADD COLUMN IF NOT EXISTS competition_notify BOOLEAN DEFAULT TRUE;

--- a/backend/migrations/015_add_start_notify_flag.sql
+++ b/backend/migrations/015_add_start_notify_flag.sql
@@ -1,0 +1,2 @@
+ALTER TABLE competitions
+  ADD COLUMN IF NOT EXISTS start_notification_sent BOOLEAN DEFAULT FALSE;

--- a/backend/tests/additionalApi.test.js
+++ b/backend/tests/additionalApi.test.js
@@ -9,6 +9,9 @@ jest.mock('../db', () => ({
 }));
 const db = require('../db');
 
+jest.mock('../mail', () => ({ sendMail: jest.fn() }));
+const { sendMail } = require('../mail');
+
 jest.mock('axios');
 const axios = require('axios');
 const jwt = require('jsonwebtoken');
@@ -29,6 +32,7 @@ const app = require('../server');
 beforeEach(() => {
   db.query.mockClear();
   axios.post.mockClear();
+  sendMail.mockClear();
   stripeMock.checkout.sessions.create.mockResolvedValue({
     id: 'cs_test',
     url: 'https://stripe.test',
@@ -340,4 +344,27 @@ test('GET /api/shared/:slug 404 when missing', async () => {
   db.getShareBySlug = jest.fn().mockResolvedValue(null);
   const res = await request(app).get('/api/shared/bad');
   expect(res.status).toBe(404);
+});
+
+test('POST /api/admin/competitions sends emails', async () => {
+  db.query
+    .mockResolvedValueOnce({ rows: [{ id: 'c1', name: 'Comp' }] })
+    .mockResolvedValueOnce({ rows: [{ email: 'a@a.com' }, { email: 'b@b.com' }] });
+  const res = await request(app)
+    .post('/api/admin/competitions')
+    .set('x-admin-token', 'admin')
+    .send({ name: 'Comp', start_date: '2025-01-01', end_date: '2025-01-31' });
+  expect(res.status).toBe(200);
+  expect(sendMail).toHaveBeenCalledTimes(2);
+});
+
+test('checkCompetitionStart sends voting emails', async () => {
+  db.query
+    .mockResolvedValueOnce({ rows: [{ id: 'c1', name: 'Comp' }] })
+    .mockResolvedValueOnce({ rows: [{ email: 'a@a.com' }] })
+    .mockResolvedValueOnce({});
+  await app.checkCompetitionStart();
+  expect(sendMail).toHaveBeenCalledWith('a@a.com', 'Voting Open', expect.stringContaining('Comp'));
+  const call = db.query.mock.calls.find((c) => c[0].includes('UPDATE competitions'));
+  expect(call[1][0]).toBe('c1');
 });


### PR DESCRIPTION
## Summary
- add competition_notify flag to profiles
- send notification emails on competition creation
- email again when voting opens
- expose scheduler for voting emails
- test notification logic

## Testing
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_6842fd2e1fa0832d91d47b8b82d477da