### PR TITLE
Improve wizard progress bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -367,11 +367,11 @@
       </div>
     </div>
 
-    <div id="wizard-banner" class="fixed bottom-0 left-0 right-0 flex divide-x divide-[#1A1A1D] text-[#1A1A1D] font-semibold bg-gradient-to-r from-teal-400 via-cyan-300 to-teal-500 z-40">
-      <div id="wizard-step-prompt" class="flex-1 text-center py-2">Create prompt</div>
-      <div id="wizard-step-building" class="flex-1 text-center py-2 opacity-50">Building model</div>
-      <div id="wizard-step-print" class="flex-1 text-center py-2 opacity-50">Print model</div>
-      <div id="wizard-step-purchase" class="flex-1 text-center py-2 opacity-50">Purchase model</div>
+    <div id="wizard-banner" class="fixed bottom-0 left-0 right-0 flex divide-x divide-[#1A1A1D] text-white font-semibold bg-[#1A1A1D] z-40">
+      <div id="wizard-step-prompt" class="flex-1 text-center py-2 bg-[#2A2A2E]">Create prompt</div>
+      <div id="wizard-step-building" class="flex-1 text-center py-2">Building model</div>
+      <div id="wizard-step-print" class="flex-1 text-center py-2">Print model</div>
+      <div id="wizard-step-purchase" class="flex-1 text-center py-2">Purchase model</div>
     </div>
 
     <!-- ▸▸▸ SCRIPTS ------------------------------------------------------ -->

--- a/js/index.js
+++ b/js/index.js
@@ -75,6 +75,13 @@ let progressInterval = null;
 let progressStart = null;
 let usingViewerProgress = false;
 
+function updateWizardFromInputs() {
+  if (!window.setWizardStage) return;
+  const hasPrompt = refs.promptInput.value.trim().length >= 5;
+  const hasImages = uploadedFiles.length > 0;
+  window.setWizardStage(hasPrompt || hasImages ? 'building' : 'prompt');
+}
+
 async function captureModelSnapshot(url) {
   if (!url) return null;
   const viewer = document.createElement('model-viewer');
@@ -242,7 +249,7 @@ refs.promptInput.addEventListener('input', () => {
   editsPending = true;
   refs.buyNowBtn?.classList.add('hidden');
   setStep('prompt');
-  if (window.setWizardStage) window.setWizardStage('prompt');
+  updateWizardFromInputs();
 });
 
 refs.promptInput.addEventListener('keydown', (e) => {
@@ -296,6 +303,7 @@ function renderThumbnails(arr) {
       uploadedFiles.splice(i, 1);
       localStorage.setItem('print3Images', JSON.stringify(arr));
       renderThumbnails(arr);
+      updateWizardFromInputs();
     };
     wrap.appendChild(btn);
     refs.imagePreviewArea.appendChild(wrap);
@@ -337,6 +345,7 @@ async function processFiles(files) {
   editsPending = true;
   refs.buyNowBtn?.classList.add('hidden');
   setStep('prompt');
+  updateWizardFromInputs();
 }
 
 refs.uploadInput.addEventListener('change', (e) => {
@@ -486,6 +495,7 @@ async function init() {
     refs.examples.textContent = `Try: ${EXAMPLES.join(' · ')}`;
   }
   if (thumbs.length) renderThumbnails(thumbs);
+  updateWizardFromInputs();
 
   if (refs.trending) {
     refs.trending.textContent = `Trending: ${TRENDING.join(' · ')}`;

--- a/js/wizard.js
+++ b/js/wizard.js
@@ -22,17 +22,16 @@ export function updateWizard() {
   order.forEach((key, i) => {
     const el = document.getElementById(map[key]);
     if (!el) return;
+    el.classList.remove('bg-[#30D5C8]', 'bg-[#2A2A2E]', 'text-[#1A1A1D]', 'opacity-50');
     if (i < idx) {
       // Completed steps turn blue
-      el.classList.remove('opacity-50');
       el.classList.add('bg-[#30D5C8]', 'text-[#1A1A1D]');
     } else if (i === idx) {
-      // Current step is highlighted but not blue
-      el.classList.remove('opacity-50', 'bg-[#30D5C8]', 'text-[#1A1A1D]');
+      // Current step highlighted in grey
+      el.classList.add('bg-[#2A2A2E]');
     } else {
-      // Future steps are dimmed
-      el.classList.add('opacity-50');
-      el.classList.remove('bg-[#30D5C8]', 'text-[#1A1A1D]');
+      // Future steps have no background
+      el.classList.remove('bg-[#2A2A2E]', 'bg-[#30D5C8]');
     }
   });
 }

--- a/payment.html
+++ b/payment.html
@@ -354,11 +354,11 @@
       </div>
     </div>
 
-    <div id="wizard-banner" class="fixed bottom-0 left-0 right-0 flex divide-x divide-[#1A1A1D] text-[#1A1A1D] font-semibold bg-gradient-to-r from-teal-400 via-cyan-300 to-teal-500 z-40">
-      <div id="wizard-step-prompt" class="flex-1 text-center py-2">Create prompt</div>
-      <div id="wizard-step-building" class="flex-1 text-center py-2 opacity-50">Building model</div>
-      <div id="wizard-step-print" class="flex-1 text-center py-2 opacity-50">Print model</div>
-      <div id="wizard-step-purchase" class="flex-1 text-center py-2 opacity-50">Purchase model</div>
+    <div id="wizard-banner" class="fixed bottom-0 left-0 right-0 flex divide-x divide-[#1A1A1D] text-white font-semibold bg-[#1A1A1D] z-40">
+      <div id="wizard-step-prompt" class="flex-1 text-center py-2 bg-[#2A2A2E]">Create prompt</div>
+      <div id="wizard-step-building" class="flex-1 text-center py-2">Building model</div>
+      <div id="wizard-step-print" class="flex-1 text-center py-2">Print model</div>
+      <div id="wizard-step-purchase" class="flex-1 text-center py-2">Purchase model</div>
     </div>
 
     <!-- ─────────── Init -->


### PR DESCRIPTION
## Summary
- tweak wizard banner styles for dynamic colors
- track prompt/images to set next wizard step automatically
- keep banner in sync across index and payment pages

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684aaec7e8dc832d8bffce06838a3140