### PR TITLE
Implement competition subscription banner

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -1285,6 +1285,25 @@ app.post('/api/subscribe', async (req, res) => {
   }
 });
 
+app.post('/api/competitions/subscribe', async (req, res) => {
+  const { email } = req.body;
+  if (!email) return res.status(400).json({ error: 'Email required' });
+  const token = uuidv4();
+  try {
+    await db.query(
+      `INSERT INTO mailing_list(email, token) VALUES($1,$2)
+       ON CONFLICT (email) DO UPDATE SET token=$2, confirmed=FALSE, unsubscribed=FALSE`,
+      [email, token]
+    );
+    const url = `${req.headers.origin}/api/confirm-subscription?token=${token}`;
+    await sendMail(email, 'Confirm Subscription', `Click to confirm: ${url}`);
+    res.sendStatus(204);
+  } catch (err) {
+    logError(err);
+    res.status(500).json({ error: 'Failed to subscribe' });
+  }
+});
+
 app.get('/api/confirm-subscription', async (req, res) => {
   const { token } = req.query;
   if (!token) return res.status(400).send('Invalid token');

--- a/competitions.html
+++ b/competitions.html
@@ -103,6 +103,13 @@
       </div>
     </header>
     <main class="flex-1 p-4 space-y-6">
+      <div
+        id="printclub-banner"
+        class="bg-blue-600 text-white p-3 rounded-xl text-center hidden"
+      >
+        Join <strong>Print Club</strong> for weekly prints.
+        <a href="#" id="printclub-banner-link" class="underline">Learn more</a>
+      </div>
       <section class="bg-[#2A2A2E] p-4 rounded-xl">
         <p class="mb-2">
           Put your modelling skills to the test! Enter our themed contests, climb the leaderboard
@@ -117,6 +124,17 @@
       </section>
       <h2 class="text-2xl">Active Competitions</h2>
       <div id="list" class="space-y-4"></div>
+      <form id="comp-subscribe" class="flex space-x-2 mt-4 max-w-sm">
+        <input
+          type="email"
+          id="comp-email"
+          class="flex-1 bg-[#1A1A1D] border border-white/10 rounded px-2"
+          placeholder="Email for updates"
+          aria-label="Email address"
+        />
+        <button class="bg-[#30D5C8] text-[#1A1A1D] px-3 rounded">Subscribe</button>
+      </form>
+      <div id="comp-subscribe-msg" class="text-sm"></div>
       <h2 class="text-2xl mt-8">Past Winners</h2>
       <div id="winners-grid" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 mt-4">
         <div

--- a/js/competitions.js
+++ b/js/competitions.js
@@ -96,6 +96,8 @@ async function load() {
       <div class="flex space-x-2">
         <button data-id="${c.id}" class="enter bg-[#30D5C8] text-[#1A1A1D] px-3 py-1 rounded">Enter</button>
         <button onclick="shareOn('twitter')" aria-label="Share on Twitter" class="w-9 h-9 flex-shrink-0 flex items-center justify-center bg-[#1A1A1D] border border-white/10 rounded hover:bg-[#3A3A3E]"><i class="fab fa-twitter"></i></button>
+        <button onclick="shareOn('facebook')" aria-label="Share on Facebook" class="w-9 h-9 flex-shrink-0 flex items-center justify-center bg-[#1A1A1D] border border-white/10 rounded hover:bg-[#3A3A3E]"><i class="fab fa-facebook-f"></i></button>
+        <button onclick="shareOn('reddit')" aria-label="Share on Reddit" class="w-9 h-9 flex-shrink-0 flex items-center justify-center bg-[#1A1A1D] border border-white/10 rounded hover:bg-[#3A3A3E]"><i class="fab fa-reddit-alien"></i></button>
       </div>
       <table class="leaderboard w-full mt-4 text-sm"></table>
 
@@ -344,4 +346,25 @@ document.addEventListener('DOMContentLoaded', () => {
 
   });
   load();
+  const subForm = document.getElementById('comp-subscribe');
+  const emailInput = document.getElementById('comp-email');
+  const msgEl = document.getElementById('comp-subscribe-msg');
+  subForm?.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const email = emailInput.value.trim();
+    if (!email) return;
+    msgEl.textContent = '';
+    const res = await fetch(`${API_BASE}/competitions/subscribe`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email }),
+    });
+    if (res.ok) {
+      msgEl.textContent = 'Check your inbox to confirm!';
+      emailInput.value = '';
+    } else {
+      const data = await res.json().catch(() => ({}));
+      msgEl.textContent = data.error || 'Subscription failed';
+    }
+  });
 });

--- a/js/printclub.js
+++ b/js/printclub.js
@@ -1,8 +1,13 @@
 const badge = document.getElementById('print-club-badge');
 const modal = document.getElementById('printclub-modal');
 const closeBtn = document.getElementById('printclub-close');
+const bannerLink = document.getElementById('printclub-banner-link');
 
 badge?.addEventListener('click', () => modal?.classList.remove('hidden'));
+bannerLink?.addEventListener('click', (e) => {
+  e.preventDefault();
+  modal?.classList.remove('hidden');
+});
 closeBtn?.addEventListener('click', () => modal?.classList.add('hidden'));
 modal?.addEventListener('click', (e) => {
   if (e.target === modal) modal.classList.add('hidden');


### PR DESCRIPTION
## Summary
- add Print Club banner and subscription form to competitions page
- hook up banner to Print Club modal
- support competition subscription form with new API endpoint
- add Facebook and Reddit share icons on competition cards
- run formatting and tests

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6851e56320b0832dbb9b30ac115023c8