### PR TITLE
Make flash discount random

### DIFF
--- a/backend/tests/frontend/flashBanner.test.js
+++ b/backend/tests/frontend/flashBanner.test.js
@@ -17,6 +17,7 @@ describe('flash banner', () => {
     });
     global.window = dom.window;
     global.document = dom.window.document;
+    dom.window.sessionStorage.setItem('flashDiscountShow', '1');
     dom.window.localStorage.setItem('flashDiscountEnd', String(Date.now() + 1000));
     const scriptSrc = fs.readFileSync(path.join(__dirname, '../../../js/payment.js'), 'utf8');
     dom.window.eval(scriptSrc);
@@ -37,6 +38,7 @@ describe('flash banner', () => {
     });
     global.window = dom.window;
     global.document = dom.window.document;
+    dom.window.sessionStorage.setItem('flashDiscountShow', '1');
     const expired = Date.now() - 1000;
     dom.window.localStorage.setItem('flashDiscountEnd', String(expired));
     const scriptSrc = fs.readFileSync(path.join(__dirname, '../../../js/payment.js'), 'utf8');
@@ -57,6 +59,7 @@ describe('flash banner', () => {
     });
     global.window = dom.window;
     global.document = dom.window.document;
+    dom.window.sessionStorage.setItem('flashDiscountShow', '1');
     const scriptSrc = fs.readFileSync(path.join(__dirname, '../../../js/payment.js'), 'utf8');
     dom.window.eval(scriptSrc);
     dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
@@ -65,5 +68,23 @@ describe('flash banner', () => {
     expect(timerEl.textContent).toBe('5:00');
     await new Promise((r) => setTimeout(r, 1100));
     expect(timerEl.textContent).toBe('4:59');
+  });
+
+  test('banner hidden when chance disabled', async () => {
+    const dom = new JSDOM(html, {
+      runScripts: 'dangerously',
+      resources: 'usable',
+      url: 'http://localhost/',
+    });
+    global.window = dom.window;
+    global.document = dom.window.document;
+    dom.window.sessionStorage.setItem('flashDiscountShow', '0');
+    const scriptSrc = fs.readFileSync(path.join(__dirname, '../../../js/payment.js'), 'utf8');
+    dom.window.eval(scriptSrc);
+    dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
+    dom.window.startFlashDiscount();
+    const banner = dom.window.document.getElementById('flash-banner');
+    expect(banner.hidden).toBe(true);
+    expect(dom.window.localStorage.getItem('flashDiscountEnd')).toBe(null);
   });
 });

--- a/js/payment.js
+++ b/js/payment.js
@@ -136,6 +136,17 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   function startFlashDiscount() {
+    let show = sessionStorage.getItem('flashDiscountShow');
+    if (!show) {
+      show = Math.random() < 0.5 ? '1' : '0';
+      sessionStorage.setItem('flashDiscountShow', show);
+    }
+    if (show === '0') {
+      flashBanner.hidden = true;
+      localStorage.removeItem('flashDiscountEnd');
+      return;
+    }
+
     let end = Number(localStorage.getItem('flashDiscountEnd'));
 
     if (!Number.isFinite(end) || end <= Date.now()) {


### PR DESCRIPTION
## Summary
- show the flash discount banner for only half of sessions
- track the random choice in `sessionStorage`
- update banner tests for the new session logic
- add a test for when the discount is disabled

## Testing
- `npm test --prefix backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68444a06bfbc832db88c8b8d828a69bc