### PR TITLE
Fix stats ticker alignment

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,7 +138,7 @@
         <div class="mt-1 flex flex-col text-sm text-gray-400 opacity-75">
           <p><span class="text-white">5400+</span> prints</p>
           <p>delivered already</p>
-          <p id="stats-ticker" class="text-orange-400 text-right"></p>
+          <p id="stats-ticker" class="text-orange-400 text-left"></p>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- align stats ticker text to the left so both lines match

## Testing
- `npm run format`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685173c4c078832dacd2b52b8d215906