### PR TITLE
Fix countdown banner reset

### DIFF
--- a/backend/tests/frontend/flashBanner.test.js
+++ b/backend/tests/frontend/flashBanner.test.js
@@ -27,10 +27,10 @@ describe('flash banner', () => {
     expect(banner.hidden).toBe(false);
     await new Promise((r) => setTimeout(r, 1100));
     expect(banner.hidden).toBe(true);
-    expect(dom.window.localStorage.getItem('flashDiscountEnd')).toBe(null);
+    expect(dom.window.localStorage.getItem('flashDiscountEnd')).toBe('0');
   });
 
-  test('startFlashDiscount restarts expired timer', async () => {
+  test('does not restart after expiration', async () => {
     const dom = new JSDOM(html, {
       runScripts: 'dangerously',
       resources: 'usable',
@@ -39,16 +39,15 @@ describe('flash banner', () => {
     global.window = dom.window;
     global.document = dom.window.document;
     dom.window.sessionStorage.setItem('flashDiscountShow', '1');
-    const expired = Date.now() - 1000;
-    dom.window.localStorage.setItem('flashDiscountEnd', String(expired));
+    dom.window.localStorage.setItem('flashDiscountEnd', '0');
     const scriptSrc = fs.readFileSync(path.join(__dirname, '../../../js/payment.js'), 'utf8');
     dom.window.eval(scriptSrc);
     dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
     dom.window.startFlashDiscount();
-    const end = Number(dom.window.localStorage.getItem('flashDiscountEnd'));
-    expect(end).toBeGreaterThan(expired);
+    const end = dom.window.localStorage.getItem('flashDiscountEnd');
+    expect(end).toBe('0');
     const banner = dom.window.document.getElementById('flash-banner');
-    expect(banner.hidden).toBe(false);
+    expect(banner.hidden).toBe(true);
   });
 
   test('countdown shows 4:59 after one second', async () => {

--- a/js/payment.js
+++ b/js/payment.js
@@ -147,7 +147,12 @@ document.addEventListener('DOMContentLoaded', async () => {
       return;
     }
 
-    let end = Number(localStorage.getItem('flashDiscountEnd'));
+    const endStr = localStorage.getItem('flashDiscountEnd');
+    if (endStr === '0') {
+      flashBanner.hidden = true;
+      return;
+    }
+    let end = Number(endStr);
 
     if (!Number.isFinite(end) || end <= Date.now()) {
       end = Date.now() + 5 * 60 * 1000;
@@ -159,7 +164,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       const diff = end - Date.now();
       if (diff <= 0) {
         flashBanner.hidden = true;
-        localStorage.removeItem('flashDiscountEnd');
+        localStorage.setItem('flashDiscountEnd', '0');
         clearInterval(timer);
         return;
       }


### PR DESCRIPTION
## Summary
- ensure flash discount banner only shows once per session
- update frontend tests for banner expiry

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844546eb174832d843260d6dc6bb6c0