### PR TITLE
Update single-color selection palette

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -186,32 +186,32 @@
                   <button
                     type="button"
                     class="w-24 h-24 rounded-full border border-white/20"
-                    style="background-color:#f87171"
-                    data-color="#f87171"
+                    style="background-color:#ff0000"
+                    data-color="#ff0000"
                   ></button>
                   <button
                     type="button"
                     class="w-24 h-24 rounded-full border border-white/20"
-                    style="background-color:#34d399"
-                    data-color="#34d399"
+                    style="background-color:#00ff00"
+                    data-color="#00ff00"
                   ></button>
                   <button
                     type="button"
                     class="w-24 h-24 rounded-full border border-white/20"
-                    style="background-color:#60a5fa"
-                    data-color="#60a5fa"
+                    style="background-color:#0000ff"
+                    data-color="#0000ff"
                   ></button>
                   <button
                     type="button"
                     class="w-24 h-24 rounded-full border border-white/20"
-                    style="background-color:#fbbf24"
-                    data-color="#fbbf24"
+                    style="background-color:#ffff00"
+                    data-color="#ffff00"
                   ></button>
                   <button
                     type="button"
                     class="w-24 h-24 rounded-full border border-white/20"
-                    style="background-color:#a78bfa"
-                    data-color="#a78bfa"
+                    style="background-color:#ff00ff"
+                    data-color="#ff00ff"
                   ></button>
                 </div>
               </label>


### PR DESCRIPTION
## Summary
- switch to fully saturated color values for the single-color print option

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f00c2af9c832dbed7acb5ee44d83d