### PR TITLE
Align wizard slot banner text

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -408,7 +408,7 @@
       <div id="wizard-step-purchase" class="relative flex-1 text-center py-2 flex justify-center items-center">
         <span
           id="wizard-slots"
-          class="absolute left-0 -translate-x-full pr-2 hidden text-sm text-red-500 whitespace-nowrap"
+          class="absolute left-1/2 -translate-x-full -translate-y-1/2 top-1/2 pr-2 hidden text-xs text-red-500 whitespace-nowrap"
           >Only 4 print slots remaining</span
         >
         <span>Purchase model</span>


### PR DESCRIPTION
## Summary
- tweak wizard slot element in `payment.html`
- make text size match the count text below the button and move it to within the last step column

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fc62991f4832d82619cce015a8f7b