### PR TITLE
Adjust etch input styling

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -377,7 +377,6 @@ async function initPaymentPage() {
     const warning = document.getElementById('etch-warning');
     if (val === 'multi' || val === 'premium') {
       etchInput.disabled = false;
-
       etchInput.classList.remove(
         'cursor-not-allowed',
         'border-amber-500',
@@ -389,8 +388,8 @@ async function initPaymentPage() {
     } else {
       etchInput.disabled = true;
       etchInput.value = '';
-      etchInput.classList.add(
-        'cursor-not-allowed',
+      etchInput.classList.add('cursor-not-allowed');
+      etchInput.classList.remove(
         'border-amber-500',
         'bg-amber-900/20',
         'text-amber-300',

--- a/payment.html
+++ b/payment.html
@@ -276,7 +276,7 @@
                 class="pointer-events-none absolute inset-y-0 left-0 flex items-center gap-2 pl-2 hidden"
               >
 
-                <div class="border-t-2 border-amber-500 w-[22ch]"></div>
+                <div class="border-t-2 border-amber-500 w-[20ch]"></div>
                 <span class="text-xs text-amber-400 whitespace-nowrap">Requires multicolour</span>
 
               </div>


### PR DESCRIPTION
## Summary
- shrink strike-through width on etch name warning
- avoid red styling when etch input disabled

## Testing
- `npm run format`
- `npm test` *(fails: Could not load CDN resources)*

------
https://chatgpt.com/codex/tasks/task_e_6851b6e1ce14832d94fcc30d1ef5f2bd