### PR TITLE
Fix flash banner z-index

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -56,7 +56,7 @@
       id="flash-banner"
       role="status"
       hidden
-      class="text-[#1A1A1D] font-semibold text-center py-2 bg-gradient-to-r from-teal-400 via-cyan-300 to-teal-500"
+      class="relative z-30 text-[#1A1A1D] font-semibold text-center py-2 bg-gradient-to-r from-teal-400 via-cyan-300 to-teal-500"
     >
       Order within <span id="flash-timer">5:00</span> to get 5% off
     </div>


### PR DESCRIPTION
## Summary
- ensure the flash sale banner sits above other elements
- run formatter and tests

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68516f723420832d9d62f1999e37f81c