### PR TITLE
Add community comments and personal gallery

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -145,6 +145,40 @@ async function insertReferralEvent(referrerId, type) {
   await query('INSERT INTO referral_events(referrer_id, type) VALUES($1,$2)', [referrerId, type]);
 }
 
+async function getUserCreations(userId, limit = 10, offset = 0) {
+  const { rows } = await query(
+    `SELECT c.id, c.title, c.category, j.job_id, j.model_url
+     FROM community_creations c
+     JOIN jobs j ON c.job_id=j.job_id
+     WHERE c.user_id=$1
+     ORDER BY c.created_at DESC
+     LIMIT $2 OFFSET $3`,
+    [userId, limit, offset]
+  );
+  return rows;
+}
+
+async function insertCommunityComment(modelId, userId, text) {
+  const { rows } = await query(
+    'INSERT INTO community_comments(model_id, user_id, text) VALUES($1,$2,$3) RETURNING id, text, created_at',
+    [modelId, userId, text]
+  );
+  return rows[0];
+}
+
+async function getCommunityComments(modelId, limit = 20) {
+  const { rows } = await query(
+    `SELECT cc.id, cc.text, cc.created_at, u.username
+     FROM community_comments cc
+     JOIN users u ON cc.user_id=u.id
+     WHERE cc.model_id=$1
+     ORDER BY cc.created_at ASC
+     LIMIT $2`,
+    [modelId, limit]
+  );
+  return rows;
+}
+
 module.exports = {
   query,
   insertShare,
@@ -163,4 +197,7 @@ module.exports = {
   adjustRewardPoints,
   getUserIdForReferral,
   insertReferralEvent,
+  getUserCreations,
+  insertCommunityComment,
+  getCommunityComments,
 };

--- a/backend/migrations/034_create_community_comments.sql
+++ b/backend/migrations/034_create_community_comments.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS community_comments (
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  model_id UUID REFERENCES community_creations(id) ON DELETE CASCADE,
+  user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+  text TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS community_comments_model_idx ON community_comments(model_id);
+
+CREATE TRIGGER community_comments_set_updated
+BEFORE UPDATE ON community_comments
+FOR EACH ROW EXECUTE PROCEDURE set_updated_at();

--- a/backend/server.js
+++ b/backend/server.js
@@ -996,6 +996,18 @@ app.get('/api/community/popular', async (req, res) => {
   }
 });
 
+app.get('/api/community/mine', authRequired, async (req, res) => {
+  const limit = parseInt(req.query.limit, 10) || 10;
+  const offset = parseInt(req.query.offset, 10) || 0;
+  try {
+    const rows = await db.getUserCreations(req.user.id, limit, offset);
+    res.json(rows);
+  } catch (err) {
+    logError(err);
+    res.status(500).json({ error: 'Failed to fetch creations' });
+  }
+});
+
 app.delete('/api/community/:id', authRequired, async (req, res) => {
   const id = req.params.id;
   try {
@@ -1026,6 +1038,28 @@ app.get('/api/community/model/:id', async (req, res) => {
   } catch (err) {
     logError(err);
     res.status(500).json({ error: 'Failed to fetch model' });
+  }
+});
+
+app.get('/api/community/:id/comments', async (req, res) => {
+  try {
+    const comments = await db.getCommunityComments(req.params.id);
+    res.json(comments);
+  } catch (err) {
+    logError(err);
+    res.status(500).json({ error: 'Failed to fetch comments' });
+  }
+});
+
+app.post('/api/community/:id/comment', authRequired, async (req, res) => {
+  const { text } = req.body || {};
+  if (!text) return res.status(400).json({ error: 'text required' });
+  try {
+    const comment = await db.insertCommunityComment(req.params.id, req.user.id, text);
+    res.status(201).json(comment);
+  } catch (err) {
+    logError(err);
+    res.status(500).json({ error: 'Failed to post comment' });
   }
 });
 

--- a/backend/tests/api.test.js
+++ b/backend/tests/api.test.js
@@ -7,6 +7,9 @@ process.env.HUNYUAN_SERVER_URL = 'http://localhost:4000';
 jest.mock('../db', () => ({
   query: jest.fn().mockResolvedValue({ rows: [] }),
   insertCommission: jest.fn().mockResolvedValue({}),
+  getUserCreations: jest.fn().mockResolvedValue([]),
+  insertCommunityComment: jest.fn().mockResolvedValue({}),
+  getCommunityComments: jest.fn().mockResolvedValue([]),
 }));
 const db = require('../db');
 
@@ -331,6 +334,38 @@ test('GET /api/community/recent pagination and category', async () => {
   db.query.mockResolvedValueOnce({ rows: [] });
   await request(app).get('/api/community/recent?limit=5&offset=2&category=art&search=bot');
   expect(db.query).toHaveBeenCalledWith(expect.any(String), [5, 2, 'art', 'bot']);
+});
+
+test('GET /api/community/mine returns creations', async () => {
+  db.getUserCreations.mockResolvedValueOnce([]);
+  const token = jwt.sign({ id: 'u1' }, 'secret');
+  await request(app).get('/api/community/mine').set('authorization', `Bearer ${token}`);
+  expect(db.getUserCreations).toHaveBeenCalledWith('u1', 10, 0);
+});
+
+test('POST /api/community/:id/comment requires auth', async () => {
+  const res = await request(app).post('/api/community/5/comment').send({ text: 'hi' });
+  expect(res.status).toBe(401);
+});
+
+test('POST /api/community/:id/comment', async () => {
+  db.insertCommunityComment.mockResolvedValueOnce({ id: 'c1', text: 'hi' });
+  const token = jwt.sign({ id: 'u1' }, 'secret');
+  const res = await request(app)
+    .post('/api/community/5/comment')
+    .set('authorization', `Bearer ${token}`)
+    .send({ text: 'hi' });
+  expect(res.status).toBe(201);
+  expect(res.body.text).toBe('hi');
+  expect(db.insertCommunityComment).toHaveBeenCalledWith('5', 'u1', 'hi');
+});
+
+test('GET /api/community/:id/comments', async () => {
+  db.getCommunityComments.mockResolvedValueOnce([{ id: 'c1', text: 'hello' }]);
+  const res = await request(app).get('/api/community/5/comments');
+  expect(res.status).toBe(200);
+  expect(res.body[0].text).toBe('hello');
+  expect(db.getCommunityComments).toHaveBeenCalledWith('5');
 });
 
 test('Admin create competition', async () => {

--- a/backend/tests/frontend/flashBanner.test.js
+++ b/backend/tests/frontend/flashBanner.test.js
@@ -8,7 +8,7 @@ const { JSDOM } = require('jsdom');
 function setupDom() {
   const html = fs
     .readFileSync(path.join(__dirname, '../../../payment.html'), 'utf8')
-    .replace(/<script[^>]+src="https?:\/\/[^"]+"><\/script>/g, '')
+    .replace(/<script[^>]+src="https?:\/\/[^"]+"[^>]*><\/script>/g, '')
     .replace(/<link[^>]+href="https?:\/\/[^"]+[^>]*>/g, '')
     .replace(/<script[^>]+src="js\/modelViewerTouchFix.js"[^>]*><\/script>/, '');
   const dom = new JSDOM(html, {


### PR DESCRIPTION
## Summary
- support user-owned community gallery
- allow posting and retrieving community comments
- add migration for community_comments table
- update frontend flashBanner test regex for remote scripts
- test new community endpoints

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851f865117c832d87ff9443965cf6bd