### PR TITLE
Increase etch warning text size

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -290,7 +290,7 @@
               >
 
                 <div class="border-t-2 border-amber-500 w-[20ch]"></div>
-                <span class="text-xs text-amber-400 whitespace-nowrap">Requires multicolour</span>
+                <span class="text-base text-amber-400 whitespace-nowrap">Requires multicolour</span>
 
               </div>
             </div>


### PR DESCRIPTION
## Summary
- enlarge the warning text in the etching name field

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6851cc43b42c832d996ab7b0a4a30595