### PR TITLE
Fix wizard slot counter

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -428,6 +428,8 @@ async function initPaymentPage() {
     }
     slotEl.textContent = adjustedSlots(baseSlots);
     slotEl.style.visibility = 'visible';
+    if (window.setWizardSlotCount)
+      window.setWizardSlotCount(adjustedSlots(baseSlots));
     if (bulkSlotEl) {
       bulkSlotEl.textContent = adjustedSlots(baseSlots);
       bulkSlotEl.style.visibility = 'visible';

--- a/js/wizard.js
+++ b/js/wizard.js
@@ -44,3 +44,8 @@ export function updateWizard() {
 
 document.addEventListener('DOMContentLoaded', updateWizard);
 window.setWizardStage = setWizardStage;
+export function setWizardSlotCount(n) {
+  const el = document.getElementById('wizard-slots');
+  if (el) el.textContent = `Only ${n} print slots remaining`;
+}
+window.setWizardSlotCount = setWizardSlotCount;


### PR DESCRIPTION
## Summary
- add `setWizardSlotCount` helper in `wizard.js`
- sync wizard slot count with the dynamic value in `payment.js`

## Testing
- `npm run format`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684f5e4d1e84832db1b4f5777cce2334