### PR TITLE
Fix consistent daily print count

### DIFF
--- a/backend/utils/dailyPrints.js
+++ b/backend/utils/dailyPrints.js
@@ -4,9 +4,21 @@ const MIN = 30;
 const MAX = 50;
 let dailyPrintsSold = 0;
 
+function getEasternDateStr(date = new Date()) {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/New_York',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(date);
+  const year = parts.find((p) => p.type === 'year').value;
+  const month = parts.find((p) => p.type === 'month').value;
+  const day = parts.find((p) => p.type === 'day').value;
+  return `${year}-${month}-${day}`; // YYYY-MM-DD
+}
+
 function computeDailyPrintsSold(date = new Date()) {
-  const eastern = new Date(date.toLocaleString('en-US', { timeZone: 'America/New_York' }));
-  const dateStr = eastern.toISOString().slice(0, 10); // YYYY-MM-DD
+  const dateStr = getEasternDateStr(date);
   const hash = crypto.createHash('sha256').update(dateStr).digest('hex');
   const int = parseInt(hash.slice(0, 8), 16);
   const rand = int / 0xffffffff;
@@ -45,4 +57,5 @@ module.exports = {
   initDailyPrintsSold,
   getDailyPrintsSold,
   _setDailyPrintsSold,
+  getEasternDateStr,
 };

--- a/js/index.js
+++ b/js/index.js
@@ -75,10 +75,16 @@ const PRINTS_MAX = 50;
 const UINT32_MAX = 0xffffffff;
 
 async function computeDailyPrintsSold(date = new Date()) {
-  const eastern = new Date(
-    date.toLocaleString('en-US', { timeZone: TZ })
-  );
-  const dateStr = eastern.toISOString().slice(0, 10);
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: TZ,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(date);
+  const year = parts.find((p) => p.type === 'year').value;
+  const month = parts.find((p) => p.type === 'month').value;
+  const day = parts.find((p) => p.type === 'day').value;
+  const dateStr = `${year}-${month}-${day}`;
   const data = new TextEncoder().encode(dateStr);
   const hash = await crypto.subtle.digest('SHA-256', data);
   const int = new DataView(hash).getUint32(0);


### PR DESCRIPTION
## Summary
- compute daily prints using Intl.DateTimeFormat so all clients derive the same date string
- export helper in dailyPrints.js

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685172de4804832db2ec99355c296d5b