### PR TITLE
Add profile redirect and logout

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,6 +112,7 @@
       <div class="flex items-center space-x-4 self-start mt-1">
         <a
           href="profile.html"
+          id="profile-link"
           class="bg-[#2A2A2E] border border-white/10 rounded-3xl px-4 py-2 text-sm hover:bg-[#3A3A3E] transition-shape"
           >Profile</a
         >
@@ -313,6 +314,14 @@
     <!-- ▸▸▸ SCRIPTS ------------------------------------------------------ -->
     <script src="js/subredditLanding.js"></script>
     <script type="module" src="js/index.js"></script>
+    <script>
+      document.getElementById('profile-link')?.addEventListener('click', function (e) {
+        if (!localStorage.getItem('token')) {
+          e.preventDefault();
+          window.location.href = 'login.html';
+        }
+      });
+    </script>
 
     <!-- Position the subreddit quote so its centre aligns with the centre
          of the checkout button -->

--- a/js/profile.js
+++ b/js/profile.js
@@ -120,5 +120,10 @@ document.addEventListener('DOMContentLoaded', () => {
   });
   const form = document.getElementById('create-account-form');
   form?.addEventListener('submit', createAccount);
+  const logoutBtn = document.getElementById('logout-btn');
+  logoutBtn?.addEventListener('click', () => {
+    localStorage.removeItem('token');
+    window.location.href = 'index.html';
+  });
   load();
 });

--- a/profile.html
+++ b/profile.html
@@ -76,6 +76,12 @@
         >
           <i class="fab fa-instagram"></i>
         </button>
+        <button
+          id="logout-btn"
+          class="bg-[#2A2A2E] border border-white/10 rounded-3xl px-3 py-2 text-sm hover:bg-[#3A3A3E] transition-shape"
+        >
+          Log Out
+        </button>
       </div>
     </header>
     <main class="flex-1 px-6 py-4">


### PR DESCRIPTION
## Summary
- add `id="profile-link"` and login redirect logic on index page
- add Logout button in profile page
- wire up logout handler in `js/profile.js`
- run backend tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844556b8174832da69d7e3d633f396b