### PR TITLE
Add signup page based on profile layout

### DIFF
--- a/signup_profile.html
+++ b/signup_profile.html
@@ -1,0 +1,76 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sign Up</title>
+    <meta property="og:title" content="Sign Up – print3" />
+    <meta
+      property="og:description"
+      content="Access your print3 account to manage models and orders."
+    />
+    <meta property="og:image" content="img/boxlogo.png" />
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body class="bg-[#1A1A1D] text-white font-sans flex flex-col min-h-screen">
+    <header class="relative flex items-center justify-between py-4 px-6">
+      <a
+        href="profile.html"
+        class="inline-flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-3xl px-5 py-2 text-lg font-medium hover:bg-[#3A3A3E] transition-shape"
+      >
+        <svg
+          class="w-4 h-4 mr-2 flex-shrink-0"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+        >
+          <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+        </svg>
+        Back
+      </a>
+      <h1
+        class="absolute inset-x-0 top-1/2 -translate-y-1/2 text-center text-2xl font-semibold pointer-events-none"
+      >
+        Sign Up
+      </h1>
+      <span class="w-9 h-9"></span>
+    </header>
+    <main class="flex-1 flex items-center justify-center">
+      <form
+        id="signupForm"
+        class="space-y-4 bg-[#2A2A2E] border border-white/10 p-6 rounded-3xl w-96"
+        aria-label="Sign up form"
+      >
+        <input
+          id="su-email"
+          type="email"
+          class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10 text-gray-300"
+          placeholder="Email"
+          aria-label="Email"
+        />
+        <input
+          id="su-name"
+          class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10 text-gray-300"
+          placeholder="Username"
+          aria-label="Username"
+        />
+        <input
+          id="su-pass"
+          type="password"
+          class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10 text-gray-300"
+          placeholder="Password"
+          aria-label="Password"
+        />
+        <div id="error" class="text-red-400" aria-live="assertive"></div>
+        <button
+          class="bg-[#30D5C8] text-[#1A1A1D] font-semibold px-4 py-2 rounded-xl hover:bg-[#28b7a8] transition"
+          type="submit"
+        >
+          Sign Up
+        </button>
+      </form>
+    </main>
+    <script type="module" src="js/signup.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add **signup_profile.html** copied from the profile layout
- tweak title, header text and back button link
- include email/username/password inputs with grey text
- change button label to `Sign Up`
- link the sign-up script

## Testing
- `npm test --silent --runInBand` *(fails: community.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_6845fbc96998832da9029b0134058766