### PR TITLE
Handle SendGrid webhooks for bounces

### DIFF
--- a/backend/migrations/020_add_unsubscribed_flag.sql
+++ b/backend/migrations/020_add_unsubscribed_flag.sql
@@ -1,0 +1,2 @@
+ALTER TABLE mailing_list
+  ADD COLUMN IF NOT EXISTS unsubscribed BOOLEAN DEFAULT FALSE;

--- a/backend/server.js
+++ b/backend/server.js
@@ -791,6 +791,30 @@ app.get('/api/confirm-subscription', async (req, res) => {
 });
 
 /**
+ * POST /api/webhook/sendgrid
+ * Handle SendGrid event notifications
+ */
+app.post('/api/webhook/sendgrid', async (req, res) => {
+  const events = Array.isArray(req.body) ? req.body : [];
+  try {
+    for (const evt of events) {
+      if (evt.event === 'bounce' || evt.event === 'spamreport') {
+        const email = evt.email;
+        if (email) {
+          await db.query(
+            'UPDATE mailing_list SET unsubscribed=TRUE WHERE email=$1',
+            [email]
+          );
+        }
+      }
+    }
+  } catch (err) {
+    console.error('Failed to process SendGrid webhook', err);
+  }
+  res.sendStatus(204);
+});
+
+/**
  * POST /api/webhook/stripe
  * Handle Stripe payment confirmation
  */

--- a/docs/mailing_list.md
+++ b/docs/mailing_list.md
@@ -9,3 +9,8 @@ that link marks the address as confirmed.
 To configure the email service, set `SENDGRID_API_KEY` and `EMAIL_FROM` in `.env`.
 Subscriptions are processed through the `/api/subscribe` endpoint which inserts
 or updates the address and dispatches the confirmation email.
+
+To keep the list healthy, SendGrid's Event Webhook should be pointed at
+`/api/webhook/sendgrid`. Configure this URL in the SendGrid dashboard so that
+bounce or spam complaint events automatically mark the matching email as
+`unsubscribed` in the database.


### PR DESCRIPTION
## Summary
- add `unsubscribed` flag to mailing list records
- process SendGrid event webhooks and mark bounced/spam emails as unsubscribed
- document configuring the SendGrid webhook URL

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843339ab634832db50b3356838d127b