### PR TITLE
Keep etching input visible with disabled state

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -310,6 +310,7 @@ async function initPaymentPage() {
   const singleButton = singleLabel?.querySelector('span');
   const etchInput = document.getElementById('etch-name');
   const etchContainer = document.getElementById('etch-name-container');
+  const etchWarning = document.getElementById('etch-warning');
   const storedRadio = document.querySelector(`#material-options input[value="${storedMaterial}"]`);
   if (storedRadio) storedRadio.checked = true;
   updateEtchVisibility(storedMaterial);
@@ -374,12 +375,14 @@ async function initPaymentPage() {
   function updateEtchVisibility(val) {
     if (!etchInput || !etchContainer) return;
     if (val === 'multi' || val === 'premium') {
-      etchContainer.classList.remove('hidden');
       etchInput.disabled = false;
+      etchInput.classList.remove('opacity-50', 'border-red-500', 'text-red-300');
+      if (etchWarning) etchWarning.classList.add('hidden');
     } else {
-      etchContainer.classList.add('hidden');
       etchInput.disabled = true;
       etchInput.value = '';
+      etchInput.classList.add('opacity-50', 'border-red-500', 'text-red-300');
+      if (etchWarning) etchWarning.classList.remove('hidden');
     }
   }
 

--- a/payment.html
+++ b/payment.html
@@ -263,7 +263,7 @@
                 aria-label="Full Name"
               />
             </div>
-            <div id="etch-name-container" class="hidden">
+            <div id="etch-name-container">
               <input
                 id="etch-name"
                 class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10"
@@ -272,6 +272,12 @@
                 aria-label="Etched Name"
                 disabled
               />
+              <p
+                id="etch-warning"
+                class="mt-1 text-xs text-red-300 hidden"
+              >
+                The £34.99 option is required for etching.
+              </p>
             </div>
             <div>
               <input


### PR DESCRIPTION
## Summary
- keep the etching name input visible at all times
- disable it and show a warning when the single-colour £27.99 option is chosen

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6851a514ac90832daaf84bad586c4922