### PR TITLE
Enable model viewer on competition entries

### DIFF
--- a/competitions.html
+++ b/competitions.html
@@ -242,7 +242,7 @@
         }
 
         document.addEventListener('click', (e) => {
-          const card = e.target.closest('.model-card');
+          const card = e.target.closest('.model-card, .entry-card');
           if (card) {
             viewer.src = card.dataset.model;
             checkoutBtn.dataset.model = card.dataset.model;


### PR DESCRIPTION
## Summary
- allow competition entry thumbnails to open the 3D model viewer
- ran formatting and tests

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685172b0a254832da6101e12a506dc56