### PR TITLE
Fix stats ticker alignment and wording

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,7 +139,7 @@
         <div class="mt-1 flex flex-col text-sm text-gray-400 opacity-75">
           <p><span class="text-white">5400+</span> prints</p>
           <p>delivered already</p>
-          <p id="stats-ticker" class="text-orange-400"></p>
+          <p id="stats-ticker" class="text-orange-400 text-right"></p>
         </div>
       </div>
 

--- a/js/index.js
+++ b/js/index.js
@@ -600,11 +600,11 @@ async function init() {
       .then((r) => (r.ok ? r.json() : null))
       .then((data) => {
         const prints = data?.printsSold ?? 42;
-        el.innerHTML = `\u{1F525} ${prints} prints sold<br>in the last 24 h`;
+        el.innerHTML = `\u{1F525} ${prints} prints sold<br>in last 24 h`;
       })
       .catch(() => {
         el.innerHTML =
-          '\u{1F525} 42 prints sold<br>in the last 24 h';
+          '\u{1F525} 42 prints sold<br>in last 24 h';
       });
   }
 


### PR DESCRIPTION
## Summary
- tweak header ticker markup so the text is right aligned
- update ticker wording to remove extra **the**

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f472b0fa8832d85cbd4b51d89a2cf