### PR TITLE
Codex: harden Jest CI by patching open handles and enforcing format/test checks

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -25,8 +25,20 @@ jobs:
         working-directory: backend/hunyuan_server
         run: npm ci
 
-      - run: npm run test-ci
+      - name: Run tests
         working-directory: backend
+        run: |
+          set -o pipefail
+          npm run test-ci 2>&1 | tee test.log
+          if grep -i "open handles" test.log; then
+            echo "Open handle warnings detected" && exit 1
+          fi
+
+      - name: Check formatting
+        working-directory: backend
+        run: |
+          npm run format
+          git diff --exit-code
 
       - run: npx prettier --check "**/*.{js,jsx,json,md,html}"
         working-directory: backend

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -29,6 +29,7 @@
       "devDependencies": {
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^30.0.0-beta.3",
+        "jest-localstorage-mock": "^2.4.26",
         "jsdom": "^23.0.0",
         "prettier": "^3.1.0",
         "supertest": "^7.1.1"
@@ -4262,6 +4263,16 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-localstorage-mock": {
+      "version": "2.4.26",
+      "resolved": "https://registry.npmjs.org/jest-localstorage-mock/-/jest-localstorage-mock-2.4.26.tgz",
+      "integrity": "sha512-owAJrYnjulVlMIXOYQIPRCCn3MmqI3GzgfZCXdD3/pmwrIvFMXcKVWZ+aMc44IzaASapg0Z4SEFxR+v5qxDA2w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=6.16.0"
       }
     },
     "node_modules/jest-matcher-utils": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -21,6 +21,7 @@
     "axios": "^1.9.0",
     "bcryptjs": "^2.4.3",
     "body-parser": "^2.2.0",
+    "compression": "^1.7.4",
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
@@ -32,12 +33,12 @@
     "nodemailer-sendgrid": "^1.0.0",
     "pg": "^8.16.0",
     "stripe": "^18.2.1",
-    "uuid": "^11.1.0",
-    "compression": "^1.7.4"
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^30.0.0-beta.3",
+    "jest-localstorage-mock": "^2.4.26",
     "jsdom": "^23.0.0",
     "prettier": "^3.1.0",
     "supertest": "^7.1.1"
@@ -45,6 +46,7 @@
   "jest": {
     "testEnvironment": "jsdom",
     "setupFiles": [
+      "jest-localstorage-mock",
       "<rootDir>/tests/setup.js"
     ]
   },

