### PR TITLE
Fix color menu centering

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -182,7 +182,7 @@
 
             <!-- Material/Size Options -->
             <fieldset id="material-options" class="flex justify-around my-4">
-              <label id="single-label" class="cursor-pointer text-center relative">
+              <label id="single-label" class="cursor-pointer text-center relative inline-block">
                 <input
                   type="radio"
                   name="material"
@@ -199,7 +199,7 @@
                 </span>
                 <div
                   id="single-color-menu"
-                  class="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 flex gap-2 p-2 bg-[#2A2A2E] border border-white/20 rounded-3xl hidden"
+                  class="absolute inset-0 flex items-center justify-center gap-2 p-2 bg-[#2A2A2E] border border-white/20 rounded-3xl hidden"
                 >
                   <button
                     type="button"


### PR DESCRIPTION
## Summary
- tweak layout of the single colour option so the colour menu aligns perfectly

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684a1def3020832d942102fe50b5ba5b