### PR TITLE
Update pricing text and values

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -196,7 +196,7 @@
             onmouseover="this.style.opacity='0.85'"
             onmouseout="this.style.opacity='1'"
           >
-            Print it for £25 →
+            Print it for £24.99 →
           </a>
         </div>
         <button

--- a/competitions.html
+++ b/competitions.html
@@ -205,7 +205,7 @@
             onmouseover="this.style.opacity='0.85'"
             onmouseout="this.style.opacity='1'"
           >
-            Print it for £25 →
+            Print it for £24.99 →
           </a>
         </div>
         <button

--- a/index.html
+++ b/index.html
@@ -259,7 +259,7 @@
               onmouseover="this.style.opacity='0.85'"
               onmouseout="this.style.opacity='1'"
             >
-              Print it for £25 →
+              Print it for £24.99 →
             </a>
           </div>
           <button

--- a/js/payment.js
+++ b/js/payment.js
@@ -6,9 +6,9 @@ let stripe = null;
 // and is not dependent on external CDNs.
 const FALLBACK_GLB = 'https://modelviewer.dev/shared-assets/models/Astronaut.glb';
 const PRICES = {
-  single: 2500,
-  multi: 3500,
-  premium: 6000,
+  single: 2499,
+  multi: 3499,
+  premium: 5999,
 };
 let selectedPrice = PRICES.multi;
 const API_BASE = (window.API_ORIGIN || '') + '/api';

--- a/payment.html
+++ b/payment.html
@@ -176,7 +176,7 @@
                 <span
                   class="w-24 h-24 flex flex-col items-center justify-center rounded-full border border-white/20 peer-checked:border-4 peer-checked:border-green-500 pt-0"
                 >
-                  <span class="font-semibold">£25</span>
+                  <span class="font-semibold">£24.99</span>
                   <span class="text-xs">single colour</span>
                 </span>
                 <div
@@ -229,7 +229,7 @@
                   class="w-24 h-24 flex flex-col items-center justify-center rounded-full border border-white/20
                          peer-checked:border-4 peer-checked:border-green-500 pt-0"
                 >
-                  <span class="font-semibold">£35</span>
+                  <span class="font-semibold">£34.99</span>
                   <span class="text-xs">multi-colour</span>
                 </span>
                 <span class="block text-xs mt-1 text-red-300 w-24">
@@ -249,7 +249,7 @@
                 <span
                   class="w-24 h-24 flex flex-col items-center justify-center rounded-full border border-white/20 pt-0"
                 >
-                  <span class="font-semibold">£60</span>
+                  <span class="font-semibold">£59.99</span>
                   <span class="text-xs">premium</span>
                 </span>
                 <span class="block text-xs mt-1">coming soon</span>


### PR DESCRIPTION
## Summary
- update price display from £25/35/60 to £24.99/34.99/59.99
- adjust corresponding payment constants

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ef8ef4534832d84876ab6246839ec