### PR TITLE
Fix viewer resume when no animations

### DIFF
--- a/index.html
+++ b/index.html
@@ -218,7 +218,7 @@
             auto-rotate
             loading="eager"
             crossOrigin="anonymous"
-            style="width: 100%; height: 100%; display: none"
+            style="width: 100%; height: 100%; visibility: hidden"
           ></model-viewer>
 
           <!-- loader -->

--- a/index.html
+++ b/index.html
@@ -218,7 +218,7 @@
             auto-rotate
             loading="eager"
             crossOrigin="anonymous"
-            style="width: 100%; height: 100%; visibility: hidden"
+            style="width: 100%; height: 100%; opacity: 0; pointer-events: none"
           ></model-viewer>
 
           <!-- loader -->

--- a/js/index.js
+++ b/js/index.js
@@ -133,7 +133,12 @@ function stopProgress() {
 const hideAll = () => {
   refs.previewImg.style.display = 'none';
   refs.loader.style.display = 'none';
-  refs.viewer.style.display = 'none';
+  refs.viewer.style.visibility = 'hidden';
+  if ('paused' in refs.viewer) {
+    refs.viewer.paused = true;
+  } else if (typeof refs.viewer.pause === 'function') {
+    refs.viewer.pause();
+  }
 };
 const showLoader = () => {
   hideAll();
@@ -143,6 +148,12 @@ const showLoader = () => {
 const showModel = () => {
   hideAll();
   refs.viewer.style.display = 'block';
+  refs.viewer.style.visibility = 'visible';
+  if ('paused' in refs.viewer) {
+    refs.viewer.paused = false;
+  } else if (typeof refs.viewer.play === 'function') {
+    refs.viewer.play();
+  }
   stopProgress();
   // Force a render in case Safari paused the canvas while hidden
   if (typeof refs.viewer.requestUpdate === 'function') {

--- a/js/index.js
+++ b/js/index.js
@@ -133,7 +133,8 @@ function stopProgress() {
 const hideAll = () => {
   refs.previewImg.style.display = 'none';
   refs.loader.style.display = 'none';
-  refs.viewer.style.visibility = 'hidden';
+  refs.viewer.style.opacity = '0';
+  refs.viewer.style.pointerEvents = 'none';
   if ('paused' in refs.viewer) {
     refs.viewer.paused = true;
   } else if (typeof refs.viewer.pause === 'function') {
@@ -148,7 +149,8 @@ const showLoader = () => {
 const showModel = () => {
   hideAll();
   refs.viewer.style.display = 'block';
-  refs.viewer.style.visibility = 'visible';
+  refs.viewer.style.opacity = '1';
+  refs.viewer.style.pointerEvents = 'auto';
   if ('paused' in refs.viewer) {
     refs.viewer.paused = false;
   } else if (typeof refs.viewer.play === 'function') {


### PR DESCRIPTION
## Summary
- pause/unpause model viewer using the `paused` property
- ensure viewer resumes rendering for models without animations

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684aad332380832d8ae39b8693d6c1c0