### PR TITLE
Deterministic stats fallback

### DIFF
--- a/backend/utils/dailyPrints.js
+++ b/backend/utils/dailyPrints.js
@@ -1,23 +1,35 @@
+const crypto = require('crypto');
+
 const MIN = 30;
 const MAX = 50;
-let dailyPrintsSold = Math.floor(Math.random() * (MAX - MIN + 1)) + MIN;
+let dailyPrintsSold = 0;
+
+function computeDailyPrintsSold(date = new Date()) {
+  const eastern = new Date(date.toLocaleString('en-US', { timeZone: 'America/New_York' }));
+  const dateStr = eastern.toISOString().slice(0, 10); // YYYY-MM-DD
+  const hash = crypto.createHash('sha256').update(dateStr).digest('hex');
+  const int = parseInt(hash.slice(0, 8), 16);
+  const rand = int / 0xffffffff;
+  return Math.floor(rand * (MAX - MIN + 1)) + MIN;
+}
 
 function scheduleNextUpdate() {
   const now = new Date();
   const easternNow = new Date(now.toLocaleString('en-US', { timeZone: 'America/New_York' }));
   const next = new Date(easternNow);
-  next.setHours(23, 59, 0, 0);
+  next.setHours(24, 0, 0, 0);
   if (easternNow >= next) {
     next.setDate(next.getDate() + 1);
   }
   const ms = next - easternNow;
   setTimeout(() => {
-    dailyPrintsSold = Math.floor(Math.random() * (MAX - MIN + 1)) + MIN;
+    dailyPrintsSold = computeDailyPrintsSold();
     scheduleNextUpdate();
   }, ms);
 }
 
 function initDailyPrintsSold() {
+  dailyPrintsSold = computeDailyPrintsSold();
   scheduleNextUpdate();
 }
 

--- a/js/index.js
+++ b/js/index.js
@@ -70,6 +70,21 @@ const TZ = 'America/New_York';
 const FALLBACK_GLB = 'https://modelviewer.dev/shared-assets/models/Astronaut.glb';
 const EXAMPLES = ['cute robot figurine', 'ornate chess piece', 'geometric flower vase'];
 const TRENDING = ['dragon statue', 'space rover', 'anime character'];
+const PRINTS_MIN = 30;
+const PRINTS_MAX = 50;
+const UINT32_MAX = 0xffffffff;
+
+async function computeDailyPrintsSold(date = new Date()) {
+  const eastern = new Date(
+    date.toLocaleString('en-US', { timeZone: TZ })
+  );
+  const dateStr = eastern.toISOString().slice(0, 10);
+  const data = new TextEncoder().encode(dateStr);
+  const hash = await crypto.subtle.digest('SHA-256', data);
+  const int = new DataView(hash).getUint32(0);
+  const rand = int / UINT32_MAX;
+  return Math.floor(rand * (PRINTS_MAX - PRINTS_MIN + 1)) + PRINTS_MIN;
+}
 const $ = (id) => document.getElementById(id);
 const refs = {
   previewImg: $('preview-img'),
@@ -695,22 +710,26 @@ async function init() {
     }
   });
 
-  function updateStats() {
+  async function updateStats() {
     const el = document.getElementById('stats-ticker');
     if (!el) return;
-    const randomPrints = () => Math.floor(Math.random() * (50 - 30 + 1)) + 30;
-    fetch(`${API_BASE}/stats`)
-      .then((r) => (r.ok ? r.json() : null))
-      .then((data) => {
-
-        const prints =
-          typeof data?.printsSold === 'number' ? data.printsSold : randomPrints();
-
-        el.textContent = `\u{1F525} ${prints} prints sold in last 24 hrs`;
-      })
-      .catch(() => {
-        el.textContent = `\u{1F525} ${randomPrints()} prints sold in last 24 hrs`;
-      });
+    try {
+      const res = await fetch(`${API_BASE}/stats`);
+      let prints;
+      if (res.ok) {
+        const data = await res.json();
+        prints =
+          typeof data?.printsSold === 'number'
+            ? data.printsSold
+            : await computeDailyPrintsSold();
+      } else {
+        prints = await computeDailyPrintsSold();
+      }
+      el.textContent = `\u{1F525} ${prints} prints sold in last 24 hrs`;
+    } catch {
+      const prints = await computeDailyPrintsSold();
+      el.textContent = `\u{1F525} ${prints} prints sold in last 24 hrs`;
+    }
   }
 
   updateStats();


### PR DESCRIPTION
## Summary
- compute daily prints in the browser using SHA-256 when API fails
- use deterministic fallback in updateStats

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68516c525730832db7f3406e389da2b5