### PR TITLE
Adjust golden color for optional etching

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -213,7 +213,7 @@
                 >
                   <span class="font-semibold leading-none">£34.99</span>
                   <span class="text-xs leading-tight">multi-colour</span>
-                  <span class="text-[10px] leading-tight text-center mt-2 text-[#ffd700]">+ (optional) name<br />etching</span>
+                  <span class="text-[10px] leading-tight text-center mt-2 text-[#d4af37]">+ (optional) name<br />etching</span>
                 </span>
                 <span class="block text-xs mt-1 text-red-300 w-28">
                   Only <span id="color-slot-count" style="visibility: hidden"></span> coloured prints left


### PR DESCRIPTION
## Summary
- tweak the optional etching text color to a richer golden shade
- run prettier and backend tests

## Testing
- `npm run format`
- `npm test -- --runInBand --colors=false`

------
https://chatgpt.com/codex/tasks/task_e_68509b0a611c832d81edf867f1b6ed12