### PR TITLE
Adjust color menu size

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -227,7 +227,7 @@
                     -translate-y-[25%]
                   grid grid-cols-3 gap-2 p-2
                   bg-[#2A2A2E] border border-white/20
-                  rounded-3xl w-32 h-32
+                  rounded-3xl w-28 h-28
                   z-20 hidden
                 "
               >


### PR DESCRIPTION
## Summary
- shrink single color palette on payment page so it closely fits the circle button

## Testing
- `npm run format`
- `npm run test-ci` *(fails: Could not load font-awesome CDN)*

------
https://chatgpt.com/codex/tasks/task_e_6851be865d2c832dae17c327dc5f67d2