### PR TITLE
Add competition profit ideas

### DIFF
--- a/docs/task_list.md
+++ b/docs/task_list.md
@@ -106,3 +106,17 @@
 - Add `sync-mailing-list.js` script to push confirmed addresses to SendGrid.
 - Schedule the sync script to run daily.
 - Add unit tests for subscribe, confirm, unsubscribe, webhook handling and sync logic.
+
+## Competitions Profit Drivers
+
+- Show purchase buttons for past winners.
+  - Add a "Buy Print" button below each winning model in `competitions.html`.
+  - Pre-fill `print3Model` and `print3JobId` in local storage when the button is clicked.
+- Promote Print Club on the competitions page.
+  - Insert a short banner explaining membership benefits with a sign-up link.
+- Offer a discount for printing your competition entry.
+  - Generate a one-time code after an entry is submitted.
+  - Display the code in the success message.
+- Capture emails for future promotions.
+  - Add a small mailing list form on the competitions page.
+  - POST addresses to `/api/subscribe` and show confirmation.


### PR DESCRIPTION
## Summary
- add tasks to improve profits via the competitions page

## Testing
- `npm run format`
- `npm test`
- `npm test` in `backend/hunyuan_server`


------
https://chatgpt.com/codex/tasks/task_e_68516cc7e22c832db6a34060bac5f225