### PR TITLE
Implement model deletion API

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -370,6 +370,23 @@ app.post('/api/models/:id/share', authRequired, async (req, res) => {
   }
 });
 
+app.delete('/api/models/:id', authRequired, async (req, res) => {
+  const jobId = req.params.id;
+  try {
+    const { rows } = await db.query(
+      'DELETE FROM jobs WHERE job_id=$1 AND user_id=$2 RETURNING job_id',
+      [jobId, req.user.id]
+    );
+    if (!rows.length) return res.status(404).json({ error: 'Model not found' });
+    await db.query('DELETE FROM likes WHERE model_id=$1', [jobId]);
+    await db.query('DELETE FROM shares WHERE job_id=$1', [jobId]);
+    res.sendStatus(204);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to delete model' });
+  }
+});
+
 app.get('/api/shared/:slug', async (req, res) => {
   try {
     const share = await db.getShareBySlug(req.params.slug);

--- a/backend/tests/additionalApi.test.js
+++ b/backend/tests/additionalApi.test.js
@@ -170,9 +170,7 @@ test('DELETE /api/models/:id deletes model', async () => {
     .mockResolvedValueOnce({})
     .mockResolvedValueOnce({});
   const token = jwt.sign({ id: 'u1' }, 'secret');
-  const res = await request(app)
-    .delete('/api/models/j1')
-    .set('authorization', `Bearer ${token}`);
+  const res = await request(app).delete('/api/models/j1').set('authorization', `Bearer ${token}`);
   expect(res.status).toBe(204);
   const call = db.query.mock.calls[0][0];
   expect(call).toContain('DELETE FROM jobs');
@@ -181,9 +179,7 @@ test('DELETE /api/models/:id deletes model', async () => {
 test('DELETE /api/models/:id 404 when missing', async () => {
   db.query.mockResolvedValueOnce({ rows: [] });
   const token = jwt.sign({ id: 'u1' }, 'secret');
-  const res = await request(app)
-    .delete('/api/models/bad')
-    .set('authorization', `Bearer ${token}`);
+  const res = await request(app).delete('/api/models/bad').set('authorization', `Bearer ${token}`);
   expect(res.status).toBe(404);
 });
 

--- a/backend/tests/additionalApi.test.js
+++ b/backend/tests/additionalApi.test.js
@@ -164,6 +164,29 @@ test('POST /api/models/:id/public requires boolean', async () => {
   expect(res.status).toBe(400);
 });
 
+test('DELETE /api/models/:id deletes model', async () => {
+  db.query
+    .mockResolvedValueOnce({ rows: [{ job_id: 'j1' }] })
+    .mockResolvedValueOnce({})
+    .mockResolvedValueOnce({});
+  const token = jwt.sign({ id: 'u1' }, 'secret');
+  const res = await request(app)
+    .delete('/api/models/j1')
+    .set('authorization', `Bearer ${token}`);
+  expect(res.status).toBe(204);
+  const call = db.query.mock.calls[0][0];
+  expect(call).toContain('DELETE FROM jobs');
+});
+
+test('DELETE /api/models/:id 404 when missing', async () => {
+  db.query.mockResolvedValueOnce({ rows: [] });
+  const token = jwt.sign({ id: 'u1' }, 'secret');
+  const res = await request(app)
+    .delete('/api/models/bad')
+    .set('authorization', `Bearer ${token}`);
+  expect(res.status).toBe(404);
+});
+
 test('GET /api/community/recent pagination and category', async () => {
   db.query.mockResolvedValueOnce({ rows: [] });
 


### PR DESCRIPTION
## Summary
- add DELETE `/api/models/:id` route
- clean up likes and shares when deleting
- test deleting models and missing models

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684303b572e4832d8853c8b3c8b6ab56