### PR TITLE
Fix model viewer initialization

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1,6 +1,15 @@
 'use strict';
 import { shareOn } from './share.js';
 
+function ensureModelViewerLoaded() {
+  if (window.customElements?.get('model-viewer')) return;
+  const s = document.createElement('script');
+  s.type = 'module';
+  s.src =
+    'https://cdn.jsdelivr.net/npm/@google/model-viewer@1.12.0/dist/model-viewer.min.js';
+  document.head.appendChild(s);
+}
+
 if (
   localStorage.getItem('hasGenerated') === 'true' ||
   localStorage.getItem('demoDismissed') === 'true'
@@ -388,6 +397,7 @@ refs.submitBtn.addEventListener('click', async () => {
 });
 
 async function init() {
+  ensureModelViewerLoaded();
   syncUploadHeights();
   window.addEventListener('resize', syncUploadHeights);
   setStep('prompt');

--- a/js/payment.js
+++ b/js/payment.js
@@ -14,6 +14,15 @@ const API_BASE = (window.API_ORIGIN || '') + '/api';
 const TZ = 'America/New_York';
 let flashTimerId = null;
 
+function ensureModelViewerLoaded() {
+  if (window.customElements?.get('model-viewer')) return;
+  const s = document.createElement('script');
+  s.type = 'module';
+  s.src =
+    'https://cdn.jsdelivr.net/npm/@google/model-viewer@1.12.0/dist/model-viewer.min.js';
+  document.head.appendChild(s);
+}
+
 function getCycleKey() {
   const now = new Date();
   const dateFmt = new Intl.DateTimeFormat('en-US', {
@@ -103,6 +112,7 @@ async function createCheckout(quantity, discount, discountCode, shippingInfo) {
 }
 
 document.addEventListener('DOMContentLoaded', async () => {
+  ensureModelViewerLoaded();
   if (window.setWizardStage) window.setWizardStage('purchase');
   // Safely initialize Stripe once the DOM is ready. If the Stripe library
   // failed to load, we fall back to plain redirects.


### PR DESCRIPTION
## Summary
- ensure the `<model-viewer>` library is loaded even if the CDN fails
- call the loader function during page setup for index and payment pages

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a17cba65c832dbb238b7c048e5873