### PR TITLE
Fix CORS for GLB snapshots

### DIFF
--- a/js/community.js
+++ b/js/community.js
@@ -132,6 +132,7 @@ async function captureSnapshots(container) {
     if (img && img.src) continue;
     const glbUrl = card.dataset.model;
     const viewer = document.createElement('model-viewer');
+    viewer.crossOrigin = 'anonymous';
     viewer.src = glbUrl;
     viewer.setAttribute(
       'environment-image',

--- a/js/competitions.js
+++ b/js/competitions.js
@@ -24,6 +24,7 @@ async function captureSnapshots(container) {
     if (img && img.src) continue;
     const glbUrl = card.dataset.model;
     const viewer = document.createElement('model-viewer');
+    viewer.crossOrigin = 'anonymous';
     viewer.src = glbUrl;
     viewer.setAttribute(
       'environment-image',

--- a/js/profile.js
+++ b/js/profile.js
@@ -62,6 +62,7 @@ async function captureSnapshots(container) {
     if (img && img.src) continue;
     const glbUrl = card.dataset.model;
     const viewer = document.createElement('model-viewer');
+    viewer.crossOrigin = 'anonymous';
     viewer.src = glbUrl;
     viewer.setAttribute(
       'environment-image',


### PR DESCRIPTION
## Summary
- set `viewer.crossOrigin = 'anonymous'` in snapshot helpers to avoid CORS errors

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_6845a8283b10832d8990dbb59d8937dd