### PR TITLE
Implement circular close button for exit discount overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -366,10 +366,21 @@
       <div class="relative bg-[#2A2A2E] border border-white/10 rounded-3xl p-6 text-center">
         <button
           id="exit-discount-close"
-          class="absolute top-2 right-2 text-white text-2xl"
+          class="absolute -top-8 -right-8 w-[9rem] h-[9rem] rounded-full bg-white text-black flex items-center justify-center z-50"
           aria-label="Close"
         >
-          &times;
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            class="w-20 h-20"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="3"
+            stroke-linecap="round"
+          >
+            <line x1="6" y1="6" x2="18" y2="18" />
+            <line x1="6" y1="18" x2="18" y2="6" />
+          </svg>
         </button>
         <h2 class="text-xl font-semibold mb-2 text-white">Wait! Before you go…</h2>
         <p class="mb-4 text-gray-300">

--- a/payment.html
+++ b/payment.html
@@ -331,10 +331,21 @@
       <div class="relative bg-[#2A2A2E] border border-white/10 rounded-3xl p-6 text-center">
         <button
           id="exit-discount-close"
-          class="absolute top-2 right-2 text-white text-2xl"
+          class="absolute -top-8 -right-8 w-[9rem] h-[9rem] rounded-full bg-white text-black flex items-center justify-center z-50"
           aria-label="Close"
         >
-          &times;
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            class="w-20 h-20"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="3"
+            stroke-linecap="round"
+          >
+            <line x1="6" y1="6" x2="18" y2="18" />
+            <line x1="6" y1="18" x2="18" y2="6" />
+          </svg>
         </button>
         <h2 class="text-xl font-semibold mb-2 text-white">Wait! Before you go…</h2>
         <p class="mb-4 text-gray-300">


### PR DESCRIPTION
## Summary
- style the exit discount overlay close button like other modals
- keep same behavior on payment page

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684efb89f948832da590408207998cf8