### PR TITLE
Fix flash discount countdown

### DIFF
--- a/backend/tests/frontend/flashBanner.test.js
+++ b/backend/tests/frontend/flashBanner.test.js
@@ -57,10 +57,7 @@ describe('flash banner', () => {
     });
     global.window = dom.window;
     global.document = dom.window.document;
-    const scriptSrc = fs.readFileSync(
-      path.join(__dirname, '../../../js/payment.js'),
-      'utf8'
-    );
+    const scriptSrc = fs.readFileSync(path.join(__dirname, '../../../js/payment.js'), 'utf8');
     dom.window.eval(scriptSrc);
     dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
     dom.window.startFlashDiscount();

--- a/backend/tests/frontend/flashBanner.test.js
+++ b/backend/tests/frontend/flashBanner.test.js
@@ -48,4 +48,25 @@ describe('flash banner', () => {
     const banner = dom.window.document.getElementById('flash-banner');
     expect(banner.hidden).toBe(false);
   });
+
+  test('countdown shows 4:59 after one second', async () => {
+    const dom = new JSDOM(html, {
+      runScripts: 'dangerously',
+      resources: 'usable',
+      url: 'http://localhost/',
+    });
+    global.window = dom.window;
+    global.document = dom.window.document;
+    const scriptSrc = fs.readFileSync(
+      path.join(__dirname, '../../../js/payment.js'),
+      'utf8'
+    );
+    dom.window.eval(scriptSrc);
+    dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
+    dom.window.startFlashDiscount();
+    const timerEl = dom.window.document.getElementById('flash-timer');
+    expect(timerEl.textContent).toBe('5:00');
+    await new Promise((r) => setTimeout(r, 1100));
+    expect(timerEl.textContent).toBe('4:59');
+  });
 });

--- a/index.html
+++ b/index.html
@@ -101,7 +101,6 @@
     <!-- ▸▸▸ HEADER ------------------------------------------------------- -->
 
     <header class="relative flex items-center justify-between py-4 px-6">
-
       <div class="flex flex-col items-start">
         <img src="img/textlogo.png" alt="print3" class="h-10 w-auto" />
         <div class="mt-1 flex flex-col text-sm text-gray-400 opacity-75">
@@ -231,7 +230,6 @@
           >
             Buy&nbsp;Now
           </button>
-
         </section>
 
         <div

--- a/js/payment.js
+++ b/js/payment.js
@@ -99,7 +99,6 @@ document.addEventListener('DOMContentLoaded', async () => {
   if (sessionId) recordPurchase();
   let baseSlots = null;
 
-
   if (slotEl) {
     try {
       const resp = await fetch('/api/print-slots');

--- a/js/payment.js
+++ b/js/payment.js
@@ -154,10 +154,9 @@ document.addEventListener('DOMContentLoaded', async () => {
         clearInterval(timer);
         return;
       }
-      const m = Math.floor(diff / 60000);
-      const s = Math.floor((diff % 60000) / 1000)
-        .toString()
-        .padStart(2, '0');
+      const diffSec = Math.ceil(diff / 1000);
+      const m = Math.floor(diffSec / 60);
+      const s = String(diffSec % 60).padStart(2, '0');
       flashTimer.textContent = `${m}:${s}`;
     };
 

--- a/payment.html
+++ b/payment.html
@@ -182,7 +182,9 @@
               Pay Now
             </button>
           </form>
-          <p class="mt-2 text-xs text-red-300 text-center">Only <span id="slot-count">9</span> print slots remaining</p>
+          <p class="mt-2 text-xs text-red-300 text-center">
+            Only <span id="slot-count">9</span> print slots remaining
+          </p>
           <div class="flex justify-center gap-4 mt-4 text-2xl text-white">
             <i class="fas fa-lock" aria-label="Secure checkout"></i>
             <i class="fas fa-shield-alt" aria-label="Money-back guarantee"></i>


### PR DESCRIPTION
## Summary
- handle sub-second delays in the payment countdown
- test that the countdown updates to `4:59` after a second

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68442c2a050c832dbf41b7064013b0c6