### PR TITLE
Optimize community page loading

### DIFF
--- a/js/community.js
+++ b/js/community.js
@@ -108,8 +108,7 @@ function createCard(model) {
     'model-card relative h-32 bg-[#2A2A2E] border border-white/10 rounded-xl hover:bg-[#3A3A3E] transition-shape flex items-center justify-center cursor-pointer';
   div.dataset.model = model.model_url;
   div.dataset.job = model.job_id;
-  div.innerHTML = `\n      <img src="${model.snapshot || ''}" alt="Model" class="w-full h-full object-contain pointer-events-none" />\n      <span class="sr-only">${model.title || 'Model'}</span>\n      <button class="like absolute bottom-1 right-1 text-xs bg-red-600 px-1 rounded">\u2665</button>\n      <span class="absolute bottom-8 right-1 text-xs bg-black/50 px-1 rounded" id="likes-${model.id}">${model.likes}</span>\n      <button class="purchase absolute bottom-1 left-1 font-bold text-sm py-1 px-2 rounded-full shadow-md transition" style="background-color: #1f3b65; color: #5ec2c5">Buy</button>`;
-  prefetchModel(model.model_url);
+  div.innerHTML = `\n      <img src="${model.snapshot || ''}" alt="Model" loading="lazy" fetchpriority="low" class="w-full h-full object-contain pointer-events-none" />\n      <span class="sr-only">${model.title || 'Model'}</span>\n      <button class="like absolute bottom-1 right-1 text-xs bg-red-600 px-1 rounded">\u2665</button>\n      <span class="absolute bottom-8 right-1 text-xs bg-black/50 px-1 rounded" id="likes-${model.id}">${model.likes}</span>\n      <button class="purchase absolute bottom-1 left-1 font-bold text-sm py-1 px-2 rounded-full shadow-md transition" style="background-color: #1f3b65; color: #5ec2c5">Buy</button>`;
   div.querySelector('.purchase').addEventListener('click', (e) => {
     e.stopPropagation();
     localStorage.setItem('print3Model', model.model_url);


### PR DESCRIPTION
## Summary
- preload fewer models by only prefetching on hover
- lazy-load community thumbnails

## Testing
- `npm run format` in `backend/`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846f227ec44832dad0be0d318a2b6ad