### PR TITLE
Fix CI lint step path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Install backend deps
+        run: npm ci
+        working-directory: backend
+
       - name: Install Husky hooks
         run: npm run prepare
 
@@ -30,5 +34,6 @@ jobs:
 
       - name: Run ESLint
         run: npm run lint
+        working-directory: backend
 
       # ← you can add additional steps here, like your tests


### PR DESCRIPTION
## Summary
- install backend deps in CI workflow
- run ESLint from the backend folder so it can find its config

## Testing
- `npm run lint` (fails locally but workflow now runs from backend)
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851680eb7d8832d86541bb944209eaa