### PR TITLE
Auto-post new models to community gallery

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -186,6 +186,12 @@ app.post('/api/generate', authOptional, upload.array('images'), async (req, res)
       jobId,
     ]);
 
+    // Automatically add new models to the community gallery
+    await db.query(
+      'INSERT INTO community_creations(job_id, title, category) SELECT $1,$2,$3 WHERE NOT EXISTS (SELECT 1 FROM community_creations WHERE job_id=$1)',
+      [jobId, prompt || '', '']
+    );
+
     res.json({ jobId, glb_url: generatedUrl });
   } catch (err) {
     console.error(err);

--- a/backend/tests/api.test.js
+++ b/backend/tests/api.test.js
@@ -356,6 +356,13 @@ test('/api/generate saves authenticated user id', async () => {
   expect(insertCall[1][4]).toBe('u1');
 });
 
+test('/api/generate inserts community row', async () => {
+  axios.post.mockResolvedValueOnce({ data: { glb_url: '/m.glb' } });
+  await request(app).post('/api/generate').send({ prompt: 't' });
+  const communityCall = db.query.mock.calls.find((c) => c[0].includes('INSERT INTO community_creations'));
+  expect(communityCall).toBeDefined();
+});
+
 test('/api/status supports limit and offset', async () => {
   db.query.mockResolvedValueOnce({ rows: [] });
   await request(app).get('/api/status?limit=5&offset=2');


### PR DESCRIPTION
## Summary
- automatically insert new jobs into community_creations
- test that generating a model inserts into community table

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_68461f175a40832db6a8f2b2679960e2