### PR TITLE
Add shipping note to payment badge

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -325,8 +325,9 @@
             "
             class="whitespace-nowrap text-sm pointer-events-none"
           >
-            <p>🛡️ Money-Back Guarantee</p>
             <p>🔒 Secure Checkout</p>
+            <p>🛡️ Money-Back Guarantee</p>
+            <p>🚚 Free UK Shipping</p>
           </div>
 
         </div>


### PR DESCRIPTION
## Summary
- show a "Free UK Shipping" line in the floating badge next to the Pay button

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f4b19b1b4832d947a0fa0c885504e