### PR TITLE
Fix Community Creations tier styling

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -195,35 +195,34 @@
           id="modal-checkout-container"
           class="absolute bottom-4 right-4 flex flex-col items-center"
         >
-          <p class="mb-3 text-sm text-gray-400">Free UK Shipping</p>
-          <div id="tier-toggle" class="flex gap-1 mb-2 text-xs">
-            <button
-              type="button"
-              data-tier="bronze"
+        <div id="tier-toggle" class="flex gap-1 mb-2 text-xs">
+          <button
+            type="button"
+            data-tier="bronze"
 
-              class="tier-option px-2 py-1 rounded-full border border-white/20 opacity-50" style="background-color:#cd7f32"
-            >
-              1 colour
+            class="tier-option px-2 py-1 rounded-full border border-white/20 opacity-50 text-black" style="background-color:#cd7f32"
+          >
+            1 colour
 
-            </button>
-            <button
-              type="button"
-              data-tier="silver"
+          </button>
+          <button
+            type="button"
+            data-tier="silver"
 
-              class="tier-option px-2 py-1 rounded-full border border-white/20 opacity-50" style="background-color:#c0c0c0"
-            >
-              multicolour
+            class="tier-option px-2 py-1 rounded-full border border-white/20 opacity-50 text-black" style="background-color:#c0c0c0"
+          >
+            multicolour
 
-            </button>
-            <button
-              type="button"
-              data-tier="gold"
+          </button>
+          <button
+            type="button"
+            data-tier="gold"
 
-              class="tier-option px-2 py-1 rounded-full border border-white/20 opacity-50" style="background-color:#ffd700"
-            >
-              premium
+            class="tier-option px-2 py-1 rounded-full border border-white/20 opacity-50 text-black" style="background-color:#ffd700"
+          >
+            premium
 
-            </button>
+          </button>
           </div>
           <a
             id="modal-checkout"
@@ -235,7 +234,6 @@
           >
             Print for £34.99 →
           </a>
-          <p id="tier-scarcity" class="mt-1 text-xs text-red-300">Only 3 left at this tier!</p>
         </div>
         <button
           id="modal-add-basket"


### PR DESCRIPTION
## Summary
- tweak CommunityCreations page styles
  - make tier option text black
  - remove "Free UK Shipping" message
  - remove scarcity notice
- run formatter and tests

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f4823df34832dacc7ce6dde755a75