### PR TITLE
Remove mailing list opt-in from payment

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -39,7 +39,6 @@ document.addEventListener('DOMContentLoaded', async () => {
   const viewer = document.getElementById('viewer');
   const optOut = document.getElementById('opt-out');
   const emailEl = document.getElementById('checkout-email');
-  const optInEl = document.getElementById('ml-optin');
   const successMsg = document.getElementById('success');
   const cancelMsg = document.getElementById('cancel');
   const flashBanner = document.getElementById('flash-banner');
@@ -170,7 +169,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       // Fallback if Stripe failed to load: just navigate to the checkout URL
       window.location.href = url;
     }
-    if (optInEl && optInEl.checked && emailEl.value) {
+    if (emailEl.value) {
       fetch('/api/subscribe', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/payment.html
+++ b/payment.html
@@ -167,10 +167,6 @@
                 aria-label="ZIP code"
               />
             </div>
-            <label class="flex items-center text-sm">
-              <input id="ml-optin" type="checkbox" class="mr-2" />
-              Join our mailing list
-            </label>
 
             <div id="payment-element" class="text-center text-gray-400">
               [Stripe payment form will go here]


### PR DESCRIPTION
## Summary
- drop `Join our mailing list` checkbox from checkout page
- always subscribe customers to the mailing list when completing the payment

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684316f2dcf0832d80738de0eac24302