### PR TITLE
Add SIGTERM handle dump

### DIFF
--- a/backend/tests/setup.js
+++ b/backend/tests/setup.js
@@ -1,5 +1,10 @@
 const { TextEncoder, TextDecoder } = require('util');
 require('jest-localstorage-mock');
+process.on('SIGTERM', () => {
+  // eslint-disable-next-line no-console
+  console.log('Active handles just before SIGTERM:', process._getActiveHandles());
+  process.exit(1);
+});
 if (typeof global.TextEncoder === 'undefined') {
   global.TextEncoder = TextEncoder;
 }


### PR DESCRIPTION
## Summary
- log active handles when receiving SIGTERM in tests

## Testing
- `npm run format`
- `npm test` *(fails: process killed due to excessive output)*

------
https://chatgpt.com/codex/tasks/task_e_68497f8e2088832d98ee6996f9e5b97f