### PR TITLE
Add dbPrintQueue test

### DIFF
--- a/backend/queue/dbPrintQueue.js
+++ b/backend/queue/dbPrintQueue.js
@@ -1,0 +1,11 @@
+const db = require('../db');
+
+async function enqueuePrint(jobId, orderId, options) {
+  return db.query('INSERT INTO print_jobs(job_id, order_id, options) VALUES($1,$2,$3)', [
+    jobId,
+    orderId,
+    options,
+  ]);
+}
+
+module.exports = { enqueuePrint };

--- a/backend/tests/queue/dbPrintQueue.test.js
+++ b/backend/tests/queue/dbPrintQueue.test.js
@@ -1,0 +1,17 @@
+process.env.DB_URL = 'postgres://user:pass@localhost/db';
+
+jest.mock('../../db', () => ({
+  query: jest.fn().mockResolvedValue({}),
+}));
+const db = require('../../db');
+
+const { enqueuePrint } = require('../../queue/dbPrintQueue');
+
+test('enqueuePrint inserts print job', async () => {
+  await enqueuePrint('j1', 'o1', {});
+  expect(db.query).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO print_jobs'), [
+    'j1',
+    'o1',
+    {},
+  ]);
+});


### PR DESCRIPTION
## Summary
- implement a simple `dbPrintQueue` with `enqueuePrint`
- test that `enqueuePrint` issues the correct INSERT

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68433174014c832d9ba4ad1dc40c4d23