### PR TITLE
Implement automatic model title generation

### DIFF
--- a/backend/migrations/022_add_generated_title_to_jobs.sql
+++ b/backend/migrations/022_add_generated_title_to_jobs.sql
@@ -1,0 +1,2 @@
+ALTER TABLE jobs
+  ADD COLUMN IF NOT EXISTS generated_title TEXT;

--- a/backend/server.js
+++ b/backend/server.js
@@ -175,10 +175,12 @@ app.post('/api/generate', authOptional, upload.array('images'), async (req, res)
     }
 
     const autoTitle = generateTitle(prompt);
-    await db.query(
-      'UPDATE jobs SET status=$1, model_url=$2, generated_title=$3 WHERE job_id=$4',
-      ['complete', generatedUrl, autoTitle, jobId]
-    );
+    await db.query('UPDATE jobs SET status=$1, model_url=$2, generated_title=$3 WHERE job_id=$4', [
+      'complete',
+      generatedUrl,
+      autoTitle,
+      jobId,
+    ]);
 
     res.json({ jobId, glb_url: generatedUrl });
   } catch (err) {

--- a/backend/utils/generateTitle.js
+++ b/backend/utils/generateTitle.js
@@ -1,0 +1,23 @@
+function generateTitle(prompt = '') {
+  if (typeof prompt !== 'string' || !prompt.trim()) return 'Untitled Model';
+
+  // remove punctuation except spaces
+  const cleaned = prompt.replace(/[^\w\s]/g, '');
+  const words = cleaned.split(/\s+/).filter(Boolean);
+  if (!words.length) return 'Untitled Model';
+
+  // pick up to first 3 nouns/keywords heuristically (just unique words)
+  const unique = [];
+  for (const w of words) {
+    const lower = w.toLowerCase();
+    if (!unique.includes(lower)) unique.push(lower);
+    if (unique.length >= 3) break;
+  }
+
+  const title = unique
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+  return title || 'Untitled Model';
+}
+
+module.exports = generateTitle;

--- a/backend/utils/generateTitle.js
+++ b/backend/utils/generateTitle.js
@@ -14,9 +14,7 @@ function generateTitle(prompt = '') {
     if (unique.length >= 3) break;
   }
 
-  const title = unique
-    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
-    .join(' ');
+  const title = unique.map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
   return title || 'Untitled Model';
 }
 


### PR DESCRIPTION
## Summary
- add a migration to store generated titles on jobs
- generate a short title from the prompt when a model is created
- use the generated title when submitting to the community gallery
- expose the generated title from the status endpoint
- add tests for the new behaviour

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68461d5dc228832db4660aec7fc10772