### PR TITLE
Add email validation on signup

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -24,6 +24,10 @@ const ADMIN_TOKEN = process.env.ADMIN_TOKEN || 'admin';
 
 const AUTH_SECRET = process.env.AUTH_SECRET || 'secret';
 
+function isValidEmail(email) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
 // Array of subreddit quote entries stored server-side
 let subredditModels = [];
 try {
@@ -73,6 +77,9 @@ app.post('/api/register', async (req, res) => {
   const { username, email, password } = req.body;
   if (!username || !email || !password) {
     return res.status(400).json({ error: 'Missing fields' });
+  }
+  if (!isValidEmail(email)) {
+    return res.status(400).json({ error: 'Invalid email' });
   }
   try {
     const hash = await bcrypt.hash(password, 10);

--- a/backend/tests/api.test.js
+++ b/backend/tests/api.test.js
@@ -305,6 +305,13 @@ test('registration missing password', async () => {
   expect(res.status).toBe(400);
 });
 
+test('registration invalid email', async () => {
+  const res = await request(app)
+    .post('/api/register')
+    .send({ username: 'a', email: 'invalid', password: 'p' });
+  expect(res.status).toBe(400);
+});
+
 test('registration duplicate username', async () => {
   db.query.mockRejectedValueOnce(new Error('duplicate key'));
   const res = await request(app)

--- a/backend/tests/frontend/signup.test.js
+++ b/backend/tests/frontend/signup.test.js
@@ -26,6 +26,7 @@ describe('signup form', () => {
     dom.window.document.getElementById('su-pass').value = 'p';
     dom.window.document.getElementById('signupForm').dispatchEvent(new dom.window.Event('submit'));
     await new Promise((r) => setTimeout(r, 0));
-    expect(dom.window.document.getElementById('error').textContent).toBe('fail');
+    expect(dom.window.document.getElementById('error').textContent).toBe('Invalid email format');
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/js/profile.js
+++ b/js/profile.js
@@ -2,6 +2,10 @@ import { captureSnapshots } from './snapshot.js';
 
 const API_BASE = (window.API_ORIGIN || '') + '/api';
 
+function isValidEmail(email) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
 function createCard(model) {
   const div = document.createElement('div');
   div.className =
@@ -39,6 +43,11 @@ async function createAccount(e) {
     if (!username) nameEl.classList.add('border-red-500');
     if (!email) emailEl.classList.add('border-red-500');
     if (!password) passEl.classList.add('border-red-500');
+    return;
+  }
+  if (!isValidEmail(email)) {
+    document.getElementById('ca-error').textContent = 'Invalid email format';
+    emailEl.classList.add('border-red-500');
     return;
   }
   const res = await fetch(`${API_BASE}/register`, {

--- a/js/signup.js
+++ b/js/signup.js
@@ -1,5 +1,9 @@
 const API_BASE = (window.API_ORIGIN || '') + '/api';
 
+function isValidEmail(email) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
 async function signup(e) {
   e.preventDefault();
   const nameEl = document.getElementById('su-name');
@@ -16,6 +20,11 @@ async function signup(e) {
     if (!username) nameEl.classList.add('border-red-500');
     if (!email) emailEl.classList.add('border-red-500');
     if (!password) passEl.classList.add('border-red-500');
+    return;
+  }
+  if (!isValidEmail(email)) {
+    document.getElementById('error').textContent = 'Invalid email format';
+    emailEl.classList.add('border-red-500');
     return;
   }
   const res = await fetch(`${API_BASE}/register`, {


### PR DESCRIPTION
## Summary
- validate email format in server and front end
- check email validity when creating account in profile page
- update tests for invalid email handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68461c99a7b4832da2320b930d1cde96