### PR TITLE
Add Jest regression guard (fail CI on open handles + format issues)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm ci
+        working-directory: backend
+      - name: Install hunyuan_server deps
+        if: ${{ hashFiles('backend/hunyuan_server/package.json') != '' }}
+        run: npm ci
+        working-directory: backend/hunyuan_server
+      - name: Format check
+        run: |
+          npm run format
+          git diff --quiet || (echo "::error::Formatting required" && exit 1)
+        working-directory: backend
+      - name: Run tests
+        run: npm run test-ci
+        working-directory: backend
+      - name: Comment on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = `❌ This PR broke Jest CI stability.
+
+Please:
+1. Fix or re-mock lingering async handles
+2. Ensure \`jest-localstorage-mock\` remains in setupFiles
+3. Run \`npm run format\`
+
+Then re-run \`npm run test-ci\`. CI must pass before merge is allowed.`;
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body
+            });
+

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  setupFiles: ['jest-localstorage-mock', '<rootDir>/tests/setup.js'],
+  globalTeardown: './jest.teardown.js',
+};

--- a/backend/jest.teardown.js
+++ b/backend/jest.teardown.js
@@ -1,0 +1,12 @@
+module.exports = async () => {
+  // Wait a tick for outstanding timers to settle
+  await new Promise((r) => setTimeout(r, 10));
+  const handles = process
+    ._getActiveHandles()
+    .filter((h) => ![process.stdin, process.stdout, process.stderr].includes(h));
+  if (handles.length > 0) {
+    console.error('Lingering async handles detected:');
+    handles.forEach((h) => console.error(h));
+    process.exit(1);
+  }
+};

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -29,6 +29,7 @@
       "devDependencies": {
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^30.0.0-beta.3",
+        "jest-localstorage-mock": "^2.4.26",
         "jsdom": "^23.0.0",
         "prettier": "^3.1.0",
         "supertest": "^7.1.1"
@@ -4262,6 +4263,16 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-localstorage-mock": {
+      "version": "2.4.26",
+      "resolved": "https://registry.npmjs.org/jest-localstorage-mock/-/jest-localstorage-mock-2.4.26.tgz",
+      "integrity": "sha512-owAJrYnjulVlMIXOYQIPRCCn3MmqI3GzgfZCXdD3/pmwrIvFMXcKVWZ+aMc44IzaASapg0Z4SEFxR+v5qxDA2w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=6.16.0"
       }
     },
     "node_modules/jest-matcher-utils": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -21,6 +21,7 @@
     "axios": "^1.9.0",
     "bcryptjs": "^2.4.3",
     "body-parser": "^2.2.0",
+    "compression": "^1.7.4",
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
@@ -32,21 +33,15 @@
     "nodemailer-sendgrid": "^1.0.0",
     "pg": "^8.16.0",
     "stripe": "^18.2.1",
-    "uuid": "^11.1.0",
-    "compression": "^1.7.4"
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^30.0.0-beta.3",
+    "jest-localstorage-mock": "^2.4.26",
     "jsdom": "^23.0.0",
     "prettier": "^3.1.0",
     "supertest": "^7.1.1"
-  },
-  "jest": {
-    "testEnvironment": "jsdom",
-    "setupFiles": [
-      "<rootDir>/tests/setup.js"
-    ]
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
## Summary
- add CI workflow to run formatting and tests and comment on failures
- add Jest teardown to detect lingering handles
- add Jest config with `jest-localstorage-mock`
- install `jest-localstorage-mock` devDependency

## Testing
- `npm run format`
- `npm run test-ci` *(fails with open handle warning)*

------
https://chatgpt.com/codex/tasks/task_e_684737b44114832d9ccfad5d3087bbe2