### PR TITLE
Fix recent creations initial load bug

### DIFF
--- a/js/community.js
+++ b/js/community.js
@@ -202,7 +202,7 @@ function renderGrid(type, filters = getFilters()) {
   const { key } = filters;
   const grid = document.getElementById(`${type}-grid`);
   grid.innerHTML = '';
-  const state = window.communityState[type][key];
+  let state = window.communityState[type][key];
   if (state && state.models.length) {
     state.models.forEach((m) => grid.appendChild(createCard(m)));
     captureSnapshots(grid);
@@ -213,8 +213,9 @@ function renderGrid(type, filters = getFilters()) {
     }
   } else {
     loadMore(type, filters);
+    state = window.communityState[type][key];
   }
-  state.loading = false;
+  if (state) state.loading = false;
 }
 
 // IntersectionObserver support has been removed in favor of explicit "More"


### PR DESCRIPTION
## Summary
- ensure `renderGrid` doesn't crash when state isn't initialized

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849e4e70bb4832db8da75076cb9e20f