### PR TITLE
Add flash sale functionality

### DIFF
--- a/admin/flash-sale.html
+++ b/admin/flash-sale.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Admin Flash Sale</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body class="bg-[#1A1A1D] text-white font-sans flex flex-col min-h-screen">
+    <header class="relative flex items-center justify-between py-4 px-6">
+      <a
+        href="../index.html"
+        class="bg-[#2A2A2E] border border-white/10 rounded-3xl px-4 py-2 hover:bg-[#3A3A3E] transition-shape"
+        >Back</a
+      >
+      <h1 class="absolute inset-x-0 top-1/2 -translate-y-1/2 text-center text-2xl font-semibold">
+        Admin Flash Sale
+      </h1>
+      <span class="w-16"></span>
+    </header>
+    <main class="flex-1 p-4 space-y-4">
+      <div class="space-x-2">
+        <input
+          id="token"
+          type="password"
+          placeholder="Admin token"
+          class="bg-[#2A2A2E] border border-white/10 rounded px-2 py-1"
+        />
+        <button id="set-token" class="bg-[#30D5C8] text-[#1A1A1D] px-3 py-1 rounded">
+          Set Token
+        </button>
+      </div>
+      <div id="sale" class="space-y-4"></div>
+    </main>
+    <script type="module" src="../js/adminFlashSale.js"></script>
+  </body>
+</html>

