### PR TITLE
Add password reset frontend pages

### DIFF
--- a/js/requestReset.js
+++ b/js/requestReset.js
@@ -1,0 +1,36 @@
+const API_BASE = (window.API_ORIGIN || '') + '/api';
+
+function isValidEmail(email) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
+async function sendRequest(e) {
+  e.preventDefault();
+  const emailEl = document.getElementById('req-email');
+  emailEl.classList.remove('border-red-500');
+  const email = emailEl.value.trim();
+  if (!email || !isValidEmail(email)) {
+    document.getElementById('msg').textContent = 'Valid email required';
+    emailEl.classList.add('border-red-500');
+    return;
+  }
+  const res = await fetch(`${API_BASE}/request-password-reset`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email }),
+  });
+  if (res.status === 204) {
+    document.getElementById('msg').classList.remove('text-red-400');
+    document.getElementById('msg').classList.add('text-green-400');
+    document.getElementById('msg').textContent =
+      'If the address is registered, a reset link has been sent.';
+  } else {
+    const data = await res.json();
+    document.getElementById('msg').textContent =
+      data.error || 'Failed to send email';
+  }
+}
+
+document
+  .getElementById('resetRequestForm')
+  .addEventListener('submit', sendRequest);

--- a/js/resetPassword.js
+++ b/js/resetPassword.js
@@ -1,0 +1,41 @@
+const API_BASE = (window.API_ORIGIN || '') + '/api';
+
+const params = new URLSearchParams(window.location.search);
+const token = params.get('token');
+
+async function resetPassword(e) {
+  e.preventDefault();
+  const passEl = document.getElementById('new-pass');
+  passEl.classList.remove('border-red-500');
+  const password = passEl.value.trim();
+  if (!password) {
+    document.getElementById('msg').textContent = 'Password required';
+    passEl.classList.add('border-red-500');
+    return;
+  }
+  const res = await fetch(`${API_BASE}/reset-password`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ token, password }),
+  });
+  if (res.status === 204) {
+    document.getElementById('msg').classList.remove('text-red-400');
+    document.getElementById('msg').classList.add('text-green-400');
+    document.getElementById('msg').textContent =
+      'Password updated. You may now log in.';
+  } else {
+    const data = await res.json();
+    document.getElementById('msg').textContent =
+      data.error || 'Failed to reset password';
+    passEl.classList.add('border-red-500');
+  }
+}
+
+document
+  .getElementById('resetPasswordForm')
+  .addEventListener('submit', resetPassword);
+
+if (!token) {
+  document.getElementById('msg').textContent = 'Invalid or expired link';
+  document.querySelector('#resetPasswordForm button').disabled = true;
+}

--- a/request-reset.html
+++ b/request-reset.html
@@ -3,12 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Login</title>
-    <meta property="og:title" content="Login – print3" />
-    <meta
-      property="og:description"
-      content="Access your print3 account to manage models and orders."
-    />
+    <title>Password Reset Request</title>
+    <meta property="og:title" content="Reset Password – print3" />
     <meta property="og:image" content="img/boxlogo.png" />
     <script src="https://cdn.tailwindcss.com"></script>
     <link
@@ -19,7 +15,7 @@
   <body class="bg-[#1A1A1D] text-white font-sans flex flex-col min-h-screen">
     <header class="relative flex items-center justify-between py-4 px-6">
       <a
-        href="index.html"
+        href="login.html"
         class="inline-flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-3xl px-5 py-2 text-lg font-medium hover:bg-[#3A3A3E] transition-shape"
       >
         <svg
@@ -36,7 +32,7 @@
       <h1
         class="absolute inset-x-0 top-1/2 -translate-y-1/2 text-center text-3xl font-semibold pointer-events-none"
       >
-        Login
+        Reset Password
       </h1>
       <div class="flex space-x-2">
         <button
@@ -78,42 +74,27 @@
     </header>
     <main class="flex-1 flex items-center justify-center">
       <form
-        id="loginForm"
+        id="resetRequestForm"
         class="space-y-4 bg-[#2A2A2E] border border-white/10 p-6 rounded-3xl w-96"
-        aria-label="Login form"
+        aria-label="Request password reset"
       >
         <input
-          id="li-name"
+          id="req-email"
+          type="email"
           class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10"
