### PR TITLE
Add secure checkout banner to payment page

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -321,19 +321,6 @@
             <i class="fas fa-shield-alt" aria-label="Money-back guarantee"></i>
           </div>
 
-          <!-- repositioned badge -->
-          <div
-            id="money-back-badge"
-            style="
-              position: absolute;
-              left: calc(100% + 0.55cm);
-              top: 85%;
-              transform: translateY(-72%);
-            "
-            class="whitespace-nowrap text-sm pointer-events-none"
-          >
-            🛡️ Money-Back Guarantee
-          </div>
         </div>
 
         <div class="absolute left-0 bottom-4 w-full md:w-1/2 max-w-lg text-center text-sm text-gray-400/75">
@@ -412,6 +399,14 @@
         <span id="wizard-slots" class="hidden text-red-500 mr-2 whitespace-nowrap">Only 4 print slots remaining</span>
         <span>Purchase model</span>
       </div>
+    </div>
+
+    <div
+      id="checkout-guarantee"
+      class="fixed bottom-20 right-4 text-right text-sm leading-snug z-40"
+    >
+      <p>🔒 Secure Checkout</p>
+      <p>🛡 Money-Back Guarantee</p>
     </div>
 
     <!-- Init scripts -->


### PR DESCRIPTION
## Summary
- remove old money back badge on the payment page
- add the `checkout-guarantee` banner to payment.html to match index.html

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f44e2cb08832dbec9ec348782363d