### PR TITLE
Optimize initial data load

### DIFF
--- a/backend/tests/additionalApi.test.js
+++ b/backend/tests/additionalApi.test.js
@@ -487,3 +487,15 @@ test('static assets send cache headers', async () => {
   expect(res.status).toBe(200);
   expect(res.headers['cache-control']).toBe('public, max-age=31536000, immutable');
 });
+
+test('GET /api/init-data returns slots, stats, and profile', async () => {
+  const { _setDailyPrintsSold } = require('../utils/dailyPrints');
+  _setDailyPrintsSold(10);
+  db.query.mockResolvedValueOnce({ rows: [{ display_name: 'A' }] });
+  const token = jwt.sign({ id: 'u1' }, 'secret');
+  const res = await request(app).get('/api/init-data').set('authorization', `Bearer ${token}`);
+  expect(res.status).toBe(200);
+  expect(typeof res.body.slots).toBe('number');
+  expect(res.body.stats.printsSold).toBe(10);
+  expect(res.body.profile.display_name).toBe('A');
+});


### PR DESCRIPTION
## Summary
- add `computePrintSlots` helper and new `/api/init-data` endpoint
- combine initial API requests in `index.js`
- test new API route
- run `npm run format` and `npm test`

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851dcc58724832dbb643ee056c50c44