### PR TITLE
Adjust multi-colour option label

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -213,7 +213,7 @@
                 >
                   <span class="font-semibold leading-none">£34.99</span>
                   <span class="text-xs leading-tight">multi-colour</span>
-                  <span class="text-[10px] leading-tight text-center">+ your name etched<br />(optional)</span>
+                  <span class="text-[10px] leading-tight text-center mt-2" style="color:#ffd700">+ (optional) name<br />etching</span>
                 </span>
                 <span class="block text-xs mt-1 text-red-300 w-28">
                   Only <span id="color-slot-count" style="visibility: hidden"></span> coloured prints left


### PR DESCRIPTION
## Summary
- tweak text for multi-colour print option
- add spacing and gold colour for optional name etching

## Testing
- `npm run format`
- `npm test --silent --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_685090279614832dbc275fa7625d8391