### PR TITLE
Implement last-chance exit overlay

### DIFF
--- a/backend/migrations/023_seed_reddit5_discount.sql
+++ b/backend/migrations/023_seed_reddit5_discount.sql
@@ -1,0 +1,3 @@
+INSERT INTO discount_codes(code, amount_cents, expires_at, max_uses)
+VALUES('REDDIT5', 100, NULL, NULL)
+ON CONFLICT (code) DO NOTHING;

--- a/backend/tests/frontend/exitOverlay.test.js
+++ b/backend/tests/frontend/exitOverlay.test.js
@@ -1,0 +1,45 @@
+/** @jest-environment node */
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+let html = fs.readFileSync(path.join(__dirname, '../../../payment.html'), 'utf8');
+html = html
+  .replace(/<script[^>]+src="https?:\/\/[^>]+><\/script>/g, '')
+  .replace(/<link[^>]+href="https?:\/\/[^>]+>/g, '')
+  .replace(/<script[^>]+src="js\/modelViewerTouchFix.js"[^>]*><\/script>/, '');
+
+describe('exit overlay', () => {
+  function setup() {
+    const dom = new JSDOM(html, {
+      runScripts: 'dangerously',
+      resources: 'usable',
+      url: 'http://localhost/',
+    });
+    global.window = dom.window;
+    global.document = dom.window.document;
+    const scriptSrc = fs.readFileSync(path.join(__dirname, '../../../js/payment.js'), 'utf8');
+    dom.window.eval(scriptSrc);
+    dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
+    return dom;
+  }
+
+  test('shows when triggered', () => {
+    const dom = setup();
+    const overlay = dom.window.document.getElementById('exit-overlay');
+    expect(overlay.classList.contains('hidden')).toBe(true);
+    dom.window.triggerExitOverlay();
+    expect(overlay.classList.contains('hidden')).toBe(false);
+  });
+
+  test('hides after countdown ends', async () => {
+    const dom = setup();
+    dom.window.localStorage.setItem('exitOfferEnd', String(Date.now() + 1000));
+    dom.window.startExitOverlay();
+    const overlay = dom.window.document.getElementById('exit-overlay');
+    expect(overlay.classList.contains('hidden')).toBe(false);
+    await new Promise((r) => setTimeout(r, 1100));
+    expect(overlay.classList.contains('hidden')).toBe(true);
+    expect(dom.window.localStorage.getItem('exitOfferEnd')).toBe('0');
+  });
+});

--- a/payment.html
+++ b/payment.html
@@ -234,6 +234,26 @@
       </div>
     </main>
 
+    <div
+      id="exit-overlay"
+      class="fixed inset-0 bg-black/80 flex items-center justify-center hidden z-50"
+    >
+      <div class="relative bg-white text-black p-6 rounded-xl w-80 text-center">
+        <button id="exit-close" class="absolute top-2 right-3 text-2xl">&times;</button>
+        <p class="mb-4 font-semibold">
+          Use code <span class="font-mono">REDDIT5</span> for 5% off—only valid for
+          the next <span id="exit-timer">5:00</span>.
+        </p>
+        <button
+          id="exit-apply"
+          type="button"
+          class="px-4 py-2 bg-[#30D5C8] text-[#1A1A1D] rounded-md hover:bg-[#28b7a8] transition"
+        >
+          Apply Code
+        </button>
+      </div>
+    </div>
+
     <!-- ─────────── Init -->
     <script src="js/modelViewerTouchFix.js"></script>
     <script type="module" src="js/payment.js"></script>


### PR DESCRIPTION
## Summary
- add exit-intent overlay markup on the payment page
- implement overlay timer and trigger logic in `payment.js`
- seed new `REDDIT5` discount code
- test overlay behaviour

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846fe163e58832d9a5e5c150dbf830e