### PR TITLE
Add share buttons to signup page

### DIFF
--- a/signup.html
+++ b/signup.html
@@ -11,6 +11,10 @@
     />
     <meta property="og:image" content="img/boxlogo.png" />
     <script src="https://cdn.tailwindcss.com"></script>
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css"
+    />
   </head>
   <body class="bg-[#1A1A1D] text-white font-sans flex flex-col min-h-screen">
     <header class="relative flex items-center justify-between py-4 px-6">
@@ -34,7 +38,43 @@
       >
         Sign Up
       </h1>
-      <span class="w-9 h-9"></span>
+      <div class="flex space-x-2">
+        <button
+          class="w-9 h-9 flex-shrink-0 flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-full hover:bg-[#3A3A3E] transition-shape"
+          onclick="shareOn('twitter')"
+          aria-label="Share on Twitter"
+        >
+          <i class="fab fa-twitter"></i>
+        </button>
+        <button
+          class="w-9 h-9 flex-shrink-0 flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-full hover:bg-[#3A3A3E] transition-shape"
+          onclick="shareOn('facebook')"
+          aria-label="Share on Facebook"
+        >
+          <i class="fab fa-facebook-f"></i>
+        </button>
+        <button
+          class="w-9 h-9 flex-shrink-0 flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-full hover:bg-[#3A3A3E] transition-shape"
+          onclick="shareOn('reddit')"
+          aria-label="Share on Reddit"
+        >
+          <i class="fab fa-reddit-alien"></i>
+        </button>
+        <button
+          class="w-9 h-9 flex-shrink-0 flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-full hover:bg-[#3A3A3E] transition-shape"
+          onclick="shareOn('tiktok')"
+          aria-label="Share on TikTok"
+        >
+          <i class="fab fa-tiktok"></i>
+        </button>
+        <button
+          class="w-9 h-9 flex-shrink-0 flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-full hover:bg-[#3A3A3E] transition-shape"
+          onclick="shareOn('instagram')"
+          aria-label="Share on Instagram"
+        >
+          <i class="fab fa-instagram"></i>
+        </button>
+      </div>
     </header>
     <main class="flex-1 flex items-center justify-center">
       <form
@@ -72,5 +112,9 @@
       </form>
     </main>
     <script type="module" src="js/signup.js"></script>
+    <script type="module">
+      import { shareOn } from './js/share.js';
+      window.shareOn = shareOn;
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- include Font Awesome stylesheet
- add 5 social share buttons to signup header
- load share.js so buttons work

## Testing
- `npm test --silent` *(fails: community.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_684601ab1b94832dbd3901dfd0f3a041