-          placeholder="Username or email"
-          aria-label="Username or email"
+          placeholder="Email"
+          aria-label="Email"
         />
-        <input
-          id="li-pass"
-          type="password"
-          class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10"
-          placeholder="Password"
-          aria-label="Password"
-        />
-        <div id="error" class="text-red-400" aria-live="assertive"></div>
-        <div class="flex items-center justify-between">
+        <div id="msg" class="text-red-400" aria-live="assertive"></div>
         <button
           class="bg-[#30D5C8] text-[#1A1A1D] font-semibold px-4 py-2 rounded-xl hover:bg-[#28b7a8] transition"
           type="submit"
         >
-          Login
+          Send Reset Link
         </button>
-        <p class="text-sm text-white mr-1">
-          Don't have an account?
-          <a href="signup.html" class="font-bold text-[#30D5C8]">Sign up</a>
-        </p>
-      </div>
-      <p class="text-sm text-right mt-2">
-        <a href="request-reset.html" class="font-bold text-[#30D5C8]">Forgot password?</a>
-      </p>
       </form>
     </main>
-    <script type="module" src="js/login.js"></script>
+    <script type="module" src="js/requestReset.js"></script>
     <script type="module">
       import { shareOn } from './js/share.js';
       window.shareOn = shareOn;

--- a/reset-password.html
+++ b/reset-password.html
@@ -3,12 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Login</title>
-    <meta property="og:title" content="Login – print3" />
-    <meta
-      property="og:description"
-      content="Access your print3 account to manage models and orders."
-    />
+    <title>Reset Password</title>
+    <meta property="og:title" content="Reset Password – print3" />
     <meta property="og:image" content="img/boxlogo.png" />
     <script src="https://cdn.tailwindcss.com"></script>
     <link
@@ -19,7 +15,7 @@
   <body class="bg-[#1A1A1D] text-white font-sans flex flex-col min-h-screen">
     <header class="relative flex items-center justify-between py-4 px-6">
       <a
-        href="index.html"
+        href="login.html"
         class="inline-flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-3xl px-5 py-2 text-lg font-medium hover:bg-[#3A3A3E] transition-shape"
       >
         <svg
@@ -36,7 +32,7 @@
       <h1
         class="absolute inset-x-0 top-1/2 -translate-y-1/2 text-center text-3xl font-semibold pointer-events-none"
       >
-        Login
+        Reset Password
       </h1>
       <div class="flex space-x-2">
         <button
@@ -78,42 +74,27 @@
     </header>
     <main class="flex-1 flex items-center justify-center">
       <form
-        id="loginForm"
+        id="resetPasswordForm"
         class="space-y-4 bg-[#2A2A2E] border border-white/10 p-6 rounded-3xl w-96"
-        aria-label="Login form"
+        aria-label="Reset password form"
       >
         <input
-          id="li-name"
-          class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10"
-          placeholder="Username or email"
-          aria-label="Username or email"
-        />
-        <input
-          id="li-pass"
+          id="new-pass"
           type="password"
           class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10"
-          placeholder="Password"
-          aria-label="Password"
+          placeholder="New password"
+          aria-label="New password"
         />
-        <div id="error" class="text-red-400" aria-live="assertive"></div>
-        <div class="flex items-center justify-between">
+        <div id="msg" class="text-red-400" aria-live="assertive"></div>
         <button
           class="bg-[#30D5C8] text-[#1A1A1D] font-semibold px-4 py-2 rounded-xl hover:bg-[#28b7a8] transition"
           type="submit"
         >
-          Login
+          Reset Password
         </button>
-        <p class="text-sm text-white mr-1">
-          Don't have an account?
-          <a href="signup.html" class="font-bold text-[#30D5C8]">Sign up</a>
-        </p>
-      </div>
-      <p class="text-sm text-right mt-2">
-        <a href="request-reset.html" class="font-bold text-[#30D5C8]">Forgot password?</a>
-      </p>
       </form>
     </main>
-    <script type="module" src="js/login.js"></script>
+    <script type="module" src="js/resetPassword.js"></script>
     <script type="module">
       import { shareOn } from './js/share.js';
       window.shareOn = shareOn;


### PR DESCRIPTION
## Summary
- implement password reset request and reset pages
- add JavaScript logic for requesting and setting passwords
- link forgotten password from login page
- run formatting and tests

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849d852a630832d96c73261fe61693c