### PR TITLE
Add commissions endpoints and tests

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -45,6 +45,18 @@ async function getCommissionsForUser(userId) {
   ).then((res) => res.rows);
 }
 
+async function getCommissionsForSeller(userId) {
+  return query('SELECT * FROM model_commissions WHERE seller_user_id=$1 ORDER BY created_at DESC', [
+    userId,
+  ]).then((res) => res.rows);
+}
+
+async function markCommissionPaid(id) {
+  return query('UPDATE model_commissions SET status=$1 WHERE id=$2 RETURNING *', ['paid', id]).then(
+    (res) => res.rows[0]
+  );
+}
+
 module.exports = {
   query,
   insertShare,
@@ -52,4 +64,6 @@ module.exports = {
   getShareByJobId,
   insertCommission,
   getCommissionsForUser,
+  getCommissionsForSeller,
+  markCommissionPaid,
 };

--- a/backend/tests/commissions.test.js
+++ b/backend/tests/commissions.test.js
@@ -1,0 +1,55 @@
+process.env.STRIPE_SECRET_KEY = 'test';
+process.env.STRIPE_WEBHOOK_SECRET = 'whsec';
+process.env.DB_URL = 'postgres://user:pass@localhost/db';
+process.env.HUNYUAN_API_KEY = 'test';
+process.env.HUNYUAN_SERVER_URL = 'http://localhost:4000';
+
+jest.mock('../db', () => ({
+  query: jest.fn(),
+  insertCommission: jest.fn(),
+  getCommissionsForSeller: jest.fn(),
+  markCommissionPaid: jest.fn(),
+}));
+const db = require('../db');
+
+const jwt = require('jsonwebtoken');
+const request = require('supertest');
+const app = require('../server');
+
+beforeEach(() => {
+  db.query.mockReset();
+  db.getCommissionsForSeller.mockReset();
+  db.markCommissionPaid.mockReset();
+});
+
+test('GET /api/commissions returns commissions and totals', async () => {
+  db.getCommissionsForSeller.mockResolvedValueOnce([
+    { id: 'c1', commission_cents: 50, status: 'pending' },
+  ]);
+  db.query.mockResolvedValueOnce({ rows: [{ pending: 50, paid: 0 }] });
+  const token = jwt.sign({ id: 'u1' }, 'secret');
+  const res = await request(app).get('/api/commissions').set('authorization', `Bearer ${token}`);
+  expect(res.status).toBe(200);
+  expect(res.body.commissions[0].id).toBe('c1');
+  expect(res.body.totalPending).toBe(50);
+  expect(res.body.totalPaid).toBe(0);
+});
+
+test('GET /api/commissions requires auth', async () => {
+  const res = await request(app).get('/api/commissions');
+  expect(res.status).toBe(401);
+});
+
+test('POST /api/commissions/:id/mark-paid updates status', async () => {
+  db.markCommissionPaid.mockResolvedValueOnce({ id: 'c1', status: 'paid' });
+  const res = await request(app)
+    .post('/api/commissions/c1/mark-paid')
+    .set('x-admin-token', 'admin');
+  expect(res.status).toBe(200);
+  expect(res.body.status).toBe('paid');
+});
+
+test('POST /api/commissions/:id/mark-paid unauthorized', async () => {
+  const res = await request(app).post('/api/commissions/c1/mark-paid');
+  expect(res.status).toBe(401);
+});


### PR DESCRIPTION
## Summary
- create DB helpers for getting and updating commissions
- add `/api/commissions` for sellers to view commission totals
- add admin endpoint to mark commissions paid
- cover new routes with unit tests

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a0e8962e8832d8f8d9780bf32ebfe