### PR TITLE
Fix stats fallback message

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -599,12 +599,12 @@ async function init() {
     fetch(`${API_BASE}/stats`)
       .then((r) => (r.ok ? r.json() : null))
       .then((data) => {
-        const prints = data?.printsSold ?? 42;
+        const prints = data?.printsSold ?? 41;
 
         el.textContent = `\u{1F525} ${prints} in last 24 hr`;
       })
       .catch(() => {
-        el.textContent = '\u{1F525} 42 in last 24 hr';
+        el.textContent = '\u{1F525} 41 in last 24 hr';
 
       });
   }


### PR DESCRIPTION
## Summary
- adjust fallback count from 42 to 41 in stats ticker

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f5a19cf88832dbb768304a43ad246