### PR TITLE
Add subscription progress indicator

### DIFF
--- a/docs/task_list.md
+++ b/docs/task_list.md
@@ -81,7 +81,7 @@
 ## Subscription Service
 
 
-- Show a progress bar on the account dashboard with prints used this week and an upgrade CTA.
+- ~~Show a progress bar on the account dashboard with prints used this week and an upgrade CTA.~~
 - Require prints to be redeemed in pairs and reset credits weekly without rollover.
 - Send monthly reminder emails to subscribers encouraging them to use remaining prints.
 - Track sign‑ups and churn; A/B test pricing (£140 vs £160) and monitor ARPU.

--- a/js/my_profile.js
+++ b/js/my_profile.js
@@ -113,6 +113,29 @@ async function requestPayout() {
   }
 }
 
+async function loadCredits() {
+  const token = localStorage.getItem('token');
+  if (!token) return;
+  try {
+    const res = await fetch(`${API_BASE}/subscription/credits`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) return;
+    const data = await res.json();
+    const used = data.total - data.remaining;
+    const bar = document.getElementById('progress-bar');
+    const text = document.getElementById('progress-text');
+    const percent = data.total ? Math.min(100, (used / data.total) * 100) : 0;
+    if (bar) bar.style.width = `${percent}%`;
+    if (text) text.textContent = `${used} of ${data.total} prints used`;
+    if (data.remaining === 0) {
+      document.getElementById('upgrade-cta')?.classList.remove('hidden');
+    }
+  } catch (err) {
+    console.error('Failed to load credits', err);
+  }
+}
+
 function createObserver() {
   const sentinel = document.getElementById('models-sentinel');
   if (!sentinel) return;
@@ -142,4 +165,5 @@ document.addEventListener('DOMContentLoaded', () => {
   loadCommissions();
   createObserver();
   loadMore();
+  loadCredits();
 });

--- a/my_profile.html
+++ b/my_profile.html
@@ -125,6 +125,22 @@
         </button>
         <p id="payout-msg" class="text-sm mt-2"></p>
       </div>
+      <div
+        id="subscription-progress"
+        class="bg-[#2A2A2E] border border-white/10 p-6 rounded-3xl w-96 mb-6"
+      >
+        <h2 class="text-lg font-semibold mb-2">Print Club Usage</h2>
+        <div class="w-full bg-white/20 rounded h-4">
+          <div id="progress-bar" class="bg-blue-600 h-full rounded" style="width: 0%"></div>
+        </div>
+        <p id="progress-text" class="text-sm mt-2"></p>
+        <button
+          id="upgrade-cta"
+          class="hidden mt-2 px-3 py-1 bg-gradient-to-r from-purple-500 to-pink-500 rounded-3xl"
+        >
+          Upgrade
+        </button>
+      </div>
       <div id="models" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4"></div>
       <div id="models-sentinel" class="h-8"></div>
     </main>


### PR DESCRIPTION
## Summary
- show subscription credit progress on profile page
- display upgrade CTA when out of credits
- load credits from `/api/subscription/credits`
- mark progress bar task complete in `docs/task_list.md`

## Validation
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851142fed3c832d878cc63a56763034