### PR TITLE
Fix portrait layout issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,35 +130,35 @@
         <!-- social buttons -->
         <div class="flex space-x-2">
           <button
-            class="w-9 h-9 flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-full hover:bg-[#3A3A3E] transition-shape"
+            class="w-9 h-9 flex-shrink-0 flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-full hover:bg-[#3A3A3E] transition-shape"
             onclick="shareOn('twitter')"
             aria-label="Share on Twitter"
           >
             <i class="fab fa-twitter"></i>
           </button>
           <button
-            class="w-9 h-9 flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-full hover:bg-[#3A3A3E] transition-shape"
+            class="w-9 h-9 flex-shrink-0 flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-full hover:bg-[#3A3A3E] transition-shape"
             onclick="shareOn('facebook')"
             aria-label="Share on Facebook"
           >
             <i class="fab fa-facebook-f"></i>
           </button>
           <button
-            class="w-9 h-9 flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-full hover:bg-[#3A3A3E] transition-shape"
+            class="w-9 h-9 flex-shrink-0 flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-full hover:bg-[#3A3A3E] transition-shape"
             onclick="shareOn('reddit')"
             aria-label="Share on Reddit"
           >
             <i class="fab fa-reddit-alien"></i>
           </button>
           <button
-            class="w-9 h-9 flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-full hover:bg-[#3A3A3E] transition-shape"
+            class="w-9 h-9 flex-shrink-0 flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-full hover:bg-[#3A3A3E] transition-shape"
             onclick="shareOn('tiktok')"
             aria-label="Share on TikTok"
           >
             <i class="fab fa-tiktok"></i>
           </button>
           <button
-            class="w-9 h-9 flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-full hover:bg-[#3A3A3E] transition-shape"
+            class="w-9 h-9 flex-shrink-0 flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-full hover:bg-[#3A3A3E] transition-shape"
             onclick="shareOn('instagram')"
             aria-label="Share on Instagram"
           >
@@ -243,10 +243,12 @@
         <!-- subreddit quote -->
         <div
           id="subreddit-quote"
-          class="absolute left-full ml-4 flex text-sm text-gray-400 text-left leading-snug invisible"
+          class="flex text-sm text-gray-400 text-left leading-snug invisible mt-2 lg:mt-0 lg:absolute lg:left-full lg:ml-4 lg:max-w-none"
+          style="max-width: 22ch"
         >
-          <p class="whitespace-nowrap">
-            "I'm astonished at how high-quality the print<br />is" – email from an
+          <p class="lg:whitespace-nowrap">
+            "I'm astonished at how high-quality the print
+            <br class="hidden lg:block" />is" – email from an
             <span class="text-white">r/subreddit</span> user
           </p>
         </div>
@@ -335,6 +337,11 @@
         const quote = document.getElementById('subreddit-quote');
         const checkout = document.getElementById('checkout-button');
         if (!quote || !checkout) return;
+
+        if (getComputedStyle(quote).position !== 'absolute') {
+          quote.classList.remove('invisible');
+          return;
+        }
 
         // bounding rectangles relative to viewport
         const wrapperRect = checkout.parentElement.getBoundingClientRect();


### PR DESCRIPTION
## Summary
- adjust quote block layout for narrow screens
- ensure share buttons keep their size on mobile
- only position quote absolutely when needed

## Testing
- `npm run format` (from `backend/`)
- `npm test` *(fails: SyntaxError Cannot use import statement outside a module)*
- `npm run test-ci` *(fails: SyntaxError Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_6845d1829b94832daf5c468545dabe0f