### PR TITLE
Close open handles – Jest exits cleanly

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -4,4 +4,5 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/tests/setup.js'],
   testEnvironment: 'node',
   testMatch: ['<rootDir>/tests/**/*.test.js'],
+  globalTeardown: '<rootDir>/tests/globalTeardown.js',
 };

--- a/backend/tests/globalTeardown.js
+++ b/backend/tests/globalTeardown.js
@@ -1,0 +1,22 @@
+module.exports = async () => {
+  const leaks = global.__LEAKS__ || [];
+  for (const leak of leaks) {
+    try {
+      if (typeof leak.close === 'function') {
+        await new Promise((res) => leak.close(res));
+      } else if (typeof leak.clear === 'function') {
+        leak.clear();
+      } else if (typeof leak === 'function') {
+        leak();
+      }
+    } catch (err) {
+      console.error('Error closing leak', err);
+    }
+  }
+  const ignored = [process.stdout, process.stderr];
+  const open = process._getActiveHandles().filter((h) => !ignored.includes(h));
+  if (open.length) {
+    console.error('\u274c Teardown detected lingering handles:', open);
+    process.exit(1);
+  }
+};

--- a/backend/tests/setup.js
+++ b/backend/tests/setup.js
@@ -4,7 +4,7 @@ const { TextEncoder, TextDecoder } = require('util');
 require('jest-localstorage-mock');
 
 // Dump open handles shortly before CI’s global timeout to aid debugging
-setTimeout(
+const dumpHandle = setTimeout(
   () => {
     // eslint-disable-next-line no-console
     console.log('Active handles before forced timeout:');
@@ -14,6 +14,8 @@ setTimeout(
   },
   19.5 * 60 * 1000
 );
+global.__LEAKS__ = global.__LEAKS__ || [];
+global.__LEAKS__.push({ clear: () => clearTimeout(dumpHandle) });
 
 // On GitHub Actions “Cancel workflow” → SIGTERM path
 process.on('SIGTERM', () => {
@@ -48,6 +50,10 @@ afterEach(() => {
     jest.clearAllTimers();
     jest.useRealTimers();
   }
+});
+
+afterAll(() => {
+  clearTimeout(dumpHandle);
 });
 
 // Final diagnostic dump on normal Jest exit


### PR DESCRIPTION
## Summary
- ensure long diagnostics timer can be cleared
- add global teardown that closes leaked handles
- configure Jest to run this teardown

## Validation
- `npm run format`
- `npm run test-ci`


------
https://chatgpt.com/codex/tasks/task_e_6849c6cdbe1c832db5453026d37ac7cb