### PR TITLE
Enhance basket preview

### DIFF
--- a/js/basket.js
+++ b/js/basket.js
@@ -35,6 +35,23 @@ function updateBadge() {
     badge.hidden = n === 0;
   }
 }
+let viewerModal;
+let viewerEl;
+
+function showModel(modelUrl, poster) {
+  if (!viewerModal || !viewerEl) return;
+  if (poster) viewerEl.setAttribute('poster', poster);
+  viewerEl.src = modelUrl;
+  viewerModal.classList.remove('hidden');
+  document.body.classList.add('overflow-hidden');
+}
+
+function hideModel() {
+  if (!viewerModal) return;
+  viewerModal.classList.add('hidden');
+  document.body.classList.remove('overflow-hidden');
+}
+
 function renderList() {
   const list = document.getElementById('basket-list');
   if (!list) return;
@@ -51,6 +68,7 @@ function renderList() {
     img.src = it.snapshot || it.modelUrl || '';
     img.alt = 'Model';
     img.className = 'w-16 h-16 object-contain bg-[#2A2A2E] mr-2';
+    img.addEventListener('click', () => showModel(it.modelUrl, it.snapshot));
     const btn = document.createElement('button');
     btn.textContent = 'Remove';
     btn.className = 'remove text-xs px-2 py-1 bg-red-600 rounded';
@@ -92,6 +110,24 @@ export function setupBasketUI() {
     closeBasket();
     window.location.href = 'payment.html';
   });
+
+  const viewerOverlay = document.createElement('div');
+  viewerOverlay.id = 'basket-model-modal';
+  viewerOverlay.className =
+    'fixed inset-0 bg-black/80 flex items-center justify-center hidden z-50';
+  viewerOverlay.innerHTML = `
+    <div class="relative w-11/12 max-w-3xl">
+      <button id="basket-model-close" class="absolute -top-4 -right-4 w-[4.5rem] h-[4.5rem] rounded-full bg-white text-black flex items-center justify-center z-50" type="button">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="w-10 h-10" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"><line x1="6" y1="6" x2="18" y2="18" /><line x1="6" y1="18" x2="18" y2="6" /></svg>
+        <span class="sr-only">Close</span>
+      </button>
+      <model-viewer src="" alt="3D model preview" environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr" camera-controls auto-rotate class="w-full h-96 bg-[#2A2A2E] rounded-xl"></model-viewer>
+    </div>`;
+  document.body.appendChild(viewerOverlay);
+  viewerModal = viewerOverlay;
+  viewerEl = viewerOverlay.querySelector('model-viewer');
+  viewerOverlay.querySelector('#basket-model-close').addEventListener('click', hideModel);
+
   updateBadge();
 }
 window.addEventListener('DOMContentLoaded', setupBasketUI);


### PR DESCRIPTION
## Summary
- allow showing basket items as 3D models when clicked
- include a model-viewer modal for basket items

## Testing
- `npm run format`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684a06d6de50832d97ec35368756fcc4