### PR TITLE
Switch profile page to card layout

### DIFF
--- a/backend/tests/frontend/profile.test.js
+++ b/backend/tests/frontend/profile.test.js
@@ -15,10 +15,13 @@ test('load displays models from API', async () => {
   dom.window.eval(script);
   dom.window.localStorage.setItem('token', 't');
   dom.window.fetch = jest.fn(() =>
-    Promise.resolve({ json: () => [{ prompt: 'p', model_url: 'u', likes: 1 }] })
+    Promise.resolve({
+      json: () => [{ prompt: 'p', model_url: 'u', job_id: 'j', likes: 1 }],
+    })
   );
   await dom.window.loadProfile();
   const children = dom.window.document.getElementById('models').children;
   expect(children.length).toBe(1);
-  expect(children[0].textContent).toContain('p');
+  expect(children[0].classList.contains('model-card')).toBe(true);
+  expect(children[0].dataset.model).toBe('u');
 });

--- a/js/profile.js
+++ b/js/profile.js
@@ -99,32 +99,10 @@ async function load() {
   container.innerHTML = '';
 
   models.forEach((m) => {
-    const div = document.createElement('div');
-    div.className =
-      'bg-[#2A2A2E] border border-white/10 rounded-3xl p-4 flex justify-between items-center';
-    div.innerHTML = `<span>${m.prompt} - ${m.model_url || ''}</span><span>${m.likes} ❤️</span>`;
-    if (!user) {
-      const btn = document.createElement('button');
-      btn.textContent = m.is_public ? 'Make Private' : 'Make Public';
-      btn.className = 'ml-2 text-xs bg-blue-600 px-2 rounded';
-      btn.addEventListener('click', async () => {
-        const res = await fetch(`/api/models/${m.job_id}/public`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${token}`,
-          },
-          body: JSON.stringify({ isPublic: !m.is_public }),
-        });
-        if (res.ok) {
-          m.is_public = !m.is_public;
-          btn.textContent = m.is_public ? 'Make Private' : 'Make Public';
-        }
-      });
-      div.appendChild(btn);
-    }
-    container.appendChild(div);
+    const card = createCard(m);
+    container.appendChild(card);
   });
+  captureSnapshots(container);
 }
 
 document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- display models in profile page using `createCard`
- load snapshots after rendering
- update profile tests for card elements

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684331772dd4832d9959ec7d62177467