### PR TITLE
Update single tier pricing to 27.99

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -196,7 +196,7 @@
             onmouseover="this.style.opacity='0.85'"
             onmouseout="this.style.opacity='1'"
           >
-            Print it from £24.99 →
+          Print it from £27.99 →
           </a>
         </div>
         <button

--- a/competitions.html
+++ b/competitions.html
@@ -205,7 +205,7 @@
             onmouseover="this.style.opacity='0.85'"
             onmouseout="this.style.opacity='1'"
           >
-            Print it from £24.99 →
+          Print it from £27.99 →
           </a>
         </div>
         <button

--- a/index.html
+++ b/index.html
@@ -259,7 +259,7 @@
               onmouseover="this.style.opacity='0.85'"
               onmouseout="this.style.opacity='1'"
             >
-              Print from £24.99 →
+              Print from £27.99 →
             </a>
           </div>
           <button

--- a/js/payment.js
+++ b/js/payment.js
@@ -6,7 +6,7 @@ let stripe = null;
 // and is not dependent on external CDNs.
 const FALLBACK_GLB = 'https://modelviewer.dev/shared-assets/models/Astronaut.glb';
 const PRICES = {
-  single: 2499,
+  single: 2799,
   multi: 3499,
   premium: 5999,
 };

--- a/payment.html
+++ b/payment.html
@@ -215,7 +215,7 @@
                 <span
                   class="w-24 h-24 flex flex-col items-center justify-center rounded-full border border-white/20 peer-checked:border-4 peer-checked:border-green-500 pt-0"
                 >
-                  <span class="font-semibold">£24.99</span>
+                  <span class="font-semibold">£27.99</span>
                   <span class="text-xs">single colour</span>
                 </span>
                 <div


### PR DESCRIPTION
## Summary
- bump single tier price to £27.99 across pages
- update payment script price constant
- run prettier and tests

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f0b6ab190832d8ab20107b6d6aea0