### PR TITLE
Fix past competition date spacing

### DIFF
--- a/competitions.html
+++ b/competitions.html
@@ -122,7 +122,7 @@
             alt="Fox"
             class="w-full h-full object-contain pointer-events-none"
           />
-          <span class="absolute top-1 left-1 bg-black/60 text-xs px-1 rounded">Ended 05/24</span>
+          <span class="absolute top-1 left-1 bg-black/60 text-xs px-1 rounded">Ended 03/24</span>
         </div>
         <div
           class="model-card relative h-32 bg-[#2A2A2E] border border-white/10 rounded-xl hover:bg-[#3A3A3E] transition-shape flex items-center justify-center cursor-pointer"
@@ -134,7 +134,7 @@
             alt="BoomBox"
             class="w-full h-full object-contain pointer-events-none"
           />
-          <span class="absolute top-1 left-1 bg-black/60 text-xs px-1 rounded">Ended 05/23</span>
+          <span class="absolute top-1 left-1 bg-black/60 text-xs px-1 rounded">Ended 01/23</span>
         </div>
       </div>
     </main>


### PR DESCRIPTION
## Summary
- adjust past competition dates to be spaced two months apart

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684aade2512c832d82d1290fbacd875f