### PR TITLE
Add daily generation limit

### DIFF
--- a/backend/tests/api.test.js
+++ b/backend/tests/api.test.js
@@ -428,6 +428,16 @@ test('/api/generate saves authenticated user id', async () => {
   expect(insertCall[1][4]).toBe('u1');
 });
 
+test('/api/generate enforces daily limit', async () => {
+  db.query.mockResolvedValueOnce({ rows: [{ count: '50' }] });
+  const token = jwt.sign({ id: 'u1' }, 'secret');
+  const res = await request(app)
+    .post('/api/generate')
+    .set('authorization', `Bearer ${token}`)
+    .send({ prompt: 't' });
+  expect(res.status).toBe(429);
+});
+
 test('/api/generate inserts community row', async () => {
   axios.post.mockResolvedValueOnce({ data: { glb_url: '/m.glb' } });
   await request(app).post('/api/generate').send({ prompt: 't' });

--- a/index.html
+++ b/index.html
@@ -490,6 +490,18 @@
       window.addEventListener('resize', positionQuote);
     </script>
     <div
+      id="limit-popup"
+      class="fixed inset-0 bg-black/70 flex items-center justify-center z-50 hidden"
+    >
+      <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center">
+        <h2 class="text-2xl font-semibold mb-2 text-white">Limit Reached</h2>
+        <p class="mb-4 text-gray-300">
+          You've used up your free models for today. Buy a print to generate 50 more.
+        </p>
+        <button id="limit-close" class="mt-2 px-4 py-2 bg-blue-600 rounded-3xl">OK</button>
+      </div>
+    </div>
+    <div
       id="printclub-modal"
       class="fixed inset-0 bg-black/70 flex items-center justify-center z-50 hidden"
     >

--- a/js/index.js
+++ b/js/index.js
@@ -540,13 +540,18 @@ async function fetchGlb(prompt, files) {
       method: 'POST',
       body: fd,
     });
+    if (r.status === 429) {
+      window.showLimitPopup?.();
+      throw new Error('limit');
+    }
     if (!r.ok) throw new Error();
     const data = await r.json();
     lastJobId = data.jobId;
     return data.glb_url;
   } catch (err) {
-    showError('Generation failed');
-
+    if (err.message !== 'limit') {
+      showError('Generation failed');
+    }
     return FALLBACK_GLB;
   }
 }
@@ -773,6 +778,14 @@ async function init() {
   clubModal?.addEventListener('click', (e) => {
     if (e.target === clubModal) clubModal.classList.add('hidden');
   });
+
+  const limitModal = document.getElementById('limit-popup');
+  const limitClose = document.getElementById('limit-close');
+  limitClose?.addEventListener('click', () => limitModal?.classList.add('hidden'));
+  limitModal?.addEventListener('click', (e) => {
+    if (e.target === limitModal) limitModal.classList.add('hidden');
+  });
+  window.showLimitPopup = () => limitModal?.classList.remove('hidden');
 }
 
 window.initIndexPage = init;


### PR DESCRIPTION
## Summary
- enforce per-user generation limit of 50 models per day
- surface limit on the frontend via a popup
- handle 429 responses when limit reached
- test the new limit behavior

## Testing
- `npm ci`
- `npm run format`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6851ec8f1a4c832db0c14fc5795c8a4b