### PR TITLE
Fix Jest open handles in frontend tests

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -29,6 +29,7 @@
       "devDependencies": {
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^30.0.0-beta.3",
+        "jest-localstorage-mock": "^2.4.21",
         "jsdom": "^23.0.0",
         "prettier": "^3.1.0",
         "supertest": "^7.1.1"
@@ -4262,6 +4263,16 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-localstorage-mock": {
+      "version": "2.4.21",
+      "resolved": "https://registry.npmjs.org/jest-localstorage-mock/-/jest-localstorage-mock-2.4.21.tgz",
+      "integrity": "sha512-IBXPBufnfPyr4VkoQeJ+zlfWlG84P0KbL4ejcV9j3xNI0v6OWznQlH6Ke9xjSarleR11090oSeWADSUow0PmFw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=6.16.0"
       }
     },
     "node_modules/jest-matcher-utils": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -21,6 +21,7 @@
     "axios": "^1.9.0",
     "bcryptjs": "^2.4.3",
     "body-parser": "^2.2.0",
+    "compression": "^1.7.4",
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
@@ -32,12 +33,12 @@
     "nodemailer-sendgrid": "^1.0.0",
     "pg": "^8.16.0",
     "stripe": "^18.2.1",
-    "uuid": "^11.1.0",
-    "compression": "^1.7.4"
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^30.0.0-beta.3",
+    "jest-localstorage-mock": "^2.4.21",
     "jsdom": "^23.0.0",
     "prettier": "^3.1.0",
     "supertest": "^7.1.1"

--- a/backend/tests/frontend/community.test.js
+++ b/backend/tests/frontend/community.test.js
@@ -3,8 +3,10 @@ const fs = require('fs');
 const path = require('path');
 const { JSDOM } = require('jsdom');
 
+let dom;
+
 function setup() {
-  const dom = new JSDOM('<!doctype html><html><body></body></html>', { runScripts: 'dangerously' });
+  dom = new JSDOM('<!doctype html><html><body></body></html>', { runScripts: 'dangerously' });
   global.window = dom.window;
   global.document = dom.window.document;
 
@@ -59,5 +61,11 @@ describe('community helpers', () => {
     dom.window.fetch = jest.fn(() => Promise.reject(new Error('fail')));
     const data = await dom.window.fetchCreations('recent');
     expect(data).toEqual([]);
+  });
+
+  afterEach(() => {
+    if (dom?.window?.close) dom.window.close();
+    delete global.window;
+    delete global.document;
   });
 });

--- a/backend/tests/frontend/competitions.test.js
+++ b/backend/tests/frontend/competitions.test.js
@@ -3,8 +3,10 @@ const fs = require('fs');
 const path = require('path');
 const { JSDOM } = require('jsdom');
 
