### PR TITLE
Fix model viewer on index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -219,7 +219,7 @@
             auto-rotate
             loading="eager"
             crossOrigin="anonymous"
-            style="width: 100%; height: 100%; opacity: 0; pointer-events: none"
+            style="width: 100%; height: 100%; display: block"
           ></model-viewer>
 
           <!-- loader -->


### PR DESCRIPTION
## Summary
- keep `<model-viewer>` visible on `index.html` so the fallback model loads even if JS fails
- run formatter and tests

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ee4622c30832d947a959723877ce7