### PR TITLE
Implement voting for competitions

### DIFF
--- a/backend/migrations/040_create_competition_votes.sql
+++ b/backend/migrations/040_create_competition_votes.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS competition_votes (
+  competition_id UUID REFERENCES competitions(id) ON DELETE CASCADE,
+  model_id UUID REFERENCES jobs(job_id) ON DELETE CASCADE,
+  user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+  PRIMARY KEY (competition_id, model_id, user_id)
+);

--- a/backend/tests/additionalApi.test.js
+++ b/backend/tests/additionalApi.test.js
@@ -348,29 +348,29 @@ test('GET /api/competitions/past ordering', async () => {
 });
 
 test('GET /api/competitions/:id/entries', async () => {
-  db.query.mockResolvedValueOnce({ rows: [{ model_id: 'm1', likes: 3 }] });
+  db.query.mockResolvedValueOnce({ rows: [{ model_id: 'm1', votes: 3 }] });
   const res = await request(app).get('/api/competitions/5/entries');
   expect(res.status).toBe(200);
-  expect(res.body[0].likes).toBe(3);
+  expect(res.body[0].votes).toBe(3);
 });
 
 test('GET /api/competitions/:id/entries order', async () => {
   db.query.mockResolvedValueOnce({ rows: [] });
   await request(app).get('/api/competitions/5/entries');
-  expect(db.query).toHaveBeenCalledWith(expect.stringContaining('ORDER BY likes DESC'), ['5']);
+  expect(db.query).toHaveBeenCalledWith(expect.stringContaining('ORDER BY votes DESC'), ['5']);
 });
 
 test('GET /api/competitions/:id/entries leaderboard order', async () => {
   db.query.mockResolvedValueOnce({
     rows: [
-      { model_id: 'm2', likes: 10 },
-      { model_id: 'm1', likes: 5 },
-      { model_id: 'm3', likes: 1 },
+      { model_id: 'm2', votes: 10 },
+      { model_id: 'm1', votes: 5 },
+      { model_id: 'm3', votes: 1 },
     ],
   });
   const res = await request(app).get('/api/competitions/5/entries');
   expect(res.status).toBe(200);
-  expect(res.body.map((e) => e.likes)).toEqual([10, 5, 1]);
+  expect(res.body.map((e) => e.votes)).toEqual([10, 5, 1]);
 });
 
 test('GET /api/competitions/:id/comments', async () => {
@@ -479,6 +479,31 @@ test('POST /api/competitions/:id/discount requires entry', async () => {
   expect(res.status).toBe(400);
 });
 
+test('POST /api/competitions/:id/vote stores vote', async () => {
+  db.query.mockResolvedValueOnce({}).mockResolvedValueOnce({ rows: [{ count: '1' }] });
+  const token = jwt.sign({ id: 'u1' }, 'secret');
+  const res = await request(app)
+    .post('/api/competitions/5/vote')
+    .set('authorization', `Bearer ${token}`)
+    .send({ modelId: 'm1' });
+  expect(res.status).toBe(200);
+  expect(res.body.votes).toBe(1);
+});
+
+test('POST /api/competitions/:id/vote requires modelId', async () => {
+  const token = jwt.sign({ id: 'u1' }, 'secret');
+  const res = await request(app)
+    .post('/api/competitions/5/vote')
+    .set('authorization', `Bearer ${token}`)
+    .send({});
+  expect(res.status).toBe(400);
+});
+
+test('POST /api/competitions/:id/vote requires auth', async () => {
+  const res = await request(app).post('/api/competitions/5/vote').send({ modelId: 'm1' });
+  expect(res.status).toBe(401);
+});
+
 test('DELETE /api/admin/competitions/:id', async () => {
   db.query.mockResolvedValueOnce({});
   const res = await request(app).delete('/api/admin/competitions/5').set('x-admin-token', 'admin');
@@ -550,6 +575,16 @@ test('checkCompetitionStart sends voting emails', async () => {
   expect(sendMail).toHaveBeenCalledWith('a@a.com', 'Voting Open', expect.stringContaining('Comp'));
   const call = db.query.mock.calls.find((c) => c[0].includes('UPDATE competitions'));
   expect(call[1][0]).toBe('c1');
+});
+
+test('POST /api/competitions/notify sends emails', async () => {
+  db.query.mockResolvedValueOnce({ rows: [{ email: 'a@a.com' }, { email: 'b@b.com' }] });
+  const res = await request(app)
+    .post('/api/competitions/notify')
+    .set('x-admin-token', 'admin')
+    .send({ subject: 'Hi', message: 'Hello' });
+  expect(res.status).toBe(204);
+  expect(sendMail).toHaveBeenCalledWith('a@a.com', 'Hi', 'Hello');
 });
 
 test('GET /api/print-slots returns count', async () => {

--- a/competitions.html
+++ b/competitions.html
@@ -150,7 +150,7 @@
           />
           <span class="absolute top-1 left-1 bg-black/60 text-xs px-1 rounded">Ended 05/25</span>
           <button class="like absolute bottom-1 right-1 text-xs bg-red-600 px-1 rounded">♥</button>
-          <span class="absolute bottom-8 right-1 text-xs bg-black/50 px-1 rounded" id="likes-helmet">0</span>
+          <span class="absolute bottom-8 right-1 text-xs bg-black/50 px-1 rounded" id="votes-helmet">0</span>
           <button class="purchase absolute bottom-1 left-1 font-bold text-lg py-2 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]">Buy</button>
         </div>
         <div
@@ -165,7 +165,7 @@
           />
           <span class="absolute top-1 left-1 bg-black/60 text-xs px-1 rounded">Ended 03/24</span>
           <button class="like absolute bottom-1 right-1 text-xs bg-red-600 px-1 rounded">♥</button>
-          <span class="absolute bottom-8 right-1 text-xs bg-black/50 px-1 rounded" id="likes-fox">0</span>
+          <span class="absolute bottom-8 right-1 text-xs bg-black/50 px-1 rounded" id="votes-fox">0</span>
           <button class="purchase absolute bottom-1 left-1 font-bold text-lg py-2 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]">Buy</button>
         </div>
         <div
@@ -180,7 +180,7 @@
           />
           <span class="absolute top-1 left-1 bg-black/60 text-xs px-1 rounded">Ended 01/23</span>
           <button class="like absolute bottom-1 right-1 text-xs bg-red-600 px-1 rounded">♥</button>
-          <span class="absolute bottom-8 right-1 text-xs bg-black/50 px-1 rounded" id="likes-boombox">0</span>
+          <span class="absolute bottom-8 right-1 text-xs bg-black/50 px-1 rounded" id="votes-boombox">0</span>
           <button class="purchase absolute bottom-1 left-1 font-bold text-lg py-2 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]">Buy</button>
         </div>
       </div>

--- a/js/competitions.js
+++ b/js/competitions.js
@@ -56,20 +56,22 @@ function purchase(modelUrl, jobId) {
   window.location.href = 'payment.html';
 }
 
-function like(id) {
+function vote(id) {
   const token = localStorage.getItem('token');
   if (!token) {
     alert('Login required');
     return;
   }
-  fetch(`${API_BASE}/models/${id}/like`, {
+  const compId = currentId;
+  fetch(`${API_BASE}/competitions/${compId}/vote`, {
     method: 'POST',
-    headers: { Authorization: `Bearer ${token}` },
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    body: JSON.stringify({ modelId: id }),
   })
     .then((r) => r.json())
     .then((d) => {
-      const span = document.querySelector(`#likes-${id}`);
-      if (span) span.textContent = d.likes;
+      const span = document.querySelector(`#votes-${id}`);
+      if (span && d.votes !== undefined) span.textContent = d.votes;
     });
 }
 
@@ -131,7 +133,7 @@ async function loadLeaderboard(id, table, grid) {
   if (!res.ok) return;
   const rows = await res.json();
   table.innerHTML = rows
-    .map((r, i) => `<tr><td>${i + 1}</td><td>${r.model_id}</td><td>${r.likes}</td></tr>`)
+    .map((r, i) => `<tr><td>${i + 1}</td><td>${r.model_id}</td><td>${r.votes}</td></tr>`)
     .join('');
   if (grid) {
     grid.innerHTML = '';
@@ -141,10 +143,10 @@ async function loadLeaderboard(id, table, grid) {
         'entry-card relative h-32 bg-[#2A2A2E] border border-white/10 rounded-xl flex items-center justify-center cursor-pointer';
       card.dataset.model = r.model_url;
       card.dataset.job = r.model_id;
-      card.innerHTML = `<img src="" alt="Model" class="w-full h-full object-contain pointer-events-none" />\n      <button class="like absolute bottom-1 right-1 text-xs bg-red-600 px-1 rounded">\u2665</button>\n      <span class="absolute bottom-8 right-1 text-xs bg-black/50 px-1 rounded" id="likes-${r.model_id}">${r.likes}</span>\n      <button class="purchase absolute bottom-1 left-1 font-bold text-lg py-2 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]">Buy</button>`;
+      card.innerHTML = `<img src="" alt="Model" class="w-full h-full object-contain pointer-events-none" />\n      <button class="like absolute bottom-1 right-1 text-xs bg-red-600 px-1 rounded">\u2665</button>\n      <span class="absolute bottom-8 right-1 text-xs bg-black/50 px-1 rounded" id="votes-${r.model_id}">${r.votes}</span>\n      <button class="purchase absolute bottom-1 left-1 font-bold text-lg py-2 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]">Buy</button>`;
       card.querySelector('.like').addEventListener('click', (e) => {
         e.stopPropagation();
-        like(r.model_id);
+        vote(r.model_id);
       });
       const buyBtn = card.querySelector('.purchase');
       buyBtn.addEventListener('click', (e) => {
@@ -406,7 +408,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (likeBtn) {
       likeBtn.addEventListener('click', (e) => {
         e.stopPropagation();
-        like(card.dataset.job);
+        vote(card.dataset.job);
       });
     }
     if (buyBtn) {


### PR DESCRIPTION
## Summary
- enable competition votes endpoint `/api/competitions/:id/vote`
- expose notification endpoint `/api/competitions/notify`
- add competition_votes table
- update frontend to use vote counts instead of likes
- fix printclub reminder script
- add tests for votes and notifications

## Validation
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6852c5c091c0832da8b8b23b4770ca3f