### PR TITLE
Implement unsubscribe flow

### DIFF
--- a/backend/mail.js
+++ b/backend/mail.js
@@ -1,6 +1,7 @@
 const nodemailer = require('nodemailer');
 const sgTransport = require('nodemailer-sendgrid');
 const config = require('./config');
+const db = require('./db');
 
 let transporter = null;
 if (config.sendgridKey) {
@@ -11,8 +12,32 @@ if (config.sendgridKey) {
   });
 }
 
+async function getUnsubscribeUrl(email) {
+  try {
+    const { rows } = await db.query(
+      'SELECT token, unsubscribed FROM mailing_list WHERE email=$1',
+      [email]
+    );
+    if (rows.length && rows[0].unsubscribed) {
+      return { url: null, unsubscribed: true };
+    }
+    if (rows.length) {
+      const base = process.env.BASE_URL || `http://localhost:${process.env.PORT || 3000}`;
+      return { url: `${base}/api/unsubscribe?token=${rows[0].token}`, unsubscribed: false };
+    }
+  } catch (err) {
+    console.error('Failed to lookup unsubscribe token', err);
+  }
+  return { url: null, unsubscribed: false };
+}
+
 async function sendMail(to, subject, text) {
   if (!transporter) return;
+  const { url, unsubscribed } = await getUnsubscribeUrl(to);
+  if (unsubscribed) return;
+  if (url) {
+    text = `${text}\n\nUnsubscribe: ${url}`;
+  }
   await transporter.sendMail({
     from: config.emailFrom,
     to,
@@ -21,4 +46,19 @@ async function sendMail(to, subject, text) {
   });
 }
 
-module.exports = { sendMail };
+async function sendTemplate(to, templateId, variables = {}) {
+  if (!transporter) return;
+  const { url, unsubscribed } = await getUnsubscribeUrl(to);
+  if (unsubscribed) return;
+  if (url) {
+    variables.unsubscribeUrl = url;
+  }
+  await transporter.sendMail({
+    from: config.emailFrom,
+    to,
+    templateId,
+    dynamic_template_data: variables,
+  });
+}
+
+module.exports = { sendMail, sendTemplate };

--- a/backend/migrations/020_add_unsubscribed_to_mailing_list.sql
+++ b/backend/migrations/020_add_unsubscribed_to_mailing_list.sql
@@ -1,0 +1,2 @@
+ALTER TABLE mailing_list
+  ADD COLUMN IF NOT EXISTS unsubscribed BOOLEAN DEFAULT FALSE;

--- a/backend/server.js
+++ b/backend/server.js
@@ -790,6 +790,22 @@ app.get('/api/confirm-subscription', async (req, res) => {
   }
 });
 
+app.get('/api/unsubscribe', async (req, res) => {
+  const { token } = req.query;
+  if (!token) return res.status(400).send('Invalid token');
+  try {
+    const result = await db.query(
+      'UPDATE mailing_list SET unsubscribed=TRUE WHERE token=$1',
+      [token]
+    );
+    if (result.rowCount === 0) return res.status(404).send('Invalid token');
+    res.send('You have been unsubscribed');
+  } catch (err) {
+    console.error(err);
+    res.status(500).send('Failed to unsubscribe');
+  }
+});
+
 /**
  * POST /api/webhook/stripe
  * Handle Stripe payment confirmation

--- a/backend/tests/mail.test.js
+++ b/backend/tests/mail.test.js
@@ -1,0 +1,38 @@
+process.env.STRIPE_SECRET_KEY = 'test';
+process.env.STRIPE_WEBHOOK_SECRET = 'whsec';
+process.env.DB_URL = 'postgres://user:pass@localhost/db';
+process.env.HUNYUAN_API_KEY = 'test';
+process.env.HUNYUAN_SERVER_URL = 'http://localhost:4000';
+process.env.BASE_URL = 'http://app';
+
+jest.mock('nodemailer');
+const nodemailer = require('nodemailer');
+
+jest.mock('nodemailer-sendgrid', () => () => ({}));
+
+const sendMailMock = jest.fn();
+nodemailer.createTransport.mockReturnValue({ sendMail: sendMailMock });
+
+jest.mock('../db', () => ({ query: jest.fn() }));
+const db = require('../db');
+
+const { sendMail } = require('../mail');
+
+beforeEach(() => {
+  sendMailMock.mockClear();
+  db.query.mockClear();
+});
+
+test('sendMail appends unsubscribe link', async () => {
+  db.query.mockResolvedValueOnce({ rows: [{ token: 'tok1', unsubscribed: false }] });
+  await sendMail('a@a.com', 'Sub', 'Body');
+  expect(sendMailMock).toHaveBeenCalled();
+  const mail = sendMailMock.mock.calls[0][0];
+  expect(mail.text).toContain('Unsubscribe: http://app/api/unsubscribe?token=tok1');
+});
+
+test('sendMail skips unsubscribed', async () => {
+  db.query.mockResolvedValueOnce({ rows: [{ token: 'tok1', unsubscribed: true }] });
+  await sendMail('a@a.com', 'Sub', 'Body');
+  expect(sendMailMock).not.toHaveBeenCalled();
+});

--- a/backend/tests/unsubscribe.test.js
+++ b/backend/tests/unsubscribe.test.js
@@ -1,0 +1,34 @@
+process.env.STRIPE_SECRET_KEY = 'test';
+process.env.STRIPE_WEBHOOK_SECRET = 'whsec';
+process.env.DB_URL = 'postgres://user:pass@localhost/db';
+process.env.HUNYUAN_API_KEY = 'test';
+process.env.HUNYUAN_SERVER_URL = 'http://localhost:4000';
+
+jest.mock('../db', () => ({ query: jest.fn() }));
+const db = require('../db');
+
+jest.mock('stripe');
+const Stripe = require('stripe');
+Stripe.mockImplementation(() => ({ checkout: { sessions: { create: jest.fn() } }, webhooks: { constructEvent: jest.fn(() => ({})) } }));
+
+const request = require('supertest');
+const app = require('../server');
+
+beforeEach(() => {
+  db.query.mockClear();
+});
+
+test('GET /api/unsubscribe marks unsubscribed', async () => {
+  db.query.mockResolvedValueOnce({ rowCount: 1 });
+  const res = await request(app).get('/api/unsubscribe?token=t1');
+  expect(res.status).toBe(200);
+  expect(db.query).toHaveBeenCalledWith(
+    'UPDATE mailing_list SET unsubscribed=TRUE WHERE token=$1',
+    ['t1']
+  );
+});
+
+test('GET /api/unsubscribe missing token', async () => {
+  const res = await request(app).get('/api/unsubscribe');
+  expect(res.status).toBe(400);
+});


### PR DESCRIPTION
## Summary
- add migration for `unsubscribed` column in mailing list
- append unsubscribe links in all email sends
- expose `sendTemplate` mail helper
- add `/api/unsubscribe` endpoint
- test unsubscribe flow and mail helpers

## Testing
- `npm --prefix backend test`

------
https://chatgpt.com/codex/tasks/task_e_68433398157c832daf58924fe087344f