### PR TITLE
Change name etching text color

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -184,7 +184,7 @@
                 >
                   <span class="font-semibold leading-none">£34.99</span>
                   <span class="text-xs leading-tight">multi-colour</span>
-                  <span class="text-[10px] leading-tight text-center mt-2 text-[#ffd700]"
+                  <span class="text-[10px] leading-tight text-center mt-2 text-[#30D5C8]"
                     >+ (optional) name<br />etching</span
                   >
                 </span>


### PR DESCRIPTION
## Summary
- adjust color of optional name etching label to match other pay button

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6851d6548130832daf0d0b83018427d3