### PR TITLE
Update multi-colour option styling

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -183,7 +183,7 @@
                 <span class="block text-xs mt-1">coming soon</span>
               </label>
 
-              <label class="cursor-pointer text-center relative flex flex-col items-center w-1/3">
+              <label class="cursor-pointer text-center relative flex flex-col items-center w-1/3 z-10">
                 <input
                   type="radio"
                   name="material"
@@ -193,13 +193,13 @@
                   checked
                 />
                 <span
-                  class="w-24 h-24 flex flex-col items-center justify-center rounded-full border border-white/20
+                  class="w-28 h-28 flex flex-col items-center justify-center rounded-full border-2 border-white/20 shadow-lg
                          peer-checked:border-4 peer-checked:border-green-500 pt-0"
                 >
                   <span class="font-semibold">£34.99</span>
                   <span class="text-xs">multi-colour</span>
                 </span>
-                <span class="block text-xs mt-1 text-red-300 w-24">
+                <span class="block text-xs mt-1 text-red-300 w-28">
                   Only <span id="color-slot-count" style="visibility: hidden"></span> coloured prints left
                 </span>
               </label>

--- a/payment.html
+++ b/payment.html
@@ -193,8 +193,8 @@
                   checked
                 />
                 <span
-                  class="w-28 h-28 flex flex-col items-center justify-center rounded-full border-2 border-white/20 shadow-lg
-                         peer-checked:border-4 peer-checked:border-green-500 pt-0"
+                  class="w-28 h-28 flex flex-col items-center justify-center rounded-full border-4 border-white/20 shadow-xl
+                         peer-checked:border-green-500 pt-0"
                 >
                   <span class="font-semibold">£34.99</span>
                   <span class="text-xs">multi-colour</span>


### PR DESCRIPTION
## Summary
- make the £34.99 multi-colour option more prominent with a larger circle, thicker border and drop shadow

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f07a7345c832db13c76ca819f821a