### PR TITLE
Improve wizard progress styling

### DIFF
--- a/js/wizard.js
+++ b/js/wizard.js
@@ -11,19 +11,28 @@ export function setWizardStage(stage) {
 
 export function updateWizard() {
   const stage = localStorage.getItem(STAGE_KEY) || 'prompt';
+  const order = ['prompt', 'building', 'print', 'purchase'];
   const map = {
     prompt: 'wizard-step-prompt',
     building: 'wizard-step-building',
     print: 'wizard-step-print',
     purchase: 'wizard-step-purchase',
   };
-  Object.entries(map).forEach(([key, id]) => {
-    const el = document.getElementById(id);
+  const idx = order.indexOf(stage);
+  order.forEach((key, i) => {
+    const el = document.getElementById(map[key]);
     if (!el) return;
-    if (key === stage) {
+    if (i < idx) {
+      // Completed steps turn blue
       el.classList.remove('opacity-50');
+      el.classList.add('bg-[#30D5C8]', 'text-[#1A1A1D]');
+    } else if (i === idx) {
+      // Current step is highlighted but not blue
+      el.classList.remove('opacity-50', 'bg-[#30D5C8]', 'text-[#1A1A1D]');
     } else {
+      // Future steps are dimmed
       el.classList.add('opacity-50');
+      el.classList.remove('bg-[#30D5C8]', 'text-[#1A1A1D]');
     }
   });
 }


### PR DESCRIPTION
## Summary
- adjust wizard update logic so completed steps turn blue

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a1067dcc8832d9e08a5f82939d813