### PR TITLE
Fix optional text color to match premium gold

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -213,7 +213,7 @@
                 >
                   <span class="font-semibold leading-none">£34.99</span>
                   <span class="text-xs leading-tight">multi-colour</span>
-                  <span class="text-[10px] leading-tight text-center mt-2" style="color:#ffd700">+ (optional) name<br />etching</span>
+                  <span class="text-[10px] leading-tight text-center mt-2 text-[#ffd700]">+ (optional) name<br />etching</span>
                 </span>
                 <span class="block text-xs mt-1 text-red-300 w-28">
                   Only <span id="color-slot-count" style="visibility: hidden"></span> coloured prints left


### PR DESCRIPTION
## Summary
- update color styling for the optional name etching text
- run formatter and unit tests

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68509726e234832d9a298119d72303c2