### PR TITLE
test: timed dump of handles before CI timeout

### DIFF
--- a/backend/tests/setup.js
+++ b/backend/tests/setup.js
@@ -1,5 +1,15 @@
 const { TextEncoder, TextDecoder } = require('util');
 require('jest-localstorage-mock');
+
+// Dump open handles shortly before CI's global timeout to aid debugging
+setTimeout(
+  () => {
+    console.log('Active handles before forced timeout:');
+    console.log(process._getActiveHandles());
+    console.log('Pending requests:', process._getActiveRequests());
+  },
+  19.5 * 60 * 1000
+);
 process.on('SIGTERM', () => {
   // eslint-disable-next-line no-console
   console.log('Active handles just before SIGTERM:', process._getActiveHandles());


### PR DESCRIPTION
## Summary
- set timer in tests to dump active handles before CI timeout

## Testing
- `npm run format`
- `npm run test-ci` *(fails due to environment timeout or heavy logs)*

------
https://chatgpt.com/codex/tasks/task_e_68499227b0bc832d862502d1ff9a6011