### PR TITLE
Show remaining prints in discount popup

### DIFF
--- a/backend/tests/frontend/slotCount.test.js
+++ b/backend/tests/frontend/slotCount.test.js
@@ -43,6 +43,7 @@ describe('slot count', () => {
     dom.window.eval(scriptSrc);
     await new Promise((r) => setTimeout(r, 0));
     expect(dom.window.document.getElementById('slot-count').textContent).toBe('4');
+    expect(dom.window.document.getElementById('bulk-slot-count').textContent).toBe('4');
     expect(dom.window.localStorage.getItem('slotPurchases')).toBe('1');
   });
 
@@ -61,5 +62,6 @@ describe('slot count', () => {
     dom.window.localStorage.setItem('slotPurchases', '2');
     await new Promise((r) => setTimeout(r, 0));
     expect(dom.window.document.getElementById('slot-count').textContent).toBe('4');
+    expect(dom.window.document.getElementById('bulk-slot-count').textContent).toBe('4');
   });
 });

--- a/js/payment.js
+++ b/js/payment.js
@@ -217,6 +217,7 @@ async function initPaymentPage() {
   const etaEl = document.getElementById('eta-estimate');
   const slotEl = document.getElementById('slot-count');
   const colorSlotEl = document.getElementById('color-slot-count');
+  const bulkSlotEl = document.getElementById('bulk-slot-count');
   const discountInput = document.getElementById('discount-code');
   const discountMsg = document.getElementById('discount-msg');
   const applyBtn = document.getElementById('apply-discount');
@@ -322,6 +323,9 @@ async function initPaymentPage() {
 
   if (slotEl) {
     slotEl.style.visibility = 'hidden';
+    if (bulkSlotEl) {
+      bulkSlotEl.style.visibility = 'hidden';
+    }
     // Compute a client-side slot count first so we have a reasonable value even
     // if the API fails or returns stale data.
     baseSlots = computeSlotsByTime();
@@ -339,6 +343,10 @@ async function initPaymentPage() {
     }
     slotEl.textContent = adjustedSlots(baseSlots);
     slotEl.style.visibility = 'visible';
+    if (bulkSlotEl) {
+      bulkSlotEl.textContent = adjustedSlots(baseSlots);
+      bulkSlotEl.style.visibility = 'visible';
+    }
   }
 
   if (colorSlotEl) {

--- a/payment.html
+++ b/payment.html
@@ -377,6 +377,9 @@
         <p class="mb-4 text-gray-300">
           £7 off the 2nd print and £15 off the 3rd when bought together.
         </p>
+        <p class="mb-4 text-xs text-red-300 text-center">
+          Only <span id="bulk-slot-count" style="visibility: hidden"></span> prints remaining
+        </p>
         <button
           id="bulk-discount-close"
           class="px-4 py-2 rounded-md bg-[#30D5C8] text-[#1A1A1D]"


### PR DESCRIPTION
## Summary
- show how many prints remain in bulk discount modal
- populate popup count in payment script
- verify count in popup via unit tests

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f189d3f00832db15201f6eafdf6f5