### PR TITLE
Implement shareable community model links

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -257,6 +257,12 @@
         >
           Add to Basket
         </button>
+        <button
+          id="modal-copy-link"
+          class="absolute bottom-4 left-40 font-bold py-2 px-4 rounded-full shadow-md bg-[#2A2A2E] border border-white/20"
+        >
+          Copy Link
+        </button>
       </div>
     </div>
     <script type="module">
@@ -314,6 +320,14 @@
           if (model) {
             window.addToBasket({ jobId: job, modelUrl: model, snapshot });
           }
+        });
+
+        const copyBtn = document.getElementById('modal-copy-link');
+        copyBtn?.addEventListener('click', () => {
+          const id = copyBtn.dataset.id;
+          if (!id) return;
+          const url = `${window.location.origin}/community/model/${id}`;
+          navigator.clipboard.writeText(url).then(() => alert('Link copied'));
         });
 
         closeBtn.addEventListener('click', close);

--- a/backend/server.js
+++ b/backend/server.js
@@ -872,6 +872,37 @@ app.get('/shared/:slug', async (req, res) => {
   }
 });
 
+app.get('/community/model/:id', async (req, res) => {
+  try {
+    const { rows } = await db.query(
+      `SELECT c.title, j.prompt
+       FROM community_creations c
+       JOIN jobs j ON c.job_id=j.job_id
+       WHERE c.id=$1`,
+      [req.params.id]
+    );
+    if (!rows.length) return res.status(404).send('Not found');
+    const prompt = rows[0].title || rows[0].prompt || 'Community model';
+    const ogImage = `${req.protocol}://${req.get('host')}/img/boxlogo.png`;
+    res.send(`<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta property="og:title" content="print3 community model" />
+    <meta property="og:description" content="${prompt.replace(/"/g, '&quot;')}" />
+    <meta property="og:image" content="${ogImage}" />
+    <meta property="og:url" content="${req.protocol}://${req.get('host')}/community/model/${req.params.id}" />
+  </head>
+  <body>
+    <script>window.location='/share.html?community=${req.params.id}'</script>
+  </body>
+</html>`);
+  } catch (err) {
+    logError(err);
+    res.status(500).send('Server error');
+  }
+});
+
 // Submit a generated model to the community gallery
 app.post('/api/community', authRequired, async (req, res) => {
   const { jobId, title, category } = req.body;
@@ -977,6 +1008,23 @@ app.delete('/api/community/:id', authRequired, async (req, res) => {
   } catch (err) {
     logError(err);
     res.status(500).json({ error: 'Failed to delete creation' });
+  }
+});
+
+app.get('/api/community/model/:id', async (req, res) => {
+  try {
+    const { rows } = await db.query(
+      `SELECT c.id, c.title, c.category, j.job_id, j.model_url, j.prompt
+       FROM community_creations c
+       JOIN jobs j ON c.job_id=j.job_id
+       WHERE c.id=$1`,
+      [req.params.id]
+    );
+    if (!rows.length) return res.status(404).json({ error: 'Not found' });
+    res.json(rows[0]);
+  } catch (err) {
+    logError(err);
+    res.status(500).json({ error: 'Failed to fetch model' });
   }
 });
 

--- a/backend/tests/additionalApi.test.js
+++ b/backend/tests/additionalApi.test.js
@@ -248,6 +248,13 @@ test('GET /api/community/popular uses correct ordering', async () => {
   ]);
 });
 
