### PR TITLE
Refine money-back badge placement

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -600,6 +600,19 @@ async function initPaymentPage() {
       payHandler();
     }
   });
+
+  const alignBadge = () => {
+    const badge = document.getElementById('money-back-badge');
+    if (!badge || !payBtn) return;
+    const btnRect = payBtn.getBoundingClientRect();
+    const container = badge.parentElement;
+    const containerRect = container && container.getBoundingClientRect();
+    if (!containerRect) return;
+    const offset = btnRect.top + btnRect.height / 2 - containerRect.top;
+    badge.style.top = offset - badge.offsetHeight / 2 + 'px';
+  };
+  alignBadge();
+  window.addEventListener('resize', alignBadge);
 }
 
 if (document.readyState === 'loading') {

--- a/payment.html
+++ b/payment.html
@@ -131,7 +131,7 @@
         </section>
 
         <!-- Checkout Form -->
-        <div class="w-full md:w-1/2 max-w-md bg-[#2A2A2E] border border-white/10 rounded-3xl p-6">
+        <div class="relative w-full md:w-1/2 max-w-md bg-[#2A2A2E] border border-white/10 rounded-3xl p-6">
           <h2 class="text-2xl font-semibold mb-4 text-center">Checkout</h2>
           <form id="checkout-form" class="space-y-4">
             <div>
@@ -320,6 +320,12 @@
         <div class="flex justify-center gap-4 mt-4 text-2xl text-white">
           <i class="fas fa-lock" aria-label="Secure checkout"></i>
           <i class="fas fa-shield-alt" aria-label="Money-back guarantee"></i>
+        </div>
+        <div
+          id="money-back-badge"
+          class="absolute left-full ml-[5px] whitespace-nowrap text-sm pointer-events-none"
+        >
+          🛡️ Money-Back Guarantee
         </div>
       </div>
       <div class="absolute left-0 bottom-4 w-full md:w-1/2 max-w-lg text-center text-sm text-gray-400/75">


### PR DESCRIPTION
## Summary
- center the money-back badge with the Pay button
- shift badge about 5px to the right of the checkout box

## Validation
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f2beb360c832dbebb3dfbec2e8448