### PR TITLE
Bundle subscription summary endpoint

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -669,6 +669,22 @@ app.get('/api/subscription/credits', authRequired, async (req, res) => {
   }
 });
 
+app.get('/api/subscription/summary', authRequired, async (req, res) => {
+  try {
+    const subscription = (await db.getSubscription(req.user.id)) || { active: false };
+    await db.ensureCurrentWeekCredits(req.user.id, 2);
+    const creditsRow = await db.getCurrentWeekCredits(req.user.id);
+    const credits = {
+      remaining: creditsRow.total_credits - creditsRow.used_credits,
+      total: creditsRow.total_credits,
+    };
+    res.json({ subscription, credits });
+  } catch (err) {
+    logError(err);
+    res.status(500).json({ error: 'Failed to fetch summary' });
+  }
+});
+
 app.get('/api/referral-link', authRequired, async (req, res) => {
   try {
     const code = await db.getOrCreateReferralLink(req.user.id);

--- a/backend/tests/subscriptions.test.js
+++ b/backend/tests/subscriptions.test.js
@@ -53,3 +53,13 @@ test('GET /api/subscription/credits returns remaining', async () => {
   expect(res.status).toBe(200);
   expect(res.body.remaining).toBe(1);
 });
+
+test('GET /api/subscription/summary returns subscription and credits', async () => {
+  const token = jwt.sign({ id: 'u1' }, 'secret');
+  const res = await request(app)
+    .get('/api/subscription/summary')
+    .set('authorization', `Bearer ${token}`);
+  expect(res.status).toBe(200);
+  expect(res.body.subscription.status).toBe('active');
+  expect(res.body.credits.remaining).toBe(1);
+});

--- a/js/account.js
+++ b/js/account.js
@@ -21,11 +21,11 @@ async function loadSubscription() {
   const token = localStorage.getItem('token');
   if (!token) return;
   try {
-    const subRes = await fetch(`${API_BASE}/subscription`, {
+    const resp = await fetch(`${API_BASE}/subscription/summary`, {
       headers: { Authorization: `Bearer ${token}` },
     });
-    if (!subRes.ok) return;
-    const sub = await subRes.json();
+    if (!resp.ok) return;
+    const { subscription: sub, credits } = await resp.json();
     const container = document.getElementById('subscription-progress');
     const manage = document.getElementById('manage-subscription');
     if (!sub || sub.active === false || sub.status === 'canceled') {
@@ -35,11 +35,6 @@ async function loadSubscription() {
       }
       return;
     }
-    const creditsRes = await fetch(`${API_BASE}/subscription/credits`, {
-      headers: { Authorization: `Bearer ${token}` },
-    });
-    if (!creditsRes.ok) return;
-    const credits = await creditsRes.json();
     if (container) container.classList.remove('hidden');
     const used = credits.total - credits.remaining;
     const pct = credits.total ? (used / credits.total) * 100 : 0;


### PR DESCRIPTION
## Summary
- add `/api/subscription/summary` route bundling subscription and credit data
- call new endpoint from `account.js`
- test new route

## Validation
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6851f88fa8cc832d8b234c43e95a55cb