### PR TITLE
Randomize daily stats

### DIFF
--- a/backend/tests/additionalApi.test.js
+++ b/backend/tests/additionalApi.test.js
@@ -474,7 +474,8 @@ test('GET /api/print-slots returns count', async () => {
 });
 
 test('GET /api/stats returns sales and rating', async () => {
-  db.query.mockResolvedValueOnce({ rows: [{ count: '42' }] });
+  const { _setDailyPrintsSold } = require('../utils/dailyPrints');
+  _setDailyPrintsSold(42);
   const res = await request(app).get('/api/stats');
   expect(res.status).toBe(200);
   expect(res.body.printsSold).toBe(42);

--- a/backend/utils/dailyPrints.js
+++ b/backend/utils/dailyPrints.js
@@ -1,0 +1,36 @@
+const MIN = 30;
+const MAX = 50;
+let dailyPrintsSold = Math.floor(Math.random() * (MAX - MIN + 1)) + MIN;
+
+function scheduleNextUpdate() {
+  const now = new Date();
+  const easternNow = new Date(now.toLocaleString('en-US', { timeZone: 'America/New_York' }));
+  const next = new Date(easternNow);
+  next.setHours(23, 59, 0, 0);
+  if (easternNow >= next) {
+    next.setDate(next.getDate() + 1);
+  }
+  const ms = next - easternNow;
+  setTimeout(() => {
+    dailyPrintsSold = Math.floor(Math.random() * (MAX - MIN + 1)) + MIN;
+    scheduleNextUpdate();
+  }, ms);
+}
+
+function initDailyPrintsSold() {
+  scheduleNextUpdate();
+}
+
+function getDailyPrintsSold() {
+  return dailyPrintsSold;
+}
+
+function _setDailyPrintsSold(val) {
+  dailyPrintsSold = val;
+}
+
+module.exports = {
+  initDailyPrintsSold,
+  getDailyPrintsSold,
+  _setDailyPrintsSold,
+};

--- a/js/index.js
+++ b/js/index.js
@@ -689,14 +689,11 @@ async function init() {
     fetch(`${API_BASE}/stats`)
       .then((r) => (r.ok ? r.json() : null))
       .then((data) => {
-        const prints = data?.printsSold ?? 41;
-
-        el.textContent = `\u{1F525} ${prints} in last 24 hr`;
+        if (typeof data?.printsSold === 'number') {
+          el.textContent = `\u{1F525} ${data.printsSold} in last 24 hr`;
+        }
       })
-      .catch(() => {
-        el.textContent = '\u{1F525} 41 in last 24 hr';
-
-      });
+      .catch(() => {});
   }
 
   updateStats();


### PR DESCRIPTION
## Summary
- generate a daily random `printsSold` count server-side
- remove constant default from homepage script
- expose setter to adjust counts in tests
- adjust stats API test

## Validation
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850b9c7df70832d88571d85cae22a29