### PR TITLE
Adjust checkout field order

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -163,6 +163,22 @@
               />
             </div>
 
+            <div class="flex gap-2">
+              <input
+                id="ship-city"
+                class="flex-1 p-2 rounded-md bg-[#1A1A1D] border border-white/10"
+                placeholder="City + Country"
+                autocomplete="address-level2"
+                aria-label="City + Country"
+              />
+              <input
+                id="ship-zip"
+                class="w-28 p-2 rounded-md bg-[#1A1A1D] border border-white/10"
+                placeholder="ZIP"
+                autocomplete="postal-code"
+                aria-label="ZIP code"
+              />
+            </div>
             <!-- Material/Size Options -->
             <fieldset id="material-options" class="flex w-full justify-between my-4">
               <label class="cursor-not-allowed text-center flex flex-col items-center w-1/3 opacity-50">
@@ -256,22 +272,6 @@
               </label>
             </fieldset>
 
-            <div class="flex gap-2">
-              <input
-                id="ship-city"
-                class="flex-1 p-2 rounded-md bg-[#1A1A1D] border border-white/10"
-                placeholder="City + Country"
-                autocomplete="address-level2"
-                aria-label="City + Country"
-              />
-              <input
-                id="ship-zip"
-                class="w-28 p-2 rounded-md bg-[#1A1A1D] border border-white/10"
-                placeholder="ZIP"
-                autocomplete="postal-code"
-                aria-label="ZIP code"
-              />
-            </div>
 
             <div class="flex gap-2">
               <input


### PR DESCRIPTION
## Summary
- move city & ZIP inputs above the material option buttons

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684f5c7eccd8832d9244bd8930ce637f