### PR TITLE
Fix payment form layout

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -134,51 +134,6 @@
         <div class="relative w-full md:w-1/2 max-w-md bg-[#2A2A2E] border border-white/10 rounded-3xl p-6">
           <h2 class="text-2xl font-semibold mb-4 text-center">Checkout</h2>
           <form id="checkout-form" class="space-y-4">
-            <div>
-              <input
-                id="ship-name"
-                class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10"
-                placeholder="Full Name"
-                autocomplete="name"
-                aria-label="Full Name"
-              />
-            </div>
-            <div>
-              <input
-                id="checkout-email"
-                type="email"
-                class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10"
-                placeholder="Email"
-                autocomplete="email"
-                aria-label="Email"
-              />
-            </div>
-            <div>
-              <input
-                id="ship-address"
-                class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10"
-                placeholder="Address"
-                autocomplete="address-line1"
-                aria-label="Address"
-              />
-            </div>
-
-            <div class="flex gap-2">
-              <input
-                id="ship-city"
-                class="flex-1 p-2 rounded-md bg-[#1A1A1D] border border-white/10"
-                placeholder="City + Country"
-                autocomplete="address-level2"
-                aria-label="City + Country"
-              />
-              <input
-                id="ship-zip"
-                class="w-28 p-2 rounded-md bg-[#1A1A1D] border border-white/10"
-                placeholder="ZIP"
-                autocomplete="postal-code"
-                aria-label="ZIP code"
-              />
-            </div>
             <!-- Material/Size Options -->
             <fieldset id="material-options" class="flex w-full justify-between my-4">
               <label class="cursor-not-allowed text-center flex flex-col items-center w-1/3 opacity-50">
@@ -271,6 +226,51 @@
                 </div>
               </label>
             </fieldset>
+            <div>
+              <input
+                id="ship-name"
+                class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10"
+                placeholder="Full Name"
+                autocomplete="name"
+                aria-label="Full Name"
+              />
+            </div>
+            <div>
+              <input
+                id="checkout-email"
+                type="email"
+                class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10"
+                placeholder="Email"
+                autocomplete="email"
+                aria-label="Email"
+              />
+            </div>
+            <div>
+              <input
+                id="ship-address"
+                class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10"
+                placeholder="Address"
+                autocomplete="address-line1"
+                aria-label="Address"
+              />
+            </div>
+
+            <div class="flex gap-2">
+              <input
+                id="ship-city"
+                class="flex-1 p-2 rounded-md bg-[#1A1A1D] border border-white/10"
+                placeholder="City + Country"
+                autocomplete="address-level2"
+                aria-label="City + Country"
+              />
+              <input
+                id="ship-zip"
+                class="w-28 p-2 rounded-md bg-[#1A1A1D] border border-white/10"
+                placeholder="ZIP"
+                autocomplete="postal-code"
+                aria-label="ZIP code"
+              />
+            </div>
 
 
             <div class="flex gap-2">


### PR DESCRIPTION
## Summary
- reorder Checkout page so material selection buttons come first

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6850aefcf960832d90b240cafbf5077c