### PR TITLE
Reset flash discount timer

### DIFF
--- a/backend/tests/frontend/flashBanner.test.js
+++ b/backend/tests/frontend/flashBanner.test.js
@@ -26,9 +26,10 @@ describe('flash banner', () => {
     expect(banner.hidden).toBe(false);
     await new Promise((r) => setTimeout(r, 1100));
     expect(banner.hidden).toBe(true);
+    expect(dom.window.localStorage.getItem('flashDiscountEnd')).toBe(null);
   });
 
-  test('startFlashDiscount does not restart expired timer', async () => {
+  test('startFlashDiscount restarts expired timer', async () => {
     const dom = new JSDOM(html, {
       runScripts: 'dangerously',
       resources: 'usable',
@@ -43,8 +44,8 @@ describe('flash banner', () => {
     dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
     dom.window.startFlashDiscount();
     const end = Number(dom.window.localStorage.getItem('flashDiscountEnd'));
-    expect(end).toBe(expired);
+    expect(end).toBeGreaterThan(expired);
     const banner = dom.window.document.getElementById('flash-banner');
-    expect(banner.hidden).toBe(true);
+    expect(banner.hidden).toBe(false);
   });
 });

--- a/js/payment.js
+++ b/js/payment.js
@@ -68,20 +68,21 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   function startFlashDiscount() {
-    const saved = parseInt(localStorage.getItem('flashDiscountEnd'), 10);
-    let end;
+    let end = Number(localStorage.getItem('flashDiscountEnd'));
 
-    if (Number.isFinite(saved)) {
-      end = saved;
-    } else {
+    if (!Number.isFinite(end) || end <= Date.now()) {
       end = Date.now() + 5 * 60 * 1000;
-      localStorage.setItem('flashDiscountEnd', end);
+      localStorage.setItem('flashDiscountEnd', String(end));
     }
+
+    flashBanner.hidden = false;
+
     let timer;
     const update = () => {
       const diff = end - Date.now();
       if (diff <= 0) {
         flashBanner.hidden = true;
+        localStorage.removeItem('flashDiscountEnd');
         clearInterval(timer);
         return;
       }
@@ -91,6 +92,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         .padStart(2, '0');
       flashTimer.textContent = `${m}:${s}`;
     };
+
     update();
     timer = setInterval(update, 1000);
   }


### PR DESCRIPTION
## Summary
- make the payment banner reappear on subsequent visits
- update flash banner tests to check new behaviour

## Testing
- `npm test --silent --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_6843eda8a0cc832dbc484f1190857f10