### PR TITLE
Fix open handles in Jest tests

### DIFF
--- a/backend/tests/frontend/competitions.test.js
+++ b/backend/tests/frontend/competitions.test.js
@@ -13,10 +13,18 @@ test('startCountdown closes past competitions', () => {
     .replace(/document\.addEventListener\('DOMContentLoaded'[\s\S]+$/, '');
   script += '\nwindow.startCountdown = startCountdown;';
   dom.window.eval(script);
+  const intervalIds = [];
+  const origInterval = dom.window.setInterval.bind(dom.window);
+  dom.window.setInterval = (...args) => {
+    const id = origInterval(...args);
+    intervalIds.push(id);
+    return id;
+  };
   const el = dom.window.document.getElementById('t');
   el.dataset.end = '2000-01-01';
   dom.window.startCountdown(el);
   expect(el.textContent).toBe('Closed');
+  intervalIds.forEach((id) => dom.window.clearInterval(id));
 });
 
 test('startCountdown formats remaining time', () => {
@@ -29,6 +37,13 @@ test('startCountdown formats remaining time', () => {
     .replace(/document\.addEventListener\('DOMContentLoaded'[\s\S]+$/, '');
   script += '\nwindow.startCountdown = startCountdown;';
   dom.window.eval(script);
+  const intervalIds = [];
+  const origInterval = dom.window.setInterval.bind(dom.window);
+  dom.window.setInterval = (...args) => {
+    const id = origInterval(...args);
+    intervalIds.push(id);
+    return id;
+  };
   const el = dom.window.document.getElementById('t');
   const future = new Date(Date.now() + 2 * 86400000);
   el.dataset.end = future.toISOString().slice(0, 10);
@@ -41,4 +56,5 @@ test('startCountdown formats remaining time', () => {
   const expected = `${d}d ${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
   dom.window.startCountdown(el);
   expect(el.textContent).toBe(expected);
+  intervalIds.forEach((id) => dom.window.clearInterval(id));
 });

--- a/backend/tests/frontend/flashBanner.test.js
+++ b/backend/tests/frontend/flashBanner.test.js
@@ -18,6 +18,13 @@ describe('flash banner', () => {
     });
     global.window = dom.window;
     global.document = dom.window.document;
+    const timeouts = [];
+    const origTimeout = dom.window.setTimeout.bind(dom.window);
+    dom.window.setTimeout = (...args) => {
+      const id = origTimeout(...args);
+      timeouts.push(id);
+      return id;
+    };
     dom.window.sessionStorage.setItem('flashDiscountShow', '1');
     dom.window.localStorage.setItem('flashDiscountEnd', String(Date.now() + 1000));
     const scriptSrc = fs.readFileSync(path.join(__dirname, '../../../js/payment.js'), 'utf8');
@@ -29,6 +36,7 @@ describe('flash banner', () => {
     await new Promise((r) => setTimeout(r, 1100));
     expect(banner.hidden).toBe(true);
     expect(dom.window.localStorage.getItem('flashDiscountEnd')).toBe('0');
+    timeouts.forEach((id) => dom.window.clearTimeout(id));
   });
 
   test('does not restart after expiration', async () => {
@@ -39,6 +47,13 @@ describe('flash banner', () => {
     });
     global.window = dom.window;
     global.document = dom.window.document;
+    const timeouts = [];
+    const origTimeout = dom.window.setTimeout.bind(dom.window);
+    dom.window.setTimeout = (...args) => {
+      const id = origTimeout(...args);
+      timeouts.push(id);
+      return id;
+    };
     dom.window.sessionStorage.setItem('flashDiscountShow', '1');
     dom.window.localStorage.setItem('flashDiscountEnd', '0');
     const scriptSrc = fs.readFileSync(path.join(__dirname, '../../../js/payment.js'), 'utf8');
@@ -49,6 +64,7 @@ describe('flash banner', () => {
     expect(end).toBe('0');
     const banner = dom.window.document.getElementById('flash-banner');
     expect(banner.hidden).toBe(true);
+    timeouts.forEach((id) => dom.window.clearTimeout(id));
   });
 
   test('countdown shows 4:59 after one second', async () => {
@@ -59,6 +75,13 @@ describe('flash banner', () => {
     });
     global.window = dom.window;
     global.document = dom.window.document;
+    const timeouts = [];
+    const origTimeout = dom.window.setTimeout.bind(dom.window);
+    dom.window.setTimeout = (...args) => {
+      const id = origTimeout(...args);
+      timeouts.push(id);
+      return id;
+    };
     dom.window.sessionStorage.setItem('flashDiscountShow', '1');
     const scriptSrc = fs.readFileSync(path.join(__dirname, '../../../js/payment.js'), 'utf8');
     dom.window.eval(scriptSrc);
@@ -68,6 +91,7 @@ describe('flash banner', () => {
     expect(timerEl.textContent).toBe('5:00');
     await new Promise((r) => setTimeout(r, 1100));
     expect(timerEl.textContent).toBe('4:59');
+    timeouts.forEach((id) => dom.window.clearTimeout(id));
   });
 
   test('banner hidden when chance disabled', async () => {
@@ -78,6 +102,13 @@ describe('flash banner', () => {
     });
     global.window = dom.window;
     global.document = dom.window.document;
+    const timeouts = [];
+    const origTimeout = dom.window.setTimeout.bind(dom.window);
+    dom.window.setTimeout = (...args) => {
+      const id = origTimeout(...args);
+      timeouts.push(id);
+      return id;
+    };
     dom.window.sessionStorage.setItem('flashDiscountShow', '0');
     const scriptSrc = fs.readFileSync(path.join(__dirname, '../../../js/payment.js'), 'utf8');
     dom.window.eval(scriptSrc);
@@ -86,5 +117,6 @@ describe('flash banner', () => {
     const banner = dom.window.document.getElementById('flash-banner');
     expect(banner.hidden).toBe(true);
     expect(dom.window.localStorage.getItem('flashDiscountEnd')).toBe(null);
+    timeouts.forEach((id) => dom.window.clearTimeout(id));
   });
 });


### PR DESCRIPTION
## Summary
- ensure frontend tests clean up timers to avoid open handles
- updated competitions and flash banner tests

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684733bf3488832d9c7242d517afa560