### PR TITLE
Fix basket overlay closing on item removal

### DIFF
--- a/js/basket.js
+++ b/js/basket.js
@@ -72,7 +72,10 @@ function renderList() {
     const btn = document.createElement('button');
     btn.textContent = 'Remove';
     btn.className = 'remove text-xs px-2 py-1 bg-red-600 rounded';
-    btn.addEventListener('click', () => removeFromBasket(idx));
+    btn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      removeFromBasket(idx);
+    });
     div.appendChild(img);
     div.appendChild(btn);
     list.appendChild(div);


### PR DESCRIPTION
## Summary
- keep the basket box open when removing an item

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a0f249d88832d8f9d66ffb607db5a