### PR TITLE
Add past winner dates

### DIFF
--- a/competitions.html
+++ b/competitions.html
@@ -110,6 +110,7 @@
             alt="Damaged Helmet"
             class="w-full h-full object-contain pointer-events-none"
           />
+          <span class="absolute top-1 left-1 bg-black/60 text-xs px-1 rounded">Ended 05/25</span>
         </div>
         <div
           class="model-card relative h-32 bg-[#2A2A2E] border border-white/10 rounded-xl hover:bg-[#3A3A3E] transition-shape flex items-center justify-center cursor-pointer"
@@ -121,6 +122,7 @@
             alt="Fox"
             class="w-full h-full object-contain pointer-events-none"
           />
+          <span class="absolute top-1 left-1 bg-black/60 text-xs px-1 rounded">Ended 05/24</span>
         </div>
         <div
           class="model-card relative h-32 bg-[#2A2A2E] border border-white/10 rounded-xl hover:bg-[#3A3A3E] transition-shape flex items-center justify-center cursor-pointer"
@@ -132,6 +134,7 @@
             alt="BoomBox"
             class="w-full h-full object-contain pointer-events-none"
           />
+          <span class="absolute top-1 left-1 bg-black/60 text-xs px-1 rounded">Ended 05/23</span>
         </div>
       </div>
     </main>


### PR DESCRIPTION
## Summary
- show `Ended` dates on past winner thumbnails

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684aab2334d0832d80fcf02f168654d9