### PR TITLE
Persist flash sale countdown

### DIFF
--- a/backend/tests/frontend/flashBanner.test.js
+++ b/backend/tests/frontend/flashBanner.test.js
@@ -28,7 +28,7 @@ describe('flash banner', () => {
     expect(banner.hidden).toBe(true);
   });
 
-  test('resetFlashDiscount restarts timer', async () => {
+  test('startFlashDiscount does not restart expired timer', async () => {
     const dom = new JSDOM(html, {
       runScripts: 'dangerously',
       resources: 'usable',
@@ -36,34 +36,15 @@ describe('flash banner', () => {
     });
     global.window = dom.window;
     global.document = dom.window.document;
-    const scriptSrc = fs.readFileSync(path.join(__dirname, '../../../js/payment.js'), 'utf8');
-    dom.window.eval(scriptSrc);
-    dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
-    dom.window.startFlashDiscount();
-    const first = Number(dom.window.localStorage.getItem('flashDiscountEnd'));
-    dom.window.resetFlashDiscount();
-    const second = Number(dom.window.localStorage.getItem('flashDiscountEnd'));
-    expect(second).toBeGreaterThan(first);
-    const banner = dom.window.document.getElementById('flash-banner');
-    expect(banner.hidden).toBe(false);
-  });
-
-  test('startFlashDiscount resets expired timer', async () => {
-    const dom = new JSDOM(html, {
-      runScripts: 'dangerously',
-      resources: 'usable',
-      url: 'http://localhost/',
-    });
-    global.window = dom.window;
-    global.document = dom.window.document;
-    dom.window.localStorage.setItem('flashDiscountEnd', String(Date.now() - 1000));
+    const expired = Date.now() - 1000;
+    dom.window.localStorage.setItem('flashDiscountEnd', String(expired));
     const scriptSrc = fs.readFileSync(path.join(__dirname, '../../../js/payment.js'), 'utf8');
     dom.window.eval(scriptSrc);
     dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
     dom.window.startFlashDiscount();
     const end = Number(dom.window.localStorage.getItem('flashDiscountEnd'));
-    expect(end).toBeGreaterThan(Date.now());
+    expect(end).toBe(expired);
     const banner = dom.window.document.getElementById('flash-banner');
-    expect(banner.hidden).toBe(false);
+    expect(banner.hidden).toBe(true);
   });
 });

--- a/js/payment.js
+++ b/js/payment.js
@@ -68,18 +68,21 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   function startFlashDiscount() {
-    const saved = parseInt(localStorage.getItem('flashDiscountEnd'), 10) || 0;
-    let end = saved;
-    if (!end || end < Date.now()) {
+    const saved = parseInt(localStorage.getItem('flashDiscountEnd'), 10);
+    let end;
+
+    if (Number.isFinite(saved)) {
+      end = saved;
+    } else {
       end = Date.now() + 5 * 60 * 1000;
       localStorage.setItem('flashDiscountEnd', end);
     }
+    let timer;
     const update = () => {
       const diff = end - Date.now();
       if (diff <= 0) {
         flashBanner.hidden = true;
         clearInterval(timer);
-        localStorage.removeItem('flashDiscountEnd');
         return;
       }
       const m = Math.floor(diff / 60000);
@@ -89,22 +92,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       flashTimer.textContent = `${m}:${s}`;
     };
     update();
-    const timer = setInterval(update, 1000);
-    window.resetFlashDiscount = () => {
-      clearInterval(timer);
-      const prevRaw = parseInt(localStorage.getItem('flashDiscountEnd'), 10);
-      const prev = Number.isFinite(prevRaw) ? prevRaw : 0;
-
-      let newEnd = Date.now() + 5 * 60 * 1000;
-      if (newEnd <= prev) {
-        newEnd = prev + 1;
-      }
-
-      localStorage.setItem('flashDiscountEnd', newEnd);
-
-      flashBanner.hidden = false;
-      startFlashDiscount();
-    };
+    timer = setInterval(update, 1000);
   }
   window.startFlashDiscount = startFlashDiscount;
 


### PR DESCRIPTION
## Summary
- keep `flashDiscountEnd` after the timer runs out so the discount can't restart
- remove reset functionality and update `flashBanner` tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684331851790832db53554920e8bd35c