### PR TITLE
Show upsell after payment success

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -521,6 +521,12 @@ async function initPaymentPage() {
 
   if (sessionId) {
     successMsg.hidden = false;
+    const popup = document.getElementById('bulk-discount-popup');
+    const closeBtn = document.getElementById('bulk-discount-close');
+    if (popup && closeBtn) {
+      popup.classList.remove('hidden');
+      closeBtn.addEventListener('click', () => popup.classList.add('hidden'));
+    }
     return;
   }
   if (qs('cancel')) {
@@ -620,21 +626,9 @@ async function initPaymentPage() {
   };
   window.payHandler = payHandler;
 
-  document.getElementById('submit-payment').addEventListener('click', () => {
-    const popup = document.getElementById('bulk-discount-popup');
-    const closeBtn = document.getElementById('bulk-discount-close');
-    if (popup && closeBtn) {
-      popup.classList.remove('hidden');
-      const proceed = () => {
-        popup.classList.add('hidden');
-        closeBtn.removeEventListener('click', proceed);
-        payHandler();
-      };
-      closeBtn.addEventListener('click', proceed);
-    } else {
-      payHandler();
-    }
-  });
+  document
+    .getElementById('submit-payment')
+    .addEventListener('click', () => payHandler());
 
   const alignBadge = () => {
     const badge = document.getElementById('money-back-badge');


### PR DESCRIPTION
## Summary
- show the bulk discount popup only after a successful payment
- remove popup gating from the "Pay" button handler
- ran formatting and tests

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685088aec134832db845b7964d09f1b9