### PR TITLE
Add explicit mailing list opt-in

### DIFF
--- a/docs/mailing_list.md
+++ b/docs/mailing_list.md
@@ -6,6 +6,10 @@ Users can opt in on the signup and checkout forms. After opting in, a confirmati
 message containing a link to `/api/confirm-subscription?token=...` is sent. Visiting
 that link marks the address as confirmed.
 
+Addresses are added to the `mailing_list` table only after a user has created an
+account or completed checkout and the opt‑in box is checked. The frontend triggers
+the `/api/subscribe` endpoint at that moment to queue the confirmation email.
+
 To configure the email service, set `SENDGRID_API_KEY` and `EMAIL_FROM` in `.env`.
 Subscriptions are processed through the `/api/subscribe` endpoint which inserts
 or updates the address and dispatches the confirmation email.

--- a/js/payment.js
+++ b/js/payment.js
@@ -37,7 +37,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
   const loader = document.getElementById('loader');
   const viewer = document.getElementById('viewer');
-  const optOut = document.getElementById('opt-out');
+  const optIn = document.getElementById('checkout-mailing');
   const emailEl = document.getElementById('checkout-email');
   const successMsg = document.getElementById('success');
   const cancelMsg = document.getElementById('cancel');
@@ -186,7 +186,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       // Fallback if Stripe failed to load: just navigate to the checkout URL
       window.location.href = url;
     }
-    if (emailEl.value) {
+    if (optIn && optIn.checked && emailEl.value) {
       fetch('/api/subscribe', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/payment.html
+++ b/payment.html
@@ -173,6 +173,11 @@
               [Stripe payment form will go here]
             </div>
 
+            <label class="flex items-center text-sm">
+              <input id="checkout-mailing" type="checkbox" class="mr-2" />
+              Join our mailing list
+            </label>
+
             <p id="cost-estimate" class="text-sm text-center"></p>
             <p id="eta-estimate" class="text-sm text-center"></p>
             <button


### PR DESCRIPTION
## Summary
- clarify when addresses get added in documentation
- add mailing list checkbox on checkout page
- only subscribe when checkbox is checked

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843339b32d4832d8f23100a94e3a643