### PR TITLE
Remove snapshot capture logic

### DIFF
--- a/js/community.js
+++ b/js/community.js
@@ -95,33 +95,6 @@ function createCard(model) {
   return div;
 }
 
-async function captureSnapshots(container) {
-  const cards = container.querySelectorAll('.model-card');
-  for (const card of cards) {
-    const img = card.querySelector('img');
-    if (img && img.src) continue;
-    const glbUrl = card.dataset.model;
-    const viewer = document.createElement('model-viewer');
-    viewer.src = glbUrl;
-    viewer.setAttribute(
-      'environment-image',
-      'https://modelviewer.dev/shared-assets/environments/neutral.hdr'
-    );
-    viewer.style.position = 'fixed';
-    viewer.style.left = '-10000px';
-    viewer.style.width = '300px';
-    viewer.style.height = '300px';
-    document.body.appendChild(viewer);
-    try {
-      await viewer.updateComplete;
-      img.src = await viewer.toDataURL('image/png');
-    } catch (err) {
-      console.error('Failed to capture snapshot', err);
-    } finally {
-      viewer.remove();
-    }
-  }
-}
 
 function getFilters() {
   const category = document.getElementById('category').value;
@@ -143,7 +116,6 @@ async function loadMore(type, filters = getFilters()) {
   state.models = state.models.concat(models);
   const grid = document.getElementById(`${type}-grid`);
   models.forEach((m) => grid.appendChild(createCard(m)));
-  await captureSnapshots(grid);
   const btn = document.getElementById(`${type}-load`);
   if (models.length < 6) {
     btn.classList.add('hidden');
@@ -159,7 +131,6 @@ function renderGrid(type, filters = getFilters()) {
   const state = window.communityState[type][key];
   if (state && state.models.length) {
     state.models.forEach((m) => grid.appendChild(createCard(m)));
-    captureSnapshots(grid);
     const btn = document.getElementById(`${type}-load`);
     if (state.models.length < 6) btn.classList.add('hidden');
     else btn.classList.remove('hidden');

--- a/js/competitions.js
+++ b/js/competitions.js
@@ -15,33 +15,6 @@ function like(id) {
     });
 }
 
-async function captureSnapshots(container) {
-  const cards = container.querySelectorAll('.entry-card');
-  for (const card of cards) {
-    const img = card.querySelector('img');
-    if (img && img.src) continue;
-    const glbUrl = card.dataset.model;
-    const viewer = document.createElement('model-viewer');
-    viewer.src = glbUrl;
-    viewer.setAttribute(
-      'environment-image',
-      'https://modelviewer.dev/shared-assets/environments/neutral.hdr'
-    );
-    viewer.style.position = 'fixed';
-    viewer.style.left = '-10000px';
-    viewer.style.width = '300px';
-    viewer.style.height = '300px';
-    document.body.appendChild(viewer);
-    try {
-      await viewer.updateComplete;
-      img.src = await viewer.toDataURL('image/png');
-    } catch (err) {
-      console.error('Failed to capture snapshot', err);
-    } finally {
-      viewer.remove();
-    }
-  }
-}
 
 async function load() {
   const res = await fetch('/api/competitions/active');
@@ -108,14 +81,13 @@ async function loadLeaderboard(id, table, grid) {
         'entry-card relative h-32 bg-[#2A2A2E] border border-white/10 rounded-xl flex items-center justify-center';
       card.dataset.model = r.model_url;
       card.dataset.job = r.model_id;
-      card.innerHTML = `<img src="" alt="Model" class="w-full h-full object-contain pointer-events-none" />\n      <button class="like absolute bottom-1 left-1 text-xs bg-red-600 px-1 rounded">\u2665</button>\n      <span class="absolute bottom-1 right-1 text-xs bg-black/50 px-1 rounded" id="likes-${r.model_id}">${r.likes}</span>`;
+      card.innerHTML = `<img src="${r.snapshot || ''}" alt="Model" class="w-full h-full object-contain pointer-events-none" />\n      <button class="like absolute bottom-1 left-1 text-xs bg-red-600 px-1 rounded">\u2665</button>\n      <span class="absolute bottom-1 right-1 text-xs bg-black/50 px-1 rounded" id="likes-${r.model_id}">${r.likes}</span>`;
       card.querySelector('.like').addEventListener('click', (e) => {
         e.stopPropagation();
         like(r.model_id);
       });
       grid.appendChild(card);
     });
-    captureSnapshots(grid);
   }
 }
 

--- a/js/profile.js
+++ b/js/profile.js
@@ -53,33 +53,6 @@ async function createAccount(e) {
   }
 }
 
-async function captureSnapshots(container) {
-  const cards = container.querySelectorAll('.model-card');
-  for (const card of cards) {
-    const img = card.querySelector('img');
-    if (img && img.src) continue;
-    const glbUrl = card.dataset.model;
-    const viewer = document.createElement('model-viewer');
-    viewer.src = glbUrl;
-    viewer.setAttribute(
-      'environment-image',
-      'https://modelviewer.dev/shared-assets/environments/neutral.hdr'
-    );
-    viewer.style.position = 'fixed';
-    viewer.style.left = '-10000px';
-    viewer.style.width = '300px';
-    viewer.style.height = '300px';
-    document.body.appendChild(viewer);
-    try {
-      await viewer.updateComplete;
-      img.src = await viewer.toDataURL('image/png');
-    } catch (err) {
-      console.error('Failed to capture snapshot', err);
-    } finally {
-      viewer.remove();
-    }
-  }
-}
 
 async function load() {
   const token = localStorage.getItem('token');
@@ -102,7 +75,6 @@ async function load() {
     const card = createCard(m);
     container.appendChild(card);
   });
-  captureSnapshots(container);
 }
 
 document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- stop using `captureSnapshots` helper
- rely on provided snapshot images for competition, community and profile cards

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68433b02e8c0832d99290343528858ab