### PR TITLE
chore: add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- add `.github/dependabot.yml` to enable weekly updates for npm and GitHub Actions

## Testing
- `npm run format`
- `npm test` *(fails due to lingering handles)*

------
https://chatgpt.com/codex/tasks/task_e_6849e4472208832d8587e70247f14f9c