### PR TITLE
Implement analytics tracking endpoints

### DIFF
--- a/backend/migrations/034_create_ad_clicks.sql
+++ b/backend/migrations/034_create_ad_clicks.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS ad_clicks (
+  id SERIAL PRIMARY KEY,
+  subreddit TEXT NOT NULL,
+  session_id TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS ad_clicks_session_idx ON ad_clicks(session_id);
+CREATE INDEX IF NOT EXISTS ad_clicks_sr_idx ON ad_clicks(subreddit);
+
+CREATE TRIGGER ad_clicks_set_updated
+BEFORE UPDATE ON ad_clicks
+FOR EACH ROW EXECUTE PROCEDURE set_updated_at();

--- a/backend/migrations/035_create_cart_events.sql
+++ b/backend/migrations/035_create_cart_events.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS cart_events (
+  id SERIAL PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  model_id UUID,
+  subreddit TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS cart_events_session_idx ON cart_events(session_id);
+CREATE INDEX IF NOT EXISTS cart_events_model_idx ON cart_events(model_id);
+CREATE INDEX IF NOT EXISTS cart_events_sr_idx ON cart_events(subreddit);
+
+CREATE TRIGGER cart_events_set_updated
+BEFORE UPDATE ON cart_events
+FOR EACH ROW EXECUTE PROCEDURE set_updated_at();

--- a/backend/migrations/036_create_checkout_events.sql
+++ b/backend/migrations/036_create_checkout_events.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS checkout_events (
+  id SERIAL PRIMARY KEY,
+  session_id TEXT NOT NULL,
+  subreddit TEXT,
+  step TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS checkout_events_session_idx ON checkout_events(session_id);
+CREATE INDEX IF NOT EXISTS checkout_events_sr_idx ON checkout_events(subreddit);
+CREATE INDEX IF NOT EXISTS checkout_events_step_idx ON checkout_events(step);
+
+CREATE TRIGGER checkout_events_set_updated
+BEFORE UPDATE ON checkout_events
+FOR EACH ROW EXECUTE PROCEDURE set_updated_at();

--- a/backend/tests/analytics.test.js
+++ b/backend/tests/analytics.test.js
@@ -1,0 +1,57 @@
+process.env.STRIPE_SECRET_KEY = 'test';
+process.env.STRIPE_WEBHOOK_SECRET = 'whsec';
+process.env.HUNYUAN_API_KEY = 'test';
+process.env.HUNYUAN_SERVER_URL = 'http://localhost:4000';
+
+process.env.DB_URL = 'postgres://user:pass@localhost/db';
+
+jest.mock('../db', () => ({
+  query: jest.fn(),
+  insertCommission: jest.fn(),
+  insertAdClick: jest.fn(),
+  insertCartEvent: jest.fn(),
+  insertCheckoutEvent: jest.fn(),
+  getConversionMetrics: jest.fn(),
+}));
+const db = require('../db');
+
+const request = require('supertest');
+const app = require('../server');
+
+beforeEach(() => {
+  db.insertAdClick.mockClear();
+  db.insertCartEvent.mockClear();
+  db.insertCheckoutEvent.mockClear();
+  db.getConversionMetrics.mockClear();
+});
+
+test('POST /api/track/ad-click records click', async () => {
+  const res = await request(app)
+    .post('/api/track/ad-click')
+    .send({ subreddit: '3dprinting', sessionId: 's1' });
+  expect(res.status).toBe(200);
+  expect(db.insertAdClick).toHaveBeenCalledWith('3dprinting', 's1');
+});
+
+test('POST /api/track/cart records event', async () => {
+  const res = await request(app)
+    .post('/api/track/cart')
+    .send({ sessionId: 's1', modelId: 'm1', subreddit: '3dprinting' });
+  expect(res.status).toBe(200);
+  expect(db.insertCartEvent).toHaveBeenCalledWith('s1', 'm1', '3dprinting');
+});
+
+test('POST /api/track/checkout records event', async () => {
+  const res = await request(app)
+    .post('/api/track/checkout')
+    .send({ sessionId: 's1', step: 'start', subreddit: '3dprinting' });
+  expect(res.status).toBe(200);
+  expect(db.insertCheckoutEvent).toHaveBeenCalledWith('s1', '3dprinting', 'start');
+});
+
+test('GET /api/metrics/conversion returns metrics', async () => {
+  db.getConversionMetrics.mockResolvedValueOnce([{ subreddit: '3dprinting', ctr: 0.1 }]);
+  const res = await request(app).get('/api/metrics/conversion');
+  expect(res.status).toBe(200);
+  expect(res.body[0].subreddit).toBe('3dprinting');
+});


### PR DESCRIPTION
## Summary
- add new migrations for ad, cart and checkout events
- support analytics insertion and metrics queries in the DB module
- expose `/api/track` endpoints and metrics endpoint on the server
- add unit tests for analytics routes

## Validation
- `npm ci`
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6851f93dee58832da302ff182435159e