### PR TITLE
Fix test hang by isolating SSE progress suite

### DIFF
--- a/backend/tests/additionalApi.test.js
+++ b/backend/tests/additionalApi.test.js
@@ -401,15 +401,6 @@ test('POST /api/admin/competitions unauthorized', async () => {
   expect(res.status).toBe(401);
 });
 
-test('SSE progress endpoint streams updates', async () => {
-  const req = request(app).get('/api/progress/job1');
-  setTimeout(() => {
-    progressEmitter.emit('progress', { jobId: 'job1', progress: 100 });
-  }, 50);
-  const res = await req;
-  expect(res.text).toContain('data: {"jobId":"job1","progress":100}');
-});
-
 test('POST /api/create-order rejects unknown job', async () => {
   db.query.mockResolvedValueOnce({ rows: [] });
   const res = await request(app).post('/api/create-order').send({ jobId: 'bad' });

--- a/backend/tests/sseProgress.test.js
+++ b/backend/tests/sseProgress.test.js
@@ -9,10 +9,12 @@ const { progressEmitter } = require('../queue/printQueue');
 const app = require('../server');
 
 test('SSE progress endpoint streams updates', async () => {
-  const req = request(app).get('/api/progress/job1');
+  const server = app.listen(0);
+  const req = request(server).get('/api/progress/job1');
   setTimeout(() => {
     progressEmitter.emit('progress', { jobId: 'job1', progress: 100 });
   }, 50);
   const res = await req;
   expect(res.text).toContain('data: {"jobId":"job1","progress":100}');
+  await new Promise((resolve) => server.close(resolve));
 });

--- a/backend/tests/sseProgress.test.js
+++ b/backend/tests/sseProgress.test.js
@@ -1,0 +1,18 @@
+/** @jest-environment node */
+process.env.STRIPE_SECRET_KEY = 'test';
+process.env.STRIPE_WEBHOOK_SECRET = 'whsec';
+process.env.DB_URL = 'postgres://user:pass@localhost/db';
+process.env.HUNYUAN_API_KEY = 'test';
+process.env.HUNYUAN_SERVER_URL = 'http://localhost:4000';
+const request = require('supertest');
+const { progressEmitter } = require('../queue/printQueue');
+const app = require('../server');
+
+test('SSE progress endpoint streams updates', async () => {
+  const req = request(app).get('/api/progress/job1');
+  setTimeout(() => {
+    progressEmitter.emit('progress', { jobId: 'job1', progress: 100 });
+  }, 50);
+  const res = await req;
+  expect(res.text).toContain('data: {"jobId":"job1","progress":100}');
+});


### PR DESCRIPTION
## Summary
- isolate SSE progress endpoint test into its own file
- run it using Node environment

## Testing
- `npm run format`
- `npx jest tests/sseProgress.test.js --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_684810d46ed0832d985a48f14ff04c26