### PR TITLE
test: fix syntax & async timer usage in flashBanner tests

### DIFF
--- a/backend/tests/frontend/flashBanner.test.js
+++ b/backend/tests/frontend/flashBanner.test.js
@@ -1,8 +1,6 @@
-// use Jest’s fake timer implementation
+/** @jest-environment node */
 jest.useFakeTimers();
 
-
-/** @jest-environment node */
 const fs = require('fs');
 const path = require('path');
 const { JSDOM } = require('jsdom');
@@ -13,40 +11,44 @@ html = html
   .replace(/<link[^>]+href="https?:\/\/[^>]+>/g, '')
   .replace(/<script[^>]+src="js\/modelViewerTouchFix.js"[^>]*><\/script>/, '');
 
+function setupDom() {
+  const dom = new JSDOM(html, {
+    runScripts: 'dangerously',
+    resources: 'usable',
+    url: 'http://localhost/',
+  });
+  global.window = dom.window;
+  global.document = dom.window.document;
+  const scriptSrc = fs.readFileSync(path.join(__dirname, '../../../js/payment.js'), 'utf8');
+  dom.window.eval(scriptSrc);
+  dom.window.setTimeout = setTimeout;
+  dom.window.clearTimeout = clearTimeout;
+  dom.window.setInterval = setInterval;
+  dom.window.clearInterval = clearInterval;
+  dom.window.Date = Date;
+  return dom;
+}
+
 describe('flash banner', () => {
   test('hides after countdown ends', async () => {
-    const dom = new JSDOM(html, {
-      runScripts: 'dangerously',
-      resources: 'usable',
-      url: 'http://localhost/',
-    });
-    global.window = dom.window;
-    global.document = dom.window.document;
+    const dom = setupDom();
     dom.window.sessionStorage.setItem('flashDiscountShow', '1');
     dom.window.localStorage.setItem('flashDiscountEnd', String(Date.now() + 1000));
-    const scriptSrc = fs.readFileSync(path.join(__dirname, '../../../js/payment.js'), 'utf8');
-    dom.window.eval(scriptSrc);
     dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
     dom.window.startFlashDiscount();
     const banner = dom.window.document.getElementById('flash-banner');
     expect(banner.hidden).toBe(false);
-    await new Promise((r) => setTimeout(r, 1100));
+
+    await jest.runOnlyPendingTimersAsync();
+
     expect(banner.hidden).toBe(true);
     expect(dom.window.localStorage.getItem('flashDiscountEnd')).toBe('0');
   });
 
   test('does not restart after expiration', async () => {
-    const dom = new JSDOM(html, {
-      runScripts: 'dangerously',
-      resources: 'usable',
-      url: 'http://localhost/',
-    });
-    global.window = dom.window;
-    global.document = dom.window.document;
+    const dom = setupDom();
     dom.window.sessionStorage.setItem('flashDiscountShow', '1');
     dom.window.localStorage.setItem('flashDiscountEnd', '0');
-    const scriptSrc = fs.readFileSync(path.join(__dirname, '../../../js/payment.js'), 'utf8');
-    dom.window.eval(scriptSrc);
     dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
     dom.window.startFlashDiscount();
     const end = dom.window.localStorage.getItem('flashDiscountEnd');
@@ -55,39 +57,22 @@ describe('flash banner', () => {
     expect(banner.hidden).toBe(true);
   });
 
-test('countdown shows 4:59 after one second', () => {
-  expect(timerEl.textContent).toBe('5:00');
-
-  // fast-forward 1.1 seconds
-  jest.advanceTimersByTime(1100);
-
-  expect(timerEl.textContent).toBe('4:59');
-});
-
-    global.window = dom.window;
-    global.document = dom.window.document;
+  test('countdown shows 4:59 after one second', async () => {
+    const dom = setupDom();
     dom.window.sessionStorage.setItem('flashDiscountShow', '1');
-    const scriptSrc = fs.readFileSync(path.join(__dirname, '../../../js/payment.js'), 'utf8');
-    dom.window.eval(scriptSrc);
     dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
     dom.window.startFlashDiscount();
     const timerEl = dom.window.document.getElementById('flash-timer');
     expect(timerEl.textContent).toBe('5:00');
-    await new Promise((r) => setTimeout(r, 1100));
+
+    await jest.runOnlyPendingTimersAsync();
+
     expect(timerEl.textContent).toBe('4:59');
   });
 
   test('banner hidden when chance disabled', async () => {
-    const dom = new JSDOM(html, {
-      runScripts: 'dangerously',
-      resources: 'usable',
-      url: 'http://localhost/',
-    });
-    global.window = dom.window;
-    global.document = dom.window.document;
+    const dom = setupDom();
     dom.window.sessionStorage.setItem('flashDiscountShow', '0');
-    const scriptSrc = fs.readFileSync(path.join(__dirname, '../../../js/payment.js'), 'utf8');
-    dom.window.eval(scriptSrc);
     dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
     dom.window.startFlashDiscount();
     const banner = dom.window.document.getElementById('flash-banner');


### PR DESCRIPTION
## Summary
- fix flashBanner.test.js fake timer setup and async

## Testing
- `npm run format`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685195418c68832d8a1683d173ab35b6