### PR TITLE
Fix print button text

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -196,7 +196,7 @@
             onmouseover="this.style.opacity='0.85'"
             onmouseout="this.style.opacity='1'"
           >
-          Print it from £27.99 →
+          Print from £27.99 →
           </a>
         </div>
         <button

--- a/competitions.html
+++ b/competitions.html
@@ -205,7 +205,7 @@
             onmouseover="this.style.opacity='0.85'"
             onmouseout="this.style.opacity='1'"
           >
-          Print it from £27.99 →
+          Print from £27.99 →
           </a>
         </div>
         <button


### PR DESCRIPTION
## Summary
- update checkout button text to "Print from £27.99" across pages

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f0d7e01e8832da4e03ec293558794