### PR TITLE
Add sign up/login links on competitions page

### DIFF
--- a/competitions.html
+++ b/competitions.html
@@ -89,7 +89,12 @@
           Put your modelling skills to the test! Enter our themed contests, climb the leaderboard
           and win free prints.
         </p>
-        <p>Sign up or log in to submit your best designs.</p>
+        <p>
+          <a href="signup.html" class="font-bold text-[#30D5C8]">Sign Up</a>
+          or
+          <a href="profile.html" class="font-bold text-[#30D5C8]">Log In</a>
+          to submit your best designs.
+        </p>
       </section>
       <h2 class="text-2xl">Active Competitions</h2>
       <div id="list" class="space-y-4"></div>


### PR DESCRIPTION
## Summary
- make sign up and log in links on competitions page bold blue like other pages

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684608a5dd20832d9257cfe85c0e41b1