### PR TITLE
Adjust wizard step text spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -397,7 +397,7 @@
 
       <div
         id="wizard-step-purchase"
-        class="flex-1 text-center py-2 flex justify-center items-center"
+        class="flex-1 text-center py-2 flex justify-center items-center pr-16"
       >
         <span id="wizard-slots" class="hidden text-[#30D5C8] mr-2 whitespace-nowrap"
           >Only 4 print slots remaining;</span


### PR DESCRIPTION
## Summary
- nudge purchase step text away from floating basket icon

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6851d94fb68c832d8852631fff768d17