### PR TITLE
Close open handles – Jest exits cleanly

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -2,6 +2,7 @@
 module.exports = {
   rootDir: '.',
   setupFilesAfterEnv: ['<rootDir>/tests/setup.js'],
+  globalTeardown: '<rootDir>/tests/globalTeardown.js',
   testEnvironment: 'node',
   testMatch: ['<rootDir>/tests/**/*.test.js'],
 };

--- a/backend/tests/additionalApi.test.js
+++ b/backend/tests/additionalApi.test.js
@@ -403,9 +403,11 @@ test('POST /api/admin/competitions unauthorized', async () => {
 
 test('SSE progress endpoint streams updates', async () => {
   const req = request(app).get('/api/progress/job1');
-  setTimeout(() => {
+  const id = setTimeout(() => {
     progressEmitter.emit('progress', { jobId: 'job1', progress: 100 });
   }, 50);
+  global.__LEAKS__ = global.__LEAKS__ || [];
+  global.__LEAKS__.push({ clear: () => clearTimeout(id) });
   const res = await req;
   expect(res.text).toContain('data: {"jobId":"job1","progress":100}');
 });

--- a/backend/tests/globalTeardown.js
+++ b/backend/tests/globalTeardown.js
@@ -1,0 +1,18 @@
+module.exports = async () => {
+  const leaks = global.__LEAKS__ || [];
+  for (const leak of leaks) {
+    if (typeof leak.close === 'function') {
+      await new Promise((resolve) => leak.close(resolve));
+    }
+    if (typeof leak.clear === 'function') {
+      leak.clear();
+    }
+  }
+  const ignored = [process.stdout, process.stderr];
+  const open = process._getActiveHandles().filter((h) => !ignored.includes(h));
+  if (open.length) {
+    // eslint-disable-next-line no-console
+    console.error('\u274c Teardown detected lingering handles:', open);
+    process.exit(1);
+  }
+};


### PR DESCRIPTION
## Summary
- ensure long timeout in test setup is cleaned
- clear SSE test timer
- add a global teardown to check for leaked handles
- wire teardown in Jest config

## Testing
- `npm run format`
- `npm run test-ci`

------
https://chatgpt.com/codex/tasks/task_e_6849c41262f4832d865621eb34e40108