### PR TITLE
test/block-console-error

### DIFF
--- a/backend/tests/api.test.js
+++ b/backend/tests/api.test.js
@@ -170,6 +170,7 @@ test('Stripe webhook updates order and enqueues print', async () => {
 });
 
 test('Stripe webhook invalid signature', async () => {
+  jest.spyOn(console, 'error').mockImplementation(() => {});
   stripeMock.webhooks.constructEvent.mockImplementation(() => {
     throw new Error('bad sig');
   });
@@ -183,6 +184,7 @@ test('Stripe webhook invalid signature', async () => {
 });
 
 test('Stripe webhook invalid signature does not process', async () => {
+  jest.spyOn(console, 'error').mockImplementation(() => {});
   stripeMock.webhooks.constructEvent.mockImplementation(() => {
     throw new Error('bad sig');
   });
@@ -346,6 +348,7 @@ test('registration invalid email', async () => {
 });
 
 test('registration duplicate username', async () => {
+  jest.spyOn(console, 'error').mockImplementation(() => {});
   db.query.mockRejectedValueOnce(new Error('duplicate key'));
   const res = await request(app)
     .post('/api/register')
@@ -372,6 +375,7 @@ test('/api/generate 400 when no prompt or image', async () => {
 });
 
 test('/api/generate falls back on server failure', async () => {
+  jest.spyOn(console, 'error').mockImplementation(() => {});
   axios.post.mockRejectedValueOnce(new Error('fail'));
   const res = await request(app).post('/api/generate').send({ prompt: 't' });
   expect(res.status).toBe(200);

--- a/backend/tests/setup.js
+++ b/backend/tests/setup.js
@@ -21,8 +21,16 @@ if (typeof global.setImmediate === 'undefined') {
   global.setImmediate = (cb) => setTimeout(cb, 0);
 }
 
+// Fail tests if console.error is called
+beforeEach(() => {
+  jest.spyOn(console, 'error').mockImplementation((...args) => {
+    throw new Error('console.error called: ' + args.join(' '));
+  });
+});
+
 // Clean up between tests
 afterEach(() => {
+  jest.restoreAllMocks();
   if (global.window && typeof global.window.close === 'function') {
     global.window.close();
   }


### PR DESCRIPTION
## Summary
- ensure tests fail when `console.error` is invoked
- silence error logging in specific tests

## Testing
- `npm run format`
- `npm test`
- `npm run test-ci`


------
https://chatgpt.com/codex/tasks/task_e_6849e7815cc0832d8366025573f8bcf4