### PR TITLE
Log active handles post-tests

### DIFF
--- a/backend/tests/setup.js
+++ b/backend/tests/setup.js
@@ -23,3 +23,7 @@ afterEach(() => {
     jest.useRealTimers();
   }
 });
+
+afterAll(() => {
+  console.log('Active handles:', process._getActiveHandles());
+});


### PR DESCRIPTION
## Summary
- log active handles with `process._getActiveHandles` in `tests/setup.js`

## Testing
- `npm test` *(fails: hangs, aborted)*
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68485fa128a4832da154d992a464e767