### PR TITLE
Fix competition checkout button

### DIFF
--- a/competitions.html
+++ b/competitions.html
@@ -189,15 +189,22 @@
           auto-rotate
           class="w-full h-96 bg-[#2A2A2E] rounded-xl"
         ></model-viewer>
-        <a
-          id="modal-checkout"
-          href="payment.html"
-          class="absolute bottom-4 right-4 font-bold py-3 px-5 rounded-full shadow-md transition"
-          style="background-color: #1f3b65; color: #5ec2c5"
-          onmouseover="this.style.opacity='0.85'"
-          onmouseout="this.style.opacity='1'"
-          >Checkout</a
+        <div
+          id="modal-checkout-container"
+          class="absolute bottom-4 right-4 flex flex-col items-center"
         >
+          <p class="mb-3 text-sm text-gray-400">Free UK Shipping</p>
+          <a
+            id="modal-checkout"
+            href="payment.html"
+            class="font-bold py-3 px-5 rounded-full shadow-md transition"
+            style="background-color: #1f3b65; color: #5ec2c5"
+            onmouseover="this.style.opacity='0.85'"
+            onmouseout="this.style.opacity='1'"
+          >
+            Print it for £25 →
+          </a>
+        </div>
       </div>
     </div>
     <script type="module" src="js/competitions.js"></script>


### PR DESCRIPTION
## Summary
- add shipping message and £25 checkout button on competitions page

## Testing
- `npm ci` *(fails: npm not found)*
- `npm test` *(fails: npm not found)*


------
https://chatgpt.com/codex/tasks/task_e_684706129eb0832d9b4213c75402ff8f