### PR TITLE
Fix frontend test leaks and CI timeout

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - uses: actions/checkout@v3

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -29,6 +29,7 @@
       "devDependencies": {
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^30.0.0-beta.3",
+        "jest-localstorage-mock": "^2.4.26",
         "jsdom": "^23.0.0",
         "prettier": "^3.1.0",
         "supertest": "^7.1.1"
@@ -4262,6 +4263,16 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-localstorage-mock": {
+      "version": "2.4.26",
+      "resolved": "https://registry.npmjs.org/jest-localstorage-mock/-/jest-localstorage-mock-2.4.26.tgz",
+      "integrity": "sha512-owAJrYnjulVlMIXOYQIPRCCn3MmqI3GzgfZCXdD3/pmwrIvFMXcKVWZ+aMc44IzaASapg0Z4SEFxR+v5qxDA2w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=6.16.0"
       }
     },
     "node_modules/jest-matcher-utils": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,7 @@
   "main": "server.js",
   "scripts": {
     "test": "jest",
-    "test-ci": "jest --runInBand",
+    "test-ci": "jest --runInBand --detectOpenHandles --forceExit",
     "start": "node server.js",
     "init-db": "node scripts/init-db.js",
     "migrate": "node scripts/run-migrations.js",
@@ -21,6 +21,7 @@
     "axios": "^1.9.0",
     "bcryptjs": "^2.4.3",
     "body-parser": "^2.2.0",
+    "compression": "^1.7.4",
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
@@ -32,19 +33,19 @@
     "nodemailer-sendgrid": "^1.0.0",
     "pg": "^8.16.0",
     "stripe": "^18.2.1",
-    "uuid": "^11.1.0",
-    "compression": "^1.7.4"
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^30.0.0-beta.3",
+    "jest-localstorage-mock": "^2.4.26",
     "jsdom": "^23.0.0",
     "prettier": "^3.1.0",
     "supertest": "^7.1.1"
   },
   "jest": {
     "testEnvironment": "jsdom",
-    "setupFiles": [
+    "setupFilesAfterEnv": [
       "<rootDir>/tests/setup.js"
     ]
   },

--- a/backend/tests/setup.js
+++ b/backend/tests/setup.js
@@ -1,4 +1,5 @@
 const { TextEncoder, TextDecoder } = require('util');
+require('jest-localstorage-mock');
 if (typeof global.TextEncoder === 'undefined') {
   global.TextEncoder = TextEncoder;
 }
@@ -8,3 +9,11 @@ if (typeof global.TextDecoder === 'undefined') {
 if (typeof global.setImmediate === 'undefined') {
   global.setImmediate = (cb) => setTimeout(cb, 0);
 }
+
+afterEach(() => {
+  if (global.window && typeof global.window.close === 'function') {
+    global.window.close();
+  }
+  global.window = undefined;
+  global.document = undefined;
+});


### PR DESCRIPTION
## Summary
- close JSDOM after each test and mock localStorage
- add jest-localstorage-mock
- force exit in test-ci and detect open handles
- add timeout to CI job

## Testing
- `npm run format`
- `npm run test-ci`


------
https://chatgpt.com/codex/tasks/task_e_68474fd27a6c832d9308f026d353190a