### PR TITLE
Fix print queue timer cleanup

### DIFF
--- a/backend/queue/printQueue.js
+++ b/backend/queue/printQueue.js
@@ -2,6 +2,7 @@ const { EventEmitter } = require('events');
 
 const queue = [];
 let isProcessing = false;
+let currentInterval = null;
 const progressEmitter = new EventEmitter();
 
 function enqueuePrint(jobId) {
@@ -18,11 +19,12 @@ function processQueue() {
   const jobId = queue.shift();
   let progress = 0;
   progressEmitter.emit('progress', { jobId, progress });
-  const interval = setInterval(() => {
+  currentInterval = setInterval(() => {
     progress += 20;
     if (progress >= 100) {
       progress = 100;
-      clearInterval(interval);
+      clearInterval(currentInterval);
+      currentInterval = null;
       isProcessing = false;
       progressEmitter.emit('progress', { jobId, progress });
       processQueue();
@@ -41,4 +43,12 @@ module.exports = {
   processQueue,
   _getQueue,
   progressEmitter,
+  reset: () => {
+    if (currentInterval) {
+      clearInterval(currentInterval);
+      currentInterval = null;
+    }
+    queue.length = 0;
+    isProcessing = false;
+  },
 };

--- a/backend/tests/additionalApi.test.js
+++ b/backend/tests/additionalApi.test.js
@@ -24,7 +24,7 @@ const stripeMock = {
 };
 Stripe.mockImplementation(() => stripeMock);
 
-const { progressEmitter } = require('../queue/printQueue');
+const { progressEmitter, reset } = require('../queue/printQueue');
 
 const request = require('supertest');
 const app = require('../server');
@@ -37,6 +37,10 @@ beforeEach(() => {
     id: 'cs_test',
     url: 'https://stripe.test',
   });
+});
+
+afterEach(() => {
+  reset();
 });
 
 test('GET /api/my/models returns models', async () => {

--- a/backend/tests/queue/printQueue.test.js
+++ b/backend/tests/queue/printQueue.test.js
@@ -1,10 +1,10 @@
-const { enqueuePrint, processQueue, _getQueue } = require('../../queue/printQueue');
+const { enqueuePrint, processQueue, _getQueue, reset } = require('../../queue/printQueue');
 
 jest.useFakeTimers();
 const intervalSpy = jest.spyOn(global, 'setInterval');
 
 afterEach(() => {
-  _getQueue().length = 0;
+  reset();
 });
 
 test('enqueuePrint schedules processing', () => {


### PR DESCRIPTION
## Summary
- ensure printQueue timers are cleared via new reset function
- use reset in queue tests and additionalApi tests to avoid lingering timers

## Testing
- `npm run format`
- `npm test` *(fails: tests hang and require manual interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_684831664378832da0dd14ffa2032619