### PR TITLE
Add load more buttons for community creations

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -129,6 +129,12 @@
         <h2 class="text-xl font-semibold mb-4">Popular Now</h2>
         <div id="popular-grid" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4"></div>
         <div id="popular-sentinel" class="h-8"></div>
+        <button
+          id="popular-load"
+          class="mt-4 px-4 py-2 bg-[#2A2A2E] border border-white/20 rounded-lg mx-auto block"
+        >
+          More
+        </button>
       </section>
 
       <!-- Recent Creations -->
@@ -136,6 +142,12 @@
         <h2 class="text-xl font-semibold mb-4">Recent</h2>
         <div id="recent-grid" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4"></div>
         <div id="recent-sentinel" class="h-8"></div>
+        <button
+          id="recent-load"
+          class="mt-4 px-4 py-2 bg-[#2A2A2E] border border-white/20 rounded-lg mx-auto block"
+        >
+          More
+        </button>
       </section>
     </main>
 

--- a/js/community.js
+++ b/js/community.js
@@ -190,6 +190,9 @@ function renderGrid(type, filters = getFilters()) {
   state.loading = false;
 }
 
+// IntersectionObserver support has been removed in favor of explicit "More"
+// buttons. The following function is left in place for potential future use
+// but is no longer invoked.
 function createObserver(type) {
   const sentinel = document.getElementById(`${type}-sentinel`);
   if (!sentinel) return;
@@ -207,6 +210,11 @@ function init() {
     recent: { offset: 0, done: false, loading: false, observer: null },
     popular: { offset: 0, done: false, loading: false, observer: null },
   };
+
+  const popBtn = document.getElementById('popular-load');
+  if (popBtn) popBtn.addEventListener('click', () => loadMore('popular'));
+  const recentBtn = document.getElementById('recent-load');
+  if (recentBtn) recentBtn.addEventListener('click', () => loadMore('recent'));
   document.getElementById('category').addEventListener('change', () => {
     document.getElementById('recent-grid').innerHTML = '';
     document.getElementById('popular-grid').innerHTML = '';
@@ -214,8 +222,6 @@ function init() {
       recent: { offset: 0, done: false, loading: false, observer: null },
       popular: { offset: 0, done: false, loading: false, observer: null },
     };
-    createObserver('popular');
-    createObserver('recent');
     loadMore('popular');
     loadMore('recent');
   });
@@ -228,8 +234,6 @@ function init() {
         recent: { offset: 0, done: false, loading: false, observer: null },
         popular: { offset: 0, done: false, loading: false, observer: null },
       };
-      createObserver('popular');
-      createObserver('recent');
       loadMore('popular');
       loadMore('recent');
     });
@@ -243,16 +247,12 @@ function init() {
         recent: { offset: 0, done: false, loading: false, observer: null },
         popular: { offset: 0, done: false, loading: false, observer: null },
       };
-      createObserver('popular');
-      createObserver('recent');
       loadMore('popular');
       loadMore('recent');
     }
 
     searchInput.addEventListener('input', debounce(onSearchInput, SEARCH_DELAY));
   }
-  createObserver('popular');
-  createObserver('recent');
   loadMore('popular');
   loadMore('recent');
 }


### PR DESCRIPTION
## Summary
- add 'More' buttons under popular and recent sections on Community Creations page
- hook the buttons up in `community.js`
- drop the automatic IntersectionObserver loading

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684619d4c404832dae03cc3fff1bd97f