### PR TITLE
Fix remove button layering

### DIFF
--- a/index.html
+++ b/index.html
@@ -325,10 +325,10 @@
             </div>
 
             <!-- First preview thumbnail -->
-            <div
-              id="image-preview-area"
-              class="hidden bg-[#2A2A2E] border border-white/10 rounded-3xl overflow-hidden flex items-center justify-center"
-            ></div>
+              <div
+                id="image-preview-area"
+                class="hidden relative bg-[#2A2A2E] border border-white/10 rounded-3xl overflow-hidden flex items-center justify-center"
+              ></div>
           </div>
           <!-- ▲▲  UPDATED BLOCK ▲▲ -->
         </div>

--- a/js/index.js
+++ b/js/index.js
@@ -244,7 +244,7 @@ function renderThumbnails(arr) {
     // Keep the remove button inside the rounded corner so it isn't
     // clipped by overflow hidden on the preview box.
     btn.className =
-      'absolute top-2 right-2 w-6 h-6 rounded-full bg-white text-black border border-black flex items-center justify-center z-10';
+      'absolute top-2 right-2 w-6 h-6 rounded-full bg-white text-black border border-black flex items-center justify-center z-20';
     btn.onclick = () => {
       arr.splice(i, 1);
       uploadedFiles.splice(i, 1);


### PR DESCRIPTION
## Summary
- ensure the uploaded image preview container establishes a stacking context
- raise z-index of the thumbnail remove button so it sits above the image

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846dbefd244832da178eb16de3593c5