### PR TITLE
Fix jest timers cleanup

### DIFF
--- a/backend/tests/setup.js
+++ b/backend/tests/setup.js
@@ -16,4 +16,8 @@ afterEach(() => {
   }
   global.window = undefined;
   global.document = undefined;
+  // restore real timers in case a test enabled fake timers
+  if (jest.isMockFunction(setTimeout)) {
+    jest.useRealTimers();
+  }
 });


### PR DESCRIPTION
## Summary
- restore real timers after each test to avoid lingering fake timers

## Testing
- `npm run format`
- `npm test` *(fails to exit)*

------
https://chatgpt.com/codex/tasks/task_e_68475a2db860832db2913cadf1b8ef02