### PR TITLE
Add account page and login button

### DIFF
--- a/account.html
+++ b/account.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Account</title>
+    <meta property="og:title" content="Account – print3" />
+    <meta property="og:image" content="img/boxlogo.png" />
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body class="bg-[#1A1A1D] text-white font-sans flex flex-col min-h-screen">
+    <header class="relative flex items-center justify-between py-4 px-6">
+      <a
+        href="index.html"
+        class="inline-flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-3xl px-5 py-2 text-lg font-medium hover:bg-[#3A3A3E] transition-shape"
+      >
+        <svg
+          class="w-4 h-4 mr-2 flex-shrink-0"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+        >
+          <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+        </svg>
+        Back
+      </a>
+      <h1 class="absolute inset-x-0 top-1/2 -translate-y-1/2 text-center text-2xl font-semibold pointer-events-none">
+        Account
+      </h1>
+      <span class="w-9 h-9"></span>
+    </header>
+    <main class="flex-1 p-6" id="account-info"></main>
+    <script type="module" src="js/account.js"></script>
+  </body>
+</html>

--- a/js/account.js
+++ b/js/account.js
@@ -1,0 +1,28 @@
+async function loadAccount() {
+  const token = localStorage.getItem('token');
+  if (!token) {
+    window.location.href = 'login.html';
+    return;
+  }
+  const res = await fetch('/api/profile', {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) {
+    window.location.href = 'login.html';
+    return;
+  }
+  const profile = await res.json();
+  const container = document.getElementById('account-info');
+  container.innerHTML = `
+    <div class="space-y-2">
+      <p><strong>Username:</strong> ${profile.display_name || ''}</p>
+      <pre class="bg-[#2A2A2E] p-4 rounded-xl">${JSON.stringify(
+        profile,
+        null,
+        2
+      )}</pre>
+    </div>
+  `;
+}
+
+document.addEventListener('DOMContentLoaded', loadAccount);

--- a/js/login.js
+++ b/js/login.js
@@ -20,7 +20,7 @@ async function login(e) {
   const data = await res.json();
   if (data.token) {
     localStorage.setItem('token', data.token);
-    window.location.href = 'profile.html';
+    window.location.href = 'account.html';
   } else {
     document.getElementById('error').textContent = data.error || 'Login failed';
     nameEl.classList.add('border-red-500');

--- a/js/profile.js
+++ b/js/profile.js
@@ -118,5 +118,9 @@ document.addEventListener('DOMContentLoaded', () => {
   });
   const form = document.getElementById('create-account-form');
   form?.addEventListener('submit', createAccount);
+  const loginBtn = document.getElementById('login-button');
+  loginBtn?.addEventListener('click', () => {
+    window.location.href = 'login.html';
+  });
   load();
 });

--- a/profile.html
+++ b/profile.html
@@ -106,12 +106,21 @@
           aria-label="Password"
         />
         <div id="ca-error" class="text-red-400" aria-live="assertive"></div>
-        <button
-          class="bg-[#30D5C8] text-[#1A1A1D] font-semibold px-4 py-2 rounded-xl hover:bg-[#28b7a8] transition"
-          type="submit"
-        >
-          Create Account
-        </button>
+        <div class="flex space-x-2">
+          <button
+            class="bg-[#30D5C8] text-[#1A1A1D] font-semibold px-4 py-2 rounded-xl hover:bg-[#28b7a8] transition"
+            type="submit"
+          >
+            Create Account
+          </button>
+          <button
+            id="login-button"
+            type="button"
+            class="bg-[#30D5C8] text-[#1A1A1D] font-semibold px-4 py-2 rounded-xl hover:bg-[#28b7a8] transition"
+          >
+            Login
+          </button>
+        </div>
       </form>
     </main>
     <div


### PR DESCRIPTION
## Summary
- add Login button next to Create Account on profile page
- redirect login script to new `account.html`
- create `account.html` and `js/account.js` to show profile information
- wire login button on profile page to go to login screen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68433dbe2b10832dbbf3f9b8894915a8