### PR TITLE
Use Font Awesome fire icon

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -721,10 +721,10 @@ async function init() {
       } else {
         prints = await computeDailyPrintsSold();
       }
-      el.innerHTML = `\u{1F525} ${prints} prints sold<br>in last 24 hrs`;
+      el.innerHTML = `<i class="fas fa-fire mr-1"></i> ${prints} prints sold<br>in last 24 hrs`;
     } catch {
       const prints = await computeDailyPrintsSold();
-      el.innerHTML = `\u{1F525} ${prints} prints sold<br>in last 24 hrs`;
+      el.innerHTML = `<i class="fas fa-fire mr-1"></i> ${prints} prints sold<br>in last 24 hrs`;
     }
   }
 

--- a/payment.html
+++ b/payment.html
@@ -33,11 +33,7 @@
     <script src="https://js.stripe.com/v3/" defer></script>
 
     <!-- Font Awesome (back-arrow icon) -->
-    <link
-      rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
-      referrerpolicy="no-referrer"
-    />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" referrerpolicy="no-referrer">
 
     <!-- model-viewer -->
     <script


### PR DESCRIPTION
## Summary
- replace emoji with a Font Awesome fire icon in stats ticker
- simplify external stylesheet tag so tests strip it correctly

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851d19b920c832db749ba2b0d28537e