### PR TITLE
Implement subscription summary API and fix reminders

### DIFF
--- a/backend/scripts/send-printclub-reminders.js
+++ b/backend/scripts/send-printclub-reminders.js
@@ -20,8 +20,7 @@ async function sendReminders() {
 
   const client = new Client({ connectionString: process.env.DB_URL });
   await client.connect();
-  const week = startOfWeek();
-  const weekStr = week.toISOString().slice(0, 10);
+  const weekStr = startOfWeek().toISOString().slice(0, 10);
   try {
     const { rows } = await client.query(
       `SELECT u.email, u.username

--- a/backend/server.js
+++ b/backend/server.js
@@ -712,6 +712,26 @@ app.get('/api/subscription/credits', authRequired, async (req, res) => {
   }
 });
 
+app.get('/api/subscription/summary', authRequired, async (req, res) => {
+  try {
+    await db.ensureCurrentWeekCredits(req.user.id, 2);
+    const [sub, credits] = await Promise.all([
+      db.getSubscription(req.user.id),
+      db.getCurrentWeekCredits(req.user.id),
+    ]);
+    res.json({
+      subscription: sub || { active: false },
+      credits: {
+        remaining: credits.total_credits - credits.used_credits,
+        total: credits.total_credits,
+      },
+    });
+  } catch (err) {
+    logError(err);
+    res.status(500).json({ error: 'Failed to fetch subscription summary' });
+  }
+});
+
 app.get('/api/dashboard', authRequired, async (req, res) => {
   try {
     await db.ensureCurrentWeekCredits(req.user.id, 2);

--- a/backend/tests/subscriptions.test.js
+++ b/backend/tests/subscriptions.test.js
@@ -65,6 +65,16 @@ test('GET /api/subscription/credits returns remaining', async () => {
   expect(res.body.remaining).toBe(1);
 });
 
+test('GET /api/subscription/summary returns subscription and credits', async () => {
+  const token = jwt.sign({ id: 'u1' }, 'secret');
+  const res = await request(app)
+    .get('/api/subscription/summary')
+    .set('authorization', `Bearer ${token}`);
+  expect(res.status).toBe(200);
+  expect(res.body.subscription.status).toBe('active');
+  expect(res.body.credits.remaining).toBe(1);
+});
+
 test('POST /api/subscription/portal returns url', async () => {
   db.getSubscription.mockResolvedValueOnce({ stripe_customer_id: 'cus_1' });
   stripeMock.billingPortal.sessions.create.mockResolvedValueOnce({ url: 'u' });


### PR DESCRIPTION
## Summary
- fix variable usage in `send-printclub-reminders.js`
- add `/api/subscription/summary` endpoint to provide subscription status and credits
- add test covering the new endpoint

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6852c602f4c4832dabea6f98c1700766