### PR TITLE
Fix initial timer display on payments page

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -143,8 +143,6 @@ document.addEventListener('DOMContentLoaded', async () => {
       localStorage.setItem('flashDiscountEnd', String(end));
     }
 
-    flashBanner.hidden = false;
-
     let timer;
     const update = () => {
       const diff = end - Date.now();
@@ -161,6 +159,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     };
 
     update();
+    flashBanner.hidden = false;
     timer = setInterval(update, 1000);
   }
   window.startFlashDiscount = startFlashDiscount;

--- a/payment.html
+++ b/payment.html
@@ -33,6 +33,7 @@
     <div
       id="flash-banner"
       role="status"
+      hidden
       class="text-[#1A1A1D] font-semibold text-center py-2 bg-gradient-to-r from-teal-400 via-cyan-300 to-teal-500"
     >
       Order within <span id="flash-timer">5:00</span> to get 5% off


### PR DESCRIPTION
## Summary
- hide flash sale banner until script initializes
- show updated timer value before displaying banner

## Testing
- `npm install` in backend
- `npm test` in backend

------
https://chatgpt.com/codex/tasks/task_e_684447b75bd0832d98465e1e777f2931