### PR TITLE
Add user link and deletion for community creations

### DIFF
--- a/backend/migrations/033_add_user_to_community_creations.sql
+++ b/backend/migrations/033_add_user_to_community_creations.sql
@@ -1,0 +1,2 @@
+ALTER TABLE community_creations
+  ADD COLUMN IF NOT EXISTS user_id UUID REFERENCES users(id);

--- a/backend/scripts/seed-db.js
+++ b/backend/scripts/seed-db.js
@@ -16,12 +16,22 @@ const { Client } = require('pg');
       ['00000000-0000-0000-0000-000000000000', 'Example', {}, {}]
     );
     await client.query(
-      'INSERT INTO community_creations(job_id, title, category) VALUES($1,$2,$3) ON CONFLICT DO NOTHING',
-      ['00000000-0000-0000-0000-000000000000', 'Example Model', 'demo']
+      'INSERT INTO community_creations(job_id, title, category, user_id) VALUES($1,$2,$3,$4) ON CONFLICT DO NOTHING',
+      [
+        '00000000-0000-0000-0000-000000000000',
+        'Example Model',
+        'demo',
+        '00000000-0000-0000-0000-000000000000',
+      ]
     );
     await client.query(
-      'INSERT INTO community_creations(job_id, title, category) VALUES($1,$2,$3) ON CONFLICT DO NOTHING',
-      ['00000000-0000-0000-0000-000000000000', 'Another Model', 'demo']
+      'INSERT INTO community_creations(job_id, title, category, user_id) VALUES($1,$2,$3,$4) ON CONFLICT DO NOTHING',
+      [
+        '00000000-0000-0000-0000-000000000000',
+        'Another Model',
+        'demo',
+        '00000000-0000-0000-0000-000000000000',
+      ]
     );
     // Seed data inserted
   } finally {

--- a/backend/tests/additionalApi.test.js
+++ b/backend/tests/additionalApi.test.js
@@ -230,6 +230,26 @@ test('DELETE /api/models/:id 404 when missing', async () => {
   expect(res.status).toBe(404);
 });
 
+test('DELETE /api/community/:id deletes creation', async () => {
+  db.query.mockResolvedValueOnce({ rows: [{ id: 'c1' }] });
+  const token = jwt.sign({ id: 'u1' }, 'secret');
+  const res = await request(app)
+    .delete('/api/community/c1')
+    .set('authorization', `Bearer ${token}`);
+  expect(res.status).toBe(204);
+  const call = db.query.mock.calls[0][0];
+  expect(call).toContain('DELETE FROM community_creations');
+});
+
+test('DELETE /api/community/:id 404 when missing', async () => {
+  db.query.mockResolvedValueOnce({ rows: [] });
+  const token = jwt.sign({ id: 'u1' }, 'secret');
+  const res = await request(app)
+    .delete('/api/community/bad')
+    .set('authorization', `Bearer ${token}`);
+  expect(res.status).toBe(404);
+});
+
 test('GET /api/community/recent pagination and category', async () => {
   db.query.mockResolvedValueOnce({ rows: [] });
 

--- a/backend/tests/api.test.js
+++ b/backend/tests/api.test.js
@@ -268,7 +268,7 @@ test('POST /api/community submits model', async () => {
   expect(res.status).toBe(201);
   expect(db.query).toHaveBeenCalledWith(
     expect.stringContaining('INSERT INTO community_creations'),
-    ['j1', 'Auto', '']
+    ['j1', 'Auto', '', 'u1']
   );
 });
 
@@ -285,7 +285,7 @@ test('POST /api/community uses BLIP caption for title', async () => {
   expect(res.status).toBe(201);
   expect(db.query).toHaveBeenCalledWith(
     expect.stringContaining('INSERT INTO community_creations'),
-    ['j1', caption, '']
+    ['j1', caption, '', 'u1']
   );
 });
 


### PR DESCRIPTION
## Summary
- track uploader in `community_creations`
- update community submission logic and seeding
- allow users to delete their own creations
- test updates for new parameters and deletion endpoint

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851ebeb0784832dae2b5105d814996f