### PR TITLE
Display wizard slots notice without shifting layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -396,7 +396,14 @@
     <div id="wizard-banner" class="fixed bottom-0 left-0 right-0 flex divide-x divide-[#1A1A1D] text-white font-semibold bg-[#1A1A1D] z-40">
       <div id="wizard-step-prompt" class="flex-1 text-center py-2 bg-[#2A2A2E]">Create prompt</div>
       <div id="wizard-step-building" class="flex-1 text-center py-2">Building model</div>
-      <div id="wizard-step-purchase" class="flex-1 text-center py-2">Purchase model</div>
+      <div id="wizard-step-purchase" class="relative flex-1 text-center py-2 flex justify-center items-center">
+        <span
+          id="wizard-slots"
+          class="absolute left-0 -translate-x-full pr-2 hidden text-sm text-red-500 whitespace-nowrap"
+          >Only 4 print slots remaining</span
+        >
+        <span>Purchase model</span>
+      </div>
     </div>
 
     <!-- ▸▸▸ SCRIPTS ------------------------------------------------------ -->

--- a/js/wizard.js
+++ b/js/wizard.js
@@ -34,6 +34,12 @@ export function updateWizard() {
       el.classList.remove('bg-[#2A2A2E]', 'bg-[#30D5C8]');
     }
   });
+
+  const slots = document.getElementById('wizard-slots');
+  if (slots) {
+    if (idx >= 2) slots.classList.remove('hidden');
+    else slots.classList.add('hidden');
+  }
 }
 
 document.addEventListener('DOMContentLoaded', updateWizard);

--- a/payment.html
+++ b/payment.html
@@ -408,7 +408,14 @@
         Create prompt
       </div>
       <div id="wizard-step-building" class="flex-1 text-center py-2">Building model</div>
-      <div id="wizard-step-purchase" class="flex-1 text-center py-2">Purchase model</div>
+      <div id="wizard-step-purchase" class="relative flex-1 text-center py-2 flex justify-center items-center">
+        <span
+          id="wizard-slots"
+          class="absolute left-0 -translate-x-full pr-2 hidden text-sm text-red-500 whitespace-nowrap"
+          >Only 4 print slots remaining</span
+        >
+        <span>Purchase model</span>
+      </div>
     </div>
 
     <!-- Init scripts -->


### PR DESCRIPTION
## Summary
- keep `Purchase model` centered by absolutely positioning the slot warning
- use small text and show it only at the purchase step

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f41b30718832d99cbd9861b6ec411