### PR TITLE
Implement print club maintenance scripts

### DIFF
--- a/backend/email_templates/reminder.txt
+++ b/backend/email_templates/reminder.txt
@@ -1,0 +1,5 @@
+Hi {{username}},
+
+You still have unused Print Club credits this month. Be sure to redeem your prints before they reset!
+
+Thanks for being a member.

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,6 +13,8 @@
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "send-reminders": "node scripts/send-purchase-reminders.js",
     "send-followups": "node scripts/send-post-purchase-followups.js",
+    "reset-credits": "node scripts/weekly-reset.js",
+    "send-printclub-reminders": "node scripts/send-printclub-reminders.js",
     "cleanup-tokens": "node scripts/cleanup-password-resets.js",
     "measure-load": "node scripts/measure-load.js",
     "lint": "eslint . --max-warnings=0"

--- a/backend/scripts/send-printclub-reminders.js
+++ b/backend/scripts/send-printclub-reminders.js
@@ -1,0 +1,33 @@
+require('dotenv').config();
+const { Client } = require('pg');
+const { sendTemplate } = require('../mail');
+
+async function sendReminders() {
+  const client = new Client({ connectionString: process.env.DB_URL });
+  await client.connect();
+  try {
+    const { rows } = await client.query(
+      `SELECT u.email, u.username
+         FROM subscriptions s
+         JOIN users u ON s.user_id=u.id
+        WHERE s.status='active'`
+    );
+    for (const row of rows) {
+      try {
+        await sendTemplate(row.email, 'Print Club Reminder', 'reminder.txt', {
+          username: row.username,
+        });
+      } catch (err) {
+        console.error('Failed to send reminder to', row.email, err);
+      }
+    }
+  } finally {
+    await client.end();
+  }
+}
+
+if (require.main === module) {
+  sendReminders();
+}
+
+module.exports = sendReminders;

--- a/backend/scripts/weekly-reset.js
+++ b/backend/scripts/weekly-reset.js
@@ -1,0 +1,33 @@
+require('dotenv').config();
+const { Client } = require('pg');
+
+function startOfWeek(d = new Date()) {
+  const date = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+  const day = date.getUTCDay();
+  const diff = date.getUTCDate() - day;
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), diff));
+}
+
+async function resetCredits() {
+  const client = new Client({ connectionString: process.env.DB_URL });
+  await client.connect();
+  const week = startOfWeek();
+  const weekStr = week.toISOString().slice(0, 10);
+  try {
+    await client.query(
+      `INSERT INTO subscription_credits(user_id, week_start, total_credits)
+       SELECT user_id, $1, 2 FROM subscriptions
+       WHERE status='active'
+       ON CONFLICT (user_id, week_start) DO NOTHING`,
+      [weekStr]
+    );
+  } finally {
+    await client.end();
+  }
+}
+
+if (require.main === module) {
+  resetCredits();
+}
+
+module.exports = resetCredits;


### PR DESCRIPTION
## Summary
- add weekly reset job for subscription credits
- send reminder emails to subscribers
- expose the new jobs through npm scripts
- include reminder email template

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851f8eeba20832d8a8bf718989b7f28