### PR TITLE
Fix payment option layout

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -290,8 +290,11 @@
             </div>
             <p id="discount-msg" class="text-xs text-center"></p>
 
-            <fieldset id="subscription-choice" class="flex gap-4 my-4 text-sm">
-              <label class="flex items-center gap-1">
+            <fieldset
+              id="subscription-choice"
+              class="flex flex-nowrap items-center justify-center gap-4 my-4 text-sm"
+            >
+              <label class="flex items-center gap-1 whitespace-nowrap">
                 <input
                   type="radio"
                   name="printclub"
@@ -302,7 +305,7 @@
                 One-time purchase
               </label>
               <span class="px-2 font-semibold">OR</span>
-              <label class="flex items-center gap-1">
+              <label class="flex items-center gap-1 whitespace-nowrap">
                 <input
                   type="radio"
                   name="printclub"


### PR DESCRIPTION
## Summary
- keep the "One-time purchase OR Join Print Club" section on a single line
- ran project formatting and tests

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6850b67b1600832db8baf3893f7c3543