### PR TITLE
Fix amber highlight for disabled etching input

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -389,7 +389,7 @@ async function initPaymentPage() {
       etchInput.disabled = true;
       etchInput.value = '';
       etchInput.classList.add('cursor-not-allowed');
-      etchInput.classList.remove(
+      etchInput.classList.add(
         'border-amber-500',
         'bg-amber-900/20',
         'text-amber-300',


### PR DESCRIPTION
## Summary
- restore amber styling on the etching input when the single-colour option is selected

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851c138cf7c832d89cc4cf88378127e