### PR TITLE
ci: clear diagnostic timer & fix share tests

### DIFF
--- a/backend/tests/frontend/share.test.js
+++ b/backend/tests/frontend/share.test.js
@@ -33,10 +33,8 @@ describe('shareOn', () => {
     const shareOn = load();
     global.window.open = jest.fn();
     await shareOn(net);
-    expect(global.window.open).toHaveBeenCalledWith(
-      expect.stringContaining(domain),
-      '_blank',
-      'noopener'
-    );
+    const calledUrl = global.window.open.mock.calls[0][0];
+    expect(calledUrl).toContain(domain);
+    expect(global.window.open).toHaveBeenCalledWith(calledUrl, '_blank', 'noopener');
   });
 });

--- a/backend/tests/setup.js
+++ b/backend/tests/setup.js
@@ -4,16 +4,7 @@ const { TextEncoder, TextDecoder } = require('util');
 require('jest-localstorage-mock');
 
 // Dump open handles shortly before CI’s global timeout to aid debugging
-setTimeout(
-  () => {
-    // eslint-disable-next-line no-console
-    console.log('Active handles before forced timeout:');
-    console.log(process._getActiveHandles());
-    // eslint-disable-next-line no-console
-    console.log('Pending requests:', process._getActiveRequests());
-  },
-  19.5 * 60 * 1000
-);
+// (removed now that the dump is captured on exit)
 
 // On GitHub Actions “Cancel workflow” → SIGTERM path
 process.on('SIGTERM', () => {


### PR DESCRIPTION
## Summary
- remove long diagnostic timer to avoid Jest open-handle warning
- update `share.test.js` expectations

## Testing
- `npm --prefix backend run format`
- `npm --prefix backend run test-ci`

------
https://chatgpt.com/codex/tasks/task_e_6849c4b32da4832d9e3002ce900b85a0