--- a/backend/tests/frontend/community.test.js
+++ b/backend/tests/frontend/community.test.js
@@ -47,6 +47,9 @@ function setup() {
 }
 
 describe('community helpers', () => {
+  afterEach(() => {
+    if (global.window?.close) global.window.close();
+  });
   test('getFallbackModels returns 6 items', () => {
     const dom = setup();
     const list = dom.window.getFallbackModels();

--- a/backend/tests/frontend/competitions.test.js
+++ b/backend/tests/frontend/competitions.test.js
@@ -3,6 +3,10 @@ const fs = require('fs');
 const path = require('path');
 const { JSDOM } = require('jsdom');
 
+afterEach(() => {
+  if (global.window?.close) global.window.close();
+});
+
 test('startCountdown closes past competitions', () => {
   const dom = new JSDOM('<span id="t"></span>', { runScripts: 'dangerously' });
   global.window = dom.window;

--- a/backend/tests/frontend/flashBanner.test.js
+++ b/backend/tests/frontend/flashBanner.test.js
@@ -10,6 +10,10 @@ html = html
   .replace(/<script[^>]+src="js\/modelViewerTouchFix.js"[^>]*><\/script>/, '');
 
 describe('flash banner', () => {
+  afterEach(() => {
+    if (global.window?.close) global.window.close();
+  });
+
   test('hides after countdown ends', async () => {
     const dom = new JSDOM(html, {
       runScripts: 'dangerously',

--- a/backend/tests/frontend/index.test.js
+++ b/backend/tests/frontend/index.test.js
@@ -13,6 +13,10 @@ html = html
   );
 
 describe('index validatePrompt', () => {
+  afterEach(() => {
+    if (global.window?.close) global.window.close();
+  });
+
   function setup() {
     const dom = new JSDOM(html, {
       runScripts: 'dangerously',

--- a/backend/tests/frontend/login.test.js
+++ b/backend/tests/frontend/login.test.js
@@ -9,8 +9,13 @@ html = html
   .replace(/<link[^>]+font-awesome[^>]+>/, '');
 
 describe('login form', () => {
+  let dom;
+  afterEach(() => {
+    if (dom?.window) dom.window.close();
+  });
+
   test('shows error on failed login', async () => {
-    const dom = new JSDOM(html, {
+    dom = new JSDOM(html, {
       runScripts: 'dangerously',
       resources: 'usable',
       url: 'http://localhost/login.html',

--- a/backend/tests/frontend/profile.test.js
+++ b/backend/tests/frontend/profile.test.js
@@ -3,6 +3,10 @@ const fs = require('fs');
 const path = require('path');
 const { JSDOM } = require('jsdom');
 
+afterEach(() => {
+  if (global.window?.close) global.window.close();
+});
+
 test('load displays models from API', async () => {
   const dom = new JSDOM('<div id="models"></div>', {
     runScripts: 'dangerously',

--- a/backend/tests/frontend/share.test.js
+++ b/backend/tests/frontend/share.test.js
@@ -4,6 +4,10 @@ const path = require('path');
 const { JSDOM } = require('jsdom');
 
 describe('shareOn', () => {
+  afterEach(() => {
+    if (global.window?.close) global.window.close();
+  });
+
   function load() {
     const dom = new JSDOM('<!doctype html><html><body></body></html>', {
       runScripts: 'dangerously',

--- a/backend/tests/frontend/sharedModel.test.js
+++ b/backend/tests/frontend/sharedModel.test.js
@@ -3,6 +3,10 @@ const fs = require('fs');
 const path = require('path');
 const { JSDOM } = require('jsdom');
 
+afterEach(() => {
+  if (global.window?.close) global.window.close();
+});
+
 function setup(url) {
   const dom = new JSDOM('<div id="viewer"></div><div id="error"></div>', {
     runScripts: 'dangerously',

--- a/backend/tests/frontend/signup.test.js
+++ b/backend/tests/frontend/signup.test.js
@@ -9,6 +9,10 @@ html = html
   .replace(/<link[^>]+font-awesome[^>]+>/, '');
 
 describe('signup form', () => {
+  afterEach(() => {
+    if (global.window?.close) global.window.close();
+  });
+
   test('shows error on failed signup', async () => {
     const dom = new JSDOM(html, {
       runScripts: 'dangerously',

--- a/backend/tests/frontend/slotCount.test.js
+++ b/backend/tests/frontend/slotCount.test.js
@@ -30,6 +30,10 @@ function cycleKey() {
 }
 
 describe('slot count', () => {
+  afterEach(() => {
+    if (global.window?.close) global.window.close();
+  });
+
   test('adjusts after purchase', async () => {
     const dom = new JSDOM(html, {
       runScripts: 'dangerously',

--- a/backend/tests/jest.teardown.test.js
+++ b/backend/tests/jest.teardown.test.js
@@ -1,0 +1,15 @@
+afterAll(() => {
+  const handles = process
+    ._getActiveHandles()
+    .filter((h) => ![process.stdin, process.stdout, process.stderr].includes(h));
+  if (handles.length) {
+    // eslint-disable-next-line no-console
+    console.log('Open handles detected:', handles);
+    fail(`Open handles detected: ${handles.length}`);
+  }
+  expect.hasAssertions();
+});
+
+test('jest teardown guard', () => {
+  expect(true).toBe(true);
+});


### PR DESCRIPTION
## Summary
- close JSDOM windows in frontend tests to avoid lingering handles
- install `jest-localstorage-mock` and load it in Jest setup
- add guard test to detect open handles
- fail CI if formatting changes or open handle warnings occur

## Testing
- `npm test`
- `npm run test-ci`
- `npx prettier --check "**/*.{js,jsx,json,md,html}"`

------
https://chatgpt.com/codex/tasks/task_e_6847435df3c0832d8b27ecee47701345