### PR TITLE
Fix color menu overlap on payment page

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -224,7 +224,7 @@
                     bottom-0
                     left-1/2
                     -translate-x-1/2
-                    -translate-y-[25%]
+                    -translate-y-[90%]
                   grid grid-cols-3 gap-2 p-2
                   bg-[#2A2A2E] border border-white/20
                   rounded-3xl w-28 h-28


### PR DESCRIPTION
## Summary
- raise the single color selection menu so the circle button is fully covered

## Testing
- `npm run format`
- `npm test` *(fails: Could not load external CSS during tests)*

------
https://chatgpt.com/codex/tasks/task_e_6851c0ec5338832dbe9021d236442956