### PR TITLE
Fix flash discount timer persistence

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -154,9 +154,13 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
     let end = Number(endStr);
 
-    if (!Number.isFinite(end) || end <= Date.now()) {
+    if (!Number.isFinite(end)) {
       end = Date.now() + 5 * 60 * 1000;
       localStorage.setItem('flashDiscountEnd', String(end));
+    } else if (end <= Date.now()) {
+      flashBanner.hidden = true;
+      localStorage.setItem('flashDiscountEnd', '0');
+      return;
     }
 
     let timer;


### PR DESCRIPTION
## Summary
- avoid resetting countdown if it expired while page was closed

## Testing
- `npm test` *(fails: SyntaxError in subreddit_models.json)*

------
https://chatgpt.com/codex/tasks/task_e_68458bc71594832d8f0d4550017de97b