### PR TITLE
Fix discount banner persistence

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -34,7 +34,8 @@ function updateFlashSaleBanner() {
   const flashTimer = document.getElementById('flash-timer');
   if (!flashBanner || !flashTimer) return;
   if (!flashSale) {
-    flashBanner.hidden = true;
+    // No server-driven flash sale is active. Don't hide any existing banner
+    // (e.g. the local 5% discount) when the material selection changes.
     return;
   }
   const end = new Date(flashSale.end_time).getTime();


### PR DESCRIPTION
## Summary
- avoid hiding the flash discount banner when no server-side sale is active

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68509aef9b74832d8366627d5f00b14d