### PR TITLE
Auto-add latest GLB to basket

### DIFF
--- a/js/basket.js
+++ b/js/basket.js
@@ -9,11 +9,35 @@ export function getBasket() {
 function saveBasket(items) {
   localStorage.setItem(KEY, JSON.stringify(items));
 }
-export function addToBasket(item) {
+export function addToBasket(item, opts = {}) {
   const items = getBasket();
-  items.push(item);
+  items.push({ ...item, auto: !!opts.auto });
   saveBasket(items);
   updateBadge();
+  renderList();
+}
+
+export function addAutoItem(item) {
+  const items = getBasket();
+  const idx = items.findIndex((it) => it.auto);
+  if (idx !== -1) {
+    items.splice(idx, 1);
+  }
+  items.push({ ...item, auto: true });
+  saveBasket(items);
+  updateBadge();
+  renderList();
+}
+
+export function manualizeItem(predicate) {
+  const items = getBasket();
+  const idx = items.findIndex((it) => it.auto && predicate(it));
+  if (idx !== -1) {
+    items[idx].auto = false;
+    saveBasket(items);
+  }
+  updateBadge();
+  renderList();
 }
 export function removeFromBasket(index) {
   const items = getBasket();
@@ -150,4 +174,6 @@ export function setupBasketUI() {
 }
 window.addEventListener('DOMContentLoaded', setupBasketUI);
 window.addToBasket = addToBasket;
+window.addAutoItem = addAutoItem;
+window.manualizeItem = manualizeItem;
 window.getBasket = getBasket;

--- a/js/index.js
+++ b/js/index.js
@@ -424,6 +424,13 @@ refs.submitBtn.addEventListener('click', async () => {
     refs.viewer.src = url;
     await refs.viewer.updateComplete;
     showModel();
+    if (window.addAutoItem) {
+      let snapshot = refs.previewImg?.src;
+      if (!snapshot || snapshot.includes('placehold.co')) {
+        snapshot = await captureModelSnapshot(url);
+      }
+      window.addAutoItem({ jobId: lastJobId, modelUrl: url, snapshot });
+    }
     setStep('model');
     if (window.setWizardStage) window.setWizardStage('print');
     hideDemo();
@@ -540,7 +547,14 @@ async function init() {
       snapshot = await captureModelSnapshot(refs.viewer.src);
     }
     const item = { jobId: lastJobId, modelUrl: refs.viewer.src, snapshot };
-    window.addToBasket(item);
+    if (
+      window.manualizeItem &&
+      window.getBasket?.().some((it) => it.auto && it.modelUrl === item.modelUrl)
+    ) {
+      window.manualizeItem((it) => it.modelUrl === item.modelUrl);
+    } else {
+      window.addToBasket(item);
+    }
   });
 }
 


### PR DESCRIPTION
## Summary
- add helpers to manage automatically added items in basket
- auto-add freshly generated models from index page
- keep auto-added item when user manually saves it

## Testing
- `npm run format`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684e9f4fca60832db04341c5a6b34036