### PR TITLE
Adjust wizard slot warning position

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -405,10 +405,8 @@
       </div>
       <div id="wizard-step-building" class="flex-1 text-center py-2">Building model</div>
 
-      <div id="wizard-step-purchase" class="relative flex-1 text-center py-2 flex justify-center items-center">
-        <span
-          id="wizard-slots"
-          class="absolute left-0 -translate-x-full pr-2 hidden text-sm text-red-500 whitespace-nowrap"
+      <div id="wizard-step-purchase" class="flex-1 text-center py-2 flex justify-center items-center">
+        <span id="wizard-slots" class="hidden text-xs text-red-300 mr-2 whitespace-nowrap"
           >Only 4 print slots remaining</span
         >
         <span>Purchase model</span>


### PR DESCRIPTION
## Summary
- tweak wizard sticky text styling in `payment.html`
- run prettier formatting
- run backend tests

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fc62991f4832d82619cce015a8f7b