### PR TITLE
Implement first order discount logic

### DIFF
--- a/backend/migrations/016_create_incentives.sql
+++ b/backend/migrations/016_create_incentives.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS incentives (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+  type TEXT NOT NULL,
+  used_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS incentives_user_idx ON incentives(user_id);


### PR DESCRIPTION
## Summary
- add incentives table migration
- apply automatic first-order discount in `/api/create-order`
- track the discount in the new table
- test automatic first-order discount and adjust existing tests

## Testing
- `npm --prefix backend install`
- `npm --prefix backend test`

------
https://chatgpt.com/codex/tasks/task_e_684303a8ca60832db89a00403bd7664e