### PR TITLE
Fix community fallback models and checkout viewer

### DIFF
--- a/js/community.js
+++ b/js/community.js
@@ -54,7 +54,6 @@ async function fetchCreations(
   }
 }
 
-
 function getFallbackModels(count = 6, start = 0) {
   const base = 'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0';
 
@@ -80,18 +79,6 @@ function getFallbackModels(count = 6, start = 0) {
     job_id: `fallback-${start + i}`,
     snapshot: `${base}/${s.name}/screenshot/screenshot.${s.ext}`,
   }));
-}
-
-const prefetchedModels = new Set();
-function prefetchModel(url) {
-  if (prefetchedModels.has(url)) return;
-  const link = document.createElement('link');
-  link.rel = 'prefetch';
-  link.href = url;
-  link.as = 'fetch';
-  document.head.appendChild(link);
-  prefetchedModels.add(url);
-
 }
 
 const prefetchedModels = new Set();

--- a/js/payment.js
+++ b/js/payment.js
@@ -239,8 +239,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   loader.hidden = false;
-  viewer.src =
-    localStorage.getItem('print3Model') || localStorage.getItem('print2Model') || FALLBACK_GLB;
+  viewer.src = localStorage.getItem('print3Model') || FALLBACK_GLB;
 
   // Hide the overlay if nothing happens after a short delay
   setTimeout(hideLoader, 7000);


### PR DESCRIPTION
## Summary
- clean up duplicate `prefetchedModels` declaration so community page JS loads
- default payment viewer to the generated model only

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845aa1fbef4832d9ff9a6d905ce8991