### PR TITLE
Implement basic user account page

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -105,6 +105,24 @@ app.post('/api/login', async (req, res) => {
   }
 });
 
+app.get('/api/me', authRequired, async (req, res) => {
+  try {
+    const { rows } = await db.query('SELECT id, username, email FROM users WHERE id=$1', [req.user.id]);
+    if (!rows.length) return res.status(404).json({ error: 'User not found' });
+    const user = rows[0];
+    const profile = await db.query('SELECT shipping_info, payment_info, competition_notify FROM user_profiles WHERE user_id=$1', [req.user.id]);
+    res.json({
+      id: user.id,
+      username: user.username,
+      email: user.email,
+      profile: profile.rows[0] || {},
+    });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to fetch account' });
+  }
+});
+
 /**
  * POST /api/generate
  * Accept a prompt and optional image uploads

--- a/js/account.js
+++ b/js/account.js
@@ -1,0 +1,18 @@
+const API_BASE = (window.API_ORIGIN || '') + '/api';
+
+async function loadProfile() {
+  const token = localStorage.getItem('token');
+  if (!token) {
+    window.location.href = 'login.html';
+    return;
+  }
+  const res = await fetch(`${API_BASE}/me`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) return;
+  const data = await res.json();
+  document.getElementById('mp-username').textContent = data.username;
+  document.getElementById('mp-email').textContent = data.email;
+}
+
+document.addEventListener('DOMContentLoaded', loadProfile);

--- a/js/profile.js
+++ b/js/profile.js
@@ -85,9 +85,16 @@ async function captureSnapshots(container) {
 
 async function load() {
   const token = localStorage.getItem('token');
+  const logoutBtn = document.getElementById('logout-btn');
+  const accountLink = document.getElementById('account-link');
   if (!token) {
-    document.getElementById('create-account-form').classList.remove('hidden');
+    document.getElementById('auth-options').classList.remove('hidden');
+    logoutBtn?.classList.add('hidden');
+    accountLink?.classList.add('hidden');
     return;
+  } else {
+    logoutBtn?.classList.remove('hidden');
+    accountLink?.classList.remove('hidden');
   }
   const urlParams = new URLSearchParams(window.location.search);
   const user = urlParams.get('user');
@@ -120,6 +127,11 @@ document.addEventListener('DOMContentLoaded', () => {
   });
   const form = document.getElementById('create-account-form');
   form?.addEventListener('submit', createAccount);
+  const showCreate = document.getElementById('show-create-btn');
+  showCreate?.addEventListener('click', () => {
+    document.getElementById('auth-options')?.classList.add('hidden');
+    document.getElementById('create-account-form')?.classList.remove('hidden');
+  });
   const logoutBtn = document.getElementById('logout-btn');
   logoutBtn?.addEventListener('click', () => {
     localStorage.removeItem('token');

--- a/my_profile.html
+++ b/my_profile.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>My Profile</title>
+    <meta property="og:title" content="My Profile – print3" />
+    <meta property="og:image" content="img/boxlogo.png" />
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body class="bg-[#1A1A1D] text-white font-sans flex flex-col min-h-screen">
+    <header class="relative flex items-center justify-between py-4 px-6">
+      <a
+        href="profile.html"
+        class="inline-flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-3xl px-5 py-2 text-lg font-medium hover:bg-[#3A3A3E] transition-shape"
+      >
+        <svg
+          class="w-4 h-4 mr-2 flex-shrink-0"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+        >
+          <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+        </svg>
+        Back
+      </a>
+      <h1 class="absolute inset-x-0 top-1/2 -translate-y-1/2 text-center text-2xl font-semibold pointer-events-none">
+        My Profile
+      </h1>
+      <span class="w-9 h-9"></span>
+    </header>
+    <main class="flex-1 flex items-center justify-center p-6">
+      <div id="profile-info" class="space-y-2 bg-[#2A2A2E] border border-white/10 p-6 rounded-3xl w-96">
+        <p><strong>Username:</strong> <span id="mp-username"></span></p>
+        <p><strong>Email:</strong> <span id="mp-email"></span></p>
+      </div>
+    </main>
+    <script type="module" src="js/account.js"></script>
+  </body>
+</html>

--- a/profile.html
+++ b/profile.html
@@ -77,6 +77,12 @@
         >
           <i class="fab fa-instagram"></i>
         </button>
+        <a
+          href="my_profile.html"
+          id="account-link"
+          class="bg-[#2A2A2E] border border-white/10 rounded-3xl px-3 py-2 text-sm hover:bg-[#3A3A3E] transition-shape hidden"
+          >Account</a
+        >
         <button
           id="logout-btn"
           class="bg-[#2A2A2E] border border-white/10 rounded-3xl px-3 py-2 text-sm hover:bg-[#3A3A3E] transition-shape"
@@ -87,6 +93,20 @@
     </header>
     <main class="flex-1 px-6 py-4">
       <div id="models" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4"></div>
+      <div id="auth-options" class="text-center mt-8 hidden">
+        <a
+          href="login.html"
+          id="login-btn"
+          class="bg-[#30D5C8] text-[#1A1A1D] font-semibold px-4 py-2 rounded-xl hover:bg-[#28b7a8] transition mr-2"
+          >Log In</a
+        >
+        <button
+          id="show-create-btn"
+          class="bg-[#30D5C8] text-[#1A1A1D] font-semibold px-4 py-2 rounded-xl hover:bg-[#28b7a8] transition"
+        >
+          Create Account
+        </button>
+      </div>
       <form
         id="create-account-form"
         class="space-y-4 bg-[#2A2A2E] border border-white/10 p-6 rounded-3xl w-96 mx-auto hidden mt-8"


### PR DESCRIPTION
## Summary
- add `/api/me` endpoint in backend to expose account details
- provide login and create-account options on the profile page
- include a new link to a personal profile page
- create `my_profile.html` and supporting JS module

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684594f658e4832da16dd8b917edaf65