### PR TITLE
Remove client image cropping

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Then navigate to `http://localhost:8080/index.html` or
 
 ## Uploading Reference Images
 
-Images can be added via drag-and-drop in the generator page. Dropping one or more files opens a cropping dialog powered by Cropper.js allowing you to trim each image before upload.
+Images can be added via drag-and-drop in the generator page.
 
 ## User Profiles API
 
@@ -90,11 +90,7 @@ submits the order immediately and redirects to the Stripe checkout page.
 
 ### Drag-and-Drop Image Uploads
 
-Users can drag and drop image files onto the upload area on `index.html`. A
-cropping modal powered by [Cropper.js](https://github.com/fengyuanchen/cropperjs)
-lets users resize their images to a square preview before the files are uploaded
-to the server. The same modal appears when browsing for files via the standard
-file picker.
+Users can drag and drop image files onto the upload area on `index.html`.
 
 ## Sharing API
 

--- a/index.html
+++ b/index.html
@@ -27,12 +27,7 @@
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css"
     />
 
-    <!-- Cropper.js -->
-    <link
-      rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/cropperjs@1.6.2/dist/cropper.min.css"
-    />
-    <script src="https://cdn.jsdelivr.net/npm/cropperjs@1.6.2/dist/cropper.min.js"></script>
+
 
     <!-- Google <model-viewer>  -->
     <!--  Use a CDN versioned URL so the module is served with CORS headers and the browser can actually download it.  -->
@@ -298,23 +293,7 @@
       </div>
     </div>
 
-    <div
-      id="crop-modal"
-      class="fixed inset-0 bg-black/70 flex items-center justify-center hidden z-50"
-    >
-      <div class="bg-[#2A2A2E] p-4 rounded-lg">
-        <p class="text-center text-sm text-gray-300 mb-2">
-          Drag to select the crop area. Scroll to zoom.
-        </p>
-        <img id="crop-image" class="max-w-[80vw] max-h-[80vh]" />
-        <div class="mt-2 text-right">
-          <button id="crop-cancel" class="px-4 py-2 bg-gray-500 text-white rounded mr-2">
-            Cancel
-          </button>
-          <button id="crop-confirm" class="px-4 py-2 bg-blue-600 text-white rounded">Crop</button>
-        </div>
-      </div>
-    </div>
+
 
     <!--  Application logic ----------------------------------------------- -->
     <script src="js/subredditLanding.js"></script>

--- a/js/index.js
+++ b/js/index.js
@@ -29,10 +29,6 @@ const refs = {
   uploadInput: $('uploadInput'),
   imagePreviewArea: $('image-preview-area'),
   dropZone: $('drop-zone'),
-  cropModal: $('crop-modal'),
-  cropImage: $('crop-image'),
-  cropConfirm: $('crop-confirm'),
-  cropCancel: $('crop-cancel'),
   examples: $('prompt-examples'),
   trending: $("trending-prompts"),
   checkoutBtn: $('checkout-button'),
@@ -266,40 +262,11 @@ function getThumbnail(file) {
   });
 }
 
-function openCropper(file) {
-  return new Promise((resolve) => {
-    refs.cropImage.src = URL.createObjectURL(file);
-    refs.cropModal.classList.remove('hidden');
-    const cropper = new Cropper(refs.cropImage, { aspectRatio: 1, viewMode: 1 });
-    const onKey = (e) => {
-      if (e.key === 'Escape') done(null);
-    };
-    window.addEventListener('keydown', onKey);
-    const done = (result) => {
-      cropper.destroy();
-      window.removeEventListener('keydown', onKey);
-      refs.cropModal.classList.add('hidden');
-      resolve(result);
-    };
-    refs.cropConfirm.onclick = () => {
-      const canvas = cropper.getCroppedCanvas({ width: 512, height: 512 });
-      canvas.toBlob((b) => {
-        done(new File([b], file.name, { type: 'image/png' }));
-      }, 'image/png');
-    };
-    refs.cropCancel.onclick = () => done(null);
-  });
-}
 
 async function processFiles(files) {
   if (!files.length) return;
-  const processed = [];
-  for (const f of files) {
-    const c = await openCropper(f);
-    if (c) processed.push(c);
-  }
-  uploadedFiles = processed;
-  const thumbs = await Promise.all(processed.map((f) => getThumbnail(f)));
+  uploadedFiles = [...files];
+  const thumbs = await Promise.all(uploadedFiles.map((f) => getThumbnail(f)));
   localStorage.setItem('print3Images', JSON.stringify(thumbs));
   renderThumbnails(thumbs);
   editsPending = true;


### PR DESCRIPTION
## Summary
- drop Cropper.js integration and modal
- simplify upload handling logic
- remove cropping references from README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684326496964832db4e67ebfc57e879a