### PR TITLE
Implement share tracking

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -165,6 +165,13 @@ async function insertCheckoutEvent(sessionId, subreddit, step) {
   );
 }
 
+async function insertShareEvent(shareId, network) {
+  await query('INSERT INTO share_events(share_id, network, timestamp) VALUES($1,$2,NOW())', [
+    shareId,
+    network,
+  ]);
+}
+
 async function getConversionMetrics() {
   const clicks = await query('SELECT subreddit, COUNT(*) AS c FROM ad_clicks GROUP BY subreddit');
   const carts = await query('SELECT subreddit, COUNT(*) AS c FROM cart_events GROUP BY subreddit');
@@ -267,6 +274,7 @@ module.exports = {
   insertAdClick,
   insertCartEvent,
   insertCheckoutEvent,
+  insertShareEvent,
   getConversionMetrics,
   cancelSubscription,
   getSubscription,

--- a/backend/migrations/037_create_share_events.sql
+++ b/backend/migrations/037_create_share_events.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS share_events (
+  id SERIAL PRIMARY KEY,
+  share_id INTEGER REFERENCES shares(id) ON DELETE CASCADE,
+  network TEXT NOT NULL,
+  timestamp TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS share_events_share_idx ON share_events(share_id);

--- a/backend/server.js
+++ b/backend/server.js
@@ -890,6 +890,18 @@ app.post('/api/track/checkout', async (req, res) => {
   }
 });
 
+app.post('/api/track/share', async (req, res) => {
+  const { shareId, network } = req.body || {};
+  if (!shareId || !network) return res.status(400).json({ error: 'Missing params' });
+  try {
+    await db.insertShareEvent(shareId, network);
+    res.json({ success: true });
+  } catch (err) {
+    logError(err);
+    res.status(500).json({ error: 'Failed to record share' });
+  }
+});
+
 app.get('/api/metrics/conversion', async (req, res) => {
   try {
     const data = await db.getConversionMetrics();
@@ -1024,6 +1036,7 @@ app.get('/api/shared/:slug', async (req, res) => {
     if (!rows.length) return res.status(404).json({ error: 'Share not found' });
     res.json({
       jobId: share.job_id,
+      shareId: share.id,
       slug: share.slug,
       model_url: rows[0].model_url,
       prompt: rows[0].prompt,

--- a/backend/tests/additionalApi.test.js
+++ b/backend/tests/additionalApi.test.js
@@ -511,7 +511,7 @@ test('POST /api/create-order rejects unknown job', async () => {
 });
 
 test('GET /api/shared/:slug returns data', async () => {
-  db.getShareBySlug = jest.fn().mockResolvedValue({ job_id: 'j1', slug: 's1' });
+  db.getShareBySlug = jest.fn().mockResolvedValue({ id: 2, job_id: 'j1', slug: 's1' });
   db.query.mockResolvedValueOnce({
     rows: [{ prompt: 'p', model_url: '/m.glb', snapshot: '/s.png' }],
   });
@@ -519,6 +519,7 @@ test('GET /api/shared/:slug returns data', async () => {
   expect(res.status).toBe(200);
   expect(res.body.model_url).toBe('/m.glb');
   expect(res.body.snapshot).toBe('/s.png');
+  expect(res.body.shareId).toBe(2);
 });
 
 test('GET /api/shared/:slug 404 when missing', async () => {

--- a/backend/tests/analytics.test.js
+++ b/backend/tests/analytics.test.js
@@ -10,6 +10,7 @@ jest.mock('../db', () => ({
   insertAdClick: jest.fn(),
   insertCartEvent: jest.fn(),
   insertCheckoutEvent: jest.fn(),
+  insertShareEvent: jest.fn(),
   getConversionMetrics: jest.fn(),
 }));
 const db = require('../db');
@@ -43,6 +44,12 @@ test('POST /api/track/checkout records step', async () => {
     .send({ sessionId: 's1', subreddit: 'funny', step: 'start' });
   expect(res.status).toBe(200);
   expect(db.insertCheckoutEvent).toHaveBeenCalledWith('s1', 'funny', 'start');
+});
+
+test('POST /api/track/share records share', async () => {
+  const res = await request(app).post('/api/track/share').send({ shareId: 1, network: 'twitter' });
+  expect(res.status).toBe(200);
+  expect(db.insertShareEvent).toHaveBeenCalledWith(1, 'twitter');
 });
 
 test('GET /api/metrics/conversion returns metrics', async () => {

--- a/backend/tests/frontend/sharedModel.test.js
+++ b/backend/tests/frontend/sharedModel.test.js
@@ -24,13 +24,17 @@ function setup(url) {
 test('loads model from API', async () => {
   const dom = setup('http://localhost/share.html?slug=test');
   dom.window.fetch = jest.fn(() =>
-    Promise.resolve({ ok: true, json: () => ({ model_url: 'foo.glb', snapshot: '/s.png' }) })
+    Promise.resolve({
+      ok: true,
+      json: () => ({ model_url: 'foo.glb', snapshot: '/s.png', shareId: 1 }),
+    })
   );
   dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
   await new Promise((r) => setTimeout(r, 0));
   const viewer = dom.window.document.getElementById('viewer');
   expect(viewer.src).toContain('foo.glb');
   expect(viewer.getAttribute('poster')).toBe('/s.png');
+  expect(dom.window.shareId).toBe(1);
 });
 
 test('shows error when slug missing', () => {

--- a/js/share.js
+++ b/js/share.js
@@ -67,6 +67,13 @@ async function shareOn(network) {
     }
   }
   window.open(shareUrl, '_blank', 'noopener');
+  if (window.shareId) {
+    fetch('/api/track/share', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ shareId: window.shareId, network }),
+    }).catch(() => {});
+  }
 }
 
 if (typeof module !== 'undefined') {

--- a/js/sharedModel.js
+++ b/js/sharedModel.js
@@ -18,6 +18,9 @@ document.addEventListener('DOMContentLoaded', async () => {
     if (!res.ok) throw new Error('bad');
     const data = await res.json();
     const viewer = document.getElementById('viewer');
+    if (data.shareId) {
+      window.shareId = data.shareId;
+    }
     if (data.snapshot) {
       viewer.setAttribute('poster', data.snapshot);
     }


### PR DESCRIPTION
## Summary
- create `share_events` table migration
- return `shareId` from `/api/shared/:slug`
- record share button usage in the backend
- post tracking events from `share.js`
- expose shareId in `sharedModel.js`
- cover share tracking with tests

## Testing
- `npm test`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_685286327bb0832da778315ca5dcb252