### PR TITLE
Add gifting toggle and quantity discount

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -1668,6 +1668,10 @@ app.post('/api/create-order', authOptional, async (req, res) => {
       }
     }
 
+    if ((qty || 1) >= 2) {
+      totalDiscount += Math.round((price || 0) * 0.1);
+    }
+
     const total = (price || 0) * (qty || 1) - totalDiscount;
     const session = await stripe.checkout.sessions.create({
       mode: 'payment',

--- a/backend/tests/api.test.js
+++ b/backend/tests/api.test.js
@@ -127,14 +127,26 @@ test('create-order applies discount', async () => {
     expect.objectContaining({
       line_items: [
         expect.objectContaining({
-          price_data: expect.objectContaining({ unit_amount: 180 }),
+          price_data: expect.objectContaining({ unit_amount: 170 }),
         }),
       ],
     })
   );
   const insertCall = db.query.mock.calls.find((c) => c[0].includes('INSERT INTO orders'));
-  expect(insertCall[1][3]).toBe(180);
-  expect(insertCall[1][7]).toBe(20);
+  expect(insertCall[1][3]).toBe(170);
+  expect(insertCall[1][7]).toBe(30);
+});
+
+test('create-order quantity discount', async () => {
+  db.query.mockResolvedValueOnce({ rows: [{ job_id: '1', user_id: 'u1' }] });
+  db.query.mockResolvedValueOnce({});
+  const res = await request(app).post('/api/create-order').send({ jobId: '1', price: 100, qty: 2 });
+  expect(res.status).toBe(200);
+  const createCall = stripeMock.checkout.sessions.create.mock.calls.pop()[0];
+  expect(createCall.line_items[0].price_data.unit_amount).toBe(190);
+  const orderInsert = db.query.mock.calls.find((c) => c[0].includes('INSERT INTO orders'));
+  expect(orderInsert[1][3]).toBe(190);
+  expect(orderInsert[1][7]).toBe(10);
 });
 
 test('create-order applies first-order discount', async () => {

--- a/backend/tests/frontend/competitions.test.js
+++ b/backend/tests/frontend/competitions.test.js
@@ -40,5 +40,6 @@ test('startCountdown formats remaining time', () => {
   const s = Math.floor((diff % 60000) / 1000);
   const expected = `${d}d ${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
   dom.window.startCountdown(el);
-  expect(el.textContent).toBe(expected);
+  const alt = `${d}d ${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:${String((s + 1) % 60).padStart(2, '0')}`;
+  expect([expected, alt]).toContain(el.textContent);
 });

--- a/js/payment.js
+++ b/js/payment.js
@@ -338,6 +338,8 @@ async function initPaymentPage() {
   const discountInput = document.getElementById('discount-code');
   const discountMsg = document.getElementById('discount-msg');
   const applyBtn = document.getElementById('apply-discount');
+  const surpriseToggle = document.getElementById('surprise-toggle');
+  const recipientFields = document.getElementById('recipient-fields');
   loadCheckoutCredits();
   if (referralId && discountMsg) {
     discountMsg.textContent = 'Referral discount applied';
@@ -351,6 +353,14 @@ async function initPaymentPage() {
     subscriptionRadios.forEach((r) => {
       if (r.value === 'join') r.checked = true;
     });
+  }
+  if (surpriseToggle && recipientFields) {
+    const toggle = () => {
+      if (surpriseToggle.checked) recipientFields.classList.add('hidden');
+      else recipientFields.classList.remove('hidden');
+    };
+    surpriseToggle.addEventListener('change', toggle);
+    toggle();
   }
   const payBtn = document.getElementById('submit-payment');
   const singleLabel = document.getElementById('single-label');
@@ -743,8 +753,10 @@ async function initPaymentPage() {
         body: JSON.stringify({ sessionId, subreddit, step: 'start' }),
       }).catch(() => {});
     }
-    const basket = window.getBasket ? window.getBasket() : [];
-    const qty = Math.max(1, basket.length || 0);
+    const qty = Math.max(
+      1,
+      parseInt(document.getElementById('print-qty')?.value || '1', 10)
+    );
     let discount = 0;
     const end = parseInt(localStorage.getItem('flashDiscountEnd'), 10) || 0;
     if (end && end > Date.now()) {
@@ -757,12 +769,20 @@ async function initPaymentPage() {
     ) {
       discount += Math.round(selectedPrice * (flashSale.discount_percent / 100));
     }
+    if (qty >= 2) {
+      discount += Math.round(selectedPrice * 0.1);
+      document.getElementById('bulk-discount-msg')?.classList.remove('hidden');
+    } else {
+      document.getElementById('bulk-discount-msg')?.classList.add('hidden');
+    }
     const shippingInfo = {
       name: document.getElementById('ship-name').value,
       address: document.getElementById('ship-address').value,
       city: document.getElementById('ship-city').value,
       zip: document.getElementById('ship-zip').value,
       email: emailEl.value,
+      surprise: document.getElementById('surprise-toggle')?.checked || false,
+      recipientEmail: document.getElementById('recipient-email')?.value || '',
     };
     let etchName = '';
     if (etchInput && !etchInput.disabled) {

--- a/payment.html
+++ b/payment.html
@@ -299,6 +299,20 @@
                 aria-label="Email"
               />
             </div>
+            <label class="flex items-center gap-2 text-sm my-2">
+              <input type="checkbox" id="surprise-toggle" class="accent-[#30D5C8]" />
+              This is a surprise
+            </label>
+            <div id="recipient-fields" class="mb-2">
+              <input
+                id="recipient-email"
+                type="email"
+                class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10"
+                placeholder="Recipient Email (optional)"
+                autocomplete="email"
+                aria-label="Recipient Email"
+              />
+            </div>
             <div>
               <input
                 id="ship-address"
@@ -324,6 +338,19 @@
                 autocomplete="postal-code"
                 aria-label="ZIP code"
               />
+            </div>
+
+            <div class="flex items-center gap-2 my-2 text-sm">
+              <label for="print-qty">Quantity</label>
+              <select
+                id="print-qty"
+                class="p-1 rounded-md bg-[#1A1A1D] border border-white/10"
+                aria-label="Quantity"
+              >
+                <option value="1">1</option>
+                <option value="2">2</option>
+              </select>
+              <span id="bulk-discount-msg" class="text-[#30D5C8] hidden">10% off second print!</span>
             </div>
 
             <div class="flex gap-2">


### PR DESCRIPTION
## Summary
- let buyers mark an order as a surprise and optionally enter the recipient email
- allow choosing quantity and show a second-print discount
- apply a 10% discount on the backend when two prints are ordered
- update tests for new logic and tolerate minor countdown drift

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6852862be014832d9b512928130ab496