### PR TITLE
Add viewer error handling on index page

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -498,6 +498,15 @@ async function init() {
         stopProgress();
       }
     });
+    refs.viewer.addEventListener('load', showModel, { once: true });
+    refs.viewer.addEventListener(
+      'error',
+      () => {
+        refs.viewer.src = FALLBACK_GLB;
+        showModel();
+      },
+      { once: true }
+    );
     await refs.viewer.updateComplete;
   }
   showModel();


### PR DESCRIPTION
## Summary
- handle `load` and `error` events on the index page's model viewer
- fall back to the remote Astronaut model on failure

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ee4622c30832d947a959723877ce7