### PR TITLE
Fix community stats position

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -185,7 +185,7 @@
         ></model-viewer>
         <div
           id="model-stats"
-          class="absolute top-2 right-2 text-xs bg-black/60 text-white px-2 py-1 rounded z-10 pointer-events-none"
+          class="absolute top-2 left-2 text-xs bg-black/60 text-white px-2 py-1 rounded z-10 pointer-events-none"
         >
           <span id="likes-count">❤️ 12 likes</span>
           •


### PR DESCRIPTION
## Summary
- move the model stats badge to the top-left of the model viewer on the Community page

## Testing
- `npm run format`
- `npm test -- -i`


------
https://chatgpt.com/codex/tasks/task_e_684f4b8dd3e0832daa9d423b19d3719c