### PR TITLE
Fix Jest open-handle hang + stabilise CI

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -8,6 +8,10 @@ on:
 
 jobs:
   build:
+    timeout-minutes: 20
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
 
     steps:

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  setupFiles: ['<rootDir>/tests/setup.js', 'jest-localstorage-mock'],
+  detectOpenHandles: true,
+  verbose: true,
+};

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -29,6 +29,7 @@
       "devDependencies": {
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^30.0.0-beta.3",
+        "jest-localstorage-mock": "^2.4.26",
         "jsdom": "^23.0.0",
         "prettier": "^3.1.0",
         "supertest": "^7.1.1"
@@ -4262,6 +4263,16 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-localstorage-mock": {
+      "version": "2.4.26",
+      "resolved": "https://registry.npmjs.org/jest-localstorage-mock/-/jest-localstorage-mock-2.4.26.tgz",
+      "integrity": "sha512-owAJrYnjulVlMIXOYQIPRCCn3MmqI3GzgfZCXdD3/pmwrIvFMXcKVWZ+aMc44IzaASapg0Z4SEFxR+v5qxDA2w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=6.16.0"
       }
     },
     "node_modules/jest-matcher-utils": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,7 @@
   "main": "server.js",
   "scripts": {
     "test": "jest",
-    "test-ci": "jest --runInBand",
+    "test-ci": "jest --runInBand --detectOpenHandles",
     "start": "node server.js",
     "init-db": "node scripts/init-db.js",
     "migrate": "node scripts/run-migrations.js",
@@ -21,6 +21,7 @@
     "axios": "^1.9.0",
     "bcryptjs": "^2.4.3",
     "body-parser": "^2.2.0",
+    "compression": "^1.7.4",
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
@@ -32,21 +33,15 @@
     "nodemailer-sendgrid": "^1.0.0",
     "pg": "^8.16.0",
     "stripe": "^18.2.1",
-    "uuid": "^11.1.0",
-    "compression": "^1.7.4"
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^30.0.0-beta.3",
+    "jest-localstorage-mock": "^2.4.26",
     "jsdom": "^23.0.0",
     "prettier": "^3.1.0",
     "supertest": "^7.1.1"
-  },
-  "jest": {
-    "testEnvironment": "jsdom",
-    "setupFiles": [
-      "<rootDir>/tests/setup.js"
-    ]
   },
   "engines": {
     "node": ">=18"

--- a/backend/tests/frontend/competitions.test.js
+++ b/backend/tests/frontend/competitions.test.js
@@ -15,8 +15,10 @@ test('startCountdown closes past competitions', () => {
   dom.window.eval(script);
   const el = dom.window.document.getElementById('t');
   el.dataset.end = '2000-01-01';
-  dom.window.startCountdown(el);
+  const timer = dom.window.startCountdown(el);
   expect(el.textContent).toBe('Closed');
+  clearInterval(timer);
+  dom.window.close();
 });
 
 test('startCountdown formats remaining time', () => {
@@ -39,6 +41,8 @@ test('startCountdown formats remaining time', () => {
   const h = Math.floor((diff % 86400000) / 3600000);
   const m = Math.floor((diff % 3600000) / 60000);
   const expected = `${d}d ${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
-  dom.window.startCountdown(el);
+  const timer = dom.window.startCountdown(el);
   expect(el.textContent).toBe(expected);
+  clearInterval(timer);
+  dom.window.close();
 });

--- a/backend/tests/frontend/flashBanner.test.js
+++ b/backend/tests/frontend/flashBanner.test.js
@@ -29,6 +29,8 @@ describe('flash banner', () => {
     await new Promise((r) => setTimeout(r, 1100));
     expect(banner.hidden).toBe(true);
     expect(dom.window.localStorage.getItem('flashDiscountEnd')).toBe('0');
+    dom.window.clearTimeout(dom.window.flashTimerId);
+    dom.window.close();
   });
 
   test('does not restart after expiration', async () => {
@@ -49,6 +51,8 @@ describe('flash banner', () => {
     expect(end).toBe('0');
     const banner = dom.window.document.getElementById('flash-banner');
     expect(banner.hidden).toBe(true);
+    dom.window.clearTimeout(dom.window.flashTimerId);
+    dom.window.close();
   });
 
   test('countdown shows 4:59 after one second', async () => {
@@ -68,6 +72,8 @@ describe('flash banner', () => {
     expect(timerEl.textContent).toBe('5:00');
     await new Promise((r) => setTimeout(r, 1100));
     expect(timerEl.textContent).toBe('4:59');
+    dom.window.clearTimeout(dom.window.flashTimerId);
+    dom.window.close();
   });
 
   test('banner hidden when chance disabled', async () => {
@@ -86,5 +92,7 @@ describe('flash banner', () => {
     const banner = dom.window.document.getElementById('flash-banner');
     expect(banner.hidden).toBe(true);
     expect(dom.window.localStorage.getItem('flashDiscountEnd')).toBe(null);
+    dom.window.clearTimeout(dom.window.flashTimerId);
+    dom.window.close();
   });
 });

--- a/js/competitions.js
+++ b/js/competitions.js
@@ -117,6 +117,7 @@ function startCountdown(el) {
   }
   update();
   timer = setInterval(update, 60000);
+  return timer;
 }
 
 let currentId;

--- a/js/payment.js
+++ b/js/payment.js
@@ -224,6 +224,7 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     update();
     flashBanner.hidden = false;
+    return flashTimerId;
   }
   window.startFlashDiscount = startFlashDiscount;
 


### PR DESCRIPTION
## Summary
- enable Jest open handle detection and CI workflow timeouts
- return timer handles so tests can clean them up
- mock localStorage in tests

## Testing
- `npm run format`
- `npm run test-ci`

------
https://chatgpt.com/codex/tasks/task_e_684717b07b10832d98b10ad4e5cf3c83