### PR TITLE
Implement colour selector on payment page

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -132,6 +132,9 @@ document.addEventListener('DOMContentLoaded', async () => {
   const applyBtn = document.getElementById('apply-discount');
   const materialRadios = document.querySelectorAll('#material-options input[name="material"]');
   const payBtn = document.getElementById('submit-payment');
+  const singleLabel = document.getElementById('single-label');
+  const colorMenu = document.getElementById('single-color-menu');
+  const singleButton = singleLabel?.querySelector('span');
   let discountCode = '';
   let discountValue = 0;
 
@@ -146,9 +149,27 @@ document.addEventListener('DOMContentLoaded', async () => {
       if (r.checked) {
         selectedPrice = PRICES[r.value] || PRICES.single;
         updatePayButton();
+        if (colorMenu) colorMenu.hidden = true;
       }
     });
   });
+
+  if (singleLabel && colorMenu && singleButton) {
+    singleLabel.addEventListener('click', (e) => {
+      if (document.getElementById('opt-single').checked) {
+        // Toggle menu visibility
+        colorMenu.hidden = !colorMenu.hidden;
+      }
+    });
+    colorMenu.addEventListener('click', (ev) => {
+      const btn = ev.target.closest('button[data-color]');
+      if (btn) {
+        const color = btn.dataset.color;
+        singleButton.style.backgroundColor = color;
+        colorMenu.hidden = true;
+      }
+    });
+  }
   updatePayButton();
   const sessionId = qs('session_id');
   if (sessionId) recordPurchase();

--- a/payment.html
+++ b/payment.html
@@ -178,7 +178,7 @@
 
             <!-- Material/Size Options -->
             <fieldset id="material-options" class="flex justify-around my-4">
-              <label class="cursor-pointer text-center">
+              <label id="single-label" class="cursor-pointer text-center relative">
                 <input
                   type="radio"
                   name="material"
@@ -191,8 +191,44 @@
                   class="w-24 h-24 flex flex-col items-center justify-center rounded-full border border-white/20 peer-checked:bg-[#30D5C8] peer-checked:text-[#1A1A1D]"
                 >
                   <span class="font-semibold">£25</span>
-                  <span class="text-xs">1-colour</span>
+                  <span class="text-xs">single colour</span>
                 </span>
+                <div
+                  id="single-color-menu"
+                  class="absolute left-1/2 -translate-x-1/2 top-full mt-2 flex gap-2"
+                  hidden
+                >
+                  <button
+                    type="button"
+                    class="w-24 h-24 rounded-full border border-white/20"
+                    style="background-color:#f87171"
+                    data-color="#f87171"
+                  ></button>
+                  <button
+                    type="button"
+                    class="w-24 h-24 rounded-full border border-white/20"
+                    style="background-color:#34d399"
+                    data-color="#34d399"
+                  ></button>
+                  <button
+                    type="button"
+                    class="w-24 h-24 rounded-full border border-white/20"
+                    style="background-color:#60a5fa"
+                    data-color="#60a5fa"
+                  ></button>
+                  <button
+                    type="button"
+                    class="w-24 h-24 rounded-full border border-white/20"
+                    style="background-color:#fbbf24"
+                    data-color="#fbbf24"
+                  ></button>
+                  <button
+                    type="button"
+                    class="w-24 h-24 rounded-full border border-white/20"
+                    style="background-color:#a78bfa"
+                    data-color="#a78bfa"
+                  ></button>
+                </div>
               </label>
               <label class="cursor-pointer text-center">
                 <input


### PR DESCRIPTION
## Summary
- rename '1-colour' label to 'single colour'
- add interactive colour picker for the single colour option
- adjust payment script to handle showing and selecting colours

## Testing
- `npm run format`
- `npm test -- -w=1`

------
https://chatgpt.com/codex/tasks/task_e_6849e60027c8832d84624761f4f8ab2b