### PR TITLE
Fix color popup position

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -199,7 +199,7 @@
                 </span>
                 <div
                   id="single-color-menu"
-                  class="absolute left-1/2 -translate-x-1/2 top-full mt-2 flex gap-2 p-2 bg-[#2A2A2E] border border-white/20 rounded-3xl hidden"
+                  class="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 flex gap-2 p-2 bg-[#2A2A2E] border border-white/20 rounded-3xl hidden"
                 >
                   <button
                     type="button"


### PR DESCRIPTION
## Summary
- center the single color popup over the £25 button in **payment.html**
- run prettier formatting
- run test suite

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a163857b4832da1903fa7c50ab427