### PR TITLE
Implement comment system and personal gallery API

### DIFF
--- a/backend/migrations/034_create_community_comments.sql
+++ b/backend/migrations/034_create_community_comments.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS community_comments (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  model_id UUID REFERENCES community_creations(id) ON DELETE CASCADE,
+  user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+  text TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);

--- a/backend/server.js
+++ b/backend/server.js
@@ -996,6 +996,26 @@ app.get('/api/community/popular', async (req, res) => {
   }
 });
 
+app.get('/api/community/mine', authRequired, async (req, res) => {
+  const limit = parseInt(req.query.limit, 10) || 10;
+  const offset = parseInt(req.query.offset, 10) || 0;
+  try {
+    const { rows } = await db.query(
+      `SELECT c.id, c.title, c.category, j.job_id, j.model_url
+       FROM community_creations c
+       JOIN jobs j ON c.job_id=j.job_id
+       WHERE c.user_id=$1
+       ORDER BY c.created_at DESC
+       LIMIT $2 OFFSET $3`,
+      [req.user.id, limit, offset]
+    );
+    res.json(rows);
+  } catch (err) {
+    logError(err);
+    res.status(500).json({ error: 'Failed to fetch creations' });
+  }
+});
+
 app.delete('/api/community/:id', authRequired, async (req, res) => {
   const id = req.params.id;
   try {
@@ -1026,6 +1046,41 @@ app.get('/api/community/model/:id', async (req, res) => {
   } catch (err) {
     logError(err);
     res.status(500).json({ error: 'Failed to fetch model' });
+  }
+});
+
+app.get('/api/community/:id/comments', async (req, res) => {
+  try {
+    const { rows } = await db.query(
+      `SELECT cc.id, cc.text, cc.created_at, u.username
+       FROM community_comments cc
+       JOIN users u ON cc.user_id=u.id
+       WHERE cc.model_id=$1
+       ORDER BY cc.created_at DESC
+       LIMIT 20`,
+      [req.params.id]
+    );
+    res.json(rows);
+  } catch (err) {
+    logError(err);
+    res.status(500).json({ error: 'Failed to fetch comments' });
+  }
+});
+
+app.post('/api/community/:id/comment', authRequired, async (req, res) => {
+  const { text } = req.body;
+  if (!text) return res.status(400).json({ error: 'text required' });
+  try {
+    const { rows } = await db.query(
+      `INSERT INTO community_comments(model_id, user_id, text)
+       VALUES($1,$2,$3)
+       RETURNING id, text, created_at`,
+      [req.params.id, req.user.id, text]
+    );
+    res.status(201).json(rows[0]);
+  } catch (err) {
+    logError(err);
+    res.status(500).json({ error: 'Failed to post comment' });
   }
 });
 

--- a/backend/tests/additionalApi.test.js
+++ b/backend/tests/additionalApi.test.js
@@ -275,6 +275,40 @@ test('GET /api/community/model/:id returns model', async () => {
   expect(res.body.id).toBe('c1');
 });
 
+test('GET /api/community/mine returns creations', async () => {
+  db.query.mockResolvedValueOnce({ rows: [] });
+  const token = jwt.sign({ id: 'u1' }, 'secret');
+  const res = await request(app).get('/api/community/mine').set('authorization', `Bearer ${token}`);
+  expect(res.status).toBe(200);
+  expect(db.query).toHaveBeenCalledWith(expect.stringContaining('WHERE c.user_id=$1'), [
+    'u1',
+    10,
+    0,
+  ]);
+});
+
+test('POST /api/community/:id/comment adds comment', async () => {
+  db.query.mockResolvedValueOnce({ rows: [{ id: 'x', text: 't' }] });
+  const token = jwt.sign({ id: 'u1' }, 'secret');
+  const res = await request(app)
+    .post('/api/community/c1/comment')
+    .set('authorization', `Bearer ${token}`)
+    .send({ text: 't' });
+  expect(res.status).toBe(201);
+  expect(db.query).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO community_comments'), [
+    'c1',
+    'u1',
+    't',
+  ]);
+});
+
+test('GET /api/community/:id/comments returns list', async () => {
+  db.query.mockResolvedValueOnce({ rows: [] });
+  const res = await request(app).get('/api/community/c1/comments');
+  expect(res.status).toBe(200);
+  expect(db.query).toHaveBeenCalledWith(expect.any(String), ['c1']);
+});
+
 test('GET /api/competitions/active', async () => {
   db.query.mockResolvedValueOnce({ rows: [] });
   const res = await request(app).get('/api/competitions/active');


### PR DESCRIPTION
## Summary
- add `community_comments` table migration
- expose `/api/community/mine` endpoint
- add `/api/community/:id/comment` and `/api/community/:id/comments`
- test new endpoints

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6851f8504b34832d8c2c74476ec58b1c