### PR TITLE
Enable eager model loading for competitions viewer

### DIFF
--- a/competitions.html
+++ b/competitions.html
@@ -249,6 +249,9 @@
           const card = e.target.closest('.model-card, .entry-card');
           if (card) {
             viewer.setAttribute('poster', card.querySelector('img')?.src || '');
+            // Ensure the viewer loads the model immediately
+            viewer.setAttribute('fetchpriority', 'high');
+            viewer.setAttribute('loading', 'eager');
             viewer.src = card.dataset.model;
             checkoutBtn.dataset.model = card.dataset.model;
             checkoutBtn.dataset.job = card.dataset.job;


### PR DESCRIPTION
## Summary
- tweak competitions page 3D viewer to eagerly fetch selected models

## Testing
- `npm run format`
- `npm test` *(fails: Could not load link to font-awesome)*

------
https://chatgpt.com/codex/tasks/task_e_6851a4f62250832da7e08875ae170e48