### PR TITLE
Add cleanup job for expired reset tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ This repository contains the early MVP code for print2's website and backend.
    npm run send-reminders  # inside backend/
    ```
 
+7. (Optional) Clean up expired password reset tokens periodically:
+
+   ```bash
+   npm run cleanup-tokens  # inside backend/
+   ```
+
 ## Serving the Frontend Locally
 
 `index.html` and `payment.html` use ES module scripts. When opened directly from

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,6 +12,7 @@
     "create-admin": "node scripts/create-admin.js",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "send-reminders": "node scripts/send-purchase-reminders.js",
+    "cleanup-tokens": "node scripts/cleanup-password-resets.js",
     "lint": "eslint . --max-warnings=0"
   },
   "keywords": [],

--- a/backend/scripts/cleanup-password-resets.js
+++ b/backend/scripts/cleanup-password-resets.js
@@ -1,0 +1,24 @@
+require('dotenv').config();
+const { Client } = require('pg');
+
+async function cleanupExpiredTokens() {
+  const client = new Client({ connectionString: process.env.DB_URL });
+  await client.connect();
+  try {
+    const { rowCount } = await client.query('DELETE FROM password_resets WHERE expires_at < NOW()');
+    if (rowCount && rowCount > 0) {
+      console.log(`Deleted ${rowCount} expired password reset tokens`);
+    }
+  } finally {
+    await client.end();
+  }
+}
+
+if (require.main === module) {
+  cleanupExpiredTokens().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}
+
+module.exports = cleanupExpiredTokens;

--- a/backend/tests/cleanupPasswordResets.test.js
+++ b/backend/tests/cleanupPasswordResets.test.js
@@ -1,0 +1,24 @@
+process.env.DB_URL = 'postgres://user:pass@localhost/db';
+
+jest.mock('pg');
+const { Client } = require('pg');
+const mClient = { connect: jest.fn(), end: jest.fn(), query: jest.fn() };
+Client.mockImplementation(() => mClient);
+
+const run = require('../scripts/cleanup-password-resets');
+
+beforeEach(() => {
+  mClient.connect.mockClear();
+  mClient.end.mockClear();
+  mClient.query.mockClear();
+});
+
+test('deletes expired password reset tokens', async () => {
+  mClient.query.mockResolvedValueOnce({ rowCount: 2 });
+  await run();
+  expect(mClient.connect).toHaveBeenCalled();
+  expect(mClient.query).toHaveBeenCalledWith(
+    'DELETE FROM password_resets WHERE expires_at < NOW()'
+  );
+  expect(mClient.end).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- add `cleanup-password-resets.js` script
- expose `cleanup-tokens` npm script
- test the cleanup script
- document how to run the cleanup job in README

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849d85be820832da710fa37c8742846