### PR TITLE
Add money-back guarantee outside checkout box

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -322,6 +322,7 @@
           <i class="fas fa-shield-alt" aria-label="Money-back guarantee"></i>
         </div>
       </div>
+      <span class="guarantee-badge self-end md:ml-2 text-sm whitespace-nowrap">🛡️ Money-Back Guarantee</span>
       <div class="absolute left-0 bottom-4 w-full md:w-1/2 max-w-lg text-center text-sm text-gray-400/75">
 
         <p>


### PR DESCRIPTION
## Summary
- revert previous layout changes on payment page
- position money-back guarantee text outside the checkout form to the right of the pay button

## Testing
- `npm run format`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_684f17f64e04832db8cc5a73c88a2929