### PR TITLE
Fix 3D model display on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -374,18 +374,11 @@
     </div>
 
     <!-- ▸▸▸ SCRIPTS ------------------------------------------------------ -->
-<script type="module" src="js/wizard.js"></script>
-    <!-- Lazy-load non-critical scripts -->
-    <script type="module">
-      window.addEventListener('load', () => {
-        import('./js/modelViewerTouchFix.js');
-        import('./js/subredditLanding.js');
-        import('./js/index.js').then(() => {
-          window.initIndexPage && window.initIndexPage();
-        });
-        import('./js/exitDiscount.js');
-      });
-    </script>
+    <script src="js/modelViewerTouchFix.js"></script>
+    <script type="module" src="js/wizard.js"></script>
+    <script type="module" src="js/index.js"></script>
+    <script type="module" src="js/subredditLanding.js"></script>
+    <script type="module" src="js/exitDiscount.js"></script>
     <script type="module">
       document.getElementById('profile-link')?.addEventListener('click', function (e) {
         if (!localStorage.getItem('token')) {


### PR DESCRIPTION
## Summary
- load JS modules directly on `index.html` instead of lazy imports

## Testing
- `npm run format`
- `npm test`
- `cd hunyuan_server && npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684eca58f400832d87362a72caae165c