### PR TITLE
Move membership choices

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -272,27 +272,6 @@
               />
             </div>
 
-            <fieldset id="subscription-choice" class="flex gap-4 my-4 text-sm">
-              <label class="flex items-center gap-1">
-                <input
-                  type="radio"
-                  name="printclub"
-                  value="none"
-                  class="accent-[#30D5C8]"
-                  checked
-                />
-                One-time purchase
-              </label>
-              <label class="flex items-center gap-1">
-                <input
-                  type="radio"
-                  name="printclub"
-                  value="join"
-                  class="accent-[#30D5C8]"
-                />
-                Join Print Club £140/mo
-              </label>
-            </fieldset>
 
 
             <div class="flex gap-2">
@@ -311,6 +290,29 @@
               </button>
             </div>
             <p id="discount-msg" class="text-xs text-center"></p>
+
+            <fieldset id="subscription-choice" class="flex gap-4 my-4 text-sm items-center justify-center">
+              <label class="flex items-center gap-1">
+                <input
+                  type="radio"
+                  name="printclub"
+                  value="none"
+                  class="accent-[#30D5C8]"
+                  checked
+                />
+                One-time purchase
+              </label>
+              <span class="px-2 font-semibold">OR</span>
+              <label class="flex items-center gap-1">
+                <input
+                  type="radio"
+                  name="printclub"
+                  value="join"
+                  class="accent-[#30D5C8]"
+                />
+                Join Print Club £140/mo
+              </label>
+            </fieldset>
 
             <div id="payment-element" class="text-center text-gray-400">
               [Stripe payment form will go here]

--- a/payment.html
+++ b/payment.html
@@ -272,8 +272,6 @@
               />
             </div>
 
-
-
             <div class="flex gap-2">
               <input
                 id="discount-code"
@@ -291,7 +289,7 @@
             </div>
             <p id="discount-msg" class="text-xs text-center"></p>
 
-            <fieldset id="subscription-choice" class="flex gap-4 my-4 text-sm items-center justify-center">
+            <fieldset id="subscription-choice" class="flex gap-4 my-4 text-sm">
               <label class="flex items-center gap-1">
                 <input
                   type="radio"


### PR DESCRIPTION
## Summary
- move the subscription selection below the discount code
- add an "OR" text between purchase options

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850b300cbdc832d901e558e3a7d562b