### PR TITLE
Add pagination for model lists

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -221,10 +221,12 @@ app.get('/api/progress/:jobId', (req, res) => {
 });
 
 app.get('/api/my/models', authRequired, async (req, res) => {
+  const limit = parseInt(req.query.limit, 10) || 10;
+  const offset = parseInt(req.query.offset, 10) || 0;
   try {
     const { rows } = await db.query(
-      'SELECT * FROM jobs WHERE user_id=$1 ORDER BY created_at DESC',
-      [req.user.id]
+      'SELECT * FROM jobs WHERE user_id=$1 ORDER BY created_at DESC LIMIT $2 OFFSET $3',
+      [req.user.id, limit, offset]
     );
     res.json(rows);
   } catch (err) {
@@ -281,6 +283,8 @@ app.post('/api/profile', authRequired, async (req, res) => {
 });
 
 app.get('/api/users/:username/models', async (req, res) => {
+  const limit = parseInt(req.query.limit, 10) || 10;
+  const offset = parseInt(req.query.offset, 10) || 0;
   try {
     const { rows } = await db.query('SELECT id FROM users WHERE username=$1', [
       req.params.username,
@@ -292,8 +296,8 @@ app.get('/api/users/:username/models', async (req, res) => {
        FROM jobs j
        LEFT JOIN (SELECT model_id, COUNT(*) as count FROM likes GROUP BY model_id) l
        ON j.job_id=l.model_id
-       WHERE j.user_id=$1 AND j.is_public=TRUE ORDER BY j.created_at DESC`,
-      [userId]
+       WHERE j.user_id=$1 AND j.is_public=TRUE ORDER BY j.created_at DESC LIMIT $2 OFFSET $3`,
+      [userId, limit, offset]
     );
     res.json(models.rows);
   } catch (err) {

--- a/backend/tests/additionalApi.test.js
+++ b/backend/tests/additionalApi.test.js
@@ -56,9 +56,22 @@ test('GET /api/my/models ordered by date', async () => {
   db.query.mockResolvedValueOnce({ rows: [] });
   const token = jwt.sign({ id: 'u1' }, 'secret');
   await request(app).get('/api/my/models').set('authorization', `Bearer ${token}`);
-  expect(db.query).toHaveBeenCalledWith(expect.stringContaining('ORDER BY created_at DESC'), [
-    'u1',
-  ]);
+  expect(db.query).toHaveBeenCalledWith(
+    expect.stringContaining('ORDER BY created_at DESC'),
+    ['u1', 10, 0]
+  );
+});
+
+test('GET /api/my/models supports pagination', async () => {
+  db.query.mockResolvedValueOnce({ rows: [] });
+  const token = jwt.sign({ id: 'u1' }, 'secret');
+  await request(app)
+    .get('/api/my/models?limit=5&offset=2')
+    .set('authorization', `Bearer ${token}`);
+  expect(db.query).toHaveBeenCalledWith(
+    expect.stringContaining('ORDER BY created_at DESC'),
+    ['u1', 5, 2]
+  );
 });
 
 test('GET /api/my/models returns models sorted by date', async () => {
@@ -97,6 +110,16 @@ test('GET /api/users/:username/models returns models', async () => {
   expect(res.body[0].job_id).toBe('j1');
   const call = db.query.mock.calls.find((c) => c[0].includes('FROM jobs'));
   expect(call[0]).toContain('j.is_public=TRUE');
+  expect(call[1]).toEqual(['u1', 10, 0]);
+});
+
+test('GET /api/users/:username/models supports pagination', async () => {
+  db.query
+    .mockResolvedValueOnce({ rows: [{ id: 'u1' }] })
+    .mockResolvedValueOnce({ rows: [] });
+  await request(app).get('/api/users/alice/models?limit=3&offset=1');
+  const call = db.query.mock.calls.find((c) => c[0].includes('FROM jobs'));
+  expect(call[1]).toEqual(['u1', 3, 1]);
 });
 
 test('GET /api/users/:username/models 404 when missing', async () => {


### PR DESCRIPTION
## Summary
- add `limit`/`offset` support to `/api/my/models`
- add `limit`/`offset` support to `/api/users/:username/models`
- test pagination for both routes

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_684303b00180832dbc52c6782674f0d0