### PR TITLE
Fix payment color menu toggle

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -292,9 +292,12 @@ async function initPaymentPage() {
   );
   if (storedRadio) storedRadio.checked = true;
   if (storedMaterial === 'single') {
-    if (colorMenu) colorMenu.classList.remove('hidden');
     if (singleButton && storedColor) {
       singleButton.style.backgroundColor = storedColor;
+    }
+    if (colorMenu) {
+      if (storedColor) colorMenu.classList.add('hidden');
+      else colorMenu.classList.remove('hidden');
     }
   } else if (colorMenu) {
     colorMenu.classList.add('hidden');


### PR DESCRIPTION
## Summary
- keep single color menu hidden if color already selected

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f37077fe0832dad0d338a472a0d0b