### PR TITLE
Fix Jest handle cleanup

### DIFF
--- a/backend/tests/queue/printQueue.test.js
+++ b/backend/tests/queue/printQueue.test.js
@@ -7,6 +7,11 @@ afterEach(() => {
   _getQueue().length = 0;
 });
 
+afterAll(() => {
+  jest.useRealTimers();
+  intervalSpy.mockRestore();
+});
+
 test('enqueuePrint schedules processing', () => {
   enqueuePrint('job1');
   expect(intervalSpy).toHaveBeenCalled();

--- a/backend/tests/setup.js
+++ b/backend/tests/setup.js
@@ -16,8 +16,8 @@ afterEach(() => {
   }
   global.window = undefined;
   global.document = undefined;
-  // restore real timers in case a test enabled fake timers
-  if (jest.isMockFunction(setTimeout)) {
-    jest.useRealTimers();
-  }
+});
+
+afterAll(() => {
+  jest.useRealTimers();
 });


### PR DESCRIPTION
## Summary
- restore real timers in test setup after the suite finishes
- reset timers and spies in printQueue tests

## Testing
- `npm run format`
- `npm test` *(fails: process did not exit cleanly in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_684802752ca8832d80e97791d65dad28