### PR TITLE
Maintain community grid after refresh

### DIFF
--- a/js/community.js
+++ b/js/community.js
@@ -234,8 +234,17 @@ function createObserver(type) {
 }
 
 function init() {
-  const nav = performance.getEntriesByType('navigation')[0];
-  const navType = nav ? nav.type : performance.navigation.type;
+  let navType = 'navigate';
+  if (typeof performance !== 'undefined') {
+    const entries =
+      performance.getEntriesByType?.('navigation') || [];
+    if (entries.length && entries[0].type) {
+      navType = entries[0].type;
+    } else if (performance.navigation) {
+      if (performance.navigation.type === 1) navType = 'reload';
+      else if (performance.navigation.type === 2) navType = 'back_forward';
+    }
+  }
   if (navType !== 'reload') {
     localStorage.removeItem(STATE_KEY);
   }

--- a/js/community.js
+++ b/js/community.js
@@ -234,6 +234,12 @@ function createObserver(type) {
 }
 
 function init() {
+  const nav = performance.getEntriesByType('navigation')[0];
+  const navType = nav ? nav.type : performance.navigation.type;
+  if (navType !== 'reload') {
+    localStorage.removeItem(STATE_KEY);
+  }
+
   const saved = loadState();
   window.communityState = saved || { recent: {}, popular: {} };
 
@@ -275,11 +281,6 @@ function init() {
   }
   renderGrid('popular');
   renderGrid('recent');
-
-  // Clear saved state when leaving the page so grids reset on next visit
-  window.addEventListener('pagehide', () => {
-    localStorage.removeItem(STATE_KEY);
-  });
 }
 
 export { like, init };


### PR DESCRIPTION
## Summary
- keep community grid state when reloading the page
- reset grid when navigating from another page

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849eaccf8d0832d9d56e3ade13ecee6