### PR TITLE
Execute mailing list automation tasks

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -145,6 +145,23 @@ async function insertReferralEvent(referrerId, type) {
   await query('INSERT INTO referral_events(referrer_id, type) VALUES($1,$2)', [referrerId, type]);
 }
 
+async function upsertMailingListEntry(email, token) {
+  return query(
+    `INSERT INTO mailing_list(email, token)
+     VALUES($1,$2)
+     ON CONFLICT (email) DO UPDATE SET token=$2, confirmed=FALSE, unsubscribed=FALSE`,
+    [email, token]
+  );
+}
+
+async function confirmMailingListEntry(token) {
+  return query('UPDATE mailing_list SET confirmed=TRUE WHERE token=$1', [token]);
+}
+
+async function unsubscribeMailingListEntry(token) {
+  return query('UPDATE mailing_list SET unsubscribed=TRUE WHERE token=$1', [token]);
+}
+
 module.exports = {
   query,
   insertShare,
@@ -163,4 +180,7 @@ module.exports = {
   adjustRewardPoints,
   getUserIdForReferral,
   insertReferralEvent,
+  upsertMailingListEntry,
+  confirmMailingListEntry,
+  unsubscribeMailingListEntry,
 };

--- a/backend/server.js
+++ b/backend/server.js
@@ -28,6 +28,7 @@ const {
   incrementDiscountUsage,
   createTimedCode,
 } = require('./discountCodes');
+const syncMailingList = require('./scripts/sync-mailing-list');
 const REWARD_OPTIONS = { 100: 500, 200: 1000 };
 const ADMIN_TOKEN = process.env.ADMIN_TOKEN || 'admin';
 
@@ -131,6 +132,10 @@ app.post('/api/register', async (req, res) => {
       rows[0].id,
       displayName,
     ]);
+    const mlToken = uuidv4();
+    await db.upsertMailingListEntry(email, mlToken);
+    const confirmUrl = `${req.headers.origin}/api/confirm-subscription?token=${mlToken}`;
+    await sendMail(email, 'Confirm Subscription', `Click to confirm: ${confirmUrl}`);
     const token = jwt.sign({ id: rows[0].id, username, isAdmin: false }, AUTH_SECRET);
     res.json({ token, isAdmin: false });
   } catch (err) {
@@ -1479,11 +1484,7 @@ app.post('/api/subscribe', async (req, res) => {
   if (!email) return res.status(400).json({ error: 'Email required' });
   const token = uuidv4();
   try {
-    await db.query(
-      `INSERT INTO mailing_list(email, token) VALUES($1,$2)
-       ON CONFLICT (email) DO UPDATE SET token=$2, confirmed=FALSE`,
-      [email, token]
-    );
+    await db.upsertMailingListEntry(email, token);
     const url = `${req.headers.origin}/api/confirm-subscription?token=${token}`;
     await sendMail(email, 'Confirm Subscription', `Click to confirm: ${url}`);
     res.sendStatus(204);
@@ -1498,11 +1499,7 @@ app.post('/api/competitions/subscribe', async (req, res) => {
   if (!email) return res.status(400).json({ error: 'Email required' });
   const token = uuidv4();
   try {
-    await db.query(
-      `INSERT INTO mailing_list(email, token) VALUES($1,$2)
-       ON CONFLICT (email) DO UPDATE SET token=$2, confirmed=FALSE, unsubscribed=FALSE`,
-      [email, token]
-    );
+    await db.upsertMailingListEntry(email, token);
     const url = `${req.headers.origin}/api/confirm-subscription?token=${token}`;
     await sendMail(email, 'Confirm Subscription', `Click to confirm: ${url}`);
     res.sendStatus(204);
@@ -1516,11 +1513,23 @@ app.get('/api/confirm-subscription', async (req, res) => {
   const { token } = req.query;
   if (!token) return res.status(400).send('Invalid token');
   try {
-    await db.query('UPDATE mailing_list SET confirmed=TRUE WHERE token=$1', [token]);
+    await db.confirmMailingListEntry(token);
     res.send('Subscription confirmed');
   } catch (err) {
     logError(err);
     res.status(500).send('Failed to confirm');
+  }
+});
+
+app.get('/api/unsubscribe', async (req, res) => {
+  const { token } = req.query;
+  if (!token) return res.status(400).send('Invalid token');
+  try {
+    await db.unsubscribeMailingListEntry(token);
+    res.send('You have been unsubscribed');
+  } catch (err) {
+    logError(err);
+    res.status(500).send('Failed to unsubscribe');
   }
 });
 
@@ -1647,6 +1656,13 @@ if (require.main === module) {
   initDailyPrintsSold();
   checkCompetitionStart();
   setInterval(checkCompetitionStart, 3600000);
+  syncMailingList().catch((err) => logError('Mail sync failed', err));
+  setInterval(
+    () => {
+      syncMailingList().catch((err) => logError('Mail sync failed', err));
+    },
+    24 * 3600 * 1000
+  );
 }
 
 module.exports = app;

--- a/backend/tests/api.test.js
+++ b/backend/tests/api.test.js
@@ -7,9 +7,14 @@ process.env.HUNYUAN_SERVER_URL = 'http://localhost:4000';
 jest.mock('../db', () => ({
   query: jest.fn().mockResolvedValue({ rows: [] }),
   insertCommission: jest.fn().mockResolvedValue({}),
+  upsertMailingListEntry: jest.fn().mockResolvedValue({}),
+  confirmMailingListEntry: jest.fn().mockResolvedValue({}),
+  unsubscribeMailingListEntry: jest.fn().mockResolvedValue({}),
 }));
 const db = require('../db');
 
+jest.mock('../mail', () => ({ sendMail: jest.fn() }));
+const { sendMail } = require('../mail');
 jest.mock('axios');
 const axios = require('axios');
 const jwt = require('jsonwebtoken');
@@ -59,6 +64,10 @@ const stream = require('stream');
 beforeEach(() => {
   db.query.mockClear();
   db.insertCommission.mockClear();
+  db.upsertMailingListEntry.mockClear();
+  db.confirmMailingListEntry.mockClear();
+  db.unsubscribeMailingListEntry.mockClear();
+  sendMail.mockClear();
   axios.post.mockClear();
   enqueuePrint.mockClear();
   getShippingEstimate.mockClear();

--- a/backend/tests/mailingList.test.js
+++ b/backend/tests/mailingList.test.js
@@ -1,0 +1,43 @@
+process.env.STRIPE_SECRET_KEY = 'test';
+process.env.STRIPE_WEBHOOK_SECRET = 'whsec';
+process.env.DB_URL = 'postgres://user:pass@localhost/db';
+process.env.HUNYUAN_API_KEY = 'test';
+process.env.HUNYUAN_SERVER_URL = 'http://localhost:4000';
+
+jest.mock('../db', () => ({
+  upsertMailingListEntry: jest.fn().mockResolvedValue({}),
+  confirmMailingListEntry: jest.fn().mockResolvedValue({}),
+  unsubscribeMailingListEntry: jest.fn().mockResolvedValue({}),
+  query: jest.fn().mockResolvedValue({ rows: [] }),
+  insertCommission: jest.fn().mockResolvedValue({}),
+}));
+const db = require('../db');
+
+jest.mock('../mail', () => ({ sendMail: jest.fn() }));
+const { sendMail } = require('../mail');
+
+const request = require('supertest');
+const app = require('../server');
+
+beforeEach(() => {
+  db.upsertMailingListEntry.mockClear();
+  db.unsubscribeMailingListEntry.mockClear();
+  sendMail.mockClear();
+});
+
+test('POST /api/subscribe stores address and sends email', async () => {
+  const res = await request(app).post('/api/subscribe').send({ email: 'a@a.com' });
+  expect(res.status).toBe(204);
+  expect(db.upsertMailingListEntry).toHaveBeenCalled();
+  expect(sendMail).toHaveBeenCalledWith(
+    'a@a.com',
+    'Confirm Subscription',
+    expect.stringContaining('/api/confirm-subscription?token=')
+  );
+});
+
+test('GET /api/unsubscribe marks unsubscribed', async () => {
+  const res = await request(app).get('/api/unsubscribe?token=t1');
+  expect(res.text).toMatch(/unsubscribed/i);
+  expect(db.unsubscribeMailingListEntry).toHaveBeenCalledWith('t1');
+});


### PR DESCRIPTION
## Summary
- add mailing list DB helpers
- hook registration flow to subscribe new users
- add unsubscribe endpoint and schedule daily sync
- test mailing list routes
- adjust API tests for new mocks

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6851f8d0ed1c832db330420cb0dffaea