### PR TITLE
Add exit-intent discount popup

### DIFF
--- a/index.html
+++ b/index.html
@@ -341,6 +341,25 @@
       </section>
     </main>
 
+    <!-- Exit-intent discount overlay -->
+    <div
+      id="exit-discount-overlay"
+      class="fixed inset-0 bg-black/80 flex items-center justify-center hidden z-50"
+    >
+      <div class="bg-[#2A2A2E] border border-white/10 rounded-3xl p-6 text-center">
+        <h2 class="text-xl font-semibold mb-2 text-white">Wait! Before you go…</h2>
+        <p class="mb-4 text-gray-300">
+          Use code <span class="text-white font-mono px-1">SAVE5</span> for 5% off your next order.
+        </p>
+        <button
+          id="exit-discount-close"
+          class="mt-2 px-4 py-2 rounded-md bg-[#30D5C8] text-[#1A1A1D] hover:bg-[#28b7a8] transition"
+        >
+          Close
+        </button>
+      </div>
+    </div>
+
     <!-- ▸▸▸ SCRIPTS ------------------------------------------------------ -->
     <!-- Lazy-load non-critical scripts -->
     <script type="module">
@@ -348,6 +367,7 @@
         import('./js/modelViewerTouchFix.js');
         import('./js/subredditLanding.js');
         import('./js/index.js');
+        import('./js/exitDiscount.js');
       });
     </script>
     <script type="module">

--- a/js/exitDiscount.js
+++ b/js/exitDiscount.js
@@ -1,0 +1,25 @@
+'use strict';
+
+window.addEventListener('DOMContentLoaded', () => {
+  const overlay = document.getElementById('exit-discount-overlay');
+  const closeBtn = document.getElementById('exit-discount-close');
+  if (!overlay || !closeBtn) return;
+
+  closeBtn.addEventListener('click', () => overlay.classList.add('hidden'));
+
+  let ready = false;
+  let shown = false;
+  setTimeout(() => {
+    ready = true;
+  }, 3000);
+
+  function maybeShow(e) {
+    if (!ready || shown) return;
+    if (e.clientY <= 0 && !e.relatedTarget) {
+      overlay.classList.remove('hidden');
+      shown = true;
+    }
+  }
+
+  document.addEventListener('mouseout', maybeShow);
+});

--- a/payment.html
+++ b/payment.html
@@ -234,8 +234,28 @@
       </div>
     </main>
 
+    <!-- Exit-intent discount overlay -->
+    <div
+      id="exit-discount-overlay"
+      class="fixed inset-0 bg-black/80 flex items-center justify-center hidden z-50"
+    >
+      <div class="bg-[#2A2A2E] border border-white/10 rounded-3xl p-6 text-center">
+        <h2 class="text-xl font-semibold mb-2 text-white">Wait! Before you go…</h2>
+        <p class="mb-4 text-gray-300">
+          Use code <span class="text-white font-mono px-1">SAVE5</span> for 5% off your next order.
+        </p>
+        <button
+          id="exit-discount-close"
+          class="mt-2 px-4 py-2 rounded-md bg-[#30D5C8] text-[#1A1A1D] hover:bg-[#28b7a8] transition"
+        >
+          Close
+        </button>
+      </div>
+    </div>
+
     <!-- ─────────── Init -->
     <script src="js/modelViewerTouchFix.js"></script>
     <script type="module" src="js/payment.js"></script>
+    <script type="module" src="js/exitDiscount.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- show a discount offer when users attempt to leave `index.html` or `payment.html`
- implement `js/exitDiscount.js` that listens for exit intent
- load the new script on both pages

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849e14277e4832d85983979f752409c