### PR TITLE
Add money-back guarantee outside checkout box

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -317,12 +317,13 @@
           <p class="mt-2 text-xs text-red-300 text-center">
             Only <span id="slot-count" style="visibility: hidden"></span> print slots remaining
           </p>
-        <div class="flex justify-center gap-4 mt-4 text-2xl text-white">
-          <i class="fas fa-lock" aria-label="Secure checkout"></i>
-          <i class="fas fa-shield-alt" aria-label="Money-back guarantee"></i>
+          <div class="flex justify-center gap-4 mt-4 text-2xl text-white">
+            <i class="fas fa-lock" aria-label="Secure checkout"></i>
+            <i class="fas fa-shield-alt" aria-label="Money-back guarantee"></i>
+          </div>
         </div>
-      </div>
-      <div class="absolute left-0 bottom-4 w-full md:w-1/2 max-w-lg text-center text-sm text-gray-400/75">
+        <span class="guarantee-badge self-end md:ml-2 text-sm whitespace-nowrap">🛡️ Money-Back Guarantee</span>
+        <div class="absolute left-0 bottom-4 w-full md:w-1/2 max-w-lg text-center text-sm text-gray-400/75">
 
         <p>
           Due to incredibly high demand, delivery may take 3+ weeks.<br />


### PR DESCRIPTION
## Summary
- revert pay button styling to full width
- place guarantee text outside the checkout form to the right of the pay button
- keep code formatted with Prettier

## Testing
- `npm run format`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_684f17f64e04832db8cc5a73c88a2929