### PR TITLE
Refactor snapshot helper

### DIFF
--- a/js/community.js
+++ b/js/community.js
@@ -1,3 +1,5 @@
+import { captureSnapshots } from './snapshot.js';
+
 const API_BASE = (window.API_ORIGIN || '') + '/api';
 
 function like(id) {
@@ -125,33 +127,6 @@ function createCard(model) {
   return div;
 }
 
-async function captureSnapshots(container) {
-  const cards = container.querySelectorAll('.model-card');
-  for (const card of cards) {
-    const img = card.querySelector('img');
-    if (img && img.src) continue;
-    const glbUrl = card.dataset.model;
-    const viewer = document.createElement('model-viewer');
-    viewer.src = glbUrl;
-    viewer.setAttribute(
-      'environment-image',
-      'https://modelviewer.dev/shared-assets/environments/neutral.hdr'
-    );
-    viewer.style.position = 'fixed';
-    viewer.style.left = '-10000px';
-    viewer.style.width = '300px';
-    viewer.style.height = '300px';
-    document.body.appendChild(viewer);
-    try {
-      await viewer.updateComplete;
-      img.src = await viewer.toDataURL('image/png');
-    } catch (err) {
-      console.error('Failed to capture snapshot', err);
-    } finally {
-      viewer.remove();
-    }
-  }
-}
 
 function getFilters() {
   const category = document.getElementById('category').value;

--- a/js/competitions.js
+++ b/js/competitions.js
@@ -1,3 +1,5 @@
+import { captureSnapshots } from './snapshot.js';
+
 const API_BASE = (window.API_ORIGIN || '') + '/api';
 
 function like(id) {
@@ -17,33 +19,6 @@ function like(id) {
     });
 }
 
-async function captureSnapshots(container) {
-  const cards = container.querySelectorAll('.entry-card');
-  for (const card of cards) {
-    const img = card.querySelector('img');
-    if (img && img.src) continue;
-    const glbUrl = card.dataset.model;
-    const viewer = document.createElement('model-viewer');
-    viewer.src = glbUrl;
-    viewer.setAttribute(
-      'environment-image',
-      'https://modelviewer.dev/shared-assets/environments/neutral.hdr'
-    );
-    viewer.style.position = 'fixed';
-    viewer.style.left = '-10000px';
-    viewer.style.width = '300px';
-    viewer.style.height = '300px';
-    document.body.appendChild(viewer);
-    try {
-      await viewer.updateComplete;
-      img.src = await viewer.toDataURL('image/png');
-    } catch (err) {
-      console.error('Failed to capture snapshot', err);
-    } finally {
-      viewer.remove();
-    }
-  }
-}
 
 async function load() {
   const res = await fetch(`${API_BASE}/competitions/active`);

--- a/js/profile.js
+++ b/js/profile.js
@@ -1,3 +1,5 @@
+import { captureSnapshots } from './snapshot.js';
+
 const API_BASE = (window.API_ORIGIN || '') + '/api';
 
 function createCard(model) {
@@ -55,33 +57,6 @@ async function createAccount(e) {
   }
 }
 
-async function captureSnapshots(container) {
-  const cards = container.querySelectorAll('.model-card');
-  for (const card of cards) {
-    const img = card.querySelector('img');
-    if (img && img.src) continue;
-    const glbUrl = card.dataset.model;
-    const viewer = document.createElement('model-viewer');
-    viewer.src = glbUrl;
-    viewer.setAttribute(
-      'environment-image',
-      'https://modelviewer.dev/shared-assets/environments/neutral.hdr'
-    );
-    viewer.style.position = 'fixed';
-    viewer.style.left = '-10000px';
-    viewer.style.width = '300px';
-    viewer.style.height = '300px';
-    document.body.appendChild(viewer);
-    try {
-      await viewer.updateComplete;
-      img.src = await viewer.toDataURL('image/png');
-    } catch (err) {
-      console.error('Failed to capture snapshot', err);
-    } finally {
-      viewer.remove();
-    }
-  }
-}
 
 async function load() {
   const token = localStorage.getItem('token');

--- a/js/snapshot.js
+++ b/js/snapshot.js
@@ -1,0 +1,31 @@
+export async function captureSnapshots(container) {
+  const cards = container.querySelectorAll('[data-model]');
+  for (const card of cards) {
+    const img = card.querySelector('img');
+    if (img && img.src) continue;
+    const glbUrl = card.dataset.model;
+    const viewer = document.createElement('model-viewer');
+    viewer.src = glbUrl;
+    viewer.setAttribute(
+      'environment-image',
+      'https://modelviewer.dev/shared-assets/environments/neutral.hdr'
+    );
+    viewer.style.position = 'fixed';
+    viewer.style.left = '-10000px';
+    viewer.style.width = '300px';
+    viewer.style.height = '300px';
+    document.body.appendChild(viewer);
+    try {
+      await viewer.updateComplete;
+      img.src = await viewer.toDataURL('image/png');
+    } catch (err) {
+      console.error('Failed to capture snapshot', err);
+    } finally {
+      viewer.remove();
+    }
+  }
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { captureSnapshots };
+}


### PR DESCRIPTION
## Summary
- add a `snapshot.js` helper module
- reuse `captureSnapshots` in community, profile and competitions pages

## Testing
- `npm test` *(fails: jest not found)*
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_6845a828c704832d927b13fdbdbc587d