### PR TITLE
Implement initial rewards features

### DIFF
--- a/backend/migrations/031_create_referral_links.sql
+++ b/backend/migrations/031_create_referral_links.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS referral_links (
+  user_id UUID PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+  code TEXT UNIQUE NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS referral_links_code_idx ON referral_links(code);
+
+CREATE TRIGGER referral_links_set_updated
+BEFORE UPDATE ON referral_links
+FOR EACH ROW EXECUTE PROCEDURE set_updated_at();

--- a/backend/migrations/032_create_reward_points.sql
+++ b/backend/migrations/032_create_reward_points.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS reward_points (
+  user_id UUID PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+  points INTEGER NOT NULL DEFAULT 0,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TRIGGER reward_points_set_updated
+BEFORE UPDATE ON reward_points
+FOR EACH ROW EXECUTE PROCEDURE set_updated_at();

--- a/backend/server.js
+++ b/backend/server.js
@@ -608,6 +608,26 @@ app.get('/api/subscription/credits', authRequired, async (req, res) => {
   }
 });
 
+app.get('/api/referral-link', authRequired, async (req, res) => {
+  try {
+    const code = await db.getOrCreateReferralLink(req.user.id);
+    res.json({ code });
+  } catch (err) {
+    logError(err);
+    res.status(500).json({ error: 'Failed to fetch referral link' });
+  }
+});
+
+app.get('/api/rewards', authRequired, async (req, res) => {
+  try {
+    const points = await db.getRewardPoints(req.user.id);
+    res.json({ points });
+  } catch (err) {
+    logError(err);
+    res.status(500).json({ error: 'Failed to fetch rewards' });
+  }
+});
+
 app.get('/api/users/:username/models', async (req, res) => {
   const limit = parseInt(req.query.limit, 10) || 10;
   const offset = parseInt(req.query.offset, 10) || 0;

--- a/backend/tests/rewards.test.js
+++ b/backend/tests/rewards.test.js
@@ -1,0 +1,39 @@
+process.env.STRIPE_SECRET_KEY = 'test';
+process.env.STRIPE_WEBHOOK_SECRET = 'whsec';
+process.env.DB_URL = 'postgres://user:pass@localhost/db';
+process.env.HUNYUAN_API_KEY = 'test';
+process.env.HUNYUAN_SERVER_URL = 'http://localhost:4000';
+
+jest.mock('../db', () => ({
+  query: jest.fn().mockResolvedValue({ rows: [] }),
+  insertCommission: jest.fn(),
+  getOrCreateReferralLink: jest.fn(),
+  getRewardPoints: jest.fn(),
+}));
+const db = require('../db');
+
+const jwt = require('jsonwebtoken');
+const request = require('supertest');
+const app = require('../server');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('GET /api/referral-link returns code', async () => {
+  db.getOrCreateReferralLink.mockResolvedValue('abc123');
+  const token = jwt.sign({ id: 'u1' }, 'secret');
+  const res = await request(app).get('/api/referral-link').set('authorization', `Bearer ${token}`);
+  expect(res.status).toBe(200);
+  expect(res.body.code).toBe('abc123');
+  expect(db.getOrCreateReferralLink).toHaveBeenCalledWith('u1');
+});
+
+test('GET /api/rewards returns points', async () => {
+  db.getRewardPoints.mockResolvedValue(42);
+  const token = jwt.sign({ id: 'u1' }, 'secret');
+  const res = await request(app).get('/api/rewards').set('authorization', `Bearer ${token}`);
+  expect(res.status).toBe(200);
+  expect(res.body.points).toBe(42);
+  expect(db.getRewardPoints).toHaveBeenCalledWith('u1');
+});

--- a/earn-rewards.html
+++ b/earn-rewards.html
@@ -86,14 +86,28 @@
       </div>
     </header>
     <main class="flex-1 flex items-center justify-center px-4">
-      <div class="max-w-lg text-center">
-        <p class="text-lg">Rewards for supporting print3 are coming soon. Check back later!</p>
+      <div class="max-w-lg space-y-4 text-center">
+        <p class="text-lg">
+          Invite friends to try print3 using your personal link below. When they sign up and place orders you'll earn points that can be redeemed for discounts on future prints.
+        </p>
+        <div>
+          <label class="block text-sm mb-1">Your referral link</label>
+          <div class="flex">
+            <input id="referral-link" class="flex-1 bg-[#2A2A2E] border border-white/10 rounded-l-xl px-2 py-1" readonly />
+            <button class="bg-blue-600 px-3 rounded-r-xl" onclick="copyReferral()">Copy</button>
+          </div>
+        </div>
+        <div>
+          <label class="block text-sm mb-1">Reward Points: <span id="reward-points">0</span></label>
+          <progress id="reward-progress" value="0" max="100" class="w-full h-3"></progress>
+        </div>
       </div>
     </main>
     <script type="module">
       import { shareOn } from './js/share.js';
       window.shareOn = shareOn;
     </script>
+    <script type="module" src="js/rewards.js"></script>
     <div
       id="printclub-modal"
       class="fixed inset-0 bg-black/70 flex items-center justify-center z-50 hidden"

--- a/js/rewards.js
+++ b/js/rewards.js
@@ -1,0 +1,38 @@
+const API_BASE = (window.API_ORIGIN || '') + '/api';
+
+async function loadRewards() {
+  const token = localStorage.getItem('token');
+  if (!token) return;
+  const headers = { authorization: `Bearer ${token}` };
+  try {
+    const resLink = await fetch(`${API_BASE}/referral-link`, { headers });
+    if (resLink.ok) {
+      const { code } = await resLink.json();
+      const input = document.getElementById('referral-link');
+      if (input) input.value = `${window.location.origin}?ref=${code}`;
+    }
+  } catch (err) {
+    console.error('Failed to load referral link', err);
+  }
+  try {
+    const resPts = await fetch(`${API_BASE}/rewards`, { headers });
+    if (resPts.ok) {
+      const { points } = await resPts.json();
+      const ptsEl = document.getElementById('reward-points');
+      if (ptsEl) ptsEl.textContent = points;
+      const bar = document.getElementById('reward-progress');
+      if (bar) bar.value = points;
+    }
+  } catch (err) {
+    console.error('Failed to load rewards', err);
+  }
+}
+
+function copyReferral() {
+  const input = document.getElementById('referral-link');
+  input?.select();
+  document.execCommand('copy');
+}
+
+window.copyReferral = copyReferral;
+window.addEventListener('DOMContentLoaded', loadRewards);


### PR DESCRIPTION
## Summary
- set up `referral_links` and `reward_points` tables
- add DB helpers and API routes for referral link and reward points
- update rewards page with program overview and dynamic data
- create frontend script to load referral link and balance
- add tests for new rewards endpoints

## Validation
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6851e55689f8832d9900b6538f5a7410