### PR TITLE
Fix community fallback models and checkout viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,9 @@ If omitted, the API returns up to 10 most recent models starting from offset 0.
 
 ## Contributing
 
-We welcome pull requests! Please fork the repo and create a topic branch. Ensure `npm test` runs clean before submitting.
+We welcome pull requests! Please fork the repo and create a topic branch. Run
+`npm ci` inside `backend/` to install dependencies, then ensure `npm test` runs
+clean before submitting.
 Run `npm run test-ci` for the same tests using a single process, which matches the CI configuration.
 Run `npm run format` in `backend/` to apply Prettier formatting before committing.
 For significant changes, please open an issue first to discuss what you would like to change. Be sure to follow the code style enforced by Prettier.

--- a/js/community.js
+++ b/js/community.js
@@ -54,7 +54,6 @@ async function fetchCreations(
   }
 }
 
-
 function getFallbackModels(count = 6, start = 0) {
   const base = 'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0';
 
@@ -80,18 +79,6 @@ function getFallbackModels(count = 6, start = 0) {
     job_id: `fallback-${start + i}`,
     snapshot: `${base}/${s.name}/screenshot/screenshot.${s.ext}`,
   }));
-}
-
-const prefetchedModels = new Set();
-function prefetchModel(url) {
-  if (prefetchedModels.has(url)) return;
-  const link = document.createElement('link');
-  link.rel = 'prefetch';
-  link.href = url;
-  link.as = 'fetch';
-  document.head.appendChild(link);
-  prefetchedModels.add(url);
-
 }
 
 const prefetchedModels = new Set();
@@ -183,10 +170,12 @@ async function loadMore(type, filters = getFilters()) {
   models.forEach((m) => grid.appendChild(createCard(m)));
   await captureSnapshots(grid);
   const btn = document.getElementById(`${type}-load`);
-  if (models.length < 6) {
-    btn.classList.add('hidden');
-  } else {
-    btn.classList.remove('hidden');
+  if (btn) {
+    if (models.length < 6) {
+      btn.classList.add('hidden');
+    } else {
+      btn.classList.remove('hidden');
+    }
   }
 }
 
@@ -199,8 +188,10 @@ function renderGrid(type, filters = getFilters()) {
     state.models.forEach((m) => grid.appendChild(createCard(m)));
     captureSnapshots(grid);
     const btn = document.getElementById(`${type}-load`);
-    if (state.models.length < 6) btn.classList.add('hidden');
-    else btn.classList.remove('hidden');
+    if (btn) {
+      if (state.models.length < 6) btn.classList.add('hidden');
+      else btn.classList.remove('hidden');
+    }
   } else {
     loadMore(type, filters);
   }

--- a/js/payment.js
+++ b/js/payment.js
@@ -239,8 +239,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   loader.hidden = false;
-  viewer.src =
-    localStorage.getItem('print3Model') || localStorage.getItem('print2Model') || FALLBACK_GLB;
+  viewer.src = localStorage.getItem('print3Model') || FALLBACK_GLB;
 
   // Hide the overlay if nothing happens after a short delay
   setTimeout(hideLoader, 7000);


### PR DESCRIPTION
## Summary
- clean up duplicate `prefetchedModels` declaration so community page JS loads
- default payment viewer to the generated model only
- avoid errors when community load buttons are missing

## Testing
- `npm ci --prefix backend`
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_6845aa1fbef4832d9ff9a6d905ce8991