### PR TITLE
Limit uploads to single image

### DIFF
--- a/index.html
+++ b/index.html
@@ -263,13 +263,13 @@
           </div>
 
           <div class="mt-4 w-full flex flex-col gap-4">
-            <input type="file" id="uploadInput" accept="image/*" multiple class="hidden" />
+            <input type="file" id="uploadInput" accept="image/*" class="hidden" />
             <div
               id="drop-zone"
-              aria-label="Upload Images"
+              aria-label="Upload Image"
               class="flex items-center justify-center bg-[#2A2A2E] border border-dashed border-white/10 rounded-3xl px-5 py-6 text-gray-400 cursor-pointer hover:bg-[#3A3A3E] transition-shape"
             >
-              Drag & drop images or
+              Drag & drop image or
               <label for="uploadInput" class="underline ml-1 cursor-pointer">browse</label>
             </div>
             <div

--- a/js/index.js
+++ b/js/index.js
@@ -293,6 +293,7 @@ function openCropper(file) {
 
 async function processFiles(files) {
   if (!files.length) return;
+  files = files.slice(0, 1);
   const processed = [];
   for (const f of files) {
     const c = await openCropper(f);


### PR DESCRIPTION
## Summary
- restrict file input to single image
- update drop-zone text and aria-label
- ensure only one file is processed client-side

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68432636ecd8832da8c3bee77cfd3cd7