### PR TITLE
Add post-purchase referral tasks

### DIFF
--- a/docs/task_list.md
+++ b/docs/task_list.md
@@ -78,6 +78,16 @@
 - Decide on the credit/discount amounts for both referrer and referee and persist the data.
 - Integrate referral tracking into the checkout flow alongside discount codes.
 
+## Post-Purchase Referral Engine
+
+- Show a referral link after checkout that gives the friend 10% off and the buyer 10% credit back.
+  - Include a copy-to-clipboard button for the link.
+- Reward £5 off the next order when users post their print online and tag us.
+  - Verify the tag before issuing the discount.
+- Add a one-click "order another color" button on the confirmation page.
+- Place a QR code in each package linking to the referral page.
+- Grant a free print after three successful referrals.
+
 ## Subscription Service
 
 


### PR DESCRIPTION
## Summary
- extend the task list with a new *Post-Purchase Referral Engine* section
- list specific referral and loyalty subtasks

## Testing
- `npm run format`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_685118451a20832d821e1692aa1a18b5