### PR TITLE
Fix Money-Back badge alignment

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -610,7 +610,9 @@ async function initPaymentPage() {
     if (!containerRect) return;
 
     const offset = btnRect.top + btnRect.height / 2 - containerRect.top;
-    badge.style.top = offset - badge.offsetHeight / 2 + 'px';
+    // Center the badge on the button and override the initial transform
+    badge.style.transform = 'translateY(-50%)';
+    badge.style.top = offset + 'px';
 
   };
   alignBadge();


### PR DESCRIPTION
## Summary
- adjust `money-back-badge` alignment logic so the transform does not shift it off-center

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f3368e640832dbac29685bb6543c4