+let dom;
+
 test('startCountdown closes past competitions', () => {
-  const dom = new JSDOM('<span id="t"></span>', { runScripts: 'dangerously' });
+  dom = new JSDOM('<span id="t"></span>', { runScripts: 'dangerously' });
   global.window = dom.window;
   global.document = dom.window.document;
   let script = fs
@@ -20,7 +22,7 @@ test('startCountdown closes past competitions', () => {
 });
 
 test('startCountdown formats remaining time', () => {
-  const dom = new JSDOM('<span id="t"></span>', { runScripts: 'dangerously' });
+  dom = new JSDOM('<span id="t"></span>', { runScripts: 'dangerously' });
   global.window = dom.window;
   global.document = dom.window.document;
   let script = fs
@@ -41,4 +43,10 @@ test('startCountdown formats remaining time', () => {
   const expected = `${d}d ${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
   dom.window.startCountdown(el);
   expect(el.textContent).toBe(expected);
+});
+
+afterEach(() => {
+  if (dom?.window?.close) dom.window.close();
+  delete global.window;
+  delete global.document;
 });

--- a/backend/tests/frontend/flashBanner.test.js
+++ b/backend/tests/frontend/flashBanner.test.js
@@ -3,6 +3,8 @@ const fs = require('fs');
 const path = require('path');
 const { JSDOM } = require('jsdom');
 
+let dom;
+
 let html = fs.readFileSync(path.join(__dirname, '../../../payment.html'), 'utf8');
 html = html
   .replace(/<script[^>]+src="https?:\/\/[^>]+><\/script>/g, '')
@@ -11,7 +13,7 @@ html = html
 
 describe('flash banner', () => {
   test('hides after countdown ends', async () => {
-    const dom = new JSDOM(html, {
+    dom = new JSDOM(html, {
       runScripts: 'dangerously',
       resources: 'usable',
       url: 'http://localhost/',
@@ -32,7 +34,7 @@ describe('flash banner', () => {
   });
 
   test('does not restart after expiration', async () => {
-    const dom = new JSDOM(html, {
+    dom = new JSDOM(html, {
       runScripts: 'dangerously',
       resources: 'usable',
       url: 'http://localhost/',
@@ -52,7 +54,7 @@ describe('flash banner', () => {
   });
 
   test('countdown shows 4:59 after one second', async () => {
-    const dom = new JSDOM(html, {
+    dom = new JSDOM(html, {
       runScripts: 'dangerously',
       resources: 'usable',
       url: 'http://localhost/',
@@ -71,7 +73,7 @@ describe('flash banner', () => {
   });
 
   test('banner hidden when chance disabled', async () => {
-    const dom = new JSDOM(html, {
+    dom = new JSDOM(html, {
       runScripts: 'dangerously',
       resources: 'usable',
       url: 'http://localhost/',
@@ -86,5 +88,11 @@ describe('flash banner', () => {
     const banner = dom.window.document.getElementById('flash-banner');
     expect(banner.hidden).toBe(true);
     expect(dom.window.localStorage.getItem('flashDiscountEnd')).toBe(null);
+  });
+
+  afterEach(() => {
+    if (dom?.window?.close) dom.window.close();
+    delete global.window;
+    delete global.document;
   });
 });

--- a/backend/tests/frontend/index.test.js
+++ b/backend/tests/frontend/index.test.js
@@ -3,6 +3,8 @@ const fs = require('fs');
 const path = require('path');
 const { JSDOM } = require('jsdom');
 
+let dom;
+
 let html = fs.readFileSync(path.join(__dirname, '../../../index.html'), 'utf8');
 html = html
   .replace(/<script[^>]+src="https?:\/\/[^>]+><\/script>/g, '')
@@ -14,7 +16,7 @@ html = html
 
 describe('index validatePrompt', () => {
   function setup() {
-    const dom = new JSDOM(html, {
+    dom = new JSDOM(html, {
       runScripts: 'dangerously',
       resources: 'usable',
       url: 'http://localhost/',
@@ -89,5 +91,11 @@ describe('index validatePrompt', () => {
     expect(dom.window.document.getElementById('gen-error').textContent).toBe(
       'Prompt must be under 200 characters'
     );
+  });
+
+  afterEach(() => {
+    if (dom?.window?.close) dom.window.close();
+    delete global.window;
+    delete global.document;
   });
 });

--- a/backend/tests/frontend/login.test.js
+++ b/backend/tests/frontend/login.test.js
@@ -3,6 +3,8 @@ const fs = require('fs');
 const path = require('path');
 const { JSDOM } = require('jsdom');
 
+let dom;
+
 let html = fs.readFileSync(path.join(__dirname, '../../../login.html'), 'utf8');
 html = html
   .replace(/<script[^>]+tailwind[^>]*><\/script>/, '')
@@ -10,7 +12,7 @@ html = html
 
 describe('login form', () => {
   test('shows error on failed login', async () => {
-    const dom = new JSDOM(html, {
+    dom = new JSDOM(html, {
       runScripts: 'dangerously',
       resources: 'usable',
       url: 'http://localhost/login.html',
@@ -30,5 +32,11 @@ describe('login form', () => {
     dom.window.document.getElementById('loginForm').dispatchEvent(new dom.window.Event('submit'));
     await new Promise((r) => setTimeout(r, 0));
     expect(dom.window.document.getElementById('error').textContent).toBe('fail');
+  });
+
+  afterEach(() => {
+    if (dom?.window?.close) dom.window.close();
+    delete global.window;
+    delete global.document;
   });
 });

--- a/backend/tests/frontend/profile.test.js
+++ b/backend/tests/frontend/profile.test.js
@@ -3,8 +3,10 @@ const fs = require('fs');
 const path = require('path');
 const { JSDOM } = require('jsdom');
 
+let dom;
+
 test('load displays models from API', async () => {
-  const dom = new JSDOM('<div id="models"></div>', {
+  dom = new JSDOM('<div id="models"></div>', {
     runScripts: 'dangerously',
     url: 'http://localhost/profile.html',
   });
@@ -27,4 +29,10 @@ test('load displays models from API', async () => {
   expect(children.length).toBe(1);
   expect(children[0].classList.contains('model-card')).toBe(true);
   expect(children[0].dataset.model).toBe('u');
+});
+
+afterEach(() => {
+  if (dom?.window?.close) dom.window.close();
+  delete global.window;
+  delete global.document;
 });

--- a/backend/tests/frontend/share.test.js
+++ b/backend/tests/frontend/share.test.js
@@ -3,9 +3,11 @@ const fs = require('fs');
 const path = require('path');
 const { JSDOM } = require('jsdom');
 
+let dom;
+
 describe('shareOn', () => {
   function load() {
-    const dom = new JSDOM('<!doctype html><html><body></body></html>', {
+    dom = new JSDOM('<!doctype html><html><body></body></html>', {
       runScripts: 'dangerously',
     });
     global.window = dom.window;
@@ -38,5 +40,11 @@ describe('shareOn', () => {
       '_blank',
       'noopener'
     );
+  });
+
+  afterEach(() => {
+    if (dom?.window?.close) dom.window.close();
+    delete global.window;
+    delete global.document;
   });
 });

--- a/backend/tests/frontend/sharedModel.test.js
+++ b/backend/tests/frontend/sharedModel.test.js
@@ -3,8 +3,10 @@ const fs = require('fs');
 const path = require('path');
 const { JSDOM } = require('jsdom');
 
+let dom;
+
 function setup(url) {
-  const dom = new JSDOM('<div id="viewer"></div><div id="error"></div>', {
+  dom = new JSDOM('<div id="viewer"></div><div id="error"></div>', {
     runScripts: 'dangerously',
     url,
   });
@@ -35,4 +37,10 @@ test('shows error when slug missing', () => {
   const dom = setup('http://localhost/share.html');
   dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
   expect(dom.window.document.getElementById('error').textContent).toBe('Missing share link');
+});
+
+afterEach(() => {
+  if (dom?.window?.close) dom.window.close();
+  delete global.window;
+  delete global.document;
 });

--- a/backend/tests/frontend/signup.test.js
+++ b/backend/tests/frontend/signup.test.js
@@ -3,6 +3,8 @@ const fs = require('fs');
 const path = require('path');
 const { JSDOM } = require('jsdom');
 
+let dom;
+
 let html = fs.readFileSync(path.join(__dirname, '../../../signup.html'), 'utf8');
 html = html
   .replace(/<script[^>]+tailwind[^>]*><\/script>/, '')
@@ -10,7 +12,7 @@ html = html
 
 describe('signup form', () => {
   test('shows error on failed signup', async () => {
-    const dom = new JSDOM(html, {
+    dom = new JSDOM(html, {
       runScripts: 'dangerously',
       resources: 'usable',
       url: 'http://localhost/signup.html',
@@ -30,5 +32,11 @@ describe('signup form', () => {
     await new Promise((r) => setTimeout(r, 0));
     expect(dom.window.document.getElementById('error').textContent).toBe('Invalid email format');
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  afterEach(() => {
+    if (dom?.window?.close) dom.window.close();
+    delete global.window;
+    delete global.document;
   });
 });

--- a/backend/tests/frontend/slotCount.test.js
+++ b/backend/tests/frontend/slotCount.test.js
@@ -3,6 +3,8 @@ const fs = require('fs');
 const path = require('path');
 const { JSDOM } = require('jsdom');
 
+let dom;
+
 let html = fs.readFileSync(path.join(__dirname, '../../../payment.html'), 'utf8');
 html = html
   .replace(/<script[^>]+src="https?:\/\/[^>]+><\/script>/g, '')
@@ -31,7 +33,7 @@ function cycleKey() {
 
 describe('slot count', () => {
   test('adjusts after purchase', async () => {
-    const dom = new JSDOM(html, {
+    dom = new JSDOM(html, {
       runScripts: 'dangerously',
       resources: 'usable',
       url: 'http://localhost/payment.html?session_id=1',
@@ -47,7 +49,7 @@ describe('slot count', () => {
   });
 
   test('uses stored purchase count', async () => {
-    const dom = new JSDOM(html, {
+    dom = new JSDOM(html, {
       runScripts: 'dangerously',
       resources: 'usable',
       url: 'http://localhost/payment.html',
@@ -61,5 +63,11 @@ describe('slot count', () => {
     dom.window.localStorage.setItem('slotPurchases', '2');
     await new Promise((r) => setTimeout(r, 0));
     expect(dom.window.document.getElementById('slot-count').textContent).toBe('4');
+  });
+
+  afterEach(() => {
+    if (dom?.window?.close) dom.window.close();
+    delete global.window;
+    delete global.document;
   });
 });

--- a/backend/tests/setup.js
+++ b/backend/tests/setup.js
@@ -1,3 +1,6 @@
+// Provide mock localStorage for all tests
+require('jest-localstorage-mock');
+
 const { TextEncoder, TextDecoder } = require('util');
 if (typeof global.TextEncoder === 'undefined') {
   global.TextEncoder = TextEncoder;


### PR DESCRIPTION
## Summary
- globally mock `localStorage` for tests
- close jsdom windows after each test in frontend suites
- add jest-localstorage-mock dependency

## Testing
- `npm run format`
- `npm run test-ci`

------
https://chatgpt.com/codex/tasks/task_e_6847367a8784832dbe7f2c9b08a957ab