### PR TITLE
Implement winner interviews section

### DIFF
--- a/backend/competition_winners.json
+++ b/backend/competition_winners.json
@@ -1,0 +1,17 @@
+[
+  {
+    "name": "Damaged Helmet",
+    "image": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/DamagedHelmet/screenshot/screenshot.png",
+    "quote": "I loved the challenge of perfecting the textures."
+  },
+  {
+    "name": "Fox",
+    "image": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Fox/screenshot/screenshot.jpg",
+    "quote": "The expressive pose really brings it to life."
+  },
+  {
+    "name": "BoomBox",
+    "image": "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoomBox/screenshot/screenshot.jpg",
+    "quote": "Seeing my model printed was so satisfying."
+  }
+]

--- a/backend/server.js
+++ b/backend/server.js
@@ -56,6 +56,15 @@ try {
   logError('Failed to load subreddit_models.json', err);
 }
 
+let competitionWinners = [];
+try {
+  const winnersPath = path.join(__dirname, 'competition_winners.json');
+  const raw = fs.readFileSync(winnersPath, 'utf8');
+  competitionWinners = JSON.parse(raw);
+} catch (err) {
+  logError('Failed to load competition_winners.json', err);
+}
+
 const app = express();
 app.use(morgan('dev'));
 app.use(compression());
@@ -1299,6 +1308,14 @@ app.get('/api/competitions/past', async (req, res) => {
   } catch (err) {
     logError(err);
     res.status(500).json({ error: 'Failed to fetch past competitions' });
+  }
+});
+
+app.get('/api/competitions/winners', (req, res) => {
+  if (competitionWinners.length) {
+    res.json(competitionWinners);
+  } else {
+    res.status(404).json({ error: 'Not found' });
   }
 });
 

--- a/backend/tests/additionalApi.test.js
+++ b/backend/tests/additionalApi.test.js
@@ -601,3 +601,8 @@ test('GET /api/trending returns list', async () => {
   const res = await request(app).get('/api/trending');
   expect([200, 404]).toContain(res.status);
 });
+
+test('GET /api/competitions/winners returns list', async () => {
+  const res = await request(app).get('/api/competitions/winners');
+  expect([200, 404]).toContain(res.status);
+});

--- a/competitions.html
+++ b/competitions.html
@@ -184,6 +184,8 @@
           <button class="purchase absolute bottom-1 left-1 font-bold text-lg py-2 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]">Buy</button>
         </div>
       </div>
+      <h2 class="text-2xl mt-8">Winner Interviews</h2>
+      <div id="winner-interviews" class="space-y-4 mt-4"></div>
       <h2 class="text-2xl mt-8">Trending Prints</h2>
       <div id="trending-prints" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 mt-4"></div>
     </main>

--- a/js/competitions.js
+++ b/js/competitions.js
@@ -375,6 +375,20 @@ async function loadTrending() {
   });
 }
 
+async function loadWinnerInterviews() {
+  const container = document.getElementById('winner-interviews');
+  if (!container) return;
+  const res = await fetch(`${API_BASE}/competitions/winners`);
+  if (!res.ok) return;
+  const winners = await res.json();
+  winners.forEach((w) => {
+    const div = document.createElement('div');
+    div.className = 'flex items-center space-x-4';
+    div.innerHTML = `<img src="${w.image}" alt="${w.name}" class="w-16 h-16 rounded-full object-cover" />\n      <blockquote class="text-sm italic">"${w.quote}"</blockquote>`;
+    container.appendChild(div);
+  });
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   modal = document.getElementById('enter-modal');
   form = document.getElementById('enter-form');
@@ -416,6 +430,7 @@ document.addEventListener('DOMContentLoaded', () => {
   load();
   loadPast();
   loadTrending();
+  loadWinnerInterviews();
   const subForm = document.getElementById('comp-subscribe');
   const emailInput = document.getElementById('comp-email');
   const msgEl = document.getElementById('comp-subscribe-msg');


### PR DESCRIPTION
## Summary
- load `competition_winners.json` at startup
- expose `/api/competitions/winners` endpoint
- display winner interviews on competitions page
- fetch winner interviews with new JS function
- cover new endpoint in tests

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6852a97a47e8832d94f799e29fa1e7db