### PR TITLE
Fix portrait preview on iPad

### DIFF
--- a/index.html
+++ b/index.html
@@ -327,7 +327,7 @@
             <!-- First preview thumbnail -->
             <div
               id="image-preview-area"
-              class="hidden w-24 bg-[#2A2A2E] border border-white/10 rounded-3xl overflow-visible flex items-center justify-center"
+              class="hidden w-24 bg-[#2A2A2E] border border-white/10 rounded-3xl overflow-hidden flex items-center justify-center"
             ></div>
           </div>
           <!-- ▲▲  UPDATED BLOCK ▲▲ -->


### PR DESCRIPTION
## Summary
- prevent uploaded image previews from overflowing their thumbnail box

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846b66cd880832dbfb614d43229e338