### PR TITLE
Add mailing list signup test

### DIFF
--- a/backend/tests/frontend/signup.test.js
+++ b/backend/tests/frontend/signup.test.js
@@ -49,8 +49,7 @@ describe('signup form', () => {
       resources: 'usable',
       url: 'http://localhost/signup.html',
     });
-    dom.window.document
-      .querySelectorAll('script[src*="tailwind"]').forEach((s) => s.remove());
+    dom.window.document.querySelectorAll('script[src*="tailwind"]').forEach((s) => s.remove());
     global.window = dom.window;
     global.document = dom.window.document;
     const scriptSrc = fs
@@ -76,9 +75,7 @@ describe('signup form', () => {
     dom.window.document.getElementById('su-email').value = 'a@a.com';
     dom.window.document.getElementById('su-pass').value = 'p';
     dom.window.document.getElementById('signup-mailing').checked = true;
-    dom.window.document
-      .getElementById('signupForm')
-      .dispatchEvent(new dom.window.Event('submit'));
+    dom.window.document.getElementById('signupForm').dispatchEvent(new dom.window.Event('submit'));
     await new Promise((r) => setTimeout(r, 0));
     await Promise.all(global.fetch.mock.results.map((r) => r.value));
 

--- a/backend/tests/frontend/signup.test.js
+++ b/backend/tests/frontend/signup.test.js
@@ -3,6 +3,18 @@ const fs = require('fs');
 const path = require('path');
 const { JSDOM } = require('jsdom');
 
+process.env.STRIPE_SECRET_KEY = 'test';
+process.env.STRIPE_WEBHOOK_SECRET = 'whsec';
+process.env.DB_URL = 'postgres://user:pass@localhost/db';
+process.env.HUNYUAN_API_KEY = 'test';
+process.env.HUNYUAN_SERVER_URL = 'http://localhost:4000';
+
+jest.mock('../../db', () => ({ query: jest.fn().mockResolvedValue({ rows: [] }) }));
+jest.mock('../../mail', () => ({ sendMail: jest.fn() }));
+const { sendMail } = require('../../mail');
+const request = require('supertest');
+const app = require('../../server');
+
 let html = fs.readFileSync(path.join(__dirname, '../../../signup.html'), 'utf8');
 html = html.replace(/<script[^>]+tailwind[^>]*><\/script>/, '');
 
@@ -16,7 +28,9 @@ describe('signup form', () => {
     dom.window.document.querySelectorAll('script[src*="tailwind"]').forEach((s) => s.remove());
     global.window = dom.window;
     global.document = dom.window.document;
-    const scriptSrc = fs.readFileSync(path.join(__dirname, '../../../js/signup.js'), 'utf8');
+    const scriptSrc = fs
+      .readFileSync(path.join(__dirname, '../../../js/signup.js'), 'utf8')
+      .replace("window.location.href = 'profile.html';", '');
     dom.window.eval(scriptSrc);
     const fetchMock = jest.fn(() => Promise.resolve({ json: () => ({ error: 'fail' }) }));
     dom.window.fetch = fetchMock;
@@ -27,5 +41,51 @@ describe('signup form', () => {
     dom.window.document.getElementById('signupForm').dispatchEvent(new dom.window.Event('submit'));
     await new Promise((r) => setTimeout(r, 0));
     expect(dom.window.document.getElementById('error').textContent).toBe('fail');
+  });
+
+  test('opt-in generates confirmation email', async () => {
+    const dom = new JSDOM(html, {
+      runScripts: 'dangerously',
+      resources: 'usable',
+      url: 'http://localhost/signup.html',
+    });
+    dom.window.document
+      .querySelectorAll('script[src*="tailwind"]').forEach((s) => s.remove());
+    global.window = dom.window;
+    global.document = dom.window.document;
+    const scriptSrc = fs
+      .readFileSync(path.join(__dirname, '../../../js/signup.js'), 'utf8')
+      .replace("window.location.href = 'profile.html';", '');
+    dom.window.eval(scriptSrc);
+
+    global.fetch = dom.window.fetch = jest.fn((url, opts) => {
+      if (url === '/api/register') {
+        return Promise.resolve({ json: () => ({ token: 'tok' }) });
+      }
+      if (url === '/api/subscribe') {
+        return request(app)
+          .post('/api/subscribe')
+          .set('origin', 'http://localhost')
+          .send(JSON.parse(opts.body))
+          .then(() => ({ json: () => ({}) }));
+      }
+      return Promise.resolve({ json: () => ({}) });
+    });
+
+    dom.window.document.getElementById('su-name').value = 'alice';
+    dom.window.document.getElementById('su-email').value = 'a@a.com';
+    dom.window.document.getElementById('su-pass').value = 'p';
+    dom.window.document.getElementById('signup-mailing').checked = true;
+    dom.window.document
+      .getElementById('signupForm')
+      .dispatchEvent(new dom.window.Event('submit'));
+    await new Promise((r) => setTimeout(r, 0));
+    await Promise.all(global.fetch.mock.results.map((r) => r.value));
+
+    expect(sendMail).toHaveBeenCalled();
+    const msg = sendMail.mock.calls[0][2];
+    const token = /token=([\w-]+)/.exec(msg)[1];
+    const res = await request(app).get(`/api/confirm-subscription?token=${token}`);
+    expect(res.text).toBe('Subscription confirmed');
   });
 });


### PR DESCRIPTION
## Summary
- mock backend modules in signup.test and load signup.js without redirect
- test subscribing to mailing list triggers confirmation email
- confirm token via `/api/confirm-subscription`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843339c365c832dbdba725523828083