### PR TITLE
chore: add merge-conflict guard to lint and remove existing markers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Format with Prettier
         run: npm run format
 
+      - name: Check for merge-conflict markers
+        run: npm run check-conflicts
+
       - name: Run ESLint
         run: npm run lint
         working-directory: backend

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npx lint-staged
+npm run check-conflicts && npm run lint

--- a/backend/db.js
+++ b/backend/db.js
@@ -165,7 +165,6 @@ async function insertCheckoutEvent(sessionId, subreddit, step) {
   );
 }
 
-<<<<<<< jtyxgr-codex/execute-next-subtasks-for-subscription-service
 async function insertSubscriptionEvent(userId, event, variant, priceCents) {
   await query(
     'INSERT INTO subscription_events(user_id, event, variant, price_cents) VALUES($1,$2,$3,$4)',
@@ -182,13 +181,13 @@ async function getSubscriptionMetrics() {
     active: parseInt(active.rows[0].count, 10),
     churn_last_30_days: parseInt(churn.rows[0].count, 10),
   };
-=======
+}
+
 async function insertShareEvent(shareId, network) {
   await query('INSERT INTO share_events(share_id, network, timestamp) VALUES($1,$2,NOW())', [
     shareId,
     network,
   ]);
->>>>>>> main
 }
 
 async function getConversionMetrics() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@eslint/js": "^9.29.0",
         "eslint": "^8.44.0",
         "eslint-config-prettier": "^8.10.0",
-        "husky": "^8.0.0",
+        "husky": "^9.1.7",
         "lint-staged": "^16.1.2",
         "prettier": "^3.5.3"
       }
@@ -794,15 +794,16 @@
       }
     },
     "node_modules/husky": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
-      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
       "dev": true,
+      "license": "MIT",
       "bin": {
-        "husky": "lib/bin.js"
+        "husky": "bin.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
@@ -2368,9 +2369,9 @@
       "dev": true
     },
     "husky": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
-      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
       "dev": true
     },
     "ignore": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "prepare": "husky install",
     "format": "prettier --write \"**/*.{js,jsx,json,md,html,html}\"",
-    "lint": "eslint . --max-warnings=0",
+    "check-conflicts": "! grep -R --include=*.js --include=*.jsx --include=*.ts --include=*.tsx '^(<{7}|={7}|>{7})' .",
+    "lint": "npm run check-conflicts && eslint . --max-warnings=0",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],
@@ -21,7 +22,7 @@
     "@eslint/js": "^9.29.0",
     "eslint": "^8.44.0",
     "eslint-config-prettier": "^8.10.0",
-    "husky": "^8.0.0",
+    "husky": "^9.1.7",
     "lint-staged": "^16.1.2",
     "prettier": "^3.5.3"
   },


### PR DESCRIPTION
## Summary
- remove leftover merge-conflict markers from `backend/db.js`
- check for merge markers before linting
- run merge marker check in CI
- update Husky pre-commit hook

## Testing
- `npm run format` (backend)
- `npm test` (backend)
- `npm run lint --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_68528bd9445c832d804c56b0538a74b2