### PR TITLE
Add infinite scroll for profile models

### DIFF
--- a/my_profile.html
+++ b/my_profile.html
@@ -92,6 +92,7 @@
         <p><strong>Email:</strong> <span id="mp-email"></span></p>
       </div>
       <div id="models" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4"></div>
+      <div id="models-sentinel" class="h-8"></div>
     </main>
     <div
       id="model-modal"


### PR DESCRIPTION
## Summary
- display user model list with infinite scroll on `my_profile.html`
- load models in pages via IntersectionObserver in `js/my_profile.js`

## Testing
- `npm install`
- `npm test`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_684618c1c220832da5e1454fce4906f7