### PR TITLE
Add endpoint for referral QR codes

### DIFF
--- a/backend/tests/rewards.test.js
+++ b/backend/tests/rewards.test.js
@@ -98,3 +98,15 @@ test('GET /api/orders/:id/referral-link returns code', async () => {
   expect(res.body.code).toBe('orderabc');
   expect(db.getOrCreateOrderReferralLink).toHaveBeenCalledWith('o1');
 });
+
+test('GET /api/orders/:id/referral-qr returns png', async () => {
+  db.query.mockResolvedValueOnce({ rows: [{ user_id: 'u1' }] });
+  db.getOrCreateOrderReferralLink.mockResolvedValue('orderabc');
+  const token = jwt.sign({ id: 'u1' }, 'secret');
+  const res = await request(app)
+    .get('/api/orders/o1/referral-qr')
+    .set('authorization', `Bearer ${token}`);
+  expect(res.status).toBe(200);
+  expect(res.headers['content-type']).toBe('image/png');
+  expect(db.getOrCreateOrderReferralLink).toHaveBeenCalledWith('o1');
+});


### PR DESCRIPTION
## Summary
- add endpoint to serve a QR code for order referral links
- clean up print club reminder script
- test new endpoint

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852c5c8a170832dacf4e83e7a0cdc6e