### PR TITLE
Reposition shipping note

### DIFF
--- a/index.html
+++ b/index.html
@@ -238,7 +238,7 @@
           <a
             id="checkout-button"
             href="payment.html"
-            class="absolute bottom-12 right-4 font-bold py-3 px-5 rounded-full shadow-md transition"
+            class="absolute bottom-8 right-4 font-bold py-3 px-5 rounded-full shadow-md transition"
             style="background-color: #1f3b65; color: #5ec2c5"
             onmouseover="this.style.opacity='0.85'"
             onmouseout="this.style.opacity='1'"
@@ -247,14 +247,14 @@
           </a>
           <button
             id="buy-now-button"
-            class="hidden absolute bottom-12 right-32 font-bold py-3 px-5 rounded-full shadow-md transition"
+            class="hidden absolute bottom-8 right-32 font-bold py-3 px-5 rounded-full shadow-md transition"
             style="background-color: #5ec2c5; color: #1f3b65"
           >
             Buy&nbsp;Now
           </button>
           <p
             id="shipping-note"
-            class="absolute bottom-4 right-4 text-sm text-gray-400"
+            class="absolute bottom-20 right-4 text-sm text-gray-400"
           >
             Free UK Shipping
           </p>


### PR DESCRIPTION
## Summary
- keep 'Free UK Shipping' note inside the 3-D viewer box
- move the note above the Print it for £25 button
- lower the £25 button so it no longer overlaps with the note

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6846e465d86c832da469ce3d2bde2b5f