### PR TITLE
Keep etching field visible

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -373,13 +373,26 @@ async function initPaymentPage() {
 
   function updateEtchVisibility(val) {
     if (!etchInput || !etchContainer) return;
+    etchContainer.classList.remove('hidden');
     if (val === 'multi' || val === 'premium') {
-      etchContainer.classList.remove('hidden');
       etchInput.disabled = false;
+      etchInput.placeholder = 'Name for etching (optional)';
+      etchInput.classList.remove(
+        'opacity-50',
+        'border-red-500',
+        'text-red-300',
+        'placeholder-red-300'
+      );
     } else {
-      etchContainer.classList.add('hidden');
       etchInput.disabled = true;
       etchInput.value = '';
+      etchInput.placeholder = 'Upgrade to £34.99 for name etching';
+      etchInput.classList.add(
+        'opacity-50',
+        'border-red-500',
+        'text-red-300',
+        'placeholder-red-300'
+      );
     }
   }
 

--- a/payment.html
+++ b/payment.html
@@ -263,7 +263,7 @@
                 aria-label="Full Name"
               />
             </div>
-            <div id="etch-name-container" class="hidden">
+            <div id="etch-name-container">
               <input
                 id="etch-name"
                 class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10"


### PR DESCRIPTION
## Summary
- keep the `Name for etching` field visible at all times
- disable and style the field when the £27.99 option is selected

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68517796ccbc832da1984bf761b84552