### PR TITLE
Implement competition discount codes

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -958,6 +958,23 @@ app.post('/api/competitions/:id/enter', authRequired, async (req, res) => {
   }
 });
 
+app.post('/api/competitions/:id/discount', authRequired, async (req, res) => {
+  try {
+    const { rows } = await db.query(
+      'SELECT 1 FROM competition_entries WHERE competition_id=$1 AND user_id=$2',
+      [req.params.id, req.user.id]
+    );
+    if (!rows.length) {
+      return res.status(400).json({ error: 'No entry found' });
+    }
+    const code = await createTimedCode(500, 48);
+    res.json({ code });
+  } catch (err) {
+    logError(err);
+    res.status(500).json({ error: 'Failed to generate discount' });
+  }
+});
+
 function adminCheck(req, res, next) {
   authOptional(req, res, () => {
     const headerMatch = req.headers['x-admin-token'] === ADMIN_TOKEN;

--- a/backend/tests/additionalApi.test.js
+++ b/backend/tests/additionalApi.test.js
@@ -397,6 +397,29 @@ test('POST /api/competitions/:id/enter allows repeat submission without error', 
   ]);
 });
 
+test('POST /api/competitions/:id/discount returns code', async () => {
+  db.query.mockResolvedValueOnce({ rows: [{}] }).mockResolvedValueOnce({ rows: [{ code: 'X1' }] });
+  const token = jwt.sign({ id: 'u1' }, 'secret');
+  const res = await request(app)
+    .post('/api/competitions/5/discount')
+    .set('authorization', `Bearer ${token}`)
+    .send({});
+  expect(res.status).toBe(200);
+  expect(res.body.code).toBe('X1');
+  const call = db.query.mock.calls.find((c) => c[0].includes('INSERT INTO discount_codes'));
+  expect(call).toBeTruthy();
+});
+
+test('POST /api/competitions/:id/discount requires entry', async () => {
+  db.query.mockResolvedValueOnce({ rows: [] });
+  const token = jwt.sign({ id: 'u1' }, 'secret');
+  const res = await request(app)
+    .post('/api/competitions/5/discount')
+    .set('authorization', `Bearer ${token}`)
+    .send({});
+  expect(res.status).toBe(400);
+});
+
 test('DELETE /api/admin/competitions/:id', async () => {
   db.query.mockResolvedValueOnce({});
   const res = await request(app).delete('/api/admin/competitions/5').set('x-admin-token', 'admin');

--- a/competitions.html
+++ b/competitions.html
@@ -135,6 +135,7 @@
         <button class="bg-[#30D5C8] text-[#1A1A1D] px-3 rounded">Subscribe</button>
       </form>
       <div id="comp-subscribe-msg" class="text-sm"></div>
+      <div id="entry-success" class="hidden text-green-400 mt-2"></div>
       <h2 class="text-2xl mt-8">Past Winners</h2>
       <div id="winners-grid" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 mt-4">
         <div

--- a/js/competitions.js
+++ b/js/competitions.js
@@ -256,7 +256,28 @@ async function submitEntry(e) {
     },
     body: JSON.stringify({ modelId }),
   });
-  if (res.ok) closeModal();
+  if (res.ok) {
+    closeModal();
+    const msg = document.getElementById('entry-success');
+    if (msg) {
+      try {
+        const resp = await fetch(
+          `${API_BASE}/competitions/${currentId}/discount`,
+          {
+            method: 'POST',
+            headers: { Authorization: `Bearer ${token}` },
+          }
+        );
+        if (resp.ok) {
+          const data = await resp.json();
+          msg.textContent = `Discount code: ${data.code}`;
+          msg.classList.remove('hidden');
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    }
+  }
 }
 
 async function loadComments(id, container) {


### PR DESCRIPTION
## Summary
- add `/api/competitions/:id/discount` endpoint
- show entry discount code after submitting entry
- display discount message on competitions page
- test new discount endpoint

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851ebc10a60832d8924246cc3cfe2a2