### PR TITLE
Add repeat purchase incentives tasks

### DIFF
--- a/docs/task_list.md
+++ b/docs/task_list.md
@@ -86,3 +86,31 @@
 - Send monthly reminder emails to subscribers encouraging them to use remaining prints.
 - Track sign‑ups and churn; A/B test pricing (£140 vs £160) and monitor ARPU.
 - Offer a first‑month discount or referral credit to incentivize new subscribers.
+
+## Repeat Purchase Incentives
+
+- Display a "Start your next one?" modal after checkout.
+  - Prefill the prompt box with a suggested idea.
+  - Provide a discount code valid for the next 48 hours.
+  - Include a "Refer a friend" link on the confirmation page.
+- Show gifting options at checkout and on delivery confirmation.
+  - Add a "This is a surprise" toggle for recipient details.
+  - Offer a discount when ordering two prints of the same model.
+  - Rotate limited-time seasonal bundles for gifting.
+- Run theme campaigns such as "Sci-fi month" or "D&D drop".
+  - Present "You'll love this next one" prompts to encourage another order.
+  - Award a badge when someone purchases three times in a month.
+- Build a personal library page listing all previous designs.
+  - Enable one-click reorders from the library.
+  - Add a "Remix this model" button for spin-off prints.
+  - Offer an optional monthly "time capsule" print.
+- Send automated post-purchase emails.
+  - Showcase other users' creations for inspiration.
+  - Include a direct reorder button in the email.
+  - Send a follow-up reminder 5–7 days after delivery.
+- Add loyalty features to the account area.
+  - Grant a badge after four total purchases.
+  - Highlight a "Print of the week" for quick purchase.
+  - For subscribers, show a countdown to their next free print.
+  - Provide subscriber-only design previews.
+  - Track consecutive weekly orders and badge streaks.


### PR DESCRIPTION
## Summary
- expand `docs/task_list.md` with a new **Repeat Purchase Incentives** section
- outline post-purchase prompts, gifting mechanics, themed campaigns, personal libraries, and other loyalty features

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850b058d4c0832db9de44bccd72c0e5