### PR TITLE
Prevent accidental viewer close when dragging

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -288,6 +288,9 @@
         const addBasketBtn = document.getElementById('modal-add-basket');
         const closeBtn = document.getElementById('close-modal');
         const tierToggle = document.getElementById('tier-toggle');
+        const viewer = modal.querySelector('model-viewer');
+        let dragStarted = false;
+        let dragExited = false;
 
         function setTier(tier) {
           tierToggle?.querySelectorAll('button[data-tier]').forEach((btn) => {
@@ -342,6 +345,19 @@
           navigator.clipboard.writeText(url).then(() => alert('Link copied'));
         });
 
+        viewer.addEventListener('pointerdown', () => {
+          dragStarted = true;
+        });
+        document.addEventListener('pointerup', (e) => {
+          if (dragStarted) {
+            const container = modal.querySelector('div');
+            if (!container.contains(e.target)) {
+              dragExited = true;
+            }
+            dragStarted = false;
+          }
+        });
+
         closeBtn.addEventListener('click', close);
         document.addEventListener('keydown', (e) => {
           if (e.key === 'Escape') close();
@@ -351,6 +367,10 @@
           if (modal.classList.contains('hidden')) return;
           const container = modal.querySelector('div');
           const basketBtn = document.getElementById('basket-button');
+          if (dragExited) {
+            dragExited = false;
+            return;
+          }
           if (!container.contains(e.target) && !(basketBtn && basketBtn.contains(e.target))) {
             close();
           }

--- a/competitions.html
+++ b/competitions.html
@@ -310,6 +310,8 @@
         const addBasketBtn = document.getElementById('modal-add-basket');
         const closeBtn = document.getElementById('close-modal');
         const tierToggle = document.getElementById('tier-toggle');
+        let dragStarted = false;
+        let dragExited = false;
 
         function setTier(tier) {
           tierToggle?.querySelectorAll('button[data-tier]').forEach((btn) => {
@@ -358,6 +360,19 @@
           }
         });
 
+        viewer.addEventListener('pointerdown', () => {
+          dragStarted = true;
+        });
+        document.addEventListener('pointerup', (e) => {
+          if (dragStarted) {
+            const container = modal.querySelector('div');
+            if (!container.contains(e.target)) {
+              dragExited = true;
+            }
+            dragStarted = false;
+          }
+        });
+
         closeBtn.addEventListener('click', close);
 
         document.addEventListener('keydown', (e) => {
@@ -368,6 +383,10 @@
           if (modal.classList.contains('hidden')) return;
           const container = modal.querySelector('div');
           const basketBtn = document.getElementById('basket-button');
+          if (dragExited) {
+            dragExited = false;
+            return;
+          }
           if (!container.contains(e.target) && !(basketBtn && basketBtn.contains(e.target))) {
             close();
           }


### PR DESCRIPTION
## Summary
- fix modal close logic in community and competitions pages
- ignore click event after dragging model out of viewer

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6852977b10cc832da4a3fe330078ab3f