### PR TITLE
Implement personal library page

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -428,7 +428,8 @@ app.get('/api/my/models', authRequired, async (req, res) => {
 app.get('/api/my/orders', authRequired, async (req, res) => {
   try {
     const { rows } = await db.query(
-      `SELECT o.session_id, o.job_id, o.price_cents, o.status, o.quantity, o.discount_cents, o.created_at, j.model_url
+      `SELECT o.session_id, o.job_id, o.price_cents, o.status, o.quantity, o.discount_cents, o.created_at,
+              j.model_url, j.snapshot, j.prompt
        FROM orders o
        JOIN jobs j ON o.job_id=j.job_id
        WHERE o.user_id=$1

--- a/backend/tests/api.test.js
+++ b/backend/tests/api.test.js
@@ -486,11 +486,13 @@ test('create-order inserts commission for marketplace sale', async () => {
 });
 
 test('GET /api/my/orders returns orders', async () => {
-  db.query.mockResolvedValueOnce({ rows: [{ session_id: 's1' }] });
+  db.query.mockResolvedValueOnce({ rows: [{ session_id: 's1', snapshot: 'img', prompt: 'p' }] });
   const token = jwt.sign({ id: 'u1' }, 'secret');
   const res = await request(app).get('/api/my/orders').set('authorization', `Bearer ${token}`);
   expect(res.status).toBe(200);
   expect(res.body[0].session_id).toBe('s1');
+  expect(res.body[0].snapshot).toBe('img');
+  expect(res.body[0].prompt).toBe('p');
 });
 
 test('GET /api/my/orders requires auth', async () => {

--- a/docs/task_list.md
+++ b/docs/task_list.md
@@ -97,11 +97,8 @@
 - Run theme campaigns such as "Sci-fi month" or "D&D drop".
 
   - Award a badge when someone purchases three times in a month.
-- Build a personal library page listing all previous designs.
-  - Enable one-click reorders from the library.
-  - Add a "Remix this model" button for spin-off prints.
   - Offer an optional monthly "time capsule" print.
-- Send automated post-purchase emails.
+  - Send automated post-purchase emails.
   - Showcase other users' creations for inspiration.
   - Include a direct reorder button in the email.
   - Send a follow-up reminder 5–7 days after delivery.

--- a/js/library.js
+++ b/js/library.js
@@ -1,0 +1,72 @@
+const API_BASE = (window.API_ORIGIN || '') + '/api';
+
+function createCard(order) {
+  const div = document.createElement('div');
+  div.className =
+    'relative h-32 bg-[#2A2A2E] border border-white/10 rounded-xl hover:bg-[#3A3A3E] flex items-center justify-center cursor-pointer';
+  div.dataset.model = order.model_url;
+  div.dataset.job = order.job_id;
+  div.innerHTML = `
+    <img src="${order.snapshot || ''}" alt="Model" class="w-full h-full object-contain pointer-events-none" />
+    <span class="sr-only">${order.prompt || 'Model'}</span>
+    <button class="reorder absolute bottom-1 left-1 text-xs bg-blue-600 px-1 rounded">Reorder</button>
+    <button class="remix absolute bottom-1 right-1 text-xs bg-green-600 px-1 rounded">Remix</button>`;
+  div.querySelector('.reorder').addEventListener('click', (e) => {
+    e.stopPropagation();
+    localStorage.setItem('print3Model', order.model_url);
+    localStorage.setItem('print3JobId', order.job_id);
+    window.location.href = 'payment.html';
+  });
+  div.querySelector('.remix').addEventListener('click', (e) => {
+    e.stopPropagation();
+    try {
+      localStorage.setItem('print3Prompt', order.prompt || '');
+    } catch {}
+    const url = `index.html?sr=${encodeURIComponent(order.model_url)}`;
+    window.location.href = url;
+  });
+  div.addEventListener('click', () => {
+    const modal = document.getElementById('model-modal');
+    const viewer = modal.querySelector('model-viewer');
+    viewer.src = order.model_url;
+    modal.classList.remove('hidden');
+    document.body.classList.add('overflow-hidden');
+  });
+  return div;
+}
+
+async function loadOrders() {
+  const token = localStorage.getItem('token');
+  if (!token) {
+    window.location.href = 'login.html';
+    return;
+  }
+  const res = await fetch(`${API_BASE}/my/orders`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!res.ok) return;
+  const orders = await res.json();
+  const container = document.getElementById('orders');
+  orders.forEach((o) => container.appendChild(createCard(o)));
+}
+
+function createObserver() {
+  const closeBtn = document.getElementById('close-modal');
+  function close() {
+    document.getElementById('model-modal').classList.add('hidden');
+    document.body.classList.remove('overflow-hidden');
+  }
+  closeBtn?.addEventListener('click', close);
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') close();
+  });
+  document.getElementById('logout-btn')?.addEventListener('click', () => {
+    localStorage.removeItem('token');
+    window.location.href = 'index.html';
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  createObserver();
+  loadOrders();
+});

--- a/library.html
+++ b/library.html
@@ -1,0 +1,87 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>My Library</title>
+    <meta property="og:title" content="My Library – print3" />
+    <meta property="og:description" content="Browse your previous prints and reorder." />
+    <meta property="og:image" content="img/boxlogo.png" />
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css"
+    />
+    <script type="module" src="https://cdn.jsdelivr.net/npm/@google/model-viewer@1.12.0/dist/model-viewer.min.js"></script>
+    <script src="js/modelViewerTouchFix.js"></script>
+  </head>
+  <body class="bg-[#1A1A1D] text-white font-sans flex flex-col min-h-screen">
+    <header class="relative flex items-center justify-between py-4 px-6">
+      <a
+        href="index.html"
+        class="inline-flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-3xl px-5 py-2 text-lg font-medium hover:bg-[#3A3A3E] transition-shape"
+      >
+        <svg
+          class="w-4 h-4 mr-2 flex-shrink-0"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+        >
+          <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+        </svg>
+        Back
+      </a>
+      <h1
+        class="absolute inset-x-0 top-1/2 -translate-y-1/2 text-center text-3xl font-semibold pointer-events-none"
+      >
+        My Library
+      </h1>
+      <button
+        id="logout-btn"
+        class="bg-[#2A2A2E] border border-white/10 rounded-3xl px-3 py-2 text-sm hover:bg-[#3A3A3E] transition-shape"
+      >
+        Log Out
+      </button>
+    </header>
+    <main class="flex-1 px-6 py-4">
+      <div id="orders" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4"></div>
+    </main>
+    <div
+      id="model-modal"
+      class="fixed inset-0 bg-black/80 flex items-center justify-center hidden z-50"
+    >
+      <div class="relative w-11/12 max-w-3xl">
+        <button
+          id="close-modal"
+          class="absolute -top-4 -right-4 w-[4.5rem] h-[4.5rem] rounded-full bg-white text-black flex items-center justify-center z-50"
+          type="button"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            class="w-10 h-10"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="3"
+            stroke-linecap="round"
+          >
+            <line x1="6" y1="6" x2="18" y2="18" />
+            <line x1="6" y1="18" x2="18" y2="6" />
+          </svg>
+          <span class="sr-only">Close</span>
+        </button>
+        <model-viewer
+          src=""
+          alt="3D model preview"
+          environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
+          camera-controls
+          auto-rotate
+          class="w-full h-96 bg-[#2A2A2E] rounded-xl"
+        ></model-viewer>
+      </div>
+    </div>
+    <script type="module" src="js/library.js"></script>
+    <script type="module" src="js/basket.js"></script>
+  </body>
+</html>

--- a/my_profile.html
+++ b/my_profile.html
@@ -82,6 +82,12 @@
         >
           <i class="fab fa-instagram"></i>
         </button>
+        <a
+          href="library.html"
+          id="library-link"
+          class="bg-[#2A2A2E] border border-white/10 rounded-3xl px-3 py-2 text-sm hover:bg-[#3A3A3E] transition-shape"
+          >Library</a
+        >
         <button
           id="logout-btn"
           class="bg-[#2A2A2E] border border-white/10 rounded-3xl px-3 py-2 text-sm hover:bg-[#3A3A3E] transition-shape"


### PR DESCRIPTION
## Summary
- add personal library page to browse previous models
- include reorder and remix buttons for convenience
- expose snapshot and prompt in `/api/my/orders`
- link to the new library page from account view
- adjust API test and remove finished tasks

## Testing
- `npm run format`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68511467b164832dbe5cddebedfaa9f1