### PR TITLE
Fix alignment for payment options

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -172,7 +172,7 @@
 
             <!-- Material/Size Options -->
             <fieldset id="material-options" class="flex w-full justify-between my-4">
-              <label id="single-label" class="cursor-pointer text-center relative inline-block">
+              <label id="single-label" class="cursor-pointer text-center relative flex flex-col items-center w-1/3">
                 <input
                   type="radio"
                   name="material"
@@ -189,8 +189,7 @@
                 </span>
               </label>
 
-              <!-- 👇 MIDDLE BUTTON: manually moved right by 26px here -->
-              <label class="cursor-pointer text-center relative">
+              <label class="cursor-pointer text-center relative flex flex-col items-center w-1/3">
                 <input
                   type="radio"
                   name="material"
@@ -200,20 +199,17 @@
                 />
                 <span
                   class="w-24 h-24 flex flex-col items-center justify-center rounded-full border border-white/20
-                         peer-checked:bg-[#30D5C8] peer-checked:text-[#1A1A1D] relative left-[25.5px]"
+                         peer-checked:bg-[#30D5C8] peer-checked:text-[#1A1A1D]"
                 >
                   <span class="font-semibold">£35</span>
                   <span class="text-xs">multi-colour</span>
                 </span>
-                <!-- 👇 RED TEXT: manually moved right by 26px here; only this span shifts -->
-                <span
-                  class="block text-xs mt-1 text-red-300"
-                >
+                <span class="block text-xs mt-1 text-red-300">
                   Only <span id="color-slot-count" style="visibility: hidden"></span> coloured prints left
                 </span>
               </label>
 
-              <label class="cursor-not-allowed text-center opacity-50">
+              <label class="cursor-not-allowed text-center flex flex-col items-center w-1/3 opacity-50">
                 <input
                   type="radio"
                   name="material"


### PR DESCRIPTION
## Summary
- ensure three checkout buttons have equal width
- remove manual offset on the middle option

## Testing
- `npm run format`
- `npm test`
- `npm ci` in both `backend` and `backend/hunyuan_server`


------
https://chatgpt.com/codex/tasks/task_e_684ec7d6826c832da52b37c2c745b112