### PR TITLE
Move subreddit quotes to backend

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -24,6 +24,9 @@ const ADMIN_TOKEN = process.env.ADMIN_TOKEN || 'admin';
 
 const AUTH_SECRET = process.env.AUTH_SECRET || 'secret';
 
+// Mapping of subreddit models and quotes stored server-side
+const subredditModels = require('./subreddit_models.json');
+
 const app = express();
 app.use(morgan('dev'));
 app.use(compression());
@@ -200,6 +203,17 @@ app.get('/api/status/:jobId', async (req, res) => {
  */
 app.get('/api/config/stripe', (req, res) => {
   res.json({ publishableKey: config.stripePublishable });
+});
+
+/**
+ * GET /api/subreddit/:name
+ * Retrieve model and quote for a subreddit
+ */
+app.get('/api/subreddit/:name', (req, res) => {
+  const sr = req.params.name.toLowerCase();
+  const entry = subredditModels[sr];
+  if (!entry) return res.status(404).json({ error: 'Subreddit not found' });
+  res.json(entry);
 });
 
 app.get('/api/progress/:jobId', (req, res) => {

--- a/backend/subreddit_models.json
+++ b/backend/subreddit_models.json
@@ -14,5 +14,9 @@
   "mechanicalkeyboards": {
     "glb": "models/reddit_mk.glb",
     "quote": "Craft custom keyboard parts using print3!"
+  },
+  "magic": {
+    "glb": "https://modelviewer.dev/shared-assets/models/Astronaut.glb",
+    "quote": "This feels like mgic!"
   }
 }

--- a/docs/ads_landing.md
+++ b/docs/ads_landing.md
@@ -8,4 +8,6 @@ To ensure visitors see the correct creative, include an `sr` parameter in every 
 https://print3.example.com/index.html?sr=art
 ```
 
-The value is looked up in `public/subreddit_models.json` so new subreddits can be added without modifying the script.
+The page requests data for that subreddit from the API endpoint
+`/api/subreddit/<name>`, so new subreddits can be added without modifying the
+client script.

--- a/js/subredditLanding.js
+++ b/js/subredditLanding.js
@@ -1,29 +1,25 @@
-async function loadMap() {
-  try {
-    const resp = await fetch('public/subreddit_models.json');
-    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
-    return await resp.json();
-  } catch (err) {
-    console.error('Failed to load subreddit model map', err);
-    return {};
-  }
-}
-
 function getParam(name) {
   const params = new URLSearchParams(window.location.search);
   return params.get(name);
 }
 
+async function fetchSubredditInfo(sr) {
+  try {
+    const resp = await fetch(`/api/subreddit/${encodeURIComponent(sr)}`);
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+    return await resp.json();
+  } catch (err) {
+    console.error('Failed to load subreddit data', err);
+    return null;
+  }
+}
+
 window.addEventListener('DOMContentLoaded', async () => {
-  const map = await loadMap();
   const sr = getParam('sr');
   const viewer = document.getElementById('viewer');
-
   const quoteEl = document.getElementById('subreddit-quote');
-  const entry = sr && map[sr.toLowerCase()];
-
-  if (entry && viewer) {
-    viewer.src = entry.glb;
-    if (quoteEl) quoteEl.textContent = entry.quote;
-  }
+  if (!sr) return;
+  const entry = await fetchSubredditInfo(sr);
+  if (entry && viewer) viewer.src = entry.glb;
+  if (entry && quoteEl) quoteEl.textContent = entry.quote;
 });


### PR DESCRIPTION
## Summary
- shift subreddit models/quotes into `backend/subreddit_models.json`
- expose new `/api/subreddit/:name` endpoint to return model and quote
- update landing-page script to call the API endpoint
- document new API in `docs/ads_landing.md`
- store the magic quote server-side with spelling `mgic`

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684402c69d44832d9d475f79c6fbcf9c