### PR TITLE
Fix single color menu alignment

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -218,35 +218,35 @@
                 </span>
                 <div
                   id="single-color-menu"
-                  class="absolute inset-0 flex items-center justify-center gap-2 p-2 bg-[#2A2A2E] border border-white/20 rounded-3xl hidden"
+                  class="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 grid grid-cols-3 gap-2 p-2 bg-[#2A2A2E] border border-white/20 rounded-3xl hidden w-32 h-32"
                 >
                   <button
                     type="button"
-                    class="w-24 h-24 rounded-full border border-white/20"
+                    class="w-8 h-8 rounded-full border border-white/20"
                     style="background-color: #f87171"
                     data-color="#ff0000"
                   ></button>
                   <button
                     type="button"
-                    class="w-24 h-24 rounded-full border border-white/20"
+                    class="w-8 h-8 rounded-full border border-white/20"
                     style="background-color: #34d399"
                     data-color="#00ff00"
                   ></button>
                   <button
                     type="button"
-                    class="w-24 h-24 rounded-full border border-white/20"
+                    class="w-8 h-8 rounded-full border border-white/20"
                     style="background-color: #60a5fa"
                     data-color="#0000ff"
                   ></button>
                   <button
                     type="button"
-                    class="w-24 h-24 rounded-full border border-white/20"
+                    class="w-8 h-8 rounded-full border border-white/20"
                     style="background-color: #fbbf24"
                     data-color="#ffff00"
                   ></button>
                   <button
                     type="button"
-                    class="w-24 h-24 rounded-full border border-white/20"
+                    class="w-8 h-8 rounded-full border border-white/20"
                     style="background-color: #7c3aed"
                     data-color="#7c3aed"
                   ></button>


### PR DESCRIPTION
## Summary
- size down the single color picker on the payment page
- keep the menu centered over the £27.99 option

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6851aea0b330832d9ce5c1efa4fc10d3