### PR TITLE
Add money-back badge

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -131,7 +131,7 @@
         </section>
 
         <!-- Checkout Form -->
-        <div class="w-full md:w-1/2 max-w-md bg-[#2A2A2E] border border-white/10 rounded-3xl p-6">
+        <div class="relative w-full md:w-1/2 max-w-md bg-[#2A2A2E] border border-white/10 rounded-3xl p-6">
           <h2 class="text-2xl font-semibold mb-4 text-center">Checkout</h2>
           <form id="checkout-form" class="space-y-4">
             <div>
@@ -320,6 +320,11 @@
         <div class="flex justify-center gap-4 mt-4 text-2xl text-white">
           <i class="fas fa-lock" aria-label="Secure checkout"></i>
           <i class="fas fa-shield-alt" aria-label="Money-back guarantee"></i>
+        </div>
+        <div
+          class="absolute top-1/2 left-full ml-2 -translate-y-1/2 whitespace-nowrap text-sm pointer-events-none"
+        >
+          🛡️ Money-Back Guarantee
         </div>
       </div>
       <div class="absolute left-0 bottom-4 w-full md:w-1/2 max-w-lg text-center text-sm text-gray-400/75">


### PR DESCRIPTION
## Summary
- add a `Money-Back Guarantee` badge to the payment page

## Validation
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f2beb360c832dbebb3dfbec2e8448