### PR TITLE
Enable closing competition viewer modal with outside click

### DIFF
--- a/competitions.html
+++ b/competitions.html
@@ -235,6 +235,17 @@
         });
 
         closeBtn.addEventListener('click', close);
+        document.addEventListener('click', (e) => {
+          if (modal.classList.contains('hidden')) return;
+          const container = modal.querySelector('div');
+          const basketBtn = document.getElementById('basket-button');
+          if (
+            !container.contains(e.target) &&
+            !(basketBtn && basketBtn.contains(e.target))
+          ) {
+            close();
+          }
+        });
       document.addEventListener('keydown', (e) => {
         if (e.key === 'Escape') close();
       });


### PR DESCRIPTION
## Summary
- allow closing the 3D model modal on the competitions page by clicking outside of it

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684aa96a6e4c832d9afbe8965db72da7