### PR TITLE
Add subscription system skeleton

### DIFF
--- a/backend/migrations/028_create_subscriptions.sql
+++ b/backend/migrations/028_create_subscriptions.sql
@@ -1,0 +1,36 @@
+CREATE TABLE IF NOT EXISTS subscriptions (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+  status TEXT NOT NULL,
+  current_period_start DATE,
+  current_period_end DATE,
+  stripe_customer_id TEXT,
+  stripe_subscription_id TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(user_id)
+);
+
+CREATE INDEX IF NOT EXISTS subscriptions_user_idx ON subscriptions(user_id);
+
+CREATE TABLE IF NOT EXISTS subscription_credits (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+  week_start DATE NOT NULL,
+  total_credits INTEGER NOT NULL DEFAULT 0,
+  used_credits INTEGER NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(user_id, week_start)
+);
+
+CREATE INDEX IF NOT EXISTS subscription_credits_user_idx ON subscription_credits(user_id);
+CREATE INDEX IF NOT EXISTS subscription_credits_week_idx ON subscription_credits(week_start);
+
+CREATE TRIGGER subscriptions_set_updated
+BEFORE UPDATE ON subscriptions
+FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
+
+CREATE TRIGGER subscription_credits_set_updated
+BEFORE UPDATE ON subscription_credits
+FOR EACH ROW EXECUTE PROCEDURE set_updated_at();

--- a/backend/tests/subscriptions.test.js
+++ b/backend/tests/subscriptions.test.js
@@ -1,0 +1,55 @@
+process.env.STRIPE_SECRET_KEY = 'test';
+process.env.STRIPE_WEBHOOK_SECRET = 'whsec';
+process.env.DB_URL = 'postgres://user:pass@localhost/db';
+process.env.HUNYUAN_API_KEY = 'test';
+process.env.HUNYUAN_SERVER_URL = 'http://localhost:4000';
+
+jest.mock('../db', () => ({
+  query: jest.fn().mockResolvedValue({ rows: [] }),
+  insertCommission: jest.fn().mockResolvedValue({}),
+  upsertSubscription: jest.fn().mockResolvedValue({ id: 's1', status: 'active' }),
+  cancelSubscription: jest.fn().mockResolvedValue({ id: 's1', status: 'canceled' }),
+  getSubscription: jest.fn().mockResolvedValue({ id: 's1', status: 'active' }),
+  ensureCurrentWeekCredits: jest.fn(),
+  getCurrentWeekCredits: jest.fn().mockResolvedValue({ total_credits: 2, used_credits: 1 }),
+  incrementCreditsUsed: jest.fn(),
+}));
+const db = require('../db');
+
+const request = require('supertest');
+const app = require('../server');
+const jwt = require('jsonwebtoken');
+
+beforeEach(() => {
+  db.upsertSubscription.mockClear();
+  db.cancelSubscription.mockClear();
+  db.getSubscription.mockClear();
+  db.ensureCurrentWeekCredits.mockClear();
+  db.getCurrentWeekCredits.mockClear();
+});
+
+test('GET /api/subscription returns subscription', async () => {
+  const token = jwt.sign({ id: 'u1' }, 'secret');
+  const res = await request(app).get('/api/subscription').set('authorization', `Bearer ${token}`);
+  expect(res.status).toBe(200);
+  expect(res.body.status).toBe('active');
+});
+
+test('POST /api/subscription creates record', async () => {
+  const token = jwt.sign({ id: 'u1' }, 'secret');
+  const res = await request(app)
+    .post('/api/subscription')
+    .set('authorization', `Bearer ${token}`)
+    .send({});
+  expect(res.status).toBe(200);
+  expect(db.upsertSubscription).toHaveBeenCalled();
+});
+
+test('GET /api/subscription/credits returns remaining', async () => {
+  const token = jwt.sign({ id: 'u1' }, 'secret');
+  const res = await request(app)
+    .get('/api/subscription/credits')
+    .set('authorization', `Bearer ${token}`);
+  expect(res.status).toBe(200);
+  expect(res.body.remaining).toBe(1);
+});


### PR DESCRIPTION
## Summary
- add migration for `subscriptions` and `subscription_credits`
- expose subscription helpers in `db.js`
- implement subscription CRUD endpoints and Stripe webhook updates
- create jest tests for new endpoints
- format repository and run tests

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6850a9662fd0832dbf93fe8248a8169b