### PR TITLE
Close open handles – Jest exits cleanly

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -2,6 +2,7 @@
 module.exports = {
   rootDir: '.',
   setupFilesAfterEnv: ['<rootDir>/tests/setup.js'],
+  globalTeardown: '<rootDir>/tests/globalTeardown.js',
   testEnvironment: 'node',
   testMatch: ['<rootDir>/tests/**/*.test.js'],
 };

--- a/backend/tests/globalTeardown.js
+++ b/backend/tests/globalTeardown.js
@@ -8,7 +8,7 @@ module.exports = async () => {
       leak.clear();
     }
   }
-  const ignored = [process.stdout, process.stderr];
+  const ignored = [process.stdout, process.stderr, process.stdin];
   const open = process._getActiveHandles().filter((h) => !ignored.includes(h));
   if (open.length) {
     console.error('\u274c Teardown detected lingering handles:', open);

--- a/backend/tests/globalTeardown.js
+++ b/backend/tests/globalTeardown.js
@@ -1,0 +1,17 @@
+module.exports = async () => {
+  const leaks = global.__LEAKS__ || [];
+  for (const leak of leaks) {
+    if (typeof leak.close === 'function') {
+      await new Promise((r) => leak.close(r));
+    }
+    if (typeof leak.clear === 'function') {
+      leak.clear();
+    }
+  }
+  const ignored = [process.stdout, process.stderr];
+  const open = process._getActiveHandles().filter((h) => !ignored.includes(h));
+  if (open.length) {
+    console.error('\u274c Teardown detected lingering handles:', open);
+    process.exit(1);
+  }
+};


### PR DESCRIPTION
## Summary
- add globalTeardown for closing leaked resources
- track timeout used in SSE progress test so teardown can clear it
- wire teardown in Jest configuration

## Testing
- `npm run test-ci`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_6849cc557fb0832dab09934b7abaf197