### PR TITLE
Lazy load JS on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -342,9 +342,14 @@
     </main>
 
     <!-- ▸▸▸ SCRIPTS ------------------------------------------------------ -->
-    <script src="js/subredditLanding.js" defer></script>
-    <script src="js/modelViewerTouchFix.js" defer></script>
-    <script type="module" src="js/index.js"></script>
+    <!-- Lazy-load non-critical scripts -->
+    <script type="module">
+      window.addEventListener('load', () => {
+        import('./js/modelViewerTouchFix.js');
+        import('./js/subredditLanding.js');
+        import('./js/index.js');
+      });
+    </script>
     <script type="module">
       document.getElementById('profile-link')?.addEventListener('click', function (e) {
         if (!localStorage.getItem('token')) {


### PR DESCRIPTION
## Summary
- lazy load non-critical scripts on the homepage so initial view loads faster

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849df7973b0832d9cbb402048dafadd