### PR TITLE
Improve community page thumbnails

### DIFF
--- a/js/community.js
+++ b/js/community.js
@@ -55,23 +55,44 @@ async function fetchCreations(
 }
 
 function getFallbackModels() {
-  const urls = [
-    'https://modelviewer.dev/shared-assets/models/Astronaut.glb',
-    'https://modelviewer.dev/shared-assets/models/RobotExpressive.glb',
-    'https://modelviewer.dev/shared-assets/models/Horse.glb',
+  const base = 'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0';
+  const samples = [
+    { name: 'DamagedHelmet', ext: 'png' },
+    { name: 'BoomBox', ext: 'jpg' },
+    { name: 'BarramundiFish', ext: 'jpg' },
+    { name: 'FlightHelmet', ext: 'jpg' },
+    { name: 'Avocado', ext: 'jpg' },
+    { name: 'AntiqueCamera', ext: 'png' },
+    { name: 'Lantern', ext: 'jpg' },
+    { name: 'WaterBottle', ext: 'jpg' },
+    { name: 'Corset', ext: 'jpg' },
+    { name: 'ToyCar', ext: 'jpg' },
+    { name: 'Duck', ext: 'png' },
+    { name: 'CesiumMan', ext: 'gif' },
   ];
   const models = [];
   for (let i = 0; i < 6; i++) {
-    const url = urls[i % urls.length];
+    const s = samples[i % samples.length];
     models.push({
-      model_url: url,
+      model_url: `${base}/${s.name}/glTF-Binary/${s.name}.glb`,
       likes: 0,
       id: `fallback-${i}`,
       job_id: `fallback-${i}`,
-      snapshot: '',
+      snapshot: `${base}/${s.name}/screenshot/screenshot.${s.ext}`,
     });
   }
   return models;
+}
+
+const prefetchedModels = new Set();
+function prefetchModel(url) {
+  if (prefetchedModels.has(url)) return;
+  const link = document.createElement('link');
+  link.rel = 'prefetch';
+  link.href = url;
+  link.as = 'fetch';
+  document.head.appendChild(link);
+  prefetchedModels.add(url);
 }
 
 function createCard(model) {
@@ -81,15 +102,19 @@ function createCard(model) {
   div.dataset.model = model.model_url;
   div.dataset.job = model.job_id;
   div.innerHTML = `\n      <img src="${model.snapshot || ''}" alt="Model" class="w-full h-full object-contain pointer-events-none" />\n      <span class="sr-only">${model.title || 'Model'}</span>\n      <span class="absolute bottom-1 right-1 text-xs bg-black/50 px-1 rounded" id="likes-${model.id}">${model.likes}</span>\n      <button class="purchase absolute bottom-1 left-1 text-xs bg-blue-600 px-1 rounded">Buy</button>`;
+  prefetchModel(model.model_url);
   div.querySelector('.purchase').addEventListener('click', (e) => {
     e.stopPropagation();
     localStorage.setItem('print3Model', model.model_url);
     localStorage.setItem('print3JobId', model.job_id);
     window.location.href = 'payment.html';
   });
+  div.addEventListener('pointerenter', () => prefetchModel(model.model_url));
   div.addEventListener('click', () => {
     const modal = document.getElementById('model-modal');
     const viewer = modal.querySelector('model-viewer');
+    viewer.setAttribute('poster', model.snapshot || '');
+    viewer.setAttribute('loading', 'eager');
     viewer.src = model.model_url;
     modal.classList.remove('hidden');
     document.body.classList.add('overflow-hidden');


### PR DESCRIPTION
## Summary
- show sample thumbnails for fallback models on the community page
- prefetch model files so they open faster when clicked

## Testing
- `npm test --silent --prefix backend` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684596616950832dbe37d4b56927be4b