### PR TITLE
Remove slots message from payment wizard

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -406,10 +406,6 @@
       <div id="wizard-step-building" class="flex-1 text-center py-2">Building model</div>
 
       <div id="wizard-step-purchase" class="flex-1 text-center py-2 flex justify-center items-center">
-        <span id="wizard-slots" class="hidden text-xs text-red-300 mr-2 whitespace-nowrap"
-
-          >Only 4 print slots remaining</span
-        >
         <span>Purchase model</span>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- remove `Only N print slots remaining` message from the purchase step on `payment.html`

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6850aafa0e84832dbfa0a14b0bd8e855