### PR TITLE
Implement referral post discount endpoint

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -28,6 +28,7 @@ const {
   incrementDiscountUsage,
   createTimedCode,
 } = require('./discountCodes');
+const { verifyTag } = require('./social');
 const REWARD_OPTIONS = { 100: 500, 200: 1000 };
 const ADMIN_TOKEN = process.env.ADMIN_TOKEN || 'admin';
 
@@ -733,6 +734,20 @@ app.post('/api/rewards/redeem', authRequired, async (req, res) => {
   } catch (err) {
     logError(err);
     res.status(500).json({ error: 'Failed to redeem reward' });
+  }
+});
+
+app.post('/api/referral-post', authRequired, async (req, res) => {
+  const { url } = req.body || {};
+  if (!url) return res.status(400).json({ error: 'Missing url' });
+  try {
+    const ok = await verifyTag(url);
+    if (!ok) return res.status(400).json({ error: 'Tag not found' });
+    const code = await createTimedCode(500, 168);
+    res.json({ code });
+  } catch (err) {
+    logError(err);
+    res.status(500).json({ error: 'Failed to verify post' });
   }
 });
 

--- a/backend/social.js
+++ b/backend/social.js
@@ -1,0 +1,13 @@
+async function verifyTag(url, tag = '#print2') {
+  try {
+    const res = await fetch(url);
+    if (!res.ok) return false;
+    const text = await res.text();
+    return text.includes(tag);
+  } catch (err) {
+    console.error('Failed to verify tag', err);
+    return false;
+  }
+}
+
+module.exports = { verifyTag };

--- a/backend/tests/referralPost.test.js
+++ b/backend/tests/referralPost.test.js
@@ -1,0 +1,40 @@
+process.env.STRIPE_SECRET_KEY = 'test';
+process.env.STRIPE_WEBHOOK_SECRET = 'whsec';
+process.env.DB_URL = 'postgres://user:pass@localhost/db';
+process.env.HUNYUAN_API_KEY = 'test';
+process.env.HUNYUAN_SERVER_URL = 'http://localhost:4000';
+
+const request = require('supertest');
+const jwt = require('jsonwebtoken');
+
+jest.mock('../social', () => ({ verifyTag: jest.fn() }));
+const { verifyTag } = require('../social');
+
+jest.mock('../discountCodes', () => ({
+  createTimedCode: jest.fn().mockResolvedValue('DISC1'),
+}));
+const { createTimedCode } = require('../discountCodes');
+
+const app = require('../server');
+
+test('POST /api/referral-post returns code when verified', async () => {
+  verifyTag.mockResolvedValue(true);
+  const token = jwt.sign({ id: 'u1' }, 'secret');
+  const res = await request(app)
+    .post('/api/referral-post')
+    .set('authorization', `Bearer ${token}`)
+    .send({ url: 'http://example.com/post' });
+  expect(res.status).toBe(200);
+  expect(res.body.code).toBe('DISC1');
+  expect(createTimedCode).toHaveBeenCalledWith(500, 168);
+});
+
+test('POST /api/referral-post rejects invalid tag', async () => {
+  verifyTag.mockResolvedValue(false);
+  const token = jwt.sign({ id: 'u1' }, 'secret');
+  const res = await request(app)
+    .post('/api/referral-post')
+    .set('authorization', `Bearer ${token}`)
+    .send({ url: 'http://example.com/post' });
+  expect(res.status).toBe(400);
+});


### PR DESCRIPTION
## Summary
- add `social.js` with `verifyTag`
- reward referral posts via `/api/referral-post`
- add tests for referral post discount

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6851f9075308832d87c288c33d022c3b