### PR TITLE
Add likes/sales overlay on community models

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -184,6 +184,14 @@
           class="w-full h-96 bg-[#2A2A2E] rounded-xl"
         ></model-viewer>
         <div
+          id="model-stats"
+          class="absolute top-2 right-2 text-xs bg-black/60 text-white px-2 py-1 rounded z-10 pointer-events-none"
+        >
+          <span id="likes-count">❤️ 12 likes</span>
+          •
+          <span id="print-count">🛒 4 prints sold</span>
+        </div>
+        <div
           id="modal-checkout-container"
           class="absolute bottom-4 right-4 flex flex-col items-center"
         >


### PR DESCRIPTION
## Summary
- revert unintended overlay on payment page
- show placeholder likes/print counts in community creations modal

## Testing
- `npm run format`
- `npm run test-ci`


------
https://chatgpt.com/codex/tasks/task_e_684f3b841668832d8ead00017ed46ee9