### PR TITLE
Add spacing above progress bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -192,7 +192,7 @@
     </header>
 
     <!-- ▸▸▸ MAIN --------------------------------------------------------- -->
-    <main class="flex-1 flex flex-col items-center justify-start gap-8 px-4 lg:px-16">
+    <main class="flex-1 flex flex-col items-center justify-start gap-8 px-4 lg:px-16" style="margin-top: -1.25rem;">
       <!-- 3-D preview ---------------------------------------------------- -->
       <div class="relative flex justify-center w-full max-w-lg">
         <section


### PR DESCRIPTION
## Summary
- move entire main content upward on index page to increase space between the upload section and the sticky wizard banner

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a09e22d4c832d862ad218df1947e5