### PR TITLE
Fix etch warning layout

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -273,10 +273,10 @@
               />
               <div
                 id="etch-warning"
-                class="pointer-events-none absolute inset-0 flex items-center hidden"
+                class="pointer-events-none absolute inset-y-0 left-0 flex items-center gap-2 pl-2 hidden"
               >
-                <div class="absolute inset-x-0 top-1/2 border-t-2 border-red-500 transform -translate-y-1/2"></div>
-                <span class="ml-2 text-xs text-red-400 whitespace-nowrap">name etching requires multicolour</span>
+                <div class="border-t-2 border-red-500 w-[22ch]"></div>
+                <span class="text-xs text-red-400 whitespace-nowrap">Name etching requires multicolour</span>
               </div>
             </div>
             <div>


### PR DESCRIPTION
## Summary
- tweak etching warning UI
- keep text capitalised

## Testing
- `npm run format`
- `npm test --silent | tail -n 15`

------
https://chatgpt.com/codex/tasks/task_e_6851add9f6cc832da9b01b1156c07d03