### PR TITLE
Fix color reset on payment page

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -347,7 +347,8 @@ async function initPaymentPage() {
     originalTextures = mats.map(
       (m) => m.pbrMetallicRoughness?.baseColorTexture?.texture || null
     );
-    if (storedMaterial === 'single' && storedColor) {
+    // Apply any stored single colour only if that option is currently selected
+    if (selectedMaterialValue() === 'single' && storedColor) {
       const factor = hexToFactor(storedColor);
       if (factor) applyModelColor(factor);
     }


### PR DESCRIPTION
## Summary
- ensure the viewer only reapplies stored color if the current selection is single colour

## Testing
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `npm run format` in `backend/hunyuan_server`
- `npm test` in `backend/hunyuan_server`


------
https://chatgpt.com/codex/tasks/task_e_684fc5209e6c832d956b4ecc233875a8