### PR TITLE
Implement payment init bundling

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -402,6 +402,31 @@ app.get('/api/init-data', authOptional, async (req, res) => {
   }
 });
 
+app.get('/api/payment-init', authOptional, async (req, res) => {
+  const result = {
+    slots: computePrintSlots(),
+    publishableKey: config.stripePublishable,
+  };
+  try {
+    const { rows: saleRows } = await db.query(
+      `SELECT * FROM flash_sales
+       WHERE active=TRUE AND start_time<=NOW() AND end_time>NOW()
+       ORDER BY start_time DESC LIMIT 1`
+    );
+    if (saleRows.length) result.flashSale = saleRows[0];
+    if (req.user) {
+      const { rows } = await db.query('SELECT * FROM user_profiles WHERE user_id=$1', [
+        req.user.id,
+      ]);
+      if (rows.length) result.profile = rows[0];
+    }
+    res.json(result);
+  } catch (err) {
+    logError(err);
+    res.status(500).json({ error: 'Failed to load payment data' });
+  }
+});
+
 /**
  * GET /api/subreddit/:name
  * Retrieve model and quote for a subreddit

--- a/backend/tests/additionalApi.test.js
+++ b/backend/tests/additionalApi.test.js
@@ -499,3 +499,16 @@ test('GET /api/init-data returns slots, stats, and profile', async () => {
   expect(res.body.stats.printsSold).toBe(10);
   expect(res.body.profile.display_name).toBe('A');
 });
+
+test('GET /api/payment-init bundles payment data', async () => {
+  db.query
+    .mockResolvedValueOnce({ rows: [{ id: 1, discount_percent: 5 }] })
+    .mockResolvedValueOnce({ rows: [{ display_name: 'B', shipping_info: { name: 'J' } }] });
+  const token = jwt.sign({ id: 'u2' }, 'secret');
+  const res = await request(app).get('/api/payment-init').set('authorization', `Bearer ${token}`);
+  expect(res.status).toBe(200);
+  expect(typeof res.body.slots).toBe('number');
+  expect(res.body.flashSale.id).toBe(1);
+  expect(res.body.profile.display_name).toBe('B');
+  expect(res.body.publishableKey).toBeDefined();
+});

--- a/js/payment.js
+++ b/js/payment.js
@@ -31,6 +31,16 @@ function getUserIdFromToken() {
   }
 }
 
+async function fetchPaymentInit() {
+  try {
+    const token = localStorage.getItem('token');
+    const headers = token ? { Authorization: `Bearer ${token}` } : {};
+    const res = await fetch(`${API_BASE}/payment-init`, { headers });
+    if (res.ok) return await res.json();
+  } catch {}
+  return {};
+}
+
 // Restore previously selected material option and colour
 const storedMaterial = localStorage.getItem('print3Material');
 const storedColor = localStorage.getItem('print3Color');
@@ -269,18 +279,11 @@ async function initPaymentPage() {
   await ensureModelViewerLoaded();
   const referralId = localStorage.getItem('referrerId');
   if (window.setWizardStage) window.setWizardStage('purchase');
-  // Safely initialize Stripe once the DOM is ready. If the Stripe library
-  // failed to load, we fall back to plain redirects.
-  if (window.Stripe) {
+  const initData = await fetchPaymentInit();
+  if (window.Stripe && initData.publishableKey) {
     try {
-      const resp = await fetch(`${API_BASE}/config/stripe`);
-      const data = await resp.json();
-      if (data.publishableKey) {
-        stripe = window.Stripe(data.publishableKey);
-      }
-    } catch {
-      // ignore if the config request fails
-    }
+      stripe = window.Stripe(initData.publishableKey);
+    } catch {}
   }
   const loader = document.getElementById('loader');
   const viewer = document.getElementById('viewer');
@@ -494,17 +497,8 @@ async function initPaymentPage() {
     // Compute a client-side slot count first so we have a reasonable value even
     // if the API fails or returns stale data.
     baseSlots = computeSlotsByTime();
-    try {
-      const resp = await fetch(`${API_BASE}/print-slots`);
-      if (resp.ok) {
-        const data = await resp.json();
-
-        if (typeof data.slots === 'number') {
-          baseSlots = data.slots;
-        }
-      }
-    } catch {
-      // ignore slot errors and fall back to the computed time-based value
+    if (typeof initData.slots === 'number') {
+      baseSlots = initData.slots;
     }
     slotEl.textContent = adjustedSlots(baseSlots);
     slotEl.style.visibility = 'visible';
@@ -654,29 +648,19 @@ async function initPaymentPage() {
     cancelMsg.hidden = false;
   }
 
-  if (flashBanner) {
-    await fetchFlashSale();
+  if (flashBanner && initData.flashSale) {
+    flashSale = initData.flashSale;
+    updateFlashSaleBanner();
   }
 
   // Prefill shipping fields from saved profile
-  const token = localStorage.getItem('token');
-  if (token) {
-    try {
-      const resp = await fetch(`${API_BASE}/profile`, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      if (resp.ok) {
-        const profile = await resp.json();
-        const ship = profile.shipping_info || {};
-        if (ship.name) document.getElementById('ship-name').value = ship.name;
-        if (ship.address) document.getElementById('ship-address').value = ship.address;
-        if (ship.city) document.getElementById('ship-city').value = ship.city;
-        if (ship.zip) document.getElementById('ship-zip').value = ship.zip;
-        await updateEstimate();
-      }
-    } catch {
-      /* ignore profile errors */
-    }
+  if (initData.profile) {
+    const ship = initData.profile.shipping_info || {};
+    if (ship.name) document.getElementById('ship-name').value = ship.name;
+    if (ship.address) document.getElementById('ship-address').value = ship.address;
+    if (ship.city) document.getElementById('ship-city').value = ship.city;
+    if (ship.zip) document.getElementById('ship-zip').value = ship.zip;
+    await updateEstimate();
   }
 
   ['ship-address', 'ship-city', 'ship-zip'].forEach((id) => {


### PR DESCRIPTION
## Summary
- create `/api/payment-init` to bundle flash sale, profile, slots and Stripe key
- use new endpoint in `payment.js` to reduce network requests
- add corresponding unit test

## Testing
- `npm run format`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6851ebdd5568832d85d9d8a97b11083a