### PR TITLE
Remove print stage from wizard

### DIFF
--- a/index.html
+++ b/index.html
@@ -370,7 +370,6 @@
     <div id="wizard-banner" class="fixed bottom-0 left-0 right-0 flex divide-x divide-[#1A1A1D] text-white font-semibold bg-[#1A1A1D] z-40">
       <div id="wizard-step-prompt" class="flex-1 text-center py-2 bg-[#2A2A2E]">Create prompt</div>
       <div id="wizard-step-building" class="flex-1 text-center py-2">Building model</div>
-      <div id="wizard-step-print" class="flex-1 text-center py-2">Print model</div>
       <div id="wizard-step-purchase" class="flex-1 text-center py-2">Purchase model</div>
     </div>
 

--- a/js/index.js
+++ b/js/index.js
@@ -425,7 +425,7 @@ refs.submitBtn.addEventListener('click', async () => {
     await refs.viewer.updateComplete;
     showModel();
     setStep('model');
-    if (window.setWizardStage) window.setWizardStage('print');
+    if (window.setWizardStage) window.setWizardStage('purchase');
     hideDemo();
 
     refs.checkoutBtn.classList.remove('hidden');

--- a/js/wizard.js
+++ b/js/wizard.js
@@ -10,12 +10,12 @@ export function setWizardStage(stage) {
 }
 
 export function updateWizard() {
-  const stage = localStorage.getItem(STAGE_KEY) || 'prompt';
-  const order = ['prompt', 'building', 'print', 'purchase'];
+  let stage = localStorage.getItem(STAGE_KEY) || 'prompt';
+  if (stage === 'print') stage = 'purchase';
+  const order = ['prompt', 'building', 'purchase'];
   const map = {
     prompt: 'wizard-step-prompt',
     building: 'wizard-step-building',
-    print: 'wizard-step-print',
     purchase: 'wizard-step-purchase',
   };
   const idx = order.indexOf(stage);

--- a/payment.html
+++ b/payment.html
@@ -360,7 +360,6 @@
     <div id="wizard-banner" class="fixed bottom-0 left-0 right-0 flex divide-x divide-[#1A1A1D] text-white font-semibold bg-[#1A1A1D] z-40">
       <div id="wizard-step-prompt" class="flex-1 text-center py-2 bg-[#2A2A2E]">Create prompt</div>
       <div id="wizard-step-building" class="flex-1 text-center py-2">Building model</div>
-      <div id="wizard-step-print" class="flex-1 text-center py-2">Print model</div>
       <div id="wizard-step-purchase" class="flex-1 text-center py-2">Purchase model</div>
     </div>
 


### PR DESCRIPTION
## Summary
- simplify bottom wizard UI to three steps
- drop `Print model` stage handling in wizard script and update index

## Testing
- `npm run format`
- `npm test --silent --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_684e9eb83388832d99c2a51ec23571c7