### PR TITLE
Implement trending prints and purchase buttons

### DIFF
--- a/backend/tests/additionalApi.test.js
+++ b/backend/tests/additionalApi.test.js
@@ -562,3 +562,10 @@ test('GET /api/payment-init bundles payment data', async () => {
   expect(res.body.profile.display_name).toBe('B');
   expect(res.body.publishableKey).toBeDefined();
 });
+
+test('GET /api/trending returns list', async () => {
+  db.query.mockResolvedValueOnce({ rows: [{ job_id: 'j1', model_url: '/m.glb' }] });
+  const res = await request(app).get('/api/trending');
+  expect(res.status).toBe(200);
+  expect(res.body[0].job_id).toBe('j1');
+});

--- a/competitions.html
+++ b/competitions.html
@@ -184,6 +184,8 @@
           <button class="purchase absolute bottom-1 left-1 font-bold text-lg py-2 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]">Buy</button>
         </div>
       </div>
+      <h2 class="text-2xl mt-8">Trending Prints</h2>
+      <div id="trending-prints" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 mt-4"></div>
     </main>
     <div
       id="enter-modal"


### PR DESCRIPTION
## Summary
- add purchase buttons for past winners and trending prints section
- implement `/api/trending` endpoint and extend past competitions response
- fetch trending prints and past winners in the competitions page
- add tests for trending endpoint

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851f8c43394832d8922b37a0a8a9aab