### PR TITLE
Fix 3D viewer init when scripts load after DOM

### DIFF
--- a/index.html
+++ b/index.html
@@ -374,7 +374,9 @@
       window.addEventListener('load', () => {
         import('./js/modelViewerTouchFix.js');
         import('./js/subredditLanding.js');
-        import('./js/index.js');
+        import('./js/index.js').then(() => {
+          window.initIndexPage && window.initIndexPage();
+        });
         import('./js/exitDiscount.js');
       });
     </script>

--- a/js/index.js
+++ b/js/index.js
@@ -386,7 +386,7 @@ refs.submitBtn.addEventListener('click', async () => {
   }
 });
 
-window.addEventListener('DOMContentLoaded', async () => {
+async function init() {
   syncUploadHeights();
   window.addEventListener('resize', syncUploadHeights);
   setStep('prompt');
@@ -480,4 +480,8 @@ window.addEventListener('DOMContentLoaded', async () => {
     }
     if (window.setWizardStage) window.setWizardStage('purchase');
   });
-});
+}
+
+window.initIndexPage = init;
+
+window.addEventListener('DOMContentLoaded', init);


### PR DESCRIPTION
## Summary
- ensure lazy loaded `index.js` initializes even after DOMContentLoaded
- call the init function from the loader script

## Testing
- `npm run format`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6849e875f9e4832d99421cd16f570f74