### PR TITLE
Add print job status endpoint and tests

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -822,6 +822,15 @@ app.post('/api/webhook/stripe', express.raw({ type: 'application/json' }), async
   res.sendStatus(200);
 });
 
+app.get('/api/print-jobs/:id', async (req, res) => {
+  const { rows } = await db.query(
+    'SELECT status FROM print_jobs WHERE id=$1',
+    [req.params.id]
+  );
+  if (!rows.length) return res.status(404).json({ error: 'Not found' });
+  res.json(rows[0]);
+});
+
 async function checkCompetitionStart() {
   try {
     const comps = await db.query(

--- a/backend/server.js
+++ b/backend/server.js
@@ -823,10 +823,7 @@ app.post('/api/webhook/stripe', express.raw({ type: 'application/json' }), async
 });
 
 app.get('/api/print-jobs/:id', async (req, res) => {
-  const { rows } = await db.query(
-    'SELECT status FROM print_jobs WHERE id=$1',
-    [req.params.id]
-  );
+  const { rows } = await db.query('SELECT status FROM print_jobs WHERE id=$1', [req.params.id]);
   if (!rows.length) return res.status(404).json({ error: 'Not found' });
   res.json(rows[0]);
 });

--- a/backend/tests/printJobs.test.js
+++ b/backend/tests/printJobs.test.js
@@ -1,0 +1,32 @@
+process.env.STRIPE_SECRET_KEY = 'test';
+process.env.STRIPE_WEBHOOK_SECRET = 'whsec';
+process.env.DB_URL = 'postgres://user:pass@localhost/db';
+process.env.HUNYUAN_API_KEY = 'test';
+process.env.HUNYUAN_SERVER_URL = 'http://localhost:4000';
+
+jest.mock('../db', () => ({ query: jest.fn().mockResolvedValue({ rows: [] }) }));
+const db = require('../db');
+
+jest.mock('stripe');
+const Stripe = require('stripe');
+Stripe.mockImplementation(() => ({}));
+
+const request = require('supertest');
+const app = require('../server');
+
+beforeEach(() => {
+  db.query.mockClear();
+});
+
+test('GET /api/print-jobs/:id 404 when missing', async () => {
+  db.query.mockResolvedValueOnce({ rows: [] });
+  const res = await request(app).get('/api/print-jobs/p1');
+  expect(res.status).toBe(404);
+});
+
+test('GET /api/print-jobs/:id returns status', async () => {
+  db.query.mockResolvedValueOnce({ rows: [{ status: 'queued' }] });
+  const res = await request(app).get('/api/print-jobs/p1');
+  expect(res.status).toBe(200);
+  expect(res.body.status).toBe('queued');
+});


### PR DESCRIPTION
## Summary
- expose `/api/print-jobs/:id` endpoint to get print job status
- test 404 for missing job and status return when found

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6843317aa77c832d9247dda0a7645fc5