### PR TITLE
Implement printer monitoring and job assignment

### DIFF
--- a/backend/migrations/040_create_printers.sql
+++ b/backend/migrations/040_create_printers.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS printers (
+  id SERIAL PRIMARY KEY,
+  name TEXT NOT NULL,
+  api_url TEXT NOT NULL,
+  status TEXT DEFAULT 'unknown',
+  last_seen TIMESTAMPTZ DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS printers_status_idx ON printers(status);

--- a/backend/migrations/041_add_printer_and_gcode_to_print_jobs.sql
+++ b/backend/migrations/041_add_printer_and_gcode_to_print_jobs.sql
@@ -1,0 +1,4 @@
+ALTER TABLE print_jobs
+  ADD COLUMN IF NOT EXISTS printer_id INTEGER REFERENCES printers(id),
+  ADD COLUMN IF NOT EXISTS gcode_path TEXT;
+CREATE INDEX IF NOT EXISTS print_jobs_printer_idx ON print_jobs(printer_id);

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,6 +18,8 @@
     "cleanup-tokens": "node scripts/cleanup-password-resets.js",
     "measure-load": "node scripts/measure-load.js",
     "generate-referral-qr": "node scripts/generate-referral-qr.js",
+    "poll-printers": "node scripts/poll-printers.js",
+    "assign-print-jobs": "node scripts/assign-print-jobs.js",
     "lint": "eslint . --max-warnings=0"
   },
   "keywords": [],

--- a/backend/scripts/assign-print-jobs.js
+++ b/backend/scripts/assign-print-jobs.js
@@ -1,0 +1,27 @@
+require('dotenv').config();
+const axios = require('axios');
+const db = require('../db');
+
+async function assignPrintJobs() {
+  const job = await db.getNextPendingPrintJob();
+  if (!job) return;
+  const printers = await db.getIdlePrinters();
+  if (!printers.length) return;
+  const printer = printers[0];
+  try {
+    await axios.post(`${printer.api_url}/print`, { gcodePath: job.gcode_path });
+    await db.assignJobToPrinter(job.id, printer.id);
+    await db.updatePrinterStatus(printer.id, 'printing');
+  } catch (err) {
+    console.error('Failed to assign job', err);
+  }
+}
+
+if (require.main === module) {
+  assignPrintJobs().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}
+
+module.exports = assignPrintJobs;

--- a/backend/scripts/poll-printers.js
+++ b/backend/scripts/poll-printers.js
@@ -1,0 +1,31 @@
+require('dotenv').config();
+const axios = require('axios');
+const db = require('../db');
+
+async function pollPrinters() {
+  const { rows } = await db.query('SELECT id, api_url FROM printers');
+  for (const p of rows) {
+    try {
+      const res = await axios.get(`${p.api_url}/api/printer`);
+      const state =
+        res.data.state && res.data.state.text ? res.data.state.text.toLowerCase() : 'unknown';
+      const status = state.includes('printing')
+        ? 'printing'
+        : state.includes('operational')
+          ? 'idle'
+          : 'unknown';
+      await db.updatePrinterStatus(p.id, status);
+    } catch (err) {
+      await db.updatePrinterStatus(p.id, 'error');
+    }
+  }
+}
+
+if (require.main === module) {
+  pollPrinters().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}
+
+module.exports = pollPrinters;

--- a/backend/scripts/send-printclub-reminders.js
+++ b/backend/scripts/send-printclub-reminders.js
@@ -9,7 +9,6 @@ function startOfWeek(d = new Date()) {
   return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), diff));
 }
 
-
 function daysUntilNextReset() {
   const today = new Date();
   const nextWeekStart = new Date(startOfWeek(today).getTime() + 7 * 24 * 60 * 60 * 1000);
@@ -19,14 +18,12 @@ function daysUntilNextReset() {
 async function sendReminders() {
   if (daysUntilNextReset() > 2) return;
 
-
+  const now = new Date();
   const client = new Client({ connectionString: process.env.DB_URL });
   await client.connect();
-  const week = startOfWeek();
+  const week = startOfWeek(now);
   const weekStr = week.toISOString().slice(0, 10);
   try {
-    const week = startOfWeek(now);
-    const weekStr = week.toISOString().slice(0, 10);
     const { rows } = await client.query(
       `SELECT u.email, u.username
 

--- a/backend/tests/assignPrintJobs.test.js
+++ b/backend/tests/assignPrintJobs.test.js
@@ -1,0 +1,24 @@
+jest.mock('axios');
+const axios = require('axios');
+
+jest.mock('../db', () => ({
+  getNextPendingPrintJob: jest.fn(),
+  getIdlePrinters: jest.fn(),
+  assignJobToPrinter: jest.fn(),
+  updatePrinterStatus: jest.fn(),
+}));
+const db = require('../db');
+
+const assignPrintJobs = require('../scripts/assign-print-jobs');
+
+test('assigns job to idle printer', async () => {
+  db.getNextPendingPrintJob.mockResolvedValueOnce({ id: 5, gcode_path: '/p.gcode' });
+  db.getIdlePrinters.mockResolvedValueOnce([{ id: 2, api_url: 'http://p1' }]);
+  axios.post.mockResolvedValueOnce({});
+
+  await assignPrintJobs();
+
+  expect(axios.post).toHaveBeenCalledWith('http://p1/print', { gcodePath: '/p.gcode' });
+  expect(db.assignJobToPrinter).toHaveBeenCalledWith(5, 2);
+  expect(db.updatePrinterStatus).toHaveBeenCalledWith(2, 'printing');
+});

--- a/backend/tests/pollPrinters.test.js
+++ b/backend/tests/pollPrinters.test.js
@@ -1,0 +1,20 @@
+jest.mock('axios');
+const axios = require('axios');
+
+jest.mock('../db', () => ({
+  query: jest.fn(),
+  updatePrinterStatus: jest.fn(),
+}));
+const db = require('../db');
+
+const pollPrinters = require('../scripts/poll-printers');
+
+test('pollPrinters updates printer status', async () => {
+  db.query.mockResolvedValueOnce({ rows: [{ id: 1, api_url: 'http://p1' }] });
+  axios.get.mockResolvedValueOnce({ data: { state: { text: 'Operational' } } });
+
+  await pollPrinters();
+
+  expect(axios.get).toHaveBeenCalledWith('http://p1/api/printer');
+  expect(db.updatePrinterStatus).toHaveBeenCalledWith(1, 'idle');
+});


### PR DESCRIPTION
## Summary
- add printers table and extend print_jobs with printer fields
- implement polling of printer status via OctoPrint API
- create job assignment script for idle printers
- expose helper DB functions
- fix undefined `now` variable in print club reminders script
- add unit tests for new scripts

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6852c5eaf49c832d9f3e1699750821ac