### PR TITLE
Fix share.test localStorage mocking

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -29,6 +29,7 @@
       "devDependencies": {
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^30.0.0-beta.3",
+        "jest-localstorage-mock": "^2.4.26",
         "jsdom": "^23.0.0",
         "prettier": "^3.1.0",
         "supertest": "^7.1.1"
@@ -4262,6 +4263,16 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-localstorage-mock": {
+      "version": "2.4.26",
+      "resolved": "https://registry.npmjs.org/jest-localstorage-mock/-/jest-localstorage-mock-2.4.26.tgz",
+      "integrity": "sha512-owAJrYnjulVlMIXOYQIPRCCn3MmqI3GzgfZCXdD3/pmwrIvFMXcKVWZ+aMc44IzaASapg0Z4SEFxR+v5qxDA2w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=6.16.0"
       }
     },
     "node_modules/jest-matcher-utils": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -40,11 +40,13 @@
     "jest-environment-jsdom": "^30.0.0-beta.3",
     "jsdom": "^23.0.0",
     "prettier": "^3.1.0",
-    "supertest": "^7.1.1"
+    "supertest": "^7.1.1",
+    "jest-localstorage-mock": "^2.4.26"
   },
   "jest": {
     "testEnvironment": "jsdom",
     "setupFiles": [
+      "jest-localstorage-mock",
       "<rootDir>/tests/setup.js"
     ]
   },


### PR DESCRIPTION
## Summary
- add `jest-localstorage-mock` to dev deps
- load the localStorage mock in Jest config

## Testing
- `npm run format`
- `npm test` *(fails to exit cleanly due to open handles but all tests pass)*

------
https://chatgpt.com/codex/tasks/task_e_6847269c7b48832d907ed6f3e05307cb