### PR TITLE
Implement trending prints and UI improvements

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -996,6 +996,24 @@ app.get('/api/community/popular', async (req, res) => {
   }
 });
 
+app.get('/api/trending', async (req, res) => {
+  try {
+    const { rows } = await db.query(
+      `SELECT j.job_id, j.model_url, j.snapshot, COALESCE(l.count,0) as likes
+       FROM jobs j
+       LEFT JOIN (SELECT model_id, COUNT(*) as count FROM likes GROUP BY model_id) l
+       ON j.job_id = l.model_id
+       WHERE j.model_url IS NOT NULL
+       ORDER BY likes DESC, j.created_at DESC
+       LIMIT 5`
+    );
+    res.json(rows);
+  } catch (err) {
+    logError(err);
+    res.status(500).json({ error: 'Failed to fetch trending prints' });
+  }
+});
+
 app.delete('/api/community/:id', authRequired, async (req, res) => {
   const id = req.params.id;
   try {

--- a/backend/tests/additionalApi.test.js
+++ b/backend/tests/additionalApi.test.js
@@ -562,3 +562,9 @@ test('GET /api/payment-init bundles payment data', async () => {
   expect(res.body.profile.display_name).toBe('B');
   expect(res.body.publishableKey).toBeDefined();
 });
+
+test('GET /api/trending returns models ordered by likes', async () => {
+  db.query.mockResolvedValueOnce({ rows: [] });
+  await request(app).get('/api/trending');
+  expect(db.query).toHaveBeenCalledWith(expect.stringContaining('ORDER BY likes DESC'));
+});

--- a/backend/tests/frontend/competitions.test.js
+++ b/backend/tests/frontend/competitions.test.js
@@ -38,7 +38,8 @@ test('startCountdown formats remaining time', () => {
   const d = Math.floor(diff / 86400000);
   const h = Math.floor((diff % 86400000) / 3600000);
   const m = Math.floor((diff % 3600000) / 60000);
-  const expected = `${d}d ${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+  const s = Math.floor((diff % 60000) / 1000);
+  const expected = `${d}d ${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
   dom.window.startCountdown(el);
   expect(el.textContent).toBe(expected);
 });

--- a/competitions.html
+++ b/competitions.html
@@ -151,7 +151,7 @@
           <span class="absolute top-1 left-1 bg-black/60 text-xs px-1 rounded">Ended 05/25</span>
           <button class="like absolute bottom-1 right-1 text-xs bg-red-600 px-1 rounded">♥</button>
           <span class="absolute bottom-8 right-1 text-xs bg-black/50 px-1 rounded" id="likes-helmet">0</span>
-          <button class="purchase absolute bottom-1 left-1 font-bold text-lg py-2 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]">Buy</button>
+          <button class="purchase absolute bottom-1 left-1 font-bold text-lg py-2 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]">Order Print</button>
         </div>
         <div
           class="model-card relative h-32 bg-[#2A2A2E] border border-white/10 rounded-xl hover:bg-[#3A3A3E] transition-shape flex items-center justify-center cursor-pointer"
@@ -166,7 +166,7 @@
           <span class="absolute top-1 left-1 bg-black/60 text-xs px-1 rounded">Ended 03/24</span>
           <button class="like absolute bottom-1 right-1 text-xs bg-red-600 px-1 rounded">♥</button>
           <span class="absolute bottom-8 right-1 text-xs bg-black/50 px-1 rounded" id="likes-fox">0</span>
-          <button class="purchase absolute bottom-1 left-1 font-bold text-lg py-2 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]">Buy</button>
+          <button class="purchase absolute bottom-1 left-1 font-bold text-lg py-2 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]">Order Print</button>
         </div>
         <div
           class="model-card relative h-32 bg-[#2A2A2E] border border-white/10 rounded-xl hover:bg-[#3A3A3E] transition-shape flex items-center justify-center cursor-pointer"
@@ -181,9 +181,13 @@
           <span class="absolute top-1 left-1 bg-black/60 text-xs px-1 rounded">Ended 01/23</span>
           <button class="like absolute bottom-1 right-1 text-xs bg-red-600 px-1 rounded">♥</button>
           <span class="absolute bottom-8 right-1 text-xs bg-black/50 px-1 rounded" id="likes-boombox">0</span>
-          <button class="purchase absolute bottom-1 left-1 font-bold text-lg py-2 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]">Buy</button>
+          <button class="purchase absolute bottom-1 left-1 font-bold text-lg py-2 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]">Order Print</button>
         </div>
       </div>
+      <section class="mt-8">
+        <h2 class="text-2xl">Trending Prints</h2>
+        <div id="trending-prints" class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4 mt-4"></div>
+      </section>
     </main>
     <div
       id="enter-modal"


### PR DESCRIPTION
## Summary
- show "Order Print" button to open model modal
- add countdown seconds with 1s updates
- load trending prints from new `/api/trending` endpoint
- include trending prints section in `competitions.html`
- test new API and countdown behavior

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851f858cf1c832d8a12892cf7848172