### PR TITLE
Fix basket closing on item removal

### DIFF
--- a/js/basket.js
+++ b/js/basket.js
@@ -101,7 +101,10 @@ function renderList() {
 
     btn.className =
       'remove absolute bottom-1 right-1 text-xs px-2 py-1 bg-red-600 rounded opacity-80 group-hover:opacity-100';
-    btn.addEventListener('click', () => removeFromBasket(idx));
+    btn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      removeFromBasket(idx);
+    });
 
 
     div.appendChild(img);


### PR DESCRIPTION
## Summary
- keep basket overlay open when removing items

## Testing
- `npm run format`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684ef4963550832d8fc32b7e71807130