### PR TITLE
Update login/signup error placement

### DIFF
--- a/login.html
+++ b/login.html
@@ -96,7 +96,7 @@
           aria-label="Password"
         />
         <div class="flex items-center justify-between">
-          <div class="relative flex items-center">
+          <div class="relative flex flex-col items-start">
             <button
               class="bg-[#30D5C8] text-[#1A1A1D] font-semibold px-4 py-2 rounded-xl hover:bg-[#28b7a8] transition"
               type="submit"
@@ -105,7 +105,7 @@
             </button>
             <div
               id="error"
-              class="absolute bottom-0 left-full ml-2 text-red-400 whitespace-nowrap"
+              class="absolute top-full left-0 ml-4 mt-1 text-red-400 whitespace-nowrap"
               aria-live="assertive"
             ></div>
           </div>

--- a/signup.html
+++ b/signup.html
@@ -103,7 +103,7 @@
           aria-label="Password"
         />
         <div class="flex items-center">
-          <div class="relative flex items-center">
+          <div class="relative flex flex-col items-start">
             <button
               class="bg-[#30D5C8] text-[#1A1A1D] font-semibold px-4 py-2 rounded-xl hover:bg-[#28b7a8] transition"
               type="submit"
@@ -112,7 +112,7 @@
             </button>
             <div
               id="error"
-              class="absolute bottom-0 left-full ml-2 text-red-400 whitespace-nowrap"
+              class="absolute top-full left-0 ml-4 mt-1 text-red-400 whitespace-nowrap"
               aria-live="assertive"
             ></div>
           </div>


### PR DESCRIPTION
## Summary
- align login and signup error messages under their buttons
- run prettier formatting
- run backend tests

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849da60b66c832dbb0f383555211861