### PR TITLE
Add discount code validation API

### DIFF
--- a/backend/discountCodes.js
+++ b/backend/discountCodes.js
@@ -1,0 +1,12 @@
+const DISCOUNT_CODES = {
+  SAVE5: 500,
+  SAVE10: 1000,
+};
+
+function validateDiscountCode(code) {
+  if (!code) return null;
+  const key = String(code).trim().toUpperCase();
+  return DISCOUNT_CODES[key] || null;
+}
+
+module.exports = { validateDiscountCode };

--- a/backend/server.js
+++ b/backend/server.js
@@ -20,6 +20,7 @@ const stripe = require('stripe')(config.stripeKey);
 const { enqueuePrint, processQueue, progressEmitter } = require('./queue/printQueue');
 const { sendMail } = require('./mail');
 const { getShippingEstimate } = require('./shipping');
+const { validateDiscountCode } = require('./discountCodes');
 const ADMIN_TOKEN = process.env.ADMIN_TOKEN || 'admin';
 
 const AUTH_SECRET = process.env.AUTH_SECRET || 'secret';
@@ -760,6 +761,22 @@ app.post('/api/shipping-estimate', async (req, res) => {
     console.error(err);
     res.status(500).json({ error: 'Failed to get shipping estimate' });
   }
+});
+
+/**
+ * POST /api/discount-code
+ * Validate a discount code and return the amount in cents
+ */
+app.post('/api/discount-code', (req, res) => {
+  const { code } = req.body;
+  if (!code) {
+    return res.status(400).json({ error: 'code required' });
+  }
+  const amount = validateDiscountCode(code);
+  if (!amount) {
+    return res.status(404).json({ error: 'Invalid code' });
+  }
+  res.json({ discount: amount });
 });
 
 /**

--- a/backend/tests/api.test.js
+++ b/backend/tests/api.test.js
@@ -452,3 +452,19 @@ test('POST /api/shipping-estimate returns mocked values and calls helper', async
   expect(res.body.etaDays).toBe(4);
   expect(getShippingEstimate).toHaveBeenCalledWith(body.destination, body.model);
 });
+
+test('POST /api/discount-code returns discount', async () => {
+  const res = await request(app).post('/api/discount-code').send({ code: 'SAVE5' });
+  expect(res.status).toBe(200);
+  expect(res.body.discount).toBe(500);
+});
+
+test('POST /api/discount-code invalid', async () => {
+  const res = await request(app).post('/api/discount-code').send({ code: 'BAD' });
+  expect(res.status).toBe(404);
+});
+
+test('POST /api/discount-code requires code', async () => {
+  const res = await request(app).post('/api/discount-code').send({});
+  expect(res.status).toBe(400);
+});


### PR DESCRIPTION
## Summary
- create a helper for discount codes
- expose POST `/api/discount-code` endpoint
- test discount code validation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68461b7dc470832da0d0d092cc7ecd50