### PR TITLE
Fix shipping note alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -235,16 +235,19 @@
           </div>
 
           <!-- checkout + buy-now -->
-          <a
-            id="checkout-button"
-            href="payment.html"
-            class="absolute bottom-4 right-4 font-bold py-3 px-5 rounded-full shadow-md transition"
-            style="background-color: #1f3b65; color: #5ec2c5"
-            onmouseover="this.style.opacity='0.85'"
-            onmouseout="this.style.opacity='1'"
-          >
-            Print it for £25 →
-          </a>
+          <div id="checkout-container" class="absolute bottom-4 right-4 flex flex-col items-center">
+            <p id="shipping-note" class="mb-3 text-sm text-gray-400">Free UK Shipping</p>
+            <a
+              id="checkout-button"
+              href="payment.html"
+              class="font-bold py-3 px-5 rounded-full shadow-md transition"
+              style="background-color: #1f3b65; color: #5ec2c5"
+              onmouseover="this.style.opacity='0.85'"
+              onmouseout="this.style.opacity='1'"
+            >
+              Print it for £25 →
+            </a>
+          </div>
           <button
             id="buy-now-button"
             class="hidden absolute bottom-4 right-32 font-bold py-3 px-5 rounded-full shadow-md transition"
@@ -252,12 +255,6 @@
           >
             Buy&nbsp;Now
           </button>
-          <p
-            id="shipping-note"
-            class="absolute bottom-16 right-24 text-sm text-gray-400"
-          >
-            Free UK Shipping
-          </p>
         </section>
 
         <div
@@ -331,10 +328,10 @@
             </div>
 
             <!-- First preview thumbnail -->
-              <div
-                id="image-preview-area"
-                class="hidden relative bg-[#2A2A2E] border border-white/10 rounded-3xl overflow-hidden flex items-center justify-center"
-              ></div>
+            <div
+              id="image-preview-area"
+              class="hidden relative bg-[#2A2A2E] border border-white/10 rounded-3xl overflow-hidden flex items-center justify-center"
+            ></div>
           </div>
           <!-- ▲▲  UPDATED BLOCK ▲▲ -->
         </div>


### PR DESCRIPTION
## Summary
- align the 'Free UK Shipping' note directly above the £25 button
- move the note slightly further from the button

## Testing
- `npx prettier -w index.html`

------
https://chatgpt.com/codex/tasks/task_e_6846ec4ebe74832dbd8c0d7a80c3fd14