### PR TITLE
Backend-driven countdown for print slots

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -206,6 +206,30 @@ app.get('/api/config/stripe', (req, res) => {
 });
 
 /**
+ * GET /api/print-slots
+ * Return the current number of available print slots
+ */
+app.get('/api/print-slots', (req, res) => {
+  const dtf = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/New_York',
+    hour12: false,
+    hour: 'numeric',
+  });
+  const hour = parseInt(dtf.format(new Date()), 10);
+  let slots;
+  if (hour >= 1 && hour < 4) slots = 9;
+  else if (hour >= 4 && hour < 7) slots = 8;
+  else if (hour >= 7 && hour < 10) slots = 7;
+  else if (hour >= 10 && hour < 13) slots = 6;
+  else if (hour >= 13 && hour < 16) slots = 5;
+  else if (hour >= 16 && hour < 19) slots = 4;
+  else if (hour >= 19 && hour < 22) slots = 3;
+  else if (hour >= 22 && hour < 24) slots = 2;
+  else slots = 1; // 12am - 1am
+  res.json({ slots });
+});
+
+/**
  * GET /api/subreddit/:name
  * Retrieve model and quote for a subreddit
  */

--- a/backend/tests/additionalApi.test.js
+++ b/backend/tests/additionalApi.test.js
@@ -452,3 +452,9 @@ test('checkCompetitionStart sends voting emails', async () => {
   const call = db.query.mock.calls.find((c) => c[0].includes('UPDATE competitions'));
   expect(call[1][0]).toBe('c1');
 });
+
+test('GET /api/print-slots returns count', async () => {
+  const res = await request(app).get('/api/print-slots');
+  expect(res.status).toBe(200);
+  expect(typeof res.body.slots).toBe('number');
+});

