### PR TITLE
Fix Jest cleanup

### DIFF
--- a/backend/tests/setup.js
+++ b/backend/tests/setup.js
@@ -18,6 +18,8 @@ afterEach(() => {
   global.document = undefined;
   // restore real timers in case a test enabled fake timers
   if (jest.isMockFunction(setTimeout)) {
+    // clear any pending timers to avoid open handles
+    jest.clearAllTimers();
     jest.useRealTimers();
   }
 });


### PR DESCRIPTION
## Summary
- clean up any timers left behind by tests

## Testing
- `npm run format`
- `npm test` *(fails: Jest hangs due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_6847fc9b078c832db4a7b0385eccc911