### PR TITLE
Add coloured print availability count

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -88,6 +88,19 @@ function computeSlotsByTime() {
   return 1;
 }
 
+function computeColorSlotsByTime() {
+  const dtf = new Intl.DateTimeFormat('en-US', {
+    timeZone: TZ,
+    hour12: false,
+    hour: 'numeric',
+  });
+  const hour = parseInt(dtf.format(new Date()), 10);
+  if (hour >= 15) return 3;
+  if (hour >= 12) return 4;
+  if (hour >= 9) return 5;
+  return 6;
+}
+
 function qs(name) {
   const params = new URLSearchParams(window.location.search);
   return params.get(name);
@@ -138,6 +151,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   const costEl = document.getElementById('cost-estimate');
   const etaEl = document.getElementById('eta-estimate');
   const slotEl = document.getElementById('slot-count');
+  const colorSlotEl = document.getElementById('color-slot-count');
   const discountInput = document.getElementById('discount-code');
   const discountMsg = document.getElementById('discount-msg');
   const applyBtn = document.getElementById('apply-discount');
@@ -206,6 +220,12 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
     slotEl.textContent = adjustedSlots(baseSlots);
     slotEl.style.visibility = 'visible';
+  }
+
+  if (colorSlotEl) {
+    colorSlotEl.style.visibility = 'hidden';
+    colorSlotEl.textContent = computeColorSlotsByTime();
+    colorSlotEl.style.visibility = 'visible';
   }
 
   async function updateEstimate() {

--- a/payment.html
+++ b/payment.html
@@ -248,6 +248,9 @@
                   <span class="text-xs">multi-colour</span>
                 </span>
               </label>
+              <p class="block mt-1 text-xs text-red-300 text-center">
+                Only <span id="color-slot-count" style="visibility: hidden"></span> coloured prints left
+              </p>
               <label class="cursor-not-allowed text-center opacity-50">
                 <input
                   type="radio"


### PR DESCRIPTION
## Summary
- show limited coloured print count below multi-colour option
- compute coloured print availability in `payment.js`

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684e9a4e8be8832d966983ebd5b897d6