### PR TITLE
Implement profile enhancements

### DIFF
--- a/js/profile.js
+++ b/js/profile.js
@@ -107,6 +107,26 @@ async function load() {
   captureSnapshots(container);
 }
 
+async function loadProfileHeader() {
+  const token = localStorage.getItem('token');
+  const urlParams = new URLSearchParams(window.location.search);
+  const user = urlParams.get('user');
+  let endpoint;
+  if (user) {
+    endpoint = `${API_BASE}/users/${encodeURIComponent(user)}/profile`;
+  } else {
+    endpoint = `${API_BASE}/profile`;
+  }
+  const res = await fetch(endpoint, user ? {} : { headers: { Authorization: `Bearer ${token}` } });
+  if (!res.ok) return;
+  const data = await res.json();
+  document.getElementById('profile-name').textContent = data.display_name || 'Profile';
+  const avatar = document.getElementById('profile-avatar');
+  const display = document.getElementById('profile-display');
+  if (avatar && data.avatar_url) avatar.src = data.avatar_url;
+  if (display) display.textContent = data.display_name || '';
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   const modal = document.getElementById('model-modal');
   const closeBtn = document.getElementById('close-modal');
@@ -130,5 +150,6 @@ document.addEventListener('DOMContentLoaded', () => {
     localStorage.removeItem('token');
     window.location.href = 'index.html';
   });
+  loadProfileHeader();
   load();
 });

--- a/my_profile.html
+++ b/my_profile.html
@@ -119,7 +119,31 @@
         <p><strong>Username:</strong> <span id="mp-username"></span></p>
         <p><strong>Display Name:</strong> <span id="mp-display"></span></p>
         <p><strong>Email:</strong> <span id="mp-email"></span></p>
+        <img id="avatar-preview" class="w-24 h-24 rounded-full object-cover" />
+        <input id="avatar-input" type="file" accept="image/*" class="mt-2" />
+        <button id="avatar-upload" class="mt-2 px-3 py-1 bg-blue-600 rounded-xl">Upload Avatar</button>
       </div>
+
+      <form
+        id="profile-form"
+        class="space-y-2 bg-[#2A2A2E] border border-white/10 p-6 rounded-3xl w-96 mb-6"
+      >
+        <input
+          id="shipping-input"
+          class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10"
+          placeholder="Shipping Address"
+        />
+        <input
+          id="payment-input"
+          class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10"
+          placeholder="Payment Info"
+        />
+        <label class="inline-flex items-center">
+          <input type="checkbox" id="competition-toggle" class="mr-2" />
+          Email me about competitions
+        </label>
+        <button class="bg-blue-600 px-3 py-1 rounded-xl" type="submit">Save</button>
+      </form>
       <div id="earnings" class="bg-[#2A2A2E] border border-white/10 p-6 rounded-3xl w-96 mb-6">
         <h2 class="text-lg font-semibold mb-2">Earnings</h2>
         <table class="w-full text-sm mb-2">
@@ -159,6 +183,22 @@
           Upgrade
         </button>
       </div>
+
+      <div id="orders" class="bg-[#2A2A2E] border border-white/10 p-6 rounded-3xl w-full mb-6">
+        <h2 class="text-lg font-semibold mb-2">Past Orders</h2>
+        <table class="w-full text-sm">
+          <thead>
+            <tr>
+              <th class="text-left">Date</th>
+              <th class="text-left">Quantity</th>
+              <th class="text-left">Total</th>
+              <th class="text-left">Status</th>
+            </tr>
+          </thead>
+        <tbody id="orders-body"></tbody>
+        </table>
+      </div>
+      <button id="delete-account" class="bg-red-600 px-3 py-1 rounded-xl mb-6">Delete Account</button>
       <div id="models" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4"></div>
       <div id="models-sentinel" class="h-8"></div>
     </main>

--- a/profile.html
+++ b/profile.html
@@ -114,6 +114,10 @@
       </div>
     </header>
     <main class="flex-1 px-6 py-4">
+      <div id="profile-header" class="text-center mb-6">
+        <img id="profile-avatar" class="w-24 h-24 rounded-full mx-auto mb-2" />
+        <h2 id="profile-display" class="text-xl font-semibold"></h2>
+      </div>
       <div id="models" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4"></div>
       <div id="auth-options" class="text-center mt-8 hidden">
         <a


### PR DESCRIPTION
## Summary
- support avatar uploads via new POST `/api/profile/avatar`
- allow deleting account
- fix `/api/users/:username/profile` join
- add profile form fields on `my_profile.html`
- show past orders and allow competition notifications
- display avatar and name on `profile.html`
- implement corresponding JS logic

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6851ebc9dcf8832d8f02c0b7c0f19e9d