### PR TITLE
Implement automation tasks for 3D print and ad generation

### DIFF
--- a/backend/ad_templates.json
+++ b/backend/ad_templates.json
@@ -1,0 +1,5 @@
+[
+  "Print your {subreddit} idea in 3D today!",
+  "Turn r/{subreddit} posts into reality with a custom 3D print.",
+  "Bring {subreddit} creations to life using print3."
+]

--- a/backend/migrations/037_create_printers.sql
+++ b/backend/migrations/037_create_printers.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS printers (
+  id SERIAL PRIMARY KEY,
+  name TEXT,
+  api_url TEXT NOT NULL,
+  status TEXT DEFAULT 'idle',
+  last_seen TIMESTAMPTZ DEFAULT NOW(),
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TRIGGER printers_set_updated
+BEFORE UPDATE ON printers
+FOR EACH ROW EXECUTE PROCEDURE set_updated_at();

--- a/backend/migrations/038_alter_print_jobs.sql
+++ b/backend/migrations/038_alter_print_jobs.sql
@@ -1,0 +1,3 @@
+ALTER TABLE print_jobs
+  ADD COLUMN IF NOT EXISTS printer_id INTEGER REFERENCES printers(id),
+  ADD COLUMN IF NOT EXISTS gcode_path TEXT;

--- a/backend/queue/dbPrintQueue.js
+++ b/backend/queue/dbPrintQueue.js
@@ -1,11 +1,10 @@
 const db = require('../db');
 
-async function enqueuePrint(jobId, orderId, shippingInfo) {
-  await db.query('INSERT INTO print_jobs(job_id, order_id, shipping_info) VALUES($1,$2,$3)', [
-    jobId,
-    orderId,
-    shippingInfo,
-  ]);
+async function enqueuePrint(jobId, orderId, printerId, gcodePath, shippingInfo) {
+  await db.query(
+    'INSERT INTO print_jobs(job_id, order_id, printer_id, gcode_path, shipping_info) VALUES($1,$2,$3,$4,$5)',
+    [jobId, orderId, printerId, gcodePath, shippingInfo]
+  );
 }
 
 async function getNextPendingJob() {

--- a/backend/queue/printWorker.js
+++ b/backend/queue/printWorker.js
@@ -2,41 +2,32 @@ require('dotenv').config();
 const { Client } = require('pg');
 const axios = require('axios');
 
-const PRINTER_API_URL = process.env.PRINTER_API_URL || 'http://localhost:5000/print';
+const DEFAULT_PRINTER_API_URL = process.env.PRINTER_API_URL || 'http://localhost:5000/print';
 const POLL_INTERVAL_MS = 5000;
 
 async function getNextPendingJob(client) {
   const { rows } = await client.query(
-    `SELECT j.job_id
-       FROM jobs j
-       JOIN orders o ON j.job_id=o.job_id
-      WHERE j.status='complete' AND o.status='paid'
-      ORDER BY j.created_at
+    `SELECT pj.id, pj.job_id, pj.gcode_path, pj.shipping_info, p.api_url
+       FROM print_jobs pj
+       JOIN printers p ON pj.printer_id=p.id
+      WHERE pj.status='pending'
+      ORDER BY pj.created_at
       LIMIT 1`
   );
-  return rows[0] && rows[0].job_id;
+  return rows[0] || null;
 }
 
 async function processNextJob(client) {
-  const jobId = await getNextPendingJob(client);
-  if (!jobId) return;
+  const job = await getNextPendingJob(client);
+  if (!job) return;
 
-  const { rows } = await client.query(
-    `SELECT j.model_url, o.shipping_info, o.etch_name
-       FROM jobs j
-       JOIN orders o ON j.job_id=o.job_id
-      WHERE j.job_id=$1`,
-    [jobId]
-  );
-  if (!rows.length) return;
-
-  const { model_url: modelUrl, shipping_info: shipping, etch_name } = rows[0];
+  const { id, gcode_path: gcodePath, api_url, shipping_info: shipping } = job;
+  const url = api_url || DEFAULT_PRINTER_API_URL;
   try {
-    await axios.post(PRINTER_API_URL, { modelUrl, shipping, etchName: etch_name });
-
-    await client.query('UPDATE jobs SET status=$1, error=NULL WHERE job_id=$2', ['sent', jobId]);
+    await axios.post(url, { gcodePath, shipping });
+    await client.query('UPDATE print_jobs SET status=$1 WHERE id=$2', ['sent', id]);
   } catch (err) {
-    await client.query('UPDATE jobs SET error=$1 WHERE job_id=$2', [err.message, jobId]);
+    await client.query('UPDATE print_jobs SET status=$1 WHERE id=$2', ['error', id]);
   }
 }
 

--- a/backend/scripts/assign-print-jobs.js
+++ b/backend/scripts/assign-print-jobs.js
@@ -1,0 +1,29 @@
+require('dotenv').config();
+const { Client } = require('pg');
+
+async function assignJobs() {
+  const client = new Client({ connectionString: process.env.DB_URL });
+  await client.connect();
+  try {
+    const { rows: printers } = await client.query("SELECT id FROM printers WHERE status='idle'");
+    for (const printer of printers) {
+      const { rows } = await client.query(
+        "SELECT id FROM print_jobs WHERE status='pending' AND printer_id IS NULL ORDER BY created_at LIMIT 1"
+      );
+      if (!rows.length) break;
+      const job = rows[0];
+      await client.query('UPDATE print_jobs SET printer_id=$1 WHERE id=$2', [printer.id, job.id]);
+    }
+  } finally {
+    await client.end();
+  }
+}
+
+if (require.main === module) {
+  assignJobs().catch((err) => {
+    console.error('Failed to assign jobs', err);
+    process.exit(1);
+  });
+}
+
+module.exports = assignJobs;

--- a/backend/scripts/generate-ad-copy.js
+++ b/backend/scripts/generate-ad-copy.js
@@ -1,0 +1,35 @@
+require('dotenv').config();
+const fs = require('fs');
+const path = require('path');
+const axios = require('axios');
+
+async function generateAdCopy(subreddit) {
+  const templatesPath = path.join(__dirname, '..', 'ad_templates.json');
+  const templates = JSON.parse(fs.readFileSync(templatesPath, 'utf8'));
+  const template = templates[Math.floor(Math.random() * templates.length)];
+  const prompt = template.replace(/\{subreddit\}/g, subreddit);
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) throw new Error('OPENAI_API_KEY required');
+  const { data } = await axios.post(
+    'https://api.openai.com/v1/completions',
+    { model: 'text-davinci-003', prompt, max_tokens: 32 },
+    { headers: { Authorization: `Bearer ${apiKey}` } }
+  );
+  return data.choices[0].text.trim();
+}
+
+if (require.main === module) {
+  const [subreddit] = process.argv.slice(2);
+  if (!subreddit) {
+    console.error('Usage: node generate-ad-copy.js <subreddit>');
+    process.exit(1);
+  }
+  generateAdCopy(subreddit)
+    .then((text) => console.log(text))
+    .catch((err) => {
+      console.error('Failed to generate ad copy', err);
+      process.exit(1);
+    });
+}
+
+module.exports = generateAdCopy;

--- a/backend/scripts/generate-ad-image.js
+++ b/backend/scripts/generate-ad-image.js
@@ -1,0 +1,24 @@
+require('dotenv').config();
+const axios = require('axios');
+const { dalleServerUrl } = require('../config');
+
+async function generateAdImage(prompt) {
+  const { data } = await axios.post(`${dalleServerUrl}/generate`, { prompt });
+  return data.image;
+}
+
+if (require.main === module) {
+  const prompt = process.argv.slice(2).join(' ');
+  if (!prompt) {
+    console.error('Usage: node generate-ad-image.js <prompt>');
+    process.exit(1);
+  }
+  generateAdImage(prompt)
+    .then((img) => console.log(img))
+    .catch((err) => {
+      console.error('Failed to generate image', err);
+      process.exit(1);
+    });
+}
+
+module.exports = generateAdImage;

--- a/backend/scripts/monitor-printers.js
+++ b/backend/scripts/monitor-printers.js
@@ -1,0 +1,34 @@
+require('dotenv').config();
+const { Client } = require('pg');
+const axios = require('axios');
+
+async function monitorPrinters() {
+  const client = new Client({ connectionString: process.env.DB_URL });
+  await client.connect();
+  try {
+    const { rows } = await client.query('SELECT id, api_url FROM printers');
+    for (const printer of rows) {
+      try {
+        const { data } = await axios.get(`${printer.api_url}/status`);
+        const status = data.status || 'unknown';
+        await client.query('UPDATE printers SET status=$1, last_seen=NOW() WHERE id=$2', [
+          status,
+          printer.id,
+        ]);
+      } catch (err) {
+        await client.query('UPDATE printers SET status=$1 WHERE id=$2', ['offline', printer.id]);
+      }
+    }
+  } finally {
+    await client.end();
+  }
+}
+
+if (require.main === module) {
+  monitorPrinters().catch((err) => {
+    console.error('Failed to monitor printers', err);
+    process.exit(1);
+  });
+}
+
+module.exports = monitorPrinters;

--- a/backend/tests/assignPrintJobs.test.js
+++ b/backend/tests/assignPrintJobs.test.js
@@ -1,0 +1,18 @@
+jest.mock('pg');
+const { Client } = require('pg');
+const assignJobs = require('../scripts/assign-print-jobs');
+
+const mClient = { connect: jest.fn(), query: jest.fn(), end: jest.fn() };
+Client.mockImplementation(() => mClient);
+
+test('assigns pending job to idle printer', async () => {
+  mClient.query
+    .mockResolvedValueOnce({ rows: [{ id: 1 }] })
+    .mockResolvedValueOnce({ rows: [{ id: 10 }] })
+    .mockResolvedValueOnce({});
+  await assignJobs();
+  expect(mClient.query).toHaveBeenCalledWith(
+    'UPDATE print_jobs SET printer_id=$1 WHERE id=$2',
+    [1, 10]
+  );
+});

--- a/backend/tests/generateAdCopy.test.js
+++ b/backend/tests/generateAdCopy.test.js
@@ -1,0 +1,11 @@
+process.env.OPENAI_API_KEY = 'k';
+jest.mock('axios');
+const axios = require('axios');
+const generateAdCopy = require('../scripts/generate-ad-copy');
+
+test('calls OpenAI with subreddit prompt', async () => {
+  axios.post.mockResolvedValue({ data: { choices: [{ text: 'Ad text' }] } });
+  const result = await generateAdCopy('funny');
+  expect(result).toBe('Ad text');
+  expect(axios.post).toHaveBeenCalled();
+});

--- a/backend/tests/generateAdImage.test.js
+++ b/backend/tests/generateAdImage.test.js
@@ -1,0 +1,14 @@
+process.env.DB_URL = 'postgres://u:p@localhost/db';
+process.env.STRIPE_SECRET_KEY = 'sk';
+process.env.STRIPE_WEBHOOK_SECRET = 'wh';
+process.env.HUNYUAN_API_KEY = 'key';
+jest.mock('axios');
+const axios = require('axios');
+const generateAdImage = require('../scripts/generate-ad-image');
+
+test('calls DALL-E server', async () => {
+  axios.post.mockResolvedValue({ data: { image: 'img' } });
+  const img = await generateAdImage('prompt');
+  expect(img).toBe('img');
+  expect(axios.post).toHaveBeenCalled();
+});

--- a/backend/tests/monitorPrinters.test.js
+++ b/backend/tests/monitorPrinters.test.js
@@ -1,0 +1,18 @@
+jest.mock('pg');
+const { Client } = require('pg');
+const axios = require('axios');
+const monitorPrinters = require('../scripts/monitor-printers');
+
+const mClient = { connect: jest.fn(), query: jest.fn(), end: jest.fn() };
+Client.mockImplementation(() => mClient);
+jest.mock('axios');
+
+test('updates printer status', async () => {
+  mClient.query
+    .mockResolvedValueOnce({ rows: [{ id: 1, api_url: 'http://p' }] })
+    .mockResolvedValueOnce({})
+    .mockResolvedValueOnce({});
+  axios.get.mockResolvedValue({ data: { status: 'idle' } });
+  await monitorPrinters();
+  expect(axios.get).toHaveBeenCalledWith('http://p/status');
+});

--- a/backend/tests/queue/dbPrintQueue.test.js
+++ b/backend/tests/queue/dbPrintQueue.test.js
@@ -8,10 +8,12 @@ const db = require('../../db');
 const { enqueuePrint } = require('../../queue/dbPrintQueue');
 
 test('enqueuePrint inserts print job', async () => {
-  await enqueuePrint('j1', 'o1', {});
+  await enqueuePrint('j1', 'o1', 2, '/tmp/j1.gcode', {});
   expect(db.query).toHaveBeenCalledWith(expect.stringContaining('INSERT INTO print_jobs'), [
     'j1',
     'o1',
+    2,
+    '/tmp/j1.gcode',
     {},
   ]);
 });

--- a/backend/tests/queue/printWorker.test.js
+++ b/backend/tests/queue/printWorker.test.js
@@ -19,11 +19,18 @@ beforeEach(() => {
   axios.post.mockReset();
 });
 
-test('worker posts etch name to printer API', async () => {
+test('worker posts G-code path to printer API', async () => {
   mClient.query
-    .mockResolvedValueOnce({ rows: [{ job_id: 'j1' }] })
     .mockResolvedValueOnce({
-      rows: [{ model_url: 'm', shipping_info: { a: 1 }, etch_name: 'Name' }],
+      rows: [
+        {
+          id: 1,
+          job_id: 'j1',
+          gcode_path: '/tmp/j1.gcode',
+          api_url: 'http://printer',
+          shipping_info: { a: 1 },
+        },
+      ],
     })
     .mockResolvedValueOnce({});
   axios.post.mockResolvedValue({});
@@ -33,8 +40,7 @@ test('worker posts etch name to printer API', async () => {
   await Promise.resolve();
 
   expect(axios.post).toHaveBeenCalledWith('http://printer', {
-    modelUrl: 'm',
+    gcodePath: '/tmp/j1.gcode',
     shipping: { a: 1 },
-    etchName: 'Name',
   });
 });


### PR DESCRIPTION
## Summary
- add printers table migration and extend print_jobs
- update print job queue and worker logic
- scripts for monitoring printers and assigning jobs
- json ad templates and scripts to generate ad copy and images
- tests for new printer automation and ad generation logic

## Testing
- `npm run format`
- `npm test`
- `npm run format` in hunyuan_server
- `npm test` in hunyuan_server

------
https://chatgpt.com/codex/tasks/task_e_685285ddebfc832da2a2ae422f6d37de