### PR TITLE
Change etch warning to site blue

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -384,6 +384,10 @@ async function initPaymentPage() {
       etchInput.disabled = false;
       etchInput.classList.remove(
         'cursor-not-allowed',
+        'border-[#30D5C8]',
+        'bg-[#30D5C8]/20',
+        'text-[#30D5C8]',
+        'placeholder-[#30D5C8]',
         'border-amber-500',
         'bg-amber-900/20',
         'text-amber-300',
@@ -395,10 +399,10 @@ async function initPaymentPage() {
       etchInput.value = '';
       etchInput.classList.add('cursor-not-allowed');
       etchInput.classList.add(
-        'border-amber-500',
-        'bg-amber-900/20',
-        'text-amber-300',
-        'placeholder-amber-300'
+        'border-[#30D5C8]',
+        'bg-[#30D5C8]/20',
+        'text-[#30D5C8]',
+        'placeholder-[#30D5C8]'
       );
       if (warning) warning.classList.remove('hidden');
 

--- a/payment.html
+++ b/payment.html
@@ -284,8 +284,8 @@
                 class="pointer-events-none absolute inset-y-0 left-0 flex items-center gap-2 pl-2 hidden"
               >
 
-                <div class="border-t-2 border-amber-500 w-[20ch]"></div>
-                <span class="text-sm text-amber-400 whitespace-nowrap">Requires multicolour</span>
+                <div class="border-t-2 border-[#30D5C8] w-[20ch]"></div>
+                <span class="text-sm text-[#30D5C8] whitespace-nowrap">Requires multicolour</span>
 
               </div>
             </div>


### PR DESCRIPTION
## Summary
- use site blue color for the etch-name warning banner
- update JS logic to add/remove the new color classes

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851dc3a083c832da23c4fabd16292f5