### PR TITLE
Fix etch warning text

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -273,10 +273,10 @@
               />
               <div
                 id="etch-warning"
-                class="pointer-events-none absolute inset-0 flex items-center hidden"
+                class="pointer-events-none absolute inset-y-0 left-0 flex items-center gap-2 pl-2 hidden"
               >
-                <div class="absolute inset-x-0 top-1/2 border-t-2 border-red-500 transform -translate-y-1/2"></div>
-                <span class="ml-2 text-xs text-red-400 whitespace-nowrap">name etching requires multicolour</span>
+                <div class="border-t-2 border-red-500 w-[18ch]"></div>
+                <span class="text-xs text-red-400 whitespace-nowrap">Required multicolour</span>
               </div>
             </div>
             <div>


### PR DESCRIPTION
## Summary
- shorten red strike-through to better match the input width
- simplify multicolour warning text

## Testing
- `npm run format`
- `npm test --silent` *(fails: flashBanner.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_6851add9f6cc832da9b01b1156c07d03