### PR TITLE
chore: remove leftover debug console.logs from setup.js

### DIFF
--- a/backend/tests/setup.js
+++ b/backend/tests/setup.js
@@ -5,8 +5,6 @@ require('jest-localstorage-mock');
 
 // On GitHub Actions “Cancel workflow” → SIGTERM path
 process.on('SIGTERM', () => {
-  // eslint-disable-next-line no-console
-  console.log('Active handles just before SIGTERM:', process._getActiveHandles());
   process.exit(1);
 });
 
@@ -39,9 +37,4 @@ afterEach(() => {
 });
 
 // Final diagnostic dump on normal Jest exit
-afterAll(() => {
-  // eslint-disable-next-line no-console
-  console.log('Active handles on exit:', process._getActiveHandles());
-  // eslint-disable-next-line no-console
-  console.log('Pending requests on exit:', process._getActiveRequests());
-});
+afterAll(() => {});


### PR DESCRIPTION
## Summary
- clean up debug console.log lines from backend/tests/setup.js

## Testing
- `npm run format`
- `npm run test-ci`


------
https://chatgpt.com/codex/tasks/task_e_6849cf577ecc832d95667706e38e13b6