### PR TITLE
Implement share event tracking

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -165,6 +165,13 @@ async function insertCheckoutEvent(sessionId, subreddit, step) {
   );
 }
 
+async function insertShareEvent(shareId, network) {
+  await query('INSERT INTO share_events(share_id, network, timestamp) VALUES($1,$2,NOW())', [
+    shareId,
+    network,
+  ]);
+}
+
 async function getConversionMetrics() {
   const clicks = await query('SELECT subreddit, COUNT(*) AS c FROM ad_clicks GROUP BY subreddit');
   const carts = await query('SELECT subreddit, COUNT(*) AS c FROM cart_events GROUP BY subreddit');
@@ -278,6 +285,7 @@ module.exports = {
   adjustRewardPoints,
   getUserIdForReferral,
   insertReferralEvent,
+  insertShareEvent,
   upsertMailingListEntry,
   confirmMailingListEntry,
   unsubscribeMailingListEntry,

--- a/backend/migrations/037_create_share_events.sql
+++ b/backend/migrations/037_create_share_events.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS share_events (
+  id SERIAL PRIMARY KEY,
+  share_id UUID REFERENCES shares(id) ON DELETE CASCADE,
+  network TEXT NOT NULL,
+  timestamp TIMESTAMPTZ DEFAULT NOW(),
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS share_events_share_idx ON share_events(share_id);
+CREATE INDEX IF NOT EXISTS share_events_network_idx ON share_events(network);
+
+CREATE TRIGGER share_events_set_updated
+BEFORE UPDATE ON share_events
+FOR EACH ROW EXECUTE PROCEDURE set_updated_at();

--- a/backend/server.js
+++ b/backend/server.js
@@ -890,6 +890,18 @@ app.post('/api/track/checkout', async (req, res) => {
   }
 });
 
+app.post('/api/track/share', async (req, res) => {
+  const { shareId, network } = req.body || {};
+  if (!shareId || !network) return res.status(400).json({ error: 'Missing params' });
+  try {
+    await db.insertShareEvent(shareId, network);
+    res.json({ success: true });
+  } catch (err) {
+    logError(err);
+    res.status(500).json({ error: 'Failed to record share' });
+  }
+});
+
 app.get('/api/metrics/conversion', async (req, res) => {
   try {
     const data = await db.getConversionMetrics();

--- a/backend/tests/analytics.test.js
+++ b/backend/tests/analytics.test.js
@@ -10,6 +10,7 @@ jest.mock('../db', () => ({
   insertAdClick: jest.fn(),
   insertCartEvent: jest.fn(),
   insertCheckoutEvent: jest.fn(),
+  insertShareEvent: jest.fn(),
   getConversionMetrics: jest.fn(),
 }));
 const db = require('../db');
@@ -43,6 +44,14 @@ test('POST /api/track/checkout records step', async () => {
     .send({ sessionId: 's1', subreddit: 'funny', step: 'start' });
   expect(res.status).toBe(200);
   expect(db.insertCheckoutEvent).toHaveBeenCalledWith('s1', 'funny', 'start');
+});
+
+test('POST /api/track/share records event', async () => {
+  const res = await request(app)
+    .post('/api/track/share')
+    .send({ shareId: 'sh1', network: 'facebook' });
+  expect(res.status).toBe(200);
+  expect(db.insertShareEvent).toHaveBeenCalledWith('sh1', 'facebook');
 });
 
 test('GET /api/metrics/conversion returns metrics', async () => {

--- a/js/share.js
+++ b/js/share.js
@@ -1,3 +1,5 @@
+const API_BASE = (window.API_ORIGIN || '') + '/api';
+
 async function captureSnapshot(glbUrl) {
   if (!glbUrl) return null;
   const viewer = document.createElement('model-viewer');
@@ -47,6 +49,19 @@ async function shareOn(network) {
     case 'instagram':
       shareUrl = `https://www.instagram.com/?url=${url}`;
       break;
+  }
+  if (typeof fetch === 'function') {
+    try {
+      const shareId =
+        typeof localStorage !== 'undefined' ? localStorage.getItem('shareId') : null;
+      await fetch(`${API_BASE}/track/share`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ shareId, network }),
+      });
+    } catch (err) {
+      console.error('Failed to track share', err);
+    }
   }
   const modelUrl = typeof localStorage !== 'undefined' ? localStorage.getItem('print3Model') : null;
   if (navigator.share && modelUrl) {


### PR DESCRIPTION
## Summary
- add migration for `share_events` table
- log share button clicks with `/api/track/share`
- support `insertShareEvent` in `db.js`
- record share tracking from `share.js`
- test the new endpoint

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685285c96150832daa650e7cbd693411