### PR TITLE
Add job queue test

### DIFF
--- a/backend/queue/jobQueue.js
+++ b/backend/queue/jobQueue.js
@@ -1,0 +1,33 @@
+const db = require('../db');
+
+async function getNextPendingJob() {
+  const { rows } = await db.query(
+    "SELECT job_id, webhook_url FROM print_jobs WHERE status='pending' ORDER BY created_at ASC LIMIT 1"
+  );
+  return rows[0];
+}
+
+async function updateJobStatus(jobId, status) {
+  await db.query('UPDATE print_jobs SET status=$1 WHERE job_id=$2', [status, jobId]);
+}
+
+async function processNextJob() {
+  const job = await module.exports.getNextPendingJob();
+  if (!job) return;
+  await fetch(job.webhook_url, { method: 'POST' });
+  await module.exports.updateJobStatus(job.job_id, 'sent');
+}
+
+function startProcessing(intervalMs = 1000) {
+  setTimeout(async function tick() {
+    await processNextJob();
+    setTimeout(tick, intervalMs);
+  }, intervalMs);
+}
+
+module.exports = {
+  startProcessing,
+  processNextJob,
+  getNextPendingJob,
+  updateJobStatus,
+};

--- a/backend/tests/queue/jobQueue.test.js
+++ b/backend/tests/queue/jobQueue.test.js
@@ -1,0 +1,34 @@
+jest.useFakeTimers();
+
+jest.mock('../../db', () => ({
+  query: jest.fn().mockResolvedValue({}),
+}));
+const db = require('../../db');
+
+const queue = require('../../queue/jobQueue');
+
+jest.spyOn(queue, 'getNextPendingJob');
+jest.spyOn(queue, 'updateJobStatus');
+
+beforeEach(() => {
+  queue.getNextPendingJob.mockReset();
+  queue.updateJobStatus.mockReset();
+  db.query.mockClear();
+  global.fetch = jest.fn();
+});
+
+afterEach(() => {
+  jest.clearAllTimers();
+  delete global.fetch;
+});
+
+test('processes pending job and marks sent', async () => {
+  queue.getNextPendingJob.mockResolvedValue({ job_id: 'j1', webhook_url: 'http://example.com' });
+  global.fetch.mockResolvedValue({ ok: true });
+  queue.startProcessing(1000);
+
+  await jest.runOnlyPendingTimersAsync();
+  await Promise.resolve();
+
+  expect(queue.updateJobStatus).toHaveBeenCalledWith('j1', 'sent');
+});


### PR DESCRIPTION
## Summary
- create a simple jobQueue utility for sending print jobs
- test jobQueue processing with mocked dependencies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68433175b45c832da20da1abc5fab089