### PR TITLE
Add subscription service roadmap

### DIFF
--- a/docs/task_list.md
+++ b/docs/task_list.md
@@ -77,3 +77,16 @@
 - Add an API endpoint for generating referral links and applying associated discounts for new customers.
 - Decide on the credit/discount amounts for both referrer and referee and persist the data.
 - Integrate referral tracking into the checkout flow alongside discount codes.
+
+## Subscription Service
+
+- Design `subscriptions` and `subscription_usage` tables to store plan status and weekly print totals.
+- Build REST endpoints for subscribing, canceling, and checking remaining prints.
+- Integrate a Stripe plan priced around £140/mo and process webhooks for status updates.
+- Add a "Print Club £140/mo" badge in the site header that opens a modal describing the offer.
+- Place a radio option on the checkout page to join Print Club during purchase.
+- Show a progress bar on the account dashboard with prints used this week and an upgrade CTA.
+- Require prints to be redeemed in pairs and reset credits weekly without rollover.
+- Send monthly reminder emails to subscribers encouraging them to use remaining prints.
+- Track sign‑ups and churn; A/B test pricing (£140 vs £160) and monitor ARPU.
+- Offer a first‑month discount or referral credit to incentivize new subscribers.


### PR DESCRIPTION
## Summary
- expand task list with roadmap for building a subscription service

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6850a5548e60832da5bf20349021f02a