--- a/backend/migrations/027_create_flash_sales.sql
+++ b/backend/migrations/027_create_flash_sales.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS flash_sales (
+  id SERIAL PRIMARY KEY,
+  discount_percent INTEGER NOT NULL,
+  product_type TEXT NOT NULL,
+  start_time TIMESTAMPTZ NOT NULL,
+  end_time TIMESTAMPTZ NOT NULL,
+  active BOOLEAN DEFAULT TRUE,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS flash_sales_active_idx ON flash_sales(active);
+CREATE INDEX IF NOT EXISTS flash_sales_time_idx ON flash_sales(start_time, end_time);
+
+CREATE TRIGGER flash_sales_set_updated
+BEFORE UPDATE ON flash_sales
+FOR EACH ROW EXECUTE PROCEDURE set_updated_at();

--- a/backend/server.js
+++ b/backend/server.js
@@ -999,11 +999,17 @@ app.post('/api/admin/flash-sale', adminCheck, async (req, res) => {
   if (discount_percent == null || !product_type || !start_time || !end_time) {
     return res.status(400).json({ error: 'Missing fields' });
   }
+  const start = new Date(start_time);
+  const end = new Date(end_time);
+  if (!isFinite(start) || !isFinite(end) || start >= end) {
+    return res.status(400).json({ error: 'Invalid time range' });
+  }
   try {
+    await db.query('UPDATE flash_sales SET active=FALSE WHERE active=TRUE');
     const { rows } = await db.query(
       `INSERT INTO flash_sales(discount_percent, product_type, start_time, end_time, active)
        VALUES($1,$2,$3,$4,TRUE) RETURNING *`,
-      [discount_percent, product_type, start_time, end_time]
+      [discount_percent, product_type, start.toISOString(), end.toISOString()]
     );
     res.json(rows[0]);
   } catch (err) {

--- a/backend/tests/flashSale.test.js
+++ b/backend/tests/flashSale.test.js
@@ -48,11 +48,15 @@ test('POST /api/admin/flash-sale creates sale', async () => {
     .set('x-admin-token', 'admin')
     .send(body);
   expect(res.status).toBe(200);
-  expect(db.query).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO flash_sales'), [
+  expect(db.query).toHaveBeenNthCalledWith(
+    1,
+    'UPDATE flash_sales SET active=FALSE WHERE active=TRUE'
+  );
+  expect(db.query).toHaveBeenNthCalledWith(2, expect.stringContaining('INSERT INTO flash_sales'), [
     5,
     'single',
-    body.start_time,
-    body.end_time,
+    new Date(body.start_time).toISOString(),
+    new Date(body.end_time).toISOString(),
   ]);
 });
 

--- a/backend/tests/flashSale.test.js
+++ b/backend/tests/flashSale.test.js
@@ -1,0 +1,67 @@
+process.env.STRIPE_SECRET_KEY = 'test';
+process.env.STRIPE_WEBHOOK_SECRET = 'whsec';
+process.env.DB_URL = 'postgres://user:pass@localhost/db';
+process.env.HUNYUAN_API_KEY = 'test';
+process.env.HUNYUAN_SERVER_URL = 'http://localhost:4000';
+
+jest.mock('../db', () => ({
+  query: jest.fn().mockResolvedValue({ rows: [] }),
+  insertCommission: jest.fn().mockResolvedValue({}),
+}));
+const db = require('../db');
+
+const request = require('supertest');
+const app = require('../server');
+
+beforeEach(() => {
+  db.query.mockClear();
+});
+
+test('GET /api/flash-sale returns sale', async () => {
+  db.query.mockResolvedValueOnce({ rows: [{ id: 1 }] });
+  const res = await request(app).get('/api/flash-sale');
+  expect(res.status).toBe(200);
+  expect(res.body.id).toBe(1);
+});
+
+test('GET /api/flash-sale 404 when none', async () => {
+  db.query.mockResolvedValueOnce({ rows: [] });
+  const res = await request(app).get('/api/flash-sale');
+  expect(res.status).toBe(404);
+});
+
+test('POST /api/admin/flash-sale requires admin', async () => {
+  const res = await request(app).post('/api/admin/flash-sale').send({});
+  expect(res.status).toBe(401);
+});
+
+test('POST /api/admin/flash-sale creates sale', async () => {
+  db.query.mockResolvedValueOnce({ rows: [{ id: 2 }] });
+  const body = {
+    discount_percent: 5,
+    product_type: 'single',
+    start_time: '2024-01-01T00:00:00Z',
+    end_time: '2024-01-02T00:00:00Z',
+  };
+  const res = await request(app)
+    .post('/api/admin/flash-sale')
+    .set('x-admin-token', 'admin')
+    .send(body);
+  expect(res.status).toBe(200);
+  expect(db.query).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO flash_sales'), [
+    5,
+    'single',
+    body.start_time,
+    body.end_time,
+  ]);
+});
+
+test('DELETE /api/admin/flash-sale/:id ends sale', async () => {
+  db.query.mockResolvedValueOnce({ rows: [{ id: 3 }] });
+  const res = await request(app).delete('/api/admin/flash-sale/3').set('x-admin-token', 'admin');
+  expect(res.status).toBe(200);
+  expect(db.query).toHaveBeenCalledWith(
+    'UPDATE flash_sales SET active=FALSE WHERE id=$1 RETURNING *',
+    ['3']
+  );
+});

--- a/js/adminFlashSale.js
+++ b/js/adminFlashSale.js
@@ -1,0 +1,89 @@
+function getToken() {
+  return (
+    localStorage.getItem('adminToken') || localStorage.getItem('token') || ''
+  );
+}
+
+function setToken(token) {
+  localStorage.setItem('adminToken', token);
+}
+
+function authHeaders() {
+  const admin = localStorage.getItem('adminToken');
+  if (admin) return { 'x-admin-token': admin };
+  const user = localStorage.getItem('token');
+  if (user) return { Authorization: `Bearer ${user}` };
+  return {};
+}
+
+const API_BASE = (window.API_ORIGIN || '') + '/api';
+
+async function load() {
+  const container = document.getElementById('sale');
+  container.textContent = 'Loading...';
+  let sale = null;
+  try {
+    const resp = await fetch(`${API_BASE}/flash-sale`, { headers: authHeaders() });
+    if (resp.ok) {
+      sale = await resp.json();
+    }
+  } catch {}
+  container.innerHTML = '';
+  if (sale) {
+    const div = document.createElement('div');
+    div.className = 'space-y-2';
+    div.innerHTML = `
+      <p>Active sale: ${sale.discount_percent}% off ${sale.product_type}</p>
+      <button id="end" class="bg-red-500 px-3 py-1 rounded">End Sale</button>`;
+    container.appendChild(div);
+    div.querySelector('#end').addEventListener('click', async () => {
+      const resp = await fetch(`${API_BASE}/admin/flash-sale/${sale.id}`, {
+        method: 'DELETE',
+        headers: authHeaders(),
+      });
+      if (resp.ok) load();
+      else alert('Failed');
+    });
+  } else {
+    const div = document.createElement('div');
+    div.className = 'space-y-2';
+    div.innerHTML = `
+      <label class="block text-sm">Product Type
+        <input id="prod" class="w-full mt-1 p-2 rounded bg-[#1A1A1D] border border-white/10">
+      </label>
+      <label class="block text-sm">Discount %
+        <input id="disc" type="number" class="w-full mt-1 p-2 rounded bg-[#1A1A1D] border border-white/10">
+      </label>
+      <label class="block text-sm">Duration Minutes
+        <input id="mins" type="number" value="60" class="w-full mt-1 p-2 rounded bg-[#1A1A1D] border border-white/10">
+      </label>
+      <button id="start" class="bg-[#30D5C8] text-[#1A1A1D] px-3 py-1 rounded">Start Sale</button>`;
+    container.appendChild(div);
+    div.querySelector('#start').addEventListener('click', async () => {
+      const now = Date.now();
+      const body = {
+        product_type: div.querySelector('#prod').value,
+        discount_percent: parseInt(div.querySelector('#disc').value, 10),
+        start_time: new Date(now).toISOString(),
+        end_time: new Date(now + parseInt(div.querySelector('#mins').value, 10) * 60000).toISOString(),
+      };
+      const resp = await fetch(`${API_BASE}/admin/flash-sale`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...authHeaders() },
+        body: JSON.stringify(body),
+      });
+      if (resp.ok) load();
+      else alert('Failed');
+    });
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const tokenInput = document.getElementById('token');
+  tokenInput.value = localStorage.getItem('adminToken') || '';
+  document.getElementById('set-token').addEventListener('click', () => {
+    setToken(tokenInput.value.trim());
+    load();
+  });
+  if (getToken()) load();
+});


### PR DESCRIPTION
## Summary
- create `flash_sales` table migration
- support flash sale API routes
- apply flash sale logic in payment page
- add minimal admin UI for flash sales
- test flash sale API

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f17c6b790832db035ea5c17512636