--- a/backend/tests/frontend/slotCount.test.js
+++ b/backend/tests/frontend/slotCount.test.js
@@ -1,0 +1,59 @@
+/** @jest-environment node */
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+let html = fs.readFileSync(path.join(__dirname, '../../../payment.html'), 'utf8');
+html = html
+  .replace(/<script[^>]+src="https?:\/\/[^>]+><\/script>/g, '')
+  .replace(/<link[^>]+href="https?:\/\/[^>]+>/g, '')
+  .replace(/<script[^>]+src="js\/payment.js"[^>]*><\/script>/, '');
+
+function cycleKey() {
+  const tz = 'America/New_York';
+  const now = new Date();
+  const df = new Intl.DateTimeFormat('en-US', { timeZone: tz, year: 'numeric', month: '2-digit', day: '2-digit' });
+  const tf = new Intl.DateTimeFormat('en-US', { timeZone: tz, hour: 'numeric', hour12: false });
+  const date = df.format(now);
+  const hour = parseInt(tf.format(now), 10);
+  if (hour < 1) {
+    const prev = new Date(now.getTime() - 86400000);
+    return df.format(prev);
+  }
+  return date;
+}
+
+describe('slot count', () => {
+  test('adjusts after purchase', async () => {
+    const dom = new JSDOM(html, {
+      runScripts: 'dangerously',
+      resources: 'usable',
+      url: 'http://localhost/payment.html?session_id=1',
+    });
+    global.window = dom.window;
+    global.document = dom.window.document;
+    dom.window.fetch = jest.fn(() => Promise.resolve({ ok: true, json: () => ({ slots: 5 }) }));
+    const scriptSrc = fs.readFileSync(path.join(__dirname, '../../../js/payment.js'), 'utf8');
+    dom.window.eval(scriptSrc);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(dom.window.document.getElementById('slot-count').textContent).toBe('4');
+    expect(dom.window.localStorage.getItem('slotPurchases')).toBe('1');
+  });
+
+  test('uses stored purchase count', async () => {
+    const dom = new JSDOM(html, {
+      runScripts: 'dangerously',
+      resources: 'usable',
+      url: 'http://localhost/payment.html',
+    });
+    global.window = dom.window;
+    global.document = dom.window.document;
+    dom.window.fetch = jest.fn(() => Promise.resolve({ ok: true, json: () => ({ slots: 6 }) }));
+    const scriptSrc = fs.readFileSync(path.join(__dirname, '../../../js/payment.js'), 'utf8');
+    dom.window.eval(scriptSrc);
+    dom.window.localStorage.setItem('slotCycle', cycleKey());
+    dom.window.localStorage.setItem('slotPurchases', '2');
+    await new Promise((r) => setTimeout(r, 0));
+    expect(dom.window.document.getElementById('slot-count').textContent).toBe('4');
+  });
+});

--- a/js/payment.js
+++ b/js/payment.js
@@ -4,6 +4,54 @@
 let stripe = null;
 const FALLBACK_GLB = 'https://modelviewer.dev/shared-assets/models/Astronaut.glb';
 const PRICE = 2000;
+const TZ = 'America/New_York';
+
+function getCycleKey() {
+  const now = new Date();
+  const dateFmt = new Intl.DateTimeFormat('en-US', {
+    timeZone: TZ,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+  const hourFmt = new Intl.DateTimeFormat('en-US', {
+    timeZone: TZ,
+    hour: 'numeric',
+    hour12: false,
+  });
+  const dateStr = dateFmt.format(now);
+  const hour = parseInt(hourFmt.format(now), 10);
+  if (hour < 1) {
+    const prev = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+    return dateFmt.format(prev);
+  }
+  return dateStr;
+}
+
+function resetPurchaseCount() {
+  const key = getCycleKey();
+  if (localStorage.getItem('slotCycle') !== key) {
+    localStorage.setItem('slotCycle', key);
+    localStorage.setItem('slotPurchases', '0');
+  }
+}
+
+function getPurchaseCount() {
+  resetPurchaseCount();
+  const n = parseInt(localStorage.getItem('slotPurchases'), 10);
+  return Number.isInteger(n) && n > 0 ? n : 0;
+}
+
+function recordPurchase() {
+  resetPurchaseCount();
+  const n = getPurchaseCount();
+  localStorage.setItem('slotPurchases', String(n + 1));
+}
+
+function adjustedSlots(base) {
+  const n = getPurchaseCount();
+  return Math.max(0, base - n);
+}
 
 function qs(name) {
   const params = new URLSearchParams(window.location.search);
@@ -45,6 +93,23 @@ document.addEventListener('DOMContentLoaded', async () => {
   const flashTimer = document.getElementById('flash-timer');
   const costEl = document.getElementById('cost-estimate');
   const etaEl = document.getElementById('eta-estimate');
+  const slotEl = document.getElementById('slot-count');
+  const sessionId = qs('session_id');
+  if (sessionId) recordPurchase();
+  let baseSlots = null;
+
+  if (slotEl) {
+    try {
+      const resp = await fetch('/api/print-slots');
+      if (resp.ok) {
+        const data = await resp.json();
+        baseSlots = data.slots;
+        slotEl.textContent = adjustedSlots(baseSlots);
+      }
+    } catch {
+      /* ignore slot errors */
+    }
+  }
 
   async function updateEstimate() {
     if (!costEl || !etaEl) return;
@@ -128,7 +193,6 @@ document.addEventListener('DOMContentLoaded', async () => {
   // Hide the overlay if nothing happens after a short delay
   setTimeout(hideLoader, 7000);
 
-  const sessionId = qs('session_id');
   if (sessionId) {
     successMsg.hidden = false;
     return;

--- a/payment.html
+++ b/payment.html
@@ -182,7 +182,7 @@
               Pay Now
             </button>
           </form>
-          <p class="mt-2 text-xs text-red-300 text-center">only X print slots avaiable</p>
+          <p class="mt-2 text-xs text-red-300 text-center">Only <span id="slot-count">9</span> print slots remaining</p>
           <div class="flex justify-center gap-4 mt-4 text-2xl text-white">
             <i class="fas fa-lock" aria-label="Secure checkout"></i>
             <i class="fas fa-shield-alt" aria-label="Money-back guarantee"></i>


### PR DESCRIPTION
## Summary
- show print slots remaining on payment page
- fetch the slot count from backend
- implement `/api/print-slots` endpoint
- test new endpoint
- decrement the visible slot count locally after each purchase

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68441d7cafec832d965d80d2ce21d744