### PR TITLE
Fix misaligned notice

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -205,7 +205,7 @@
                   <span class="font-semibold">£34.99</span>
                   <span class="text-xs">multi-colour</span>
                 </span>
-                <span class="block text-xs mt-1 text-red-300 w-28">
+                <span class="block text-xs mt-1 text-red-300 w-28 ml-px">
                   Only <span id="color-slot-count" style="visibility: hidden"></span> coloured prints left
                 </span>
               </label>


### PR DESCRIPTION
## Summary
- move the coloured print stock notice one pixel right

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f1b57c7e4832d9b1c98b1c4103013