### PR TITLE
Add admin competitions editor

### DIFF
--- a/admin/competitions.html
+++ b/admin/competitions.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Admin Competitions</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body class="bg-[#1A1A1D] text-white font-sans flex flex-col min-h-screen">
+    <header class="relative flex items-center justify-between py-4 px-6">
+      <a href="../index.html" class="bg-[#2A2A2E] border border-white/10 rounded-3xl px-4 py-2 hover:bg-[#3A3A3E] transition-shape">Back</a>
+      <h1 class="absolute inset-x-0 top-1/2 -translate-y-1/2 text-center text-2xl font-semibold">
+        Admin Competitions
+      </h1>
+      <span class="w-16"></span>
+    </header>
+    <main class="flex-1 p-4 space-y-4">
+      <div class="space-x-2">
+        <input id="token" type="password" placeholder="Admin token" class="bg-[#2A2A2E] border border-white/10 rounded px-2 py-1" />
+        <button id="set-token" class="bg-[#30D5C8] text-[#1A1A1D] px-3 py-1 rounded">Set Token</button>
+      </div>
+      <div id="list" class="space-y-4"></div>
+    </main>
+    <script type="module" src="../js/adminCompetitions.js"></script>
+  </body>
+</html>

--- a/js/adminCompetitions.js
+++ b/js/adminCompetitions.js
@@ -1,0 +1,65 @@
+function getToken() {
+  return localStorage.getItem('adminToken') || '';
+}
+
+function setToken(token) {
+  localStorage.setItem('adminToken', token);
+}
+
+async function load() {
+  const list = document.getElementById('list');
+  list.textContent = 'Loading...';
+  const res = await fetch('/api/competitions/active');
+  if (!res.ok) {
+    list.textContent = 'Failed to load competitions';
+    return;
+  }
+  const comps = await res.json();
+  list.innerHTML = '';
+  comps.forEach((c) => {
+    const div = document.createElement('div');
+    div.className = 'bg-[#2A2A2E] p-4 rounded space-y-2';
+    div.innerHTML = `
+      <h2 class="text-lg font-semibold">${c.name}</h2>
+      <label class="block text-sm">Prize Description
+        <input class="prize w-full mt-1 p-2 rounded bg-[#1A1A1D] border border-white/10" value="${c.prize_description || ''}">
+      </label>
+      <label class="block text-sm">Winner Model ID
+        <input class="winner w-full mt-1 p-2 rounded bg-[#1A1A1D] border border-white/10" value="${c.winner_model_id || ''}">
+      </label>
+      <button class="save bg-[#30D5C8] text-[#1A1A1D] px-3 py-1 rounded">Save</button>`;
+    list.appendChild(div);
+    div.querySelector('.save').addEventListener('click', async () => {
+      const body = {
+        name: c.name,
+        start_date: c.start_date,
+        end_date: c.end_date,
+        prize_description: div.querySelector('.prize').value,
+        winner_model_id: div.querySelector('.winner').value || null,
+      };
+      const resp = await fetch(`/api/admin/competitions/${c.id}`, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-admin-token': getToken(),
+        },
+        body: JSON.stringify(body),
+      });
+      if (resp.ok) {
+        alert('Saved');
+      } else {
+        alert('Failed to save');
+      }
+    });
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const tokenInput = document.getElementById('token');
+  tokenInput.value = getToken();
+  document.getElementById('set-token').addEventListener('click', () => {
+    setToken(tokenInput.value.trim());
+    load();
+  });
+  if (getToken()) load();
+});


### PR DESCRIPTION
## Summary
- add new `admin/competitions.html` page
- allow setting an admin token and editing active competitions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842fd27deac832d8e440f3fedf222c2