### PR TITLE
Fix portrait preview on iPad

### DIFF
--- a/index.html
+++ b/index.html
@@ -327,7 +327,7 @@
             <!-- First preview thumbnail -->
             <div
               id="image-preview-area"
-              class="hidden w-24 bg-[#2A2A2E] border border-white/10 rounded-3xl overflow-visible flex items-center justify-center"
+              class="hidden w-24 bg-[#2A2A2E] border border-white/10 rounded-3xl overflow-hidden flex items-center justify-center"
             ></div>
           </div>
           <!-- ▲▲  UPDATED BLOCK ▲▲ -->

--- a/js/index.js
+++ b/js/index.js
@@ -228,14 +228,18 @@ function renderThumbnails(arr) {
     wrap.className = 'relative';
     const img = document.createElement('img');
     img.src = url;
-    img.className = 'object-cover w-full h-full rounded-md shadow-md';
+    // Use object-contain so tall images fit within the square thumbnail
+    // without overflowing in Safari on iPad.
+    img.className = 'object-contain w-full h-full rounded-md shadow-md';
     wrap.appendChild(img);
 
     const btn = document.createElement('button');
     btn.type = 'button';
     btn.innerHTML = '<i class="fas fa-times"></i>';
+    // Position the remove button fully inside the preview box so it
+    // isn't clipped when the container has overflow-hidden.
     btn.className =
-      'absolute top-0 right-0 translate-x-1/2 -translate-y-1/2 w-6 h-6 rounded-full bg-white text-black border border-black flex items-center justify-center z-10';
+      'absolute top-1 right-1 w-6 h-6 rounded-full bg-white text-black border border-black flex items-center justify-center z-10';
     btn.onclick = () => {
       arr.splice(i, 1);
       uploadedFiles.splice(i, 1);


### PR DESCRIPTION
## Summary
- prevent portrait previews from overflowing by using `object-contain`

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6846b66cd880832dbfb614d43229e338