### PR TITLE
Fix model viewer init timing

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -570,6 +570,7 @@ async function initPaymentPage() {
   }
 
   loader.hidden = false;
+  // Assign the model source only after the load/error listeners are in place
   viewer.src = localStorage.getItem('print3Model') || FALLBACK_GLB;
 
   // Hide the overlay if nothing happens after a short delay

--- a/payment.html
+++ b/payment.html
@@ -119,7 +119,6 @@
           />
           <model-viewer
             id="viewer"
-            src="https://modelviewer.dev/shared-assets/models/Astronaut.glb"
             alt="3D astronaut"
             environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
             camera-controls


### PR DESCRIPTION
## Summary
- defer model source loading until listeners are attached
- remove baked-in model source from payment page

## Testing
- `npm run format`
- `npm test` *(fails: could not load external font resource)*

------
https://chatgpt.com/codex/tasks/task_e_6851d00b8370832dbb8a3deb621ea8e2