### PR TITLE
Implement commission tracking

### DIFF
--- a/backend/tests/additionalApi.test.js
+++ b/backend/tests/additionalApi.test.js
@@ -6,6 +6,7 @@ process.env.HUNYUAN_SERVER_URL = 'http://localhost:4000';
 
 jest.mock('../db', () => ({
   query: jest.fn().mockResolvedValue({ rows: [] }),
+  insertCommission: jest.fn().mockResolvedValue({}),
 }));
 const db = require('../db');
 
@@ -38,6 +39,7 @@ beforeAll(() => {
 
 beforeEach(() => {
   db.query.mockClear();
+  db.insertCommission.mockClear();
   axios.post.mockClear();
   sendMail.mockClear();
   stripeMock.checkout.sessions.create.mockResolvedValue({


### PR DESCRIPTION
## Summary
- insert commissions on order creation when buyer is not model owner
- mock `insertCommission` in unit tests and add coverage for commissions

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a07e0e8ac832d89acc81aa47c0895