### PR TITLE
Fix header layout shift on home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,7 +138,7 @@
         <div class="mt-1 flex flex-col text-sm text-gray-400 opacity-75">
           <p><span class="text-white">5400+</span> prints</p>
           <p>delivered already</p>
-          <p id="stats-ticker" class="text-orange-400 text-left"></p>
+          <p id="stats-ticker" class="text-orange-400 text-left" style="min-height:2.5rem"></p>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- prevent layout shift by reserving space for the stats ticker
- `npm ci`, `npm run format`, and `npm test` run logs included

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6851a941bcf8832dae1890cf600a3a1c