### PR TITLE
Fix stats ticker fallback

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -699,15 +699,16 @@ async function init() {
   function updateStats() {
     const el = document.getElementById('stats-ticker');
     if (!el) return;
+    const randomPrints = () => Math.floor(Math.random() * (50 - 30 + 1)) + 30;
     fetch(`${API_BASE}/stats`)
       .then((r) => (r.ok ? r.json() : null))
       .then((data) => {
         const prints =
-          typeof data?.printsSold === 'number' ? data.printsSold : 41;
+          typeof data?.printsSold === 'number' ? data.printsSold : randomPrints();
         el.textContent = `\u{1F525} ${prints} prints sold in last 24 hrs`;
       })
       .catch(() => {
-        el.textContent = '\u{1F525} 41 prints sold in last 24 hrs';
+        el.textContent = `\u{1F525} ${randomPrints()} prints sold in last 24 hrs`;
       });
   }
 


### PR DESCRIPTION
## Summary
- randomize fallback for stats ticker when API fails

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685121f9fe28832d8b9eba52cf7068b1