### PR TITLE
Add active handle logging

### DIFF
--- a/backend/tests/setup.js
+++ b/backend/tests/setup.js
@@ -23,3 +23,10 @@ afterEach(() => {
     jest.useRealTimers();
   }
 });
+
+afterAll(() => {
+  // Log any active handles to help debug resources preventing Jest from exiting
+  // cleanly. These may include timers, sockets, or server instances.
+  // eslint-disable-next-line no-console
+  console.log('Active handles after test file:', process._getActiveHandles());
+});


### PR DESCRIPTION
## Summary
- log all active handles after each Jest test file via `afterAll`

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848582ed47c832da117a03ba633fce3