### PR TITLE
Fix alignment of payment stock notice

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -239,7 +239,7 @@
                   <span class="font-semibold">£35</span>
                   <span class="text-xs">multi-colour</span>
                 </span>
-                <span class="block text-xs mt-1 text-red-300">
+                <span class="block text-xs mt-1 text-red-300 w-24">
                   Only <span id="color-slot-count" style="visibility: hidden"></span> coloured prints left
                 </span>
               </label>


### PR DESCRIPTION
## Summary
- tweak colour print stock text width for better centering

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ecb68c964832db28329b9de9f3b35