### PR TITLE
Add repeat purchase overlay

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -25,6 +25,7 @@ const {
   validateDiscountCode,
   getValidDiscountCode,
   incrementDiscountUsage,
+  createTimedCode,
 } = require('./discountCodes');
 const ADMIN_TOKEN = process.env.ADMIN_TOKEN || 'admin';
 
@@ -1050,6 +1051,21 @@ app.post('/api/discount-code', async (req, res) => {
     return res.status(404).json({ error: 'Invalid code' });
   }
   res.json({ discount: amount });
+});
+
+/**
+ * POST /api/generate-discount
+ * Create a unique discount code valid for 48 hours
+ */
+app.post('/api/generate-discount', async (req, res) => {
+  const amount = req.body.amount_cents || 500;
+  try {
+    const code = await createTimedCode(amount, 48);
+    res.json({ code });
+  } catch (err) {
+    logError(err);
+    res.status(500).json({ error: 'Failed to generate code' });
+  }
 });
 
 app.get('/api/flash-sale', async (req, res) => {

--- a/backend/tests/api.test.js
+++ b/backend/tests/api.test.js
@@ -544,6 +544,15 @@ test('POST /api/discount-code requires code', async () => {
   expect(db.query).not.toHaveBeenCalled();
 });
 
+test('POST /api/generate-discount creates code', async () => {
+  db.query.mockResolvedValueOnce({ rows: [{ code: 'ABCD1234' }] });
+  const res = await request(app).post('/api/generate-discount').send({});
+  expect(res.status).toBe(200);
+  expect(res.body.code).toBe('ABCD1234');
+  const call = db.query.mock.calls.find((c) => c[0].includes('INSERT INTO discount_codes'));
+  expect(call).toBeTruthy();
+});
+
 test('POST /api/dalle returns image', async () => {
   axios.post.mockResolvedValueOnce({ data: { image: 'data:image/png;base64,aaa' } });
   const res = await request(app).post('/api/dalle').send({ prompt: 'cat' });

--- a/docs/task_list.md
+++ b/docs/task_list.md
@@ -86,3 +86,28 @@
 - Send monthly reminder emails to subscribers encouraging them to use remaining prints.
 - Track sign‑ups and churn; A/B test pricing (£140 vs £160) and monitor ARPU.
 - Offer a first‑month discount or referral credit to incentivize new subscribers.
+
+## Repeat Purchase Incentives
+
+- ~~Provide a discount code valid for the next 48 hours.~~
+- Show gifting options at checkout and on delivery confirmation.
+  - Add a "This is a surprise" toggle for recipient details.
+  - Offer a discount when ordering two prints of the same model.
+  - Rotate limited-time seasonal bundles for gifting.
+- Run theme campaigns such as "Sci-fi month" or "D&D drop".
+  - ~~Present "You'll love this next one" prompts to encourage another order.~~
+  - Award a badge when someone purchases three times in a month.
+- Build a personal library page listing all previous designs.
+  - Enable one-click reorders from the library.
+  - Add a "Remix this model" button for spin-off prints.
+  - Offer an optional monthly "time capsule" print.
+- Send automated post-purchase emails.
+  - Showcase other users' creations for inspiration.
+  - Include a direct reorder button in the email.
+  - Send a follow-up reminder 5–7 days after delivery.
+- Add loyalty features to the account area.
+  - Grant a badge after four total purchases.
+  - Highlight a "Print of the week" for quick purchase.
+  - For subscribers, show a countdown to their next free print.
+  - Provide subscriber-only design previews.
+  - Track consecutive weekly orders and badge streaks.

--- a/js/payment.js
+++ b/js/payment.js
@@ -16,6 +16,11 @@ const API_BASE = (window.API_ORIGIN || '') + '/api';
 const TZ = 'America/New_York';
 let flashTimerId = null;
 let flashSale = null;
+const NEXT_PROMPTS = [
+  'cute robot figurine',
+  'ornate chess piece',
+  'geometric flower vase',
+];
 
 // Restore previously selected material option and colour
 const storedMaterial = localStorage.getItem('print3Material');
@@ -527,6 +532,29 @@ async function initPaymentPage() {
     if (popup && closeBtn) {
       popup.classList.remove('hidden');
       closeBtn.addEventListener('click', () => popup.classList.add('hidden'));
+    }
+    const nextModal = document.getElementById('next-print-modal');
+    const nextBtn = document.getElementById('next-print-btn');
+    const nextText = document.getElementById('next-print-text');
+    const discountSpan = document.getElementById('next-discount');
+    if (nextModal && nextBtn && nextText && discountSpan) {
+      const span = nextText.querySelector('span');
+      const suggestion = NEXT_PROMPTS[Math.floor(Math.random() * NEXT_PROMPTS.length)];
+      if (span) span.textContent = suggestion;
+      try {
+        const resp = await fetch(`${API_BASE}/generate-discount`, { method: 'POST' });
+        if (resp.ok) {
+          const data = await resp.json();
+          discountSpan.textContent = data.code;
+        }
+      } catch {
+        discountSpan.textContent = 'SAVE5';
+      }
+      nextBtn.addEventListener('click', () => {
+        localStorage.setItem('print3Prompt', suggestion);
+        window.location.href = 'index.html';
+      });
+      nextModal.classList.remove('hidden');
     }
     return;
   }

--- a/payment.html
+++ b/payment.html
@@ -85,7 +85,8 @@
     <main class="flex-1 flex flex-col items-center justify-center px-4 space-y-8 -mt-40">
       <div id="success" class="hidden text-green-400 text-center">
         Payment successful!
-        <a href="profile.html" class="underline">View profile</a>
+        <a href="profile.html" class="underline block">View profile</a>
+        <a href="share.html" class="underline block">Refer a friend</a>
       </div>
       <div id="cancel" class="hidden text-red-400 text-center">Payment cancelled.</div>
       <div class="relative flex flex-col md:flex-row items-start justify-center w-full max-w-4xl gap-8">
@@ -393,6 +394,28 @@
         >
           OK
         </button>
+      </div>
+    </div>
+
+    <!-- Next print suggestion -->
+    <div
+      id="next-print-modal"
+      class="fixed inset-0 bg-black/80 flex items-center justify-center hidden z-50"
+    >
+      <div class="bg-[#2A2A2E] border border-white/10 rounded-3xl p-6 text-center">
+        <h2 class="text-xl font-semibold mb-2 text-white">Start your next one?</h2>
+        <p id="next-print-text" class="mb-4 text-gray-300">
+          Try this prompt: <span class="text-white font-mono"></span>
+        </p>
+        <button
+          id="next-print-btn"
+          class="px-4 py-2 mb-2 rounded-md bg-[#30D5C8] text-[#1A1A1D]"
+        >
+          Create it
+        </button>
+        <p class="text-sm text-gray-400">
+          Use code <span id="next-discount" class="text-white font-mono px-1"></span> within 48&nbsp;h
+        </p>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- display a next-print suggestion modal after checkout success
- auto-fill the prompt input for the next model
- add refer-a-friend link on the confirmation page
- generate limited-time discount codes after purchase
- update `docs/task_list.md` to mark completed tasks

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6850b058d4c0832db9de44bccd72c0e5