### PR TITLE
Fix padding for material options

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -181,7 +181,7 @@
                   class="sr-only peer"
                 />
                 <span
-                  class="w-24 h-24 flex flex-col items-center justify-center rounded-full border border-white/20 peer-checked:border-4 peer-checked:border-green-500 pt-1"
+                  class="w-24 h-24 flex flex-col items-center justify-center rounded-full border border-white/20 peer-checked:border-4 peer-checked:border-green-500 pt-0"
                 >
                   <span class="font-semibold">£25</span>
                   <span class="text-xs">single colour</span>
@@ -234,7 +234,7 @@
                 />
                 <span
                   class="w-24 h-24 flex flex-col items-center justify-center rounded-full border border-white/20
-                         peer-checked:border-4 peer-checked:border-green-500 pt-1"
+                         peer-checked:border-4 peer-checked:border-green-500 pt-0"
                 >
                   <span class="font-semibold">£35</span>
                   <span class="text-xs">multi-colour</span>
@@ -254,7 +254,7 @@
                   disabled
                 />
                 <span
-                  class="w-24 h-24 flex flex-col items-center justify-center rounded-full border border-white/20 pt-1"
+                  class="w-24 h-24 flex flex-col items-center justify-center rounded-full border border-white/20 pt-0"
                 >
                   <span class="font-semibold">£60</span>
                   <span class="text-xs">premium</span>


### PR DESCRIPTION
## Summary
- reduce padding for the circular buttons in payment.html

## Testing
- `npm ci` in `backend/`
- `npm ci` in `backend/hunyuan_server`
- `npm run format` in `backend/`
- `npm test` in `backend/`

------
https://chatgpt.com/codex/tasks/task_e_684ed5618abc832db96181d393e58f7f