### PR TITLE
Implement static asset caching

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -57,7 +57,14 @@ app.use(morgan('dev'));
 app.use(compression());
 app.use(cors());
 app.use(bodyParser.json());
-app.use(express.static(path.join(__dirname, '..')));
+const staticOptions = {
+  setHeaders(res, filePath) {
+    if (/\.(?:glb|hdr|js|css|png|jpe?g|gif|svg)$/i.test(filePath)) {
+      res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
+    }
+  },
+};
+app.use(express.static(path.join(__dirname, '..'), staticOptions));
 const uploadsDir = path.join(__dirname, '..', 'uploads');
 fs.mkdirSync(uploadsDir, { recursive: true });
 const upload = multer({ dest: uploadsDir });

--- a/backend/tests/additionalApi.test.js
+++ b/backend/tests/additionalApi.test.js
@@ -481,3 +481,9 @@ test('GET /api/stats returns sales and rating', async () => {
   expect(res.body.printsSold).toBe(42);
   expect(res.body.averageRating).toBe(4.8);
 });
+
+test('static assets send cache headers', async () => {
+  const res = await request(app).get('/js/index.js');
+  expect(res.status).toBe(200);
+  expect(res.headers['cache-control']).toBe('public, max-age=31536000, immutable');
+});


### PR DESCRIPTION
## Summary
- set long-term caching headers for static assets
- ensure cache headers via test

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6851d759320c832d90194bd52dab0668