### PR TITLE
Reset community grid when leaving page

### DIFF
--- a/js/community.js
+++ b/js/community.js
@@ -234,8 +234,7 @@ function createObserver(type) {
 
 function init() {
   const saved = loadState();
-  window.communityState =
-    saved || { recent: {}, popular: {} };
+  window.communityState = saved || { recent: {}, popular: {} };
 
   const popBtn = document.getElementById('popular-load');
   if (popBtn) popBtn.addEventListener('click', () => loadMore('popular'));
@@ -275,6 +274,11 @@ function init() {
   }
   renderGrid('popular');
   renderGrid('recent');
+
+  // Clear saved state when leaving the page so grids reset on next visit
+  window.addEventListener('pagehide', () => {
+    localStorage.removeItem(STATE_KEY);
+  });
 }
 
 export { like, init };


### PR DESCRIPTION
## Summary
- reset stored state for Community Creations page when navigating away

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849dcda28d4832da8d8e3fa624e3fbb