### PR TITLE
Remove duplicate payment option and restore city input

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -257,28 +257,22 @@
             </div>
 
 
-            <fieldset id="subscription-choice" class="flex gap-4 my-4 text-sm">
-              <label class="flex items-center gap-1">
-                <input
-                  type="radio"
-                  name="printclub"
-                  value="none"
-                  class="accent-[#30D5C8]"
-                  checked
-                />
-                One-time purchase
-              </label>
-              <label class="flex items-center gap-1">
-                <input
-                  type="radio"
-                  name="printclub"
-                  value="join"
-                  class="accent-[#30D5C8]"
-                />
-                Join Print Club £140/mo
-              </label>
-            </fieldset>
-
+            <div class="flex gap-2">
+              <input
+                id="ship-city"
+                class="flex-1 p-2 rounded-md bg-[#1A1A1D] border border-white/10"
+                placeholder="City + Country"
+                autocomplete="address-level2"
+                aria-label="City + Country"
+              />
+              <input
+                id="ship-zip"
+                class="w-28 p-2 rounded-md bg-[#1A1A1D] border border-white/10"
+                placeholder="ZIP"
+                autocomplete="postal-code"
+                aria-label="ZIP code"
+              />
+            </div>
 
             <div class="flex gap-2">
               <input


### PR DESCRIPTION
## Summary
- fix duplicated subscription-choice block on payment page
- restore city & ZIP fields removed accidentally

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685119193884832d87e5b85d4b1aa67d