### PR TITLE
style: format printWorker files with Prettier

### DIFF
--- a/backend/queue/printWorker.js
+++ b/backend/queue/printWorker.js
@@ -30,7 +30,6 @@ async function processNextJob(client) {
   );
   if (!rows.length) return;
 
-
   const { model_url: modelUrl, shipping_info: shipping, etch_name } = rows[0];
   try {
     await axios.post(PRINTER_API_URL, { modelUrl, shipping, etchName: etch_name });

--- a/backend/tests/queue/printWorker.test.js
+++ b/backend/tests/queue/printWorker.test.js
@@ -1,4 +1,3 @@
-
 process.env.DB_URL = 'postgres://user:pass@localhost/db';
 process.env.PRINTER_API_URL = 'http://printer';
 
@@ -37,6 +36,5 @@ test('worker posts etch name to printer API', async () => {
     modelUrl: 'm',
     shipping: { a: 1 },
     etchName: 'Name',
-
   });
 });


### PR DESCRIPTION
## Summary
- format `printWorker.js` and its corresponding test with Prettier

## Validation
- `npm run format` *(fails: SyntaxError in tests/frontend/flashBanner.test.js)*
- `npm test` *(fails: SyntaxError in tests/frontend/flashBanner.test.js)*


------
https://chatgpt.com/codex/tasks/task_e_685192c2cb8c832dbd9dc86a602d6054