### PR TITLE
Update exit discount overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -363,17 +363,18 @@
       id="exit-discount-overlay"
       class="fixed inset-0 bg-black/80 flex items-center justify-center hidden z-50"
     >
-      <div class="bg-[#2A2A2E] border border-white/10 rounded-3xl p-6 text-center">
+      <div class="relative bg-[#2A2A2E] border border-white/10 rounded-3xl p-6 text-center">
+        <button
+          id="exit-discount-close"
+          class="absolute top-2 right-2 text-white text-2xl"
+          aria-label="Close"
+        >
+          &times;
+        </button>
         <h2 class="text-xl font-semibold mb-2 text-white">Wait! Before you go…</h2>
         <p class="mb-4 text-gray-300">
           Use code <span class="text-white font-mono px-1">SAVE5</span> for 5% off your next order.
         </p>
-        <button
-          id="exit-discount-close"
-          class="mt-2 px-4 py-2 rounded-md bg-[#30D5C8] text-[#1A1A1D] hover:bg-[#28b7a8] transition"
-        >
-          Close
-        </button>
       </div>
     </div>
 

--- a/js/exitDiscount.js
+++ b/js/exitDiscount.js
@@ -5,7 +5,16 @@ window.addEventListener('DOMContentLoaded', () => {
   const closeBtn = document.getElementById('exit-discount-close');
   if (!overlay || !closeBtn) return;
 
+  const container = overlay.querySelector('div');
+
   closeBtn.addEventListener('click', () => overlay.classList.add('hidden'));
+
+  overlay.addEventListener('click', (e) => {
+    const basketBtn = document.getElementById('basket-button');
+    if (!container.contains(e.target) && !(basketBtn && basketBtn.contains(e.target))) {
+      overlay.classList.add('hidden');
+    }
+  });
 
   let ready = false;
   let shown = false;

--- a/payment.html
+++ b/payment.html
@@ -327,17 +327,18 @@
       id="exit-discount-overlay"
       class="fixed inset-0 bg-black/80 flex items-center justify-center hidden z-50"
     >
-      <div class="bg-[#2A2A2E] border border-white/10 rounded-3xl p-6 text-center">
+      <div class="relative bg-[#2A2A2E] border border-white/10 rounded-3xl p-6 text-center">
+        <button
+          id="exit-discount-close"
+          class="absolute top-2 right-2 text-white text-2xl"
+          aria-label="Close"
+        >
+          &times;
+        </button>
         <h2 class="text-xl font-semibold mb-2 text-white">Wait! Before you go…</h2>
         <p class="mb-4 text-gray-300">
           Use code <span class="text-white font-mono px-1">SAVE5</span> for 5% off your next order.
         </p>
-        <button
-          id="exit-discount-close"
-          class="mt-2 px-4 py-2 rounded-md bg-[#30D5C8] text-[#1A1A1D] hover:bg-[#28b7a8] transition"
-        >
-          Close
-        </button>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- adjust exit discount overlay layout
- add click-outside handler in `exitDiscount.js`

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ef5902ad4832d9f5e183fb56d1eed