### PR TITLE
Fix multicolour notice size

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -289,7 +289,7 @@
               >
 
                 <div class="border-t-2 border-amber-500 w-[20ch]"></div>
-                <span class="text-base text-amber-400 whitespace-nowrap">Requires multicolour</span>
+                <span class="text-sm text-amber-400 whitespace-nowrap">Requires multicolour</span>
 
               </div>
             </div>


### PR DESCRIPTION
## Summary
- shrink the "Requires multicolour" notice on the payment page

## Validation
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851d2cac874832d99781bb7595424a7