### PR TITLE
Stabilize flashBanner timer test and fix Prettier in queue files

### DIFF
--- a/backend/queue/printWorker.js
+++ b/backend/queue/printWorker.js
@@ -30,7 +30,6 @@ async function processNextJob(client) {
   );
   if (!rows.length) return;
 
-
   const { model_url: modelUrl, shipping_info: shipping, etch_name } = rows[0];
   try {
     await axios.post(PRINTER_API_URL, { modelUrl, shipping, etchName: etch_name });

--- a/backend/tests/frontend/flashBanner.test.js
+++ b/backend/tests/frontend/flashBanner.test.js
@@ -1,7 +1,6 @@
 // use Jest’s fake timer implementation
 jest.useFakeTimers();
 
-
 /** @jest-environment node */
 const fs = require('fs');
 const path = require('path');
@@ -55,25 +54,14 @@ describe('flash banner', () => {
     expect(banner.hidden).toBe(true);
   });
 
-test('countdown shows 4:59 after one second', () => {
-  expect(timerEl.textContent).toBe('5:00');
-
-  // fast-forward 1.1 seconds
-  jest.advanceTimersByTime(1100);
-
-  expect(timerEl.textContent).toBe('4:59');
-});
-
-    global.window = dom.window;
-    global.document = dom.window.document;
-    dom.window.sessionStorage.setItem('flashDiscountShow', '1');
-    const scriptSrc = fs.readFileSync(path.join(__dirname, '../../../js/payment.js'), 'utf8');
-    dom.window.eval(scriptSrc);
-    dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
-    dom.window.startFlashDiscount();
-    const timerEl = dom.window.document.getElementById('flash-timer');
+  test('countdown shows 4:59 after one second', () => {
+    // initial state
     expect(timerEl.textContent).toBe('5:00');
-    await new Promise((r) => setTimeout(r, 1100));
+
+    // advance the fake clock by 1.1s
+    jest.advanceTimersByTime(1100);
+
+    // assert it ticked down
     expect(timerEl.textContent).toBe('4:59');
   });
 


### PR DESCRIPTION
## Summary
- use Jest fake timers in flashBanner frontend tests
- fix Prettier formatting issues in queue/printWorker.js

## Testing
- `npm run format`
- `npm test` *(fails: flashBanner.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68517cf513b4832db550cdc486cfda18