### PR TITLE
Add account creation on profile page

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -70,6 +70,7 @@ app.post('/api/register', async (req, res) => {
       'INSERT INTO users(username,email,password_hash) VALUES($1,$2,$3) RETURNING id,username',
       [username, email, hash]
     );
+    await db.query('INSERT INTO user_profiles(user_id) VALUES($1)', [rows[0].id]);
     const token = jwt.sign({ id: rows[0].id, username }, AUTH_SECRET);
     res.json({ token });
   } catch (err) {

--- a/js/profile.js
+++ b/js/profile.js
@@ -21,6 +21,38 @@ function createCard(model) {
   return div;
 }
 
+async function createAccount(e) {
+  e.preventDefault();
+  const nameEl = document.getElementById('ca-name');
+  const emailEl = document.getElementById('ca-email');
+  const passEl = document.getElementById('ca-pass');
+  [nameEl, emailEl, passEl].forEach((el) => el.classList.remove('border-red-500'));
+  const username = nameEl.value.trim();
+  const email = emailEl.value.trim();
+  const password = passEl.value.trim();
+  if (!username || !email || !password) {
+    document.getElementById('ca-error').textContent = 'All fields required';
+    if (!username) nameEl.classList.add('border-red-500');
+    if (!email) emailEl.classList.add('border-red-500');
+    if (!password) passEl.classList.add('border-red-500');
+    return;
+  }
+  const res = await fetch('/api/register', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, email, password }),
+  });
+  const data = await res.json();
+  if (data.token) {
+    localStorage.setItem('token', data.token);
+    document.getElementById('create-account-form').classList.add('hidden');
+    load();
+  } else {
+    document.getElementById('ca-error').textContent = data.error || 'Signup failed';
+    [nameEl, emailEl, passEl].forEach((el) => el.classList.add('border-red-500'));
+  }
+}
+
 async function captureSnapshots(container) {
   const cards = container.querySelectorAll('.model-card');
   for (const card of cards) {
@@ -52,7 +84,7 @@ async function captureSnapshots(container) {
 async function load() {
   const token = localStorage.getItem('token');
   if (!token) {
-    window.location.href = 'login.html';
+    document.getElementById('create-account-form').classList.remove('hidden');
     return;
   }
   const urlParams = new URLSearchParams(window.location.search);
@@ -106,5 +138,7 @@ document.addEventListener('DOMContentLoaded', () => {
   document.addEventListener('keydown', (e) => {
     if (e.key === 'Escape') close();
   });
+  const form = document.getElementById('create-account-form');
+  form?.addEventListener('submit', createAccount);
   load();
 });

--- a/profile.html
+++ b/profile.html
@@ -75,6 +75,39 @@
       </div>
     </header>
     <main class="flex-1 px-6 py-4">
+      <form
+        id="create-account-form"
+        class="space-y-4 bg-[#2A2A2E] border border-white/10 p-6 rounded-3xl w-96 mx-auto hidden"
+        aria-label="Create account form"
+      >
+        <input
+          id="ca-name"
+          class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10"
+          placeholder="Username"
+          aria-label="Username"
+        />
+        <input
+          id="ca-email"
+          type="email"
+          class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10"
+          placeholder="Email"
+          aria-label="Email"
+        />
+        <input
+          id="ca-pass"
+          type="password"
+          class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10"
+          placeholder="Password"
+          aria-label="Password"
+        />
+        <div id="ca-error" class="text-red-400" aria-live="assertive"></div>
+        <button
+          class="bg-[#30D5C8] text-[#1A1A1D] font-semibold px-4 py-2 rounded-xl hover:bg-[#28b7a8] transition"
+          type="submit"
+        >
+          Create Account
+        </button>
+      </form>
       <div id="models" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4"></div>
     </main>
     <div


### PR DESCRIPTION
## Summary
- allow creating an account directly on the profile page
- store a blank user profile at registration

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_68432d5fc3cc832d99d74aae6a53a050