### PR TITLE
Implement db-backed print queue

### DIFF
--- a/backend/queue/dbPrintQueue.js
+++ b/backend/queue/dbPrintQueue.js
@@ -1,0 +1,21 @@
+const db = require('../db');
+
+async function enqueuePrint(jobId, orderId, shippingInfo) {
+  await db.query(
+    'INSERT INTO print_jobs(job_id, order_id, shipping_info) VALUES($1,$2,$3)',
+    [jobId, orderId, shippingInfo]
+  );
+}
+
+async function getNextPendingJob() {
+  const { rows } = await db.query(
+    "SELECT * FROM print_jobs WHERE status='pending' ORDER BY created_at ASC LIMIT 1"
+  );
+  return rows[0] || null;
+}
+
+async function updateJobStatus(id, status) {
+  await db.query('UPDATE print_jobs SET status=$1 WHERE id=$2', [status, id]);
+}
+
+module.exports = { enqueuePrint, getNextPendingJob, updateJobStatus };


### PR DESCRIPTION
## Summary
- add print job queue using database queries

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68433171e9e8832d874914248390ca85