### PR TITLE
Optimize initial model loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,21 @@
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css"
     />
 
+    <!-- Preload default model assets -->
+    <link
+      rel="preload"
+      href="https://modelviewer.dev/shared-assets/models/Astronaut.glb"
+      as="fetch"
+      type="model/gltf-binary"
+      crossorigin
+    />
+    <link
+      rel="preload"
+      href="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
+      as="fetch"
+      crossorigin
+    />
+
     <!-- Google <model-viewer> -->
     <script
       type="module"
@@ -177,7 +192,7 @@
             camera-controls
             auto-rotate
             loading="eager"
-            style="width: 100%; height: 100%; display: block"
+            style="width: 100%; height: 100%; display: none"
           ></model-viewer>
 
           <!-- loader -->

--- a/js/index.js
+++ b/js/index.js
@@ -353,11 +353,11 @@ refs.submitBtn.addEventListener('click', async () => {
   refs.submitIcon.classList.replace('fa-stop', 'fa-arrow-up');
 });
 
-window.addEventListener('DOMContentLoaded', () => {
+window.addEventListener('DOMContentLoaded', async () => {
   syncUploadHeights();
   window.addEventListener('resize', syncUploadHeights);
   setStep('prompt');
-  showModel();
+  showLoader();
   const sr = new URLSearchParams(window.location.search).get('sr');
   if (!sr) {
     refs.viewer.src = FALLBACK_GLB;
@@ -376,7 +376,9 @@ window.addEventListener('DOMContentLoaded', () => {
         stopProgress();
       }
     });
+    await refs.viewer.updateComplete;
   }
+  showModel();
   fetchProfile().then(() => {
     if (userProfile && refs.buyNowBtn) {
       refs.buyNowBtn.classList.remove('hidden');


### PR DESCRIPTION
## Summary
- preload assets for `<model-viewer>` so the model starts fetching immediately
- hide viewer until it finishes loading

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843ed6ab1a8832d80efa30ef81ef9ba