### PR TITLE
Fix error popup placement

### DIFF
--- a/index.html
+++ b/index.html
@@ -232,12 +232,13 @@
             Buy&nbsp;Now
           </button>
 
-          <div
-            id="gen-error"
-            class="absolute bottom-2 left-0 w-full text-center text-red-400 pointer-events-none"
-            aria-live="assertive"
-          ></div>
         </section>
+
+        <div
+          id="gen-error"
+          class="absolute left-0 top-full mt-2 w-full text-center text-red-400 pointer-events-none"
+          aria-live="assertive"
+        ></div>
 
         <!-- subreddit quote -->
         <div


### PR DESCRIPTION
## Summary
- move #gen-error element outside the model viewer so messages appear below the viewer

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_6844213d8ec0832db6d5fb7eb97e9588