### PR TITLE
Add printerApiUrl config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,4 @@ HUNYUAN_VERSION=2.5
 PORT=3000
 SENDGRID_API_KEY=your_sendgrid_key
 EMAIL_FROM=noreply@example.com
+PRINTER_API_URL=http://localhost:5000/print

--- a/backend/config.js
+++ b/backend/config.js
@@ -14,4 +14,5 @@ module.exports = {
   port: process.env.PORT || 3000,
   sendgridKey: process.env.SENDGRID_API_KEY || '',
   emailFrom: process.env.EMAIL_FROM || 'noreply@example.com',
+  printerApiUrl: process.env.PRINTER_API_URL || 'http://localhost:5000/print',
 };


### PR DESCRIPTION
## Summary
- add `printerApiUrl` to backend configuration
- document `PRINTER_API_URL` example variable

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6843317559a0832d8e7b73de559517a8