### PR TITLE
Fix reminder script and simplify Print Club badge

### DIFF
--- a/js/printclub.js
+++ b/js/printclub.js
@@ -5,26 +5,6 @@ const bannerLink = document.getElementById('printclub-banner-link');
 const API_BASE = (window.API_ORIGIN || '') + '/api';
 
 
-async function updateBadgeText() {
-  const token = localStorage.getItem('token');
-  if (!token || !badge) return;
-  try {
-    const res = await fetch(`${API_BASE}/subscription`, {
-      headers: { Authorization: `Bearer ${token}` },
-    });
-    if (!res.ok) return;
-    const sub = await res.json();
-    if (sub && sub.active !== false && sub.status !== 'canceled') {
-      badge.textContent = 'Print Club';
-    }
-  } catch {
-    // ignore errors
-  }
-}
-
-updateBadgeText();
-
-
 bannerLink?.addEventListener('click', (e) => {
   e.preventDefault();
   modal?.classList.remove('hidden');


### PR DESCRIPTION
## Summary
- fix `send-printclub-reminders.js` to use current week variables
- remove duplicate logic in `printclub.js`

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6852c5babbd8832d9afbd7d882cbc9a3