### PR TITLE
Select £35 option by default

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -10,7 +10,7 @@ const PRICES = {
   multi: 3500,
   premium: 6000,
 };
-let selectedPrice = PRICES.single;
+let selectedPrice = PRICES.multi;
 const API_BASE = (window.API_ORIGIN || '') + '/api';
 // Time zone used to reset local purchase counts at 1 AM Eastern
 const TZ = 'America/New_York';

--- a/payment.html
+++ b/payment.html
@@ -179,7 +179,6 @@
                   value="single"
                   id="opt-single"
                   class="sr-only peer"
-                  checked
                 />
                 <span
                   class="w-24 h-24 flex flex-col items-center justify-center rounded-full border border-white/20 peer-checked:border-4 peer-checked:border-green-500 pt-1"
@@ -231,6 +230,7 @@
                   value="multi"
                   id="opt-multi"
                   class="sr-only peer"
+                  checked
                 />
                 <span
                   class="w-24 h-24 flex flex-col items-center justify-center rounded-full border border-white/20


### PR DESCRIPTION
## Summary
- default to the multi-colour (£35) option on the payment page
- update JavaScript default price accordingly

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ed01e9d40832d94d26e39adabed15