### PR TITLE
Fix back buttons to use history navigation

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -35,7 +35,8 @@
     <!-- Header -->
     <header class="relative flex items-center justify-between py-4 px-6">
       <a
-        href="index.html"
+        href="javascript:void(0)"
+        onclick="goBack()"
         class="inline-flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-3xl px-5 py-2 text-lg font-medium hover:bg-[#3A3A3E] transition-shape"
       >
         <svg
@@ -195,9 +196,10 @@
       </div>
     </div>
     <script type="module">
-      import { shareOn } from './js/share.js';
+      import { shareOn, goBack } from './js/share.js';
       import { init } from './js/community.js';
       window.shareOn = shareOn;
+      window.goBack = goBack;
 
       document.addEventListener('DOMContentLoaded', () => {
         const modal = document.getElementById('model-modal');

--- a/competitions.html
+++ b/competitions.html
@@ -26,7 +26,8 @@
   <body class="bg-[#1A1A1D] text-white font-sans flex flex-col min-h-screen">
     <header class="relative flex items-center justify-between py-4 px-6">
       <a
-        href="index.html"
+        href="javascript:void(0)"
+        onclick="goBack()"
         class="inline-flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-3xl px-5 py-2 text-lg font-medium hover:bg-[#3A3A3E] transition-shape"
       >
         <svg
@@ -202,8 +203,9 @@
     </div>
     <script type="module" src="js/competitions.js"></script>
     <script type="module">
-      import { shareOn } from './js/share.js';
+      import { shareOn, goBack } from './js/share.js';
       window.shareOn = shareOn;
+      window.goBack = goBack;
 
       document.addEventListener('DOMContentLoaded', () => {
         const modal = document.getElementById('model-modal');

--- a/js/share.js
+++ b/js/share.js
@@ -69,7 +69,19 @@ async function shareOn(network) {
   window.open(shareUrl, '_blank', 'noopener');
 }
 
-if (typeof module !== 'undefined') {
-  module.exports = { shareOn };
+function goBack() {
+  if (document.referrer && document.referrer !== window.location.href) {
+    window.location.href = document.referrer;
+    return;
+  }
+  if (window.history.length > 1) {
+    window.history.back();
+  } else {
+    window.location.href = 'index.html';
+  }
 }
-export { shareOn };
+
+if (typeof module !== 'undefined') {
+  module.exports = { shareOn, goBack };
+}
+export { shareOn, goBack };

--- a/login.html
+++ b/login.html
@@ -19,7 +19,8 @@
   <body class="bg-[#1A1A1D] text-white font-sans flex flex-col min-h-screen">
     <header class="relative flex items-center justify-between py-4 px-6">
       <a
-        href="index.html"
+        href="javascript:void(0)"
+        onclick="goBack()"
         class="inline-flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-3xl px-5 py-2 text-lg font-medium hover:bg-[#3A3A3E] transition-shape"
       >
         <svg
@@ -112,8 +113,9 @@
     </main>
     <script type="module" src="js/login.js"></script>
     <script type="module">
-      import { shareOn } from './js/share.js';
+      import { shareOn, goBack } from './js/share.js';
       window.shareOn = shareOn;
+      window.goBack = goBack;
     </script>
   </body>
 </html>

--- a/my_profile.html
+++ b/my_profile.html
@@ -20,7 +20,8 @@
   <body class="bg-[#1A1A1D] text-white font-sans flex flex-col min-h-screen">
     <header class="relative flex items-center justify-between py-4 px-6">
       <a
-        href="index.html"
+        href="javascript:void(0)"
+        onclick="goBack()"
         class="inline-flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-3xl px-5 py-2 text-lg font-medium hover:bg-[#3A3A3E] transition-shape"
       >
         <svg
@@ -131,8 +132,9 @@
     <script type="module" src="js/account.js"></script>
     <script type="module" src="js/my_profile.js"></script>
     <script type="module">
-      import { shareOn } from './js/share.js';
+      import { shareOn, goBack } from './js/share.js';
       window.shareOn = shareOn;
+      window.goBack = goBack;
     </script>
   </body>
 </html>

--- a/payment.html
+++ b/payment.html
@@ -64,7 +64,8 @@
     <!-- ─────────── Header -->
     <header class="relative z-10 px-6 py-4">
       <a
-        href="index.html"
+        href="javascript:void(0)"
+        onclick="goBack()"
         class="inline-flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-3xl px-5 py-2 text-lg font-medium hover:bg-[#3A3A3E] transition-shape"
       >
         <svg
@@ -220,5 +221,9 @@
     <!-- ─────────── Init -->
     <script src="js/modelViewerTouchFix.js"></script>
     <script type="module" src="js/payment.js"></script>
+    <script type="module">
+      import { goBack } from './js/share.js';
+      window.goBack = goBack;
+    </script>
   </body>
 </html>

--- a/profile.html
+++ b/profile.html
@@ -21,7 +21,8 @@
   <body class="bg-[#1A1A1D] text-white font-sans flex flex-col min-h-screen">
     <header class="relative flex items-center justify-between py-4 px-6">
       <a
-        href="index.html"
+        href="javascript:void(0)"
+        onclick="goBack()"
         class="inline-flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-3xl px-5 py-2 text-lg font-medium hover:bg-[#3A3A3E] transition-shape"
       >
         <svg
@@ -177,8 +178,9 @@
     </div>
     <script type="module" src="js/profile.js"></script>
     <script type="module">
-      import { shareOn } from './js/share.js';
+      import { shareOn, goBack } from './js/share.js';
       window.shareOn = shareOn;
+      window.goBack = goBack;
     </script>
   </body>
 </html>

--- a/share.html
+++ b/share.html
@@ -19,14 +19,16 @@
     <script src="js/modelViewerTouchFix.js"></script>
     <script type="module" src="js/sharedModel.js"></script>
     <script type="module">
-      import { shareOn } from './js/share.js';
+      import { shareOn, goBack } from './js/share.js';
       window.shareOn = shareOn;
+      window.goBack = goBack;
     </script>
   </head>
   <body class="bg-[#1A1A1D] text-white font-sans flex flex-col min-h-screen">
     <header class="p-4 flex justify-between items-center">
       <a
-        href="index.html"
+        href="javascript:void(0)"
+        onclick="goBack()"
         class="flex items-center bg-[#2A2A2E] px-3 py-1 rounded-xl hover:bg-[#3A3A3E] transition"
       >
         <i class="fas fa-arrow-left mr-2"></i>Back

--- a/signup.html
+++ b/signup.html
@@ -19,7 +19,8 @@
   <body class="bg-[#1A1A1D] text-white font-sans flex flex-col min-h-screen">
     <header class="relative flex items-center justify-between py-4 px-6">
       <a
-        href="login.html"
+        href="javascript:void(0)"
+        onclick="goBack()"
         class="inline-flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-3xl px-5 py-2 text-lg font-medium hover:bg-[#3A3A3E] transition-shape"
       >
         <svg
@@ -113,8 +114,9 @@
     </main>
     <script type="module" src="js/signup.js"></script>
     <script type="module">
-      import { shareOn } from './js/share.js';
+      import { shareOn, goBack } from './js/share.js';
       window.shareOn = shareOn;
+      window.goBack = goBack;
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add a `goBack` helper in `share.js`
- link all top-left back buttons to `goBack`
- expose `goBack` from each page

## Testing
- `npm test`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_6846e720e260832dbe4cf4846726ab3a