### PR TITLE
Fix print2 branding on rewards page

### DIFF
--- a/earn-rewards.html
+++ b/earn-rewards.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Earn Rewards</title>
-    <meta property="og:title" content="Earn Rewards – print3" />
-    <meta property="og:description" content="Learn how to earn rewards on print3." />
+    <meta property="og:title" content="Earn Rewards – print2" />
+    <meta property="og:description" content="Learn how to earn rewards on print2." />
     <meta property="og:image" content="img/boxlogo.png" />
     <script src="https://cdn.tailwindcss.com"></script>
     <link
@@ -88,7 +88,7 @@
     <main class="flex-1 flex items-center justify-center px-4">
       <div class="max-w-lg space-y-4 text-center">
         <p class="text-lg">
-          Invite friends to try print3 using your personal link below. When they sign up and place orders you'll earn points that can be redeemed for discounts on future prints.
+          Invite friends to try print2 using your personal link below. When they sign up and place orders you'll earn points that can be redeemed for discounts on future prints.
         </p>
         <div>
           <label class="block text-sm mb-1">Your referral link</label>


### PR DESCRIPTION
## Summary
- update Earn Rewards page branding from print3 to print2

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6851eb8fe200832da4bfe18b2729f988