### PR TITLE
Implement no-only lint rule

### DIFF
--- a/backend/.eslintrc.cjs
+++ b/backend/.eslintrc.cjs
@@ -1,4 +1,13 @@
 module.exports = {
   extends: ['@eslint/js', 'prettier'],
   env: { node: true, jest: true },
+  rules: {
+    'no-restricted-syntax': [
+      'error',
+      { selector: "CallExpression[callee.object.name='describe'][callee.property.name='only']", message: 'Do not commit describe.only' },
+      { selector: "CallExpression[callee.object.name='test'][callee.property.name='only']", message: 'Do not commit test.only' },
+      { selector: "CallExpression[callee.object.name='describe'][callee.property.name='skip']", message: 'Avoid describe.skip' },
+      { selector: "CallExpression[callee.object.name='test'][callee.property.name='skip']", message: 'Avoid test.skip' },
+    ],
+  },
 };


### PR DESCRIPTION
## Summary
- prevent accidental `describe.only` or `test.only` commits
- prevent `describe.skip` and `test.skip` in committed code

## Testing
- `npm run format`
- `npm run lint`
- `npm run test-ci`


------
https://chatgpt.com/codex/tasks/task_e_6849e8ff32fc832d889c726d78e62997