### PR TITLE
Improve subscription reminders

### DIFF
--- a/.github/workflows/printclub-reminders.yml
+++ b/.github/workflows/printclub-reminders.yml
@@ -1,0 +1,21 @@
+name: Print Club Reminders
+
+on:
+  schedule:
+    - cron: '0 5 * * *'
+  workflow_dispatch:
+
+jobs:
+  remind:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+          cache-dependency-path: 'backend/package-lock.json'
+      - run: npm ci
+        working-directory: backend
+      - run: npm run send-printclub-reminders
+        working-directory: backend

--- a/backend/scripts/send-printclub-reminders.js
+++ b/backend/scripts/send-printclub-reminders.js
@@ -2,15 +2,36 @@ require('dotenv').config();
 const { Client } = require('pg');
 const { sendTemplate } = require('../mail');
 
+function startOfWeek(d = new Date()) {
+  const date = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+  const day = date.getUTCDay();
+  const diff = date.getUTCDate() - day;
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), diff));
+}
+
+function daysUntilNextReset() {
+  const today = new Date();
+  const nextWeekStart = new Date(startOfWeek(today).getTime() + 7 * 24 * 60 * 60 * 1000);
+  return Math.ceil((nextWeekStart - today) / (24 * 60 * 60 * 1000));
+}
+
 async function sendReminders() {
+  if (daysUntilNextReset() > 2) return;
+
   const client = new Client({ connectionString: process.env.DB_URL });
   await client.connect();
+  const week = startOfWeek();
+  const weekStr = week.toISOString().slice(0, 10);
   try {
     const { rows } = await client.query(
       `SELECT u.email, u.username
-         FROM subscriptions s
-         JOIN users u ON s.user_id=u.id
-        WHERE s.status='active'`
+         FROM subscription_credits c
+         JOIN subscriptions s ON c.user_id=s.user_id
+         JOIN users u ON c.user_id=u.id
+        WHERE s.status='active'
+          AND c.week_start=$1
+          AND c.total_credits - c.used_credits > 0`,
+      [weekStr]
     );
     for (const row of rows) {
       try {

--- a/backend/tests/printclubReminders.test.js
+++ b/backend/tests/printclubReminders.test.js
@@ -1,0 +1,37 @@
+process.env.DB_URL = 'postgres://user:pass@localhost/db';
+
+jest.mock('pg');
+const { Client } = require('pg');
+const mClient = { connect: jest.fn(), end: jest.fn(), query: jest.fn() };
+Client.mockImplementation(() => mClient);
+
+jest.mock('../mail', () => ({ sendTemplate: jest.fn() }));
+const { sendTemplate } = require('../mail');
+
+const run = require('../scripts/send-printclub-reminders');
+
+beforeEach(() => {
+  mClient.connect.mockClear();
+  mClient.end.mockClear();
+  mClient.query.mockClear();
+  sendTemplate.mockClear();
+});
+
+test('sends reminders when credits unused and near reset', async () => {
+  jest.useFakeTimers().setSystemTime(new Date('2024-01-06T12:00:00Z'));
+  mClient.query.mockResolvedValueOnce({ rows: [{ email: 'a@a.com', username: 'alice' }] });
+  await run();
+  expect(sendTemplate).toHaveBeenCalledWith('a@a.com', 'Print Club Reminder', 'reminder.txt', {
+    username: 'alice',
+  });
+  expect(mClient.end).toHaveBeenCalled();
+  jest.useRealTimers();
+});
+
+test('exits early when reset is far away', async () => {
+  jest.useFakeTimers().setSystemTime(new Date('2024-01-02T12:00:00Z'));
+  await run();
+  expect(mClient.connect).not.toHaveBeenCalled();
+  expect(sendTemplate).not.toHaveBeenCalled();
+  jest.useRealTimers();
+});

--- a/js/payment.js
+++ b/js/payment.js
@@ -353,6 +353,14 @@ async function initPaymentPage() {
   const subscriptionRadios = document.querySelectorAll(
     '#subscription-choice input[name="printclub"]'
   );
+  const priceSpan = document.getElementById('printclub-price');
+  const hasReferral = Boolean(localStorage.getItem('referrerId'));
+  if (priceSpan) {
+    const first = (PRINT_CLUB_PRICE * 0.9) / 100;
+    priceSpan.textContent = hasReferral
+      ? `Join Print Club £${first.toFixed(2)} first month`
+      : `Join Print Club £${(PRINT_CLUB_PRICE / 100).toFixed(2)}/mo`;
+  }
   const plan = qs('plan');
   if (plan === 'printclub') {
     subscriptionRadios.forEach((r) => {
@@ -477,8 +485,12 @@ async function initPaymentPage() {
     const joinClub =
       Array.from(subscriptionRadios).find((r) => r.checked)?.value === 'join';
     if (joinClub) {
-      payBtn.textContent =
-        `Join Print Club – Pay £${(PRINT_CLUB_PRICE / 100).toFixed(2)}`;
+      const hasReferral = Boolean(localStorage.getItem('referrerId'));
+      const price = hasReferral
+        ? (PRINT_CLUB_PRICE * 0.9) / 100
+        : PRINT_CLUB_PRICE / 100;
+      const suffix = hasReferral ? ' first month' : '';
+      payBtn.textContent = `Join Print Club – Pay £${price.toFixed(2)}${suffix}`;
     } else {
       payBtn.textContent = `Pay £${(selectedPrice / 100).toFixed(2)}`;
     }

--- a/payment.html
+++ b/payment.html
@@ -387,7 +387,7 @@
               <span class="px-2 font-semibold">OR</span>
               <label class="flex items-center gap-1 whitespace-nowrap">
                 <input type="radio" name="printclub" value="join" class="accent-[#30D5C8]" />
-                Join Print Club £140/mo
+                <span id="printclub-price">Join Print Club £140/mo</span>
               </label>
             </fieldset>
 


### PR DESCRIPTION
## Summary
- add Print Club reminder workflow
- send reminders only when credits expire soon
- display referral discount for Print Club signups
- add tests for reminder script

## Testing
- `npm ci`
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852a9a96730832d8ec922ae78cf657f