### PR TITLE
Fix single colour menu toggle

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -150,7 +150,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       if (r.checked) {
         selectedPrice = PRICES[r.value] || PRICES.single;
         updatePayButton();
-        if (colorMenu) colorMenu.hidden = true;
+        if (colorMenu) colorMenu.classList.add('hidden');
       }
     });
   });
@@ -159,7 +159,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     singleLabel.addEventListener('click', (e) => {
       if (document.getElementById('opt-single').checked) {
         // Toggle menu visibility
-        colorMenu.hidden = !colorMenu.hidden;
+        colorMenu.classList.toggle('hidden');
       }
     });
     colorMenu.addEventListener('click', (ev) => {
@@ -167,7 +167,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       if (btn) {
         const color = btn.dataset.color;
         singleButton.style.backgroundColor = color;
-        colorMenu.hidden = true;
+        colorMenu.classList.add('hidden');
       }
     });
   }

--- a/payment.html
+++ b/payment.html
@@ -195,8 +195,7 @@
                 </span>
                 <div
                   id="single-color-menu"
-                  class="absolute left-1/2 -translate-x-1/2 top-full mt-2 flex gap-2"
-                  hidden
+                  class="absolute left-1/2 -translate-x-1/2 top-full mt-2 flex gap-2 p-2 bg-[#2A2A2E] border border-white/20 rounded-3xl hidden"
                 >
                   <button
                     type="button"


### PR DESCRIPTION
## Summary
- toggle colour menu with JS instead of hidden attribute
- show colours in a grey popover container

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849e8e43bd4832d90b68b6c16e3ce04