### PR TITLE
Add social share buttons and snapshot meta

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -853,15 +853,17 @@ app.get('/api/shared/:slug', async (req, res) => {
   try {
     const share = await db.getShareBySlug(req.params.slug);
     if (!share) return res.status(404).json({ error: 'Share not found' });
-    const { rows } = await db.query('SELECT prompt, model_url FROM jobs WHERE job_id=$1', [
-      share.job_id,
-    ]);
+    const { rows } = await db.query(
+      'SELECT prompt, model_url, snapshot FROM jobs WHERE job_id=$1',
+      [share.job_id]
+    );
     if (!rows.length) return res.status(404).json({ error: 'Share not found' });
     res.json({
       jobId: share.job_id,
       slug: share.slug,
       model_url: rows[0].model_url,
       prompt: rows[0].prompt,
+      snapshot: rows[0].snapshot,
     });
   } catch (err) {
     logError(err);
@@ -873,11 +875,14 @@ app.get('/shared/:slug', async (req, res) => {
   try {
     const share = await db.getShareBySlug(req.params.slug);
     if (!share) return res.status(404).send('Not found');
-    const { rows } = await db.query('SELECT prompt, model_url FROM jobs WHERE job_id=$1', [
-      share.job_id,
-    ]);
+    const { rows } = await db.query(
+      'SELECT prompt, model_url, snapshot FROM jobs WHERE job_id=$1',
+      [share.job_id]
+    );
     const prompt = rows[0]?.prompt || 'Shared model';
-    const ogImage = `${req.protocol}://${req.get('host')}/img/boxlogo.png`;
+    const ogImage = rows[0]?.snapshot
+      ? `${req.protocol}://${req.get('host')}${rows[0].snapshot}`
+      : `${req.protocol}://${req.get('host')}/img/boxlogo.png`;
     res.send(`<!doctype html>
 <html lang="en">
   <head>

--- a/backend/tests/additionalApi.test.js
+++ b/backend/tests/additionalApi.test.js
@@ -482,10 +482,13 @@ test('POST /api/create-order rejects unknown job', async () => {
 
 test('GET /api/shared/:slug returns data', async () => {
   db.getShareBySlug = jest.fn().mockResolvedValue({ job_id: 'j1', slug: 's1' });
-  db.query.mockResolvedValueOnce({ rows: [{ prompt: 'p', model_url: '/m.glb' }] });
+  db.query.mockResolvedValueOnce({
+    rows: [{ prompt: 'p', model_url: '/m.glb', snapshot: '/s.png' }],
+  });
   const res = await request(app).get('/api/shared/s1');
   expect(res.status).toBe(200);
   expect(res.body.model_url).toBe('/m.glb');
+  expect(res.body.snapshot).toBe('/s.png');
 });
 
 test('GET /api/shared/:slug 404 when missing', async () => {

--- a/backend/tests/frontend/sharedModel.test.js
+++ b/backend/tests/frontend/sharedModel.test.js
@@ -24,11 +24,13 @@ function setup(url) {
 test('loads model from API', async () => {
   const dom = setup('http://localhost/share.html?slug=test');
   dom.window.fetch = jest.fn(() =>
-    Promise.resolve({ ok: true, json: () => ({ model_url: 'foo.glb' }) })
+    Promise.resolve({ ok: true, json: () => ({ model_url: 'foo.glb', snapshot: '/s.png' }) })
   );
   dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
   await new Promise((r) => setTimeout(r, 0));
-  expect(dom.window.document.getElementById('viewer').src).toContain('foo.glb');
+  const viewer = dom.window.document.getElementById('viewer');
+  expect(viewer.src).toContain('foo.glb');
+  expect(viewer.getAttribute('poster')).toBe('/s.png');
 });
 
 test('shows error when slug missing', () => {

--- a/js/sharedModel.js
+++ b/js/sharedModel.js
@@ -18,7 +18,14 @@ document.addEventListener('DOMContentLoaded', async () => {
     if (!res.ok) throw new Error('bad');
     const data = await res.json();
     const viewer = document.getElementById('viewer');
+    if (data.snapshot) {
+      viewer.setAttribute('poster', data.snapshot);
+    }
     viewer.src = data.model_url;
+    const copyBtn = document.getElementById('copy-link');
+    copyBtn?.addEventListener('click', () => {
+      navigator.clipboard.writeText(window.location.href).then(() => alert('Link copied'));
+    });
   } catch (err) {
     document.getElementById('error').textContent = 'Failed to load model';
   }

--- a/library.html
+++ b/library.html
@@ -47,12 +47,51 @@
       >
         My Library
       </h1>
-      <button
-        id="logout-btn"
-        class="bg-[#2A2A2E] border border-white/10 rounded-3xl px-3 py-2 text-sm hover:bg-[#3A3A3E] transition-shape"
-      >
-        Log Out
-      </button>
+      <div class="flex items-center space-x-2">
+        <button
+          id="logout-btn"
+          class="bg-[#2A2A2E] border border-white/10 rounded-3xl px-3 py-2 text-sm hover:bg-[#3A3A3E] transition-shape"
+        >
+          Log Out
+        </button>
+        <div class="flex space-x-2">
+          <button
+            class="w-9 h-9 flex-shrink-0 flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-full hover:bg-[#3A3A3E] transition-shape"
+            onclick="shareOn('twitter')"
+            aria-label="Share on Twitter"
+          >
+            <i class="fab fa-twitter"></i>
+          </button>
+          <button
+            class="w-9 h-9 flex-shrink-0 flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-full hover:bg-[#3A3A3E] transition-shape"
+            onclick="shareOn('facebook')"
+            aria-label="Share on Facebook"
+          >
+            <i class="fab fa-facebook-f"></i>
+          </button>
+          <button
+            class="w-9 h-9 flex-shrink-0 flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-full hover:bg-[#3A3A3E] transition-shape"
+            onclick="shareOn('reddit')"
+            aria-label="Share on Reddit"
+          >
+            <i class="fab fa-reddit-alien"></i>
+          </button>
+          <button
+            class="w-9 h-9 flex-shrink-0 flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-full hover:bg-[#3A3A3E] transition-shape"
+            onclick="shareOn('tiktok')"
+            aria-label="Share on TikTok"
+          >
+            <i class="fab fa-tiktok"></i>
+          </button>
+          <button
+            class="w-9 h-9 flex-shrink-0 flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-full hover:bg-[#3A3A3E] transition-shape"
+            onclick="shareOn('instagram')"
+            aria-label="Share on Instagram"
+          >
+            <i class="fab fa-instagram"></i>
+          </button>
+        </div>
+      </div>
     </header>
     <main class="flex-1 px-6 py-4">
       <div id="orders" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4"></div>
@@ -93,5 +132,9 @@
     </div>
     <script type="module" src="js/library.js"></script>
     <script type="module" src="js/basket.js"></script>
+    <script type="module">
+      import { shareOn } from './js/share.js';
+      window.shareOn = shareOn;
+    </script>
   </body>
 </html>

--- a/share.html
+++ b/share.html
@@ -54,6 +54,34 @@
         >
           <i class="fab fa-facebook-f"></i>
         </button>
+        <button
+          onclick="shareOn('reddit')"
+          aria-label="Share on Reddit"
+          class="w-9 h-9 flex-shrink-0 flex items-center justify-center bg-[#1A1A1D] border border-white/10 rounded hover:bg-[#3A3A3E]"
+        >
+          <i class="fab fa-reddit-alien"></i>
+        </button>
+        <button
+          onclick="shareOn('tiktok')"
+          aria-label="Share on TikTok"
+          class="w-9 h-9 flex-shrink-0 flex items-center justify-center bg-[#1A1A1D] border border-white/10 rounded hover:bg-[#3A3A3E]"
+        >
+          <i class="fab fa-tiktok"></i>
+        </button>
+        <button
+          onclick="shareOn('instagram')"
+          aria-label="Share on Instagram"
+          class="w-9 h-9 flex-shrink-0 flex items-center justify-center bg-[#1A1A1D] border border-white/10 rounded hover:bg-[#3A3A3E]"
+        >
+          <i class="fab fa-instagram"></i>
+        </button>
+        <button
+          id="copy-link"
+          aria-label="Copy Link"
+          class="w-9 h-9 flex-shrink-0 flex items-center justify-center bg-[#1A1A1D] border border-white/10 rounded hover:bg-[#3A3A3E]"
+        >
+          <i class="fas fa-link"></i>
+        </button>
       </div>
     </header>
     <main class="flex-1 flex items-center justify-center p-4">


### PR DESCRIPTION
## Summary
- reuse share buttons on library page
- expand network options on share page with copy-link
- load snapshots in `share.html` and export via `/api/shared`
- use snapshot as OG image in `/shared/:slug`
- update unit tests accordingly

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851f8afc2fc832d8c2a4ff6982bc51c