### PR TITLE
Fix color choices for single colour option

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -187,6 +187,41 @@
                   <span class="font-semibold">£25</span>
                   <span class="text-xs">single colour</span>
                 </span>
+                <div
+                  id="single-color-menu"
+                  class="absolute inset-0 flex items-center justify-center gap-2 p-2 bg-[#2A2A2E] border border-white/20 rounded-3xl hidden"
+                >
+                  <button
+                    type="button"
+                    class="w-24 h-24 rounded-full border border-white/20"
+                    style="background-color:#f87171"
+                    data-color="#f87171"
+                  ></button>
+                  <button
+                    type="button"
+                    class="w-24 h-24 rounded-full border border-white/20"
+                    style="background-color:#34d399"
+                    data-color="#34d399"
+                  ></button>
+                  <button
+                    type="button"
+                    class="w-24 h-24 rounded-full border border-white/20"
+                    style="background-color:#60a5fa"
+                    data-color="#60a5fa"
+                  ></button>
+                  <button
+                    type="button"
+                    class="w-24 h-24 rounded-full border border-white/20"
+                    style="background-color:#fbbf24"
+                    data-color="#fbbf24"
+                  ></button>
+                  <button
+                    type="button"
+                    class="w-24 h-24 rounded-full border border-white/20"
+                    style="background-color:#a78bfa"
+                    data-color="#a78bfa"
+                  ></button>
+                </div>
               </label>
 
               <!-- 👇 MIDDLE BUTTON: manually moved right by 26px here -->


### PR DESCRIPTION
## Summary
- restore the color selection menu for the £25 single colour option

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ec81d8fec832d852269ad9f08a025