### PR TITLE
Backend-driven countdown for print slots

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -206,6 +206,30 @@ app.get('/api/config/stripe', (req, res) => {
 });
 
 /**
+ * GET /api/print-slots
+ * Return the current number of available print slots
+ */
+app.get('/api/print-slots', (req, res) => {
+  const dtf = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/New_York',
+    hour12: false,
+    hour: 'numeric',
+  });
+  const hour = parseInt(dtf.format(new Date()), 10);
+  let slots;
+  if (hour >= 1 && hour < 4) slots = 9;
+  else if (hour >= 4 && hour < 7) slots = 8;
+  else if (hour >= 7 && hour < 10) slots = 7;
+  else if (hour >= 10 && hour < 13) slots = 6;
+  else if (hour >= 13 && hour < 16) slots = 5;
+  else if (hour >= 16 && hour < 19) slots = 4;
+  else if (hour >= 19 && hour < 22) slots = 3;
+  else if (hour >= 22 && hour < 24) slots = 2;
+  else slots = 1; // 12am - 1am
+  res.json({ slots });
+});
+
+/**
  * GET /api/subreddit/:name
  * Retrieve model and quote for a subreddit
  */

--- a/backend/tests/additionalApi.test.js
+++ b/backend/tests/additionalApi.test.js
@@ -452,3 +452,9 @@ test('checkCompetitionStart sends voting emails', async () => {
   const call = db.query.mock.calls.find((c) => c[0].includes('UPDATE competitions'));
   expect(call[1][0]).toBe('c1');
 });
+
+test('GET /api/print-slots returns count', async () => {
+  const res = await request(app).get('/api/print-slots');
+  expect(res.status).toBe(200);
+  expect(typeof res.body.slots).toBe('number');
+});

--- a/js/payment.js
+++ b/js/payment.js
@@ -45,6 +45,19 @@ document.addEventListener('DOMContentLoaded', async () => {
   const flashTimer = document.getElementById('flash-timer');
   const costEl = document.getElementById('cost-estimate');
   const etaEl = document.getElementById('eta-estimate');
+  const slotEl = document.getElementById('slot-count');
+
+  if (slotEl) {
+    try {
+      const resp = await fetch('/api/print-slots');
+      if (resp.ok) {
+        const data = await resp.json();
+        slotEl.textContent = data.slots;
+      }
+    } catch {
+      /* ignore slot errors */
+    }
+  }
 
   async function updateEstimate() {
     if (!costEl || !etaEl) return;

--- a/payment.html
+++ b/payment.html
@@ -182,7 +182,7 @@
               Pay Now
             </button>
           </form>
-          <p class="mt-2 text-xs text-red-300 text-center">only X print slots avaiable</p>
+          <p class="mt-2 text-xs text-red-300 text-center">Only <span id="slot-count">9</span> print slots remaining</p>
           <div class="flex justify-center gap-4 mt-4 text-2xl text-white">
             <i class="fas fa-lock" aria-label="Secure checkout"></i>
             <i class="fas fa-shield-alt" aria-label="Money-back guarantee"></i>


### PR DESCRIPTION
## Summary
- show print slots remaining on payment page
- fetch the slot count from backend
- implement `/api/print-slots` endpoint
- test new endpoint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68441d7cafec832d965d80d2ce21d744