### PR TITLE
Add exit handler active handle dump

### DIFF
--- a/backend/tests/setup.js
+++ b/backend/tests/setup.js
@@ -5,6 +5,10 @@ process.on('SIGTERM', () => {
   console.log('Active handles just before SIGTERM:', process._getActiveHandles());
   process.exit(1);
 });
+process.on('exit', (code) => {
+  // eslint-disable-next-line no-console
+  console.log('Active handles just before exit code', code, ':', process._getActiveHandles());
+});
 if (typeof global.TextEncoder === 'undefined') {
   global.TextEncoder = TextEncoder;
 }


### PR DESCRIPTION
## Summary
- dump active handles when the Jest process exits

## Testing
- `npm run format`
- `npm test` *(fails: tests hang, truncated here)*

------
https://chatgpt.com/codex/tasks/task_e_68498ab523c4832da5a2809f1e902693