### PR TITLE
Add outside click closing for overlays

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -247,6 +247,18 @@
           if (e.key === 'Escape') close();
         });
 
+        document.addEventListener('click', (e) => {
+          if (modal.classList.contains('hidden')) return;
+          const container = modal.querySelector('div');
+          const basketBtn = document.getElementById('basket-button');
+          if (
+            !container.contains(e.target) &&
+            !(basketBtn && basketBtn.contains(e.target))
+          ) {
+            close();
+          }
+        });
+
         init();
       });
     </script>

--- a/js/basket.js
+++ b/js/basket.js
@@ -112,6 +112,13 @@ export function setupBasketUI() {
     window.location.href = 'payment.html';
   });
 
+  overlay.addEventListener('click', (e) => {
+    const container = overlay.querySelector('div');
+    if (!container.contains(e.target) && !btn.contains(e.target)) {
+      closeBasket();
+    }
+  });
+
   const viewerOverlay = document.createElement('div');
   viewerOverlay.id = 'basket-model-modal';
   viewerOverlay.className =


### PR DESCRIPTION
## Summary
- close the community 3D model viewer when clicking outside the modal
- dismiss the basket overlay when clicking outside the popup
- include new behavior in CommunityCreations scripts and basket logic

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a0875f438832d86c948507740df48