### PR TITLE
Fix remove button clipped by image preview area

### DIFF
--- a/index.html
+++ b/index.html
@@ -289,7 +289,7 @@
             <!-- First preview thumbnail -->
             <div
               id="image-preview-area"
-              class="hidden w-24 bg-[#2A2A2E] border border-white/10 rounded-3xl overflow-hidden flex items-center justify-center"
+              class="hidden w-24 bg-[#2A2A2E] border border-white/10 rounded-3xl overflow-visible flex items-center justify-center"
             ></div>
           </div>
           <!-- ▲▲  UPDATED BLOCK ▲▲ -->

--- a/js/index.js
+++ b/js/index.js
@@ -232,7 +232,7 @@ function renderThumbnails(arr) {
     btn.type = 'button';
     btn.innerHTML = '<i class="fas fa-times"></i>';
     btn.className =
-      'absolute top-0 right-0 translate-x-1/2 -translate-y-1/2 w-6 h-6 rounded-full bg-white text-black border border-black flex items-center justify-center';
+      'absolute top-0 right-0 translate-x-1/2 -translate-y-1/2 w-6 h-6 rounded-full bg-white text-black border border-black flex items-center justify-center z-10';
     btn.onclick = () => {
       arr.splice(i, 1);
       uploadedFiles.splice(i, 1);


### PR DESCRIPTION
## Summary
- show uploaded image remove button outside of preview area
- ensure remove button renders on top of the thumbnail

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_6843ec1c6af0832d8773150f9d5bade9