### PR TITLE
Fix flash banner timer rounding

### DIFF
--- a/backend/tests/frontend/flashBanner.test.js
+++ b/backend/tests/frontend/flashBanner.test.js
@@ -51,7 +51,7 @@ describe('flash banner', () => {
     expect(banner.hidden).toBe(true);
   });
 
-  test('countdown shows 4:59 after one second', async () => {
+  test('countdown shows 4:58 after one second', async () => {
     const dom = new JSDOM(html, {
       runScripts: 'dangerously',
       resources: 'usable',
@@ -67,7 +67,7 @@ describe('flash banner', () => {
     const timerEl = dom.window.document.getElementById('flash-timer');
     expect(timerEl.textContent).toBe('5:00');
     await new Promise((r) => setTimeout(r, 1100));
-    expect(timerEl.textContent).toBe('4:59');
+    expect(timerEl.textContent).toBe('4:58');
   });
 
   test('banner hidden when chance disabled', async () => {

--- a/js/payment.js
+++ b/js/payment.js
@@ -67,7 +67,7 @@ function updateFlashSaleBanner() {
       }
       return;
     }
-    const diffSec = Math.ceil(diff / 1000);
+    const diffSec = Math.floor(diff / 1000);
     const m = Math.floor(diffSec / 60);
     const s = String(diffSec % 60).padStart(2, '0');
     timerEl.textContent = `${m}:${s}`;
@@ -251,7 +251,7 @@ function startFlashDiscount() {
       }
       return;
     }
-    const diffSec = Math.ceil(diff / 1000);
+    const diffSec = Math.floor(diff / 1000);
     const m = Math.floor(diffSec / 60);
     const s = String(diffSec % 60).padStart(2, '0');
     flashTimer.textContent = `${m}:${s}`;


### PR DESCRIPTION
## Summary
- round flash sale timer down
- update flash banner test expectation

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851798ef914832dbad8e91d2adedc08