### PR TITLE
Show disabled etch box when single option selected

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -373,13 +373,28 @@ async function initPaymentPage() {
 
   function updateEtchVisibility(val) {
     if (!etchInput || !etchContainer) return;
+    const warning = document.getElementById('etch-warning');
     if (val === 'multi' || val === 'premium') {
-      etchContainer.classList.remove('hidden');
       etchInput.disabled = false;
+      etchInput.classList.remove(
+        'cursor-not-allowed',
+        'border-red-500',
+        'bg-red-900/20',
+        'text-red-300',
+        'placeholder-red-300'
+      );
+      if (warning) warning.classList.add('hidden');
     } else {
-      etchContainer.classList.add('hidden');
       etchInput.disabled = true;
       etchInput.value = '';
+      etchInput.classList.add(
+        'cursor-not-allowed',
+        'border-red-500',
+        'bg-red-900/20',
+        'text-red-300',
+        'placeholder-red-300'
+      );
+      if (warning) warning.classList.remove('hidden');
     }
   }
 

--- a/payment.html
+++ b/payment.html
@@ -263,7 +263,7 @@
                 aria-label="Full Name"
               />
             </div>
-            <div id="etch-name-container" class="hidden">
+            <div id="etch-name-container">
               <input
                 id="etch-name"
                 class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10"
@@ -272,6 +272,12 @@
                 aria-label="Etched Name"
                 disabled
               />
+              <p
+                id="etch-warning"
+                class="mt-1 text-xs text-red-400 hidden"
+              >
+                Name etching requires the £34.99 option.
+              </p>
             </div>
             <div>
               <input


### PR DESCRIPTION
## Summary
- keep the etching input always visible
- disable and highlight the field when the single (£27.99) option is chosen
- show a warning message indicating the £34.99 option is required

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851a4e5733c832db8d1a2e2a5d6c12e