### PR TITLE
Add AGENT guidelines and Codex usage instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# AGENT GUIDELINES
+
+These guidelines apply to all automated agents (e.g. the Codex agent) working on this repository.
+
+## Mandatory steps
+1. **Install dependencies** – run `npm ci` inside `backend/`. If `backend/hunyuan_server/` contains a `package.json`, run `npm ci` there as well.
+2. **Format code** – run `npm run format` in `backend/` to apply Prettier formatting.
+3. **Run tests** – execute `npm test` in `backend/`. If tests cannot run because of environment limitations, mention this in the PR.
+4. **Limit scope** – only modify files related to the task. Do not change anything under `img/`, `models/`, or `uploads/` unless explicitly requested. Avoid editing `docs/` unless the task specifically involves documentation.
+
+## PR notes
+Include a short summary of your changes and how you validated them (formatting and test output).

--- a/README.md
+++ b/README.md
@@ -171,6 +171,18 @@ Run `npm run test-ci` for the same tests using a single process, which matches t
 Run `npm run format` in `backend/` to apply Prettier formatting before committing.
 For significant changes, please open an issue first to discuss what you would like to change. Be sure to follow the code style enforced by Prettier.
 
+## Using Codex
+
+We sometimes rely on automated agents (such as the Codex agent) to make small
+changes. Agents must follow the steps in [AGENTS.md](AGENTS.md) before opening a
+pull request:
+
+1. Install dependencies with `npm ci` inside `backend/` (and
+   `backend/hunyuan_server/` if present).
+2. Run `npm run format` in `backend/`.
+3. Run `npm test` in `backend/` and include the results in the PR description.
+4. Only modify files relevant to the task.
+
 ## ToDo List
 
 All open tasks are tracked in [docs/task_list.md](docs/task_list.md).


### PR DESCRIPTION
## Summary
- add `AGENTS.md` with steps for automated agents
- mention `AGENTS.md` in the README

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846f8f715c0832d852ee7d8b2465533