### PR TITLE
Center multi colour option text

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -209,7 +209,7 @@
                   checked
                 />
                 <span
-                  class="w-28 h-28 flex flex-col items-center justify-start rounded-full border-4 border-white/20 shadow-xl peer-checked:border-green-500 pt-1"
+                  class="w-28 h-28 flex flex-col items-center justify-center rounded-full border-4 border-white/20 shadow-xl peer-checked:border-green-500"
                 >
                   <span class="font-semibold leading-none">£34.99</span>
                   <span class="text-xs leading-tight">multi-colour</span>


### PR DESCRIPTION
## Summary
- align the multi-colour option text in `payment.html`
- ran prettier formatting
- ran backend tests

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68508c2cce28832d8d0b2cea5042749c