### PR TITLE
Implement Print Club reminder logic and tests

### DIFF
--- a/backend/scripts/send-printclub-reminders.js
+++ b/backend/scripts/send-printclub-reminders.js
@@ -2,15 +2,26 @@ require('dotenv').config();
 const { Client } = require('pg');
 const { sendTemplate } = require('../mail');
 
-async function sendReminders() {
+function startOfWeek(d = new Date()) {
+  const date = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+  const day = date.getUTCDay();
+  const diff = date.getUTCDate() - day;
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), diff));
+}
+async function sendReminders(now = new Date()) {
+  if (now.getUTCDay() !== 6) return; // only send on Saturday
   const client = new Client({ connectionString: process.env.DB_URL });
   await client.connect();
   try {
+    const week = startOfWeek(now);
+    const weekStr = week.toISOString().slice(0, 10);
     const { rows } = await client.query(
       `SELECT u.email, u.username
          FROM subscriptions s
          JOIN users u ON s.user_id=u.id
-        WHERE s.status='active'`
+         JOIN subscription_credits c ON c.user_id=s.user_id AND c.week_start=$1
+        WHERE s.status='active' AND c.total_credits - c.used_credits > 0`,
+      [weekStr]
     );
     for (const row of rows) {
       try {

--- a/backend/tests/printclubReminders.test.js
+++ b/backend/tests/printclubReminders.test.js
@@ -1,0 +1,35 @@
+process.env.DB_URL = 'postgres://user:pass@localhost/db';
+
+jest.mock('pg');
+const { Client } = require('pg');
+const mClient = { connect: jest.fn(), end: jest.fn(), query: jest.fn() };
+Client.mockImplementation(() => mClient);
+
+jest.mock('../mail', () => ({ sendTemplate: jest.fn() }));
+const { sendTemplate } = require('../mail');
+
+const run = require('../scripts/send-printclub-reminders');
+
+beforeEach(() => {
+  mClient.connect.mockClear();
+  mClient.end.mockClear();
+  mClient.query.mockClear();
+  sendTemplate.mockClear();
+});
+
+test('sends reminders on Saturday when credits remain', async () => {
+  const saturday = new Date('2024-06-01T12:00:00Z');
+  mClient.query.mockResolvedValueOnce({ rows: [{ email: 'a@a.com', username: 'alice' }] });
+  await run(saturday);
+  expect(mClient.connect).toHaveBeenCalled();
+  expect(sendTemplate).toHaveBeenCalledWith('a@a.com', 'Print Club Reminder', 'reminder.txt', {
+    username: 'alice',
+  });
+  expect(mClient.end).toHaveBeenCalled();
+});
+
+test('does nothing on non-Saturday', async () => {
+  const friday = new Date('2024-05-31T12:00:00Z');
+  await run(friday);
+  expect(mClient.connect).not.toHaveBeenCalled();
+});

--- a/backend/tests/weeklyReset.test.js
+++ b/backend/tests/weeklyReset.test.js
@@ -1,0 +1,25 @@
+process.env.DB_URL = 'postgres://user:pass@localhost/db';
+
+jest.mock('pg');
+const { Client } = require('pg');
+const mClient = { connect: jest.fn(), end: jest.fn(), query: jest.fn() };
+Client.mockImplementation(() => mClient);
+
+const run = require('../scripts/weekly-reset');
+
+beforeEach(() => {
+  mClient.connect.mockClear();
+  mClient.end.mockClear();
+  mClient.query.mockClear();
+});
+
+test('inserts weekly credits', async () => {
+  mClient.query.mockResolvedValueOnce({});
+  await run();
+  expect(mClient.connect).toHaveBeenCalled();
+  expect(mClient.query).toHaveBeenCalledWith(
+    expect.stringContaining('INSERT INTO subscription_credits'),
+    [expect.any(String)]
+  );
+  expect(mClient.end).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- improve Print Club reminder script to only email on Saturdays when credits remain
- add tests for weekly credit reset and reminder job

## Testing
- `npm ci` in `backend/`
- `npm ci` in `backend/hunyuan_server`
- `npm run format` in `backend/`
- `npm test` in `backend/`

------
https://chatgpt.com/codex/tasks/task_e_6852a97018f0832da7be8ceb36ca42c7