### PR TITLE
Trim index upload button height

### DIFF
--- a/index.html
+++ b/index.html
@@ -266,7 +266,7 @@
             <div
               id="drop-zone"
               aria-label="Upload Image"
-              class="flex items-center justify-center bg-[#2A2A2E] border border-dashed border-white/10 rounded-3xl px-5 py-6 text-gray-400 cursor-pointer hover:bg-[#3A3A3E] transition-shape"
+              class="flex items-center justify-center bg-[#2A2A2E] border border-dashed border-white/10 rounded-3xl px-5 py-3 text-gray-400 cursor-pointer hover:bg-[#3A3A3E] transition-shape"
             >
               Drag & drop image or
               <label for="uploadInput" class="underline ml-1 cursor-pointer">browse</label>


### PR DESCRIPTION
## Summary
- tweak the "drag & drop" upload zone in `index.html` so it's not as tall

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68434bbe6320832d9fca0a168bc62392