+test('GET /api/community/model/:id returns model', async () => {
+  db.query.mockResolvedValueOnce({ rows: [{ id: 'c1', model_url: 'u' }] });
+  const res = await request(app).get('/api/community/model/c1');
+  expect(res.status).toBe(200);
+  expect(res.body.id).toBe('c1');
+});
+
 test('GET /api/competitions/active', async () => {
   db.query.mockResolvedValueOnce({ rows: [] });
   const res = await request(app).get('/api/competitions/active');

--- a/js/community.js
+++ b/js/community.js
@@ -170,6 +170,10 @@ function createCard(model) {
       addBasketBtn.dataset.job = model.job_id;
       addBasketBtn.dataset.snapshot = model.snapshot || '';
     }
+    const copyBtn = document.getElementById('modal-copy-link');
+    if (copyBtn) {
+      copyBtn.dataset.id = model.id;
+    }
     modal.classList.remove('hidden');
     const closeBtn = document.getElementById('close-modal');
     const svg = closeBtn?.querySelector('svg');

--- a/js/myCreations.js
+++ b/js/myCreations.js
@@ -15,7 +15,11 @@ function createCard(model) {
   div.addEventListener('click', () => {
     const modal = document.getElementById('model-modal');
     const viewer = modal.querySelector('model-viewer');
+    const copyBtn = document.getElementById('modal-copy-link');
     viewer.src = model.model_url;
+    if (copyBtn) {
+      copyBtn.dataset.id = model.id;
+    }
     modal.classList.remove('hidden');
     document.body.classList.add('overflow-hidden');
   });
@@ -77,6 +81,7 @@ function createObserver() {
 document.addEventListener('DOMContentLoaded', () => {
   const modal = document.getElementById('model-modal');
   const closeBtn = document.getElementById('close-modal');
+  const copyBtn = document.getElementById('modal-copy-link');
   function close() {
     modal.classList.add('hidden');
     document.body.classList.remove('overflow-hidden');
@@ -84,6 +89,12 @@ document.addEventListener('DOMContentLoaded', () => {
   closeBtn.addEventListener('click', close);
   document.addEventListener('keydown', (e) => {
     if (e.key === 'Escape') close();
+  });
+  copyBtn?.addEventListener('click', () => {
+    const id = copyBtn.dataset.id;
+    if (!id) return;
+    const url = `${window.location.origin}/community/model/${id}`;
+    navigator.clipboard.writeText(url).then(() => alert('Link copied'));
   });
   createObserver();
   loadMore();

--- a/js/sharedModel.js
+++ b/js/sharedModel.js
@@ -5,12 +5,16 @@ const API_BASE = (window.API_ORIGIN || '') + '/api';
 document.addEventListener('DOMContentLoaded', async () => {
   const params = new URLSearchParams(window.location.search);
   const slug = params.get('slug');
-  if (!slug) {
+  const community = params.get('community');
+  if (!slug && !community) {
     document.getElementById('error').textContent = 'Missing share link';
     return;
   }
   try {
-    const res = await fetch(`${API_BASE}/shared/${slug}`);
+    const endpoint = slug
+      ? `${API_BASE}/shared/${slug}`
+      : `${API_BASE}/community/model/${community}`;
+    const res = await fetch(endpoint);
     if (!res.ok) throw new Error('bad');
     const data = await res.json();
     const viewer = document.getElementById('viewer');

--- a/my_creations.html
+++ b/my_creations.html
@@ -57,6 +57,7 @@
           <span class="sr-only">Close</span>
         </button>
         <model-viewer src="" alt="3D model preview" environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr" camera-controls auto-rotate class="w-full h-96 bg-[#2A2A2E] rounded-xl"></model-viewer>
+        <button id="modal-copy-link" class="absolute bottom-4 left-4 font-bold py-2 px-4 rounded-full shadow-md bg-[#2A2A2E] border border-white/20 text-white">Copy Link</button>
       </div>
     </div>
     <script type="module" src="js/myCreations.js"></script>


### PR DESCRIPTION
## Summary
- allow fetching a single community model via `/api/community/model/:id`
- serve `/community/model/:id` HTML with OpenGraph metadata
- support both `slug` and `community` params on the shared model page
- add copy link buttons to community modals
- wire up copy link behaviour in `myCreations.js` and `community.js`
- test new community model API endpoint

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851edde6b48832db9d574e91518a645