### PR TITLE
Fix subreddit quote layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -230,7 +230,7 @@
           class="absolute left-full ml-4 flex text-sm text-gray-400 text-center leading-snug"
         >
           <!-- Forced two-line layout using <br> -->
-          <p>"I'm astonished at how high-quality the print<br />is" – email from an r/subreddit user</p>
+          <p class="whitespace-nowrap">"I'm astonished at how high-quality the print<br />is" – email from an r/subreddit user</p>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- make the subreddit quote not wrap extra by adding whitespace-nowrap

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684359ad8bb8832da858a560a527cc67