### PR TITLE
Update single-color selection palette

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -187,31 +187,31 @@
                     type="button"
                     class="w-24 h-24 rounded-full border border-white/20"
                     style="background-color:#f87171"
-                    data-color="#f87171"
+                    data-color="#ff0000"
                   ></button>
                   <button
                     type="button"
                     class="w-24 h-24 rounded-full border border-white/20"
                     style="background-color:#34d399"
-                    data-color="#34d399"
+                    data-color="#00ff00"
                   ></button>
                   <button
                     type="button"
                     class="w-24 h-24 rounded-full border border-white/20"
                     style="background-color:#60a5fa"
-                    data-color="#60a5fa"
+                    data-color="#0000ff"
                   ></button>
                   <button
                     type="button"
                     class="w-24 h-24 rounded-full border border-white/20"
                     style="background-color:#fbbf24"
-                    data-color="#fbbf24"
+                    data-color="#ffff00"
                   ></button>
                   <button
                     type="button"
                     class="w-24 h-24 rounded-full border border-white/20"
                     style="background-color:#a78bfa"
-                    data-color="#a78bfa"
+                    data-color="#ff00ff"
                   ></button>
                 </div>
               </label>


### PR DESCRIPTION
## Summary
- switch the color buttons back to muted tones while keeping their data-color values vivid

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f00c2af9c832dbed7acb5ee44d83d