### PR TITLE
Add slow test reporter

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -30,6 +30,7 @@
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^30.0.0-beta.3",
         "jest-localstorage-mock": "^2.4.26",
+        "jest-slow-test-reporter": "^1.0.0",
         "jsdom": "^23.0.0",
         "prettier": "^3.1.0",
         "supertest": "^7.1.1"
@@ -4456,6 +4457,13 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/jest-slow-test-reporter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/jest-slow-test-reporter/-/jest-slow-test-reporter-1.0.0.tgz",
+      "integrity": "sha512-5FG8hlaO7Wdgdo6oQxGiFAKwd1HW51+8/KmQJgUV3bsW3cCXx9TukaoGnHhBl+hwLkCYENynWL1PQnG8DwOV6w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jest-snapshot": {
       "version": "29.7.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -39,6 +39,7 @@
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^30.0.0-beta.3",
     "jest-localstorage-mock": "^2.4.26",
+    "jest-slow-test-reporter": "^1.0.0",
     "jsdom": "^23.0.0",
     "prettier": "^3.1.0",
     "supertest": "^7.1.1"
@@ -47,6 +48,15 @@
     "testEnvironment": "jsdom",
     "setupFilesAfterEnv": [
       "<rootDir>/tests/setup.js"
+    ],
+    "reporters": [
+      "default",
+      [
+        "jest-slow-test-reporter",
+        {
+          "numTests": 5
+        }
+      ]
     ]
   },
   "engines": {


### PR DESCRIPTION
## Summary
- enable jest-slow-test-reporter to track slow tests

## Testing
- `npm run format`
- `npm test -- -i --runInBand --forceExit` *(fails: Error: fail)*

------
https://chatgpt.com/codex/tasks/task_e_68480328d354832da6d0228203d25a7c