### PR TITLE
Add CAC section to task list

### DIFF
--- a/docs/task_list.md
+++ b/docs/task_list.md
@@ -61,3 +61,8 @@
 - Build an admin interface or script for creating and retiring codes securely.
 - Track code usage for auditing and store codes safely (e.g., hashed).
 - Expand the test suite to cover valid, expired, and invalid discount codes.
+
+## Decreasing CAC
+
+- Add real photo of printed object or user-generated image to hero section to reinforce the physical product.
+- Display pricing info near the prompt field such as "From $X / print" to reduce hesitation.


### PR DESCRIPTION
## Summary
- add a **Decreasing CAC** section with tasks for showing real photos and pricing info

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6846a7731f34832da5548a316a887b01