### PR TITLE
chore: add missing ESLint packages to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,10 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
+        "@eslint-community/eslint-utils": "^4.7.0",
+        "@eslint/js": "^9.29.0",
         "eslint": "^8.44.0",
-        "eslint-config-prettier": "^8.8.0",
+        "eslint-config-prettier": "^8.10.0",
         "husky": "^8.0.0",
         "prettier": "^3.5.3"
       }
@@ -20,6 +22,7 @@
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
       "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^3.4.3"
       },
@@ -66,12 +69,16 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
-      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+      "version": "9.29.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.29.0.tgz",
+      "integrity": "sha512-3PIF4cBw/y+1u2EazflInpV+lYsSG0aByVIQzAgb1m1MhHFSbqTyNqtBKHgWf/9Ykud+DhILS9EGkmekVhbKoQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -404,6 +411,7 @@
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.10.0.tgz",
       "integrity": "sha512-SM8AMJdeQqRYT9O9zguiruQZaN7+z+E4eAP9oiLNGKMtomwaB1E9dcgUD6ZAn/eQAb52USbvezbiljfZUhbJcg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -437,6 +445,16 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/@eslint/js": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/espree": {
@@ -1221,9 +1239,9 @@
       }
     },
     "@eslint/js": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
-      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+      "version": "9.29.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.29.0.tgz",
+      "integrity": "sha512-3PIF4cBw/y+1u2EazflInpV+lYsSG0aByVIQzAgb1m1MhHFSbqTyNqtBKHgWf/9Ykud+DhILS9EGkmekVhbKoQ==",
       "dev": true
     },
     "@humanwhocodes/config-array": {
@@ -1465,6 +1483,14 @@
         "optionator": "^0.9.3",
         "strip-ansi": "^6.0.1",
         "text-table": "^0.2.0"
+      },
+      "dependencies": {
+        "@eslint/js": {
+          "version": "8.57.1",
+          "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+          "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+          "dev": true
+        }
       }
     },
     "eslint-config-prettier": {

--- a/package.json
+++ b/package.json
@@ -17,9 +17,11 @@
   "license": "ISC",
   "type": "commonjs",
   "devDependencies": {
-    "husky": "^8.0.0",
-    "prettier": "^3.5.3",
+    "@eslint-community/eslint-utils": "^4.7.0",
+    "@eslint/js": "^9.29.0",
     "eslint": "^8.44.0",
-    "eslint-config-prettier": "^8.8.0"
+    "eslint-config-prettier": "^8.10.0",
+    "husky": "^8.0.0",
+    "prettier": "^3.5.3"
   }
 }


### PR DESCRIPTION
## Summary
- add missing ESLint packages to devDependencies

## Testing
- `npm run format` *(fails: SyntaxError in tests/frontend/flashBanner.test.js)*
- `npm test` *(fails: Jest failed to parse a file)*


------
https://chatgpt.com/codex/tasks/task_e_68518f49cc3c832d84c90885704a520c