### PR TITLE
Add print_jobs table migration

### DIFF
--- a/backend/migrations/019_create_print_jobs.sql
+++ b/backend/migrations/019_create_print_jobs.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS print_jobs (
+  id SERIAL PRIMARY KEY,
+  job_id UUID REFERENCES jobs(job_id) ON DELETE CASCADE,
+  order_id TEXT REFERENCES orders(session_id) ON DELETE CASCADE,
+  status TEXT DEFAULT 'pending',
+  shipping_info JSONB,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS print_jobs_status_idx ON print_jobs(status);


### PR DESCRIPTION
## Summary
- create `backend/migrations/019_create_print_jobs.sql`
- attempt to run migrations

## Testing
- `npm run migrate` *(fails: ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_684331700dcc832d9adf3faad6823ad9