### PR TITLE
Fix jest cleanup

### DIFF
--- a/backend/tests/setup.js
+++ b/backend/tests/setup.js
@@ -23,3 +23,8 @@ afterEach(() => {
     jest.useRealTimers();
   }
 });
+
+afterAll(() => {
+  const http = require('http');
+  http.globalAgent.destroy();
+});


### PR DESCRIPTION
## Summary
- ensure the HTTP agent is destroyed after tests

## Testing
- `npm run format`
- `npm run test-ci` *(tests hang without `--forceExit`)*

------
https://chatgpt.com/codex/tasks/task_e_684803448108832d98def753b7f25e7c