### PR TITLE
Fix delivery note placement

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -88,7 +88,7 @@
         <a href="profile.html" class="underline">View profile</a>
       </div>
       <div id="cancel" class="hidden text-red-400 text-center">Payment cancelled.</div>
-      <div class="flex flex-col md:flex-row items-start justify-center w-full max-w-4xl gap-8">
+      <div class="relative flex flex-col md:flex-row items-start justify-center w-full max-w-4xl gap-8">
 
         <!-- Model Preview -->
         <section
@@ -127,13 +127,6 @@
               ✅︎ If you don’t love it, we’ll reprint or refund you – no <br /> questions asked:
               <span class="text-white">enquiries@domain.com</span>
             </p>
-            <div class="absolute inset-x-0 bottom-0 pb-4">
-              <p>
-                Due to incredibly high demand, delivery may take 3+ weeks.<br />
-                Please allow for this. –
-                <span class="text-white">The print2 team: Jia and Matthew</span>
-              </p>
-            </div>
           </div>
         </section>
 
@@ -314,13 +307,20 @@
           <p class="mt-2 text-xs text-red-300 text-center">
             Only <span id="slot-count" style="visibility: hidden"></span> print slots remaining
           </p>
-          <div class="flex justify-center gap-4 mt-4 text-2xl text-white">
-            <i class="fas fa-lock" aria-label="Secure checkout"></i>
-            <i class="fas fa-shield-alt" aria-label="Money-back guarantee"></i>
-          </div>
+        <div class="flex justify-center gap-4 mt-4 text-2xl text-white">
+          <i class="fas fa-lock" aria-label="Secure checkout"></i>
+          <i class="fas fa-shield-alt" aria-label="Money-back guarantee"></i>
         </div>
       </div>
-    </main>
+      <div class="absolute left-0 bottom-4 w-full md:w-1/2 max-w-lg text-center text-sm text-gray-400/75">
+        <p>
+          Due to incredibly high demand, delivery may take 3+ weeks.<br />
+          Please allow for this. –
+          <span class="text-white">The print2 team: Jia and Matthew</span>
+        </p>
+      </div>
+    </div>
+  </main>
 
     <!-- Exit-intent discount overlay -->
     <div


### PR DESCRIPTION
## Summary
- keep delivery note aligned with preview section

## Testing
- `npm run format`
- `npm test --runInBand --silent`


------
https://chatgpt.com/codex/tasks/task_e_684ef5168f74832da1656b0374e3c90a