### PR TITLE
Add Manage Subscription portal link

### DIFF
--- a/backend/tests/subscriptions.test.js
+++ b/backend/tests/subscriptions.test.js
@@ -16,6 +16,11 @@ jest.mock('../db', () => ({
 }));
 const db = require('../db');
 
+jest.mock('stripe');
+const Stripe = require('stripe');
+const stripeMock = { billingPortal: { sessions: { create: jest.fn() } } };
+Stripe.mockImplementation(() => stripeMock);
+
 const request = require('supertest');
 const app = require('../server');
 const jwt = require('jsonwebtoken');
@@ -52,4 +57,25 @@ test('GET /api/subscription/credits returns remaining', async () => {
     .set('authorization', `Bearer ${token}`);
   expect(res.status).toBe(200);
   expect(res.body.remaining).toBe(1);
+});
+
+test('POST /api/subscription/portal returns url', async () => {
+  db.getSubscription.mockResolvedValueOnce({ stripe_customer_id: 'cus_1' });
+  stripeMock.billingPortal.sessions.create.mockResolvedValueOnce({ url: 'u' });
+  const token = jwt.sign({ id: 'u1' }, 'secret');
+  const res = await request(app)
+    .post('/api/subscription/portal')
+    .set('authorization', `Bearer ${token}`);
+  expect(res.status).toBe(200);
+  expect(res.body.url).toBe('u');
+  expect(stripeMock.billingPortal.sessions.create).toHaveBeenCalled();
+});
+
+test('POST /api/subscription/portal 404 without customer', async () => {
+  db.getSubscription.mockResolvedValueOnce(null);
+  const token = jwt.sign({ id: 'u1' }, 'secret');
+  const res = await request(app)
+    .post('/api/subscription/portal')
+    .set('authorization', `Bearer ${token}`);
+  expect(res.status).toBe(404);
 });

--- a/js/account.js
+++ b/js/account.js
@@ -31,7 +31,9 @@ async function loadSubscription() {
     if (!sub || sub.active === false || sub.status === 'canceled') {
       if (manage) {
         manage.textContent = 'Join Print Club';
-        manage.href = 'payment.html';
+        manage.onclick = () => {
+          window.location.href = 'payment.html';
+        };
       }
       return;
     }
@@ -49,10 +51,26 @@ async function loadSubscription() {
     document.getElementById('credits-total').textContent = credits.total;
     if (manage) {
       manage.textContent = 'Manage subscription';
-      manage.href = 'subscription_settings.html';
+      manage.onclick = openPortal;
     }
   } catch (err) {
     console.error('Failed to load subscription info', err);
+  }
+}
+
+async function openPortal() {
+  const token = localStorage.getItem('token');
+  if (!token) {
+    window.location.href = 'login.html';
+    return;
+  }
+  const res = await fetch(`${API_BASE}/subscription/portal`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (res.ok) {
+    const data = await res.json();
+    window.location.href = data.url;
   }
 }
 

--- a/my_profile.html
+++ b/my_profile.html
@@ -187,6 +187,10 @@
         >
           Upgrade
         </button>
+        <button
+          id="manage-subscription"
+          class="mt-2 px-3 py-1 bg-blue-600 rounded-3xl"
+        ></button>
       </div>
 
       <div id="orders" class="bg-[#2A2A2E] border border-white/10 p-6 rounded-3xl w-full mb-6">


### PR DESCRIPTION
## Summary
- add backend route for creating Stripe customer portal sessions
- show Manage Subscription button on profile page
- handle button click to open portal
- test new `/api/subscription/portal` endpoint

## Testing
- `npm run format`
- `npm run test-ci`


------
https://chatgpt.com/codex/tasks/task_e_6851f85fc9b0832db035f8208a41edd2