### PR TITLE
Implement scaling engine

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -281,6 +281,21 @@ async function getRewardOption(points) {
   return rows[0] || null;
 }
 
+async function insertScalingEvent(subreddit, oldBudget, newBudget, reason) {
+  await query(
+    'INSERT INTO scaling_events(subreddit, old_budget_cents, new_budget_cents, reason) VALUES($1,$2,$3,$4)',
+    [subreddit, oldBudget, newBudget, reason]
+  );
+}
+
+async function getScalingEvents(limit = 50) {
+  const { rows } = await query(
+    'SELECT subreddit, old_budget_cents, new_budget_cents, reason, created_at FROM scaling_events ORDER BY created_at DESC LIMIT $1',
+    [limit]
+  );
+  return rows;
+}
+
 async function getUserCreations(userId, limit = 10, offset = 0) {
   const { rows } = await query(
     `SELECT c.id, c.title, c.category, j.job_id, j.model_url
@@ -353,4 +368,6 @@ module.exports = {
   getCommunityComments,
   getRewardOptions,
   getRewardOption,
+  insertScalingEvent,
+  getScalingEvents,
 };

--- a/backend/migrations/040_create_scaling_events.sql
+++ b/backend/migrations/040_create_scaling_events.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS scaling_events (
+  id SERIAL PRIMARY KEY,
+  subreddit TEXT,
+  old_budget_cents INTEGER,
+  new_budget_cents INTEGER,
+  reason TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS scaling_events_subreddit_idx ON scaling_events(subreddit);
+
+CREATE TRIGGER scaling_events_set_updated
+BEFORE UPDATE ON scaling_events
+FOR EACH ROW EXECUTE PROCEDURE set_updated_at();

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,7 +18,8 @@
     "cleanup-tokens": "node scripts/cleanup-password-resets.js",
     "measure-load": "node scripts/measure-load.js",
     "generate-referral-qr": "node scripts/generate-referral-qr.js",
-    "lint": "eslint . --max-warnings=0"
+    "lint": "eslint . --max-warnings=0",
+    "scaling-engine": "node scalingEngine.js"
   },
   "keywords": [],
   "author": "",

--- a/backend/scalingEngine.js
+++ b/backend/scalingEngine.js
@@ -1,0 +1,88 @@
+require('dotenv').config();
+const axios = require('axios');
+const db = require('./db');
+
+const API_URL = process.env.REDDIT_ADS_API_URL || '';
+const API_TOKEN = process.env.REDDIT_ADS_API_TOKEN || '';
+const PROFIT_PER_SALE = parseInt(process.env.PROFIT_PER_SALE_CENTS || '500', 10);
+
+async function fetchCampaignPerformance() {
+  if (!API_URL) return [];
+  try {
+    const res = await axios.get(`${API_URL}/performance`, {
+      headers: { Authorization: `Bearer ${API_TOKEN}` },
+    });
+    return res.data || [];
+  } catch (err) {
+    console.error('Failed to fetch campaign performance', err.message);
+    return [];
+  }
+}
+
+async function adjustBudgets(performance) {
+  for (const camp of performance) {
+    const { subreddit, campaign_id, spend_cents, budget_cents } = camp;
+    const orders = await db.query(
+      "SELECT COUNT(*) FROM orders WHERE subreddit=$1 AND status='paid' AND created_at>=NOW()-INTERVAL '7 days'",
+      [subreddit]
+    );
+    const count = parseInt(orders.rows[0].count, 10);
+    if (!count) continue;
+    const cac = spend_cents / count;
+    let action = null;
+    let newBudget = budget_cents;
+    if (cac > PROFIT_PER_SALE * 1.5) {
+      // pause campaign
+      action = 'pause';
+      newBudget = 0;
+      try {
+        await axios.post(`${API_URL}/campaigns/${campaign_id}/pause`, null, {
+          headers: { Authorization: `Bearer ${API_TOKEN}` },
+        });
+      } catch (err) {
+        console.error('Failed to pause campaign', err.message);
+      }
+    } else if (cac > PROFIT_PER_SALE) {
+      action = 'decrease';
+      newBudget = Math.round(budget_cents * 0.8);
+      try {
+        await axios.post(
+          `${API_URL}/campaigns/${campaign_id}/budget`,
+          { budget_cents: newBudget },
+          { headers: { Authorization: `Bearer ${API_TOKEN}` } }
+        );
+      } catch (err) {
+        console.error('Failed to decrease budget', err.message);
+      }
+    } else if (cac < PROFIT_PER_SALE * 0.8) {
+      action = 'increase';
+      newBudget = Math.round(budget_cents * 1.1);
+      try {
+        await axios.post(
+          `${API_URL}/campaigns/${campaign_id}/budget`,
+          { budget_cents: newBudget },
+          { headers: { Authorization: `Bearer ${API_TOKEN}` } }
+        );
+      } catch (err) {
+        console.error('Failed to increase budget', err.message);
+      }
+    }
+    if (action) {
+      await db.insertScalingEvent(subreddit, budget_cents, newBudget, action);
+    }
+  }
+}
+
+async function runScalingEngine() {
+  const perf = await fetchCampaignPerformance();
+  await adjustBudgets(perf);
+}
+
+if (require.main === module) {
+  runScalingEngine().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}
+
+module.exports = runScalingEngine;

--- a/backend/scripts/send-printclub-reminders.js
+++ b/backend/scripts/send-printclub-reminders.js
@@ -9,7 +9,6 @@ function startOfWeek(d = new Date()) {
   return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), diff));
 }
 
-
 function daysUntilNextReset() {
   const today = new Date();
   const nextWeekStart = new Date(startOfWeek(today).getTime() + 7 * 24 * 60 * 60 * 1000);
@@ -19,14 +18,11 @@ function daysUntilNextReset() {
 async function sendReminders() {
   if (daysUntilNextReset() > 2) return;
 
-
   const client = new Client({ connectionString: process.env.DB_URL });
   await client.connect();
   const week = startOfWeek();
   const weekStr = week.toISOString().slice(0, 10);
   try {
-    const week = startOfWeek(now);
-    const weekStr = week.toISOString().slice(0, 10);
     const { rows } = await client.query(
       `SELECT u.email, u.username
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -31,6 +31,7 @@ const {
 const { verifyTag } = require('./social');
 
 const syncMailingList = require('./scripts/sync-mailing-list');
+const runScalingEngine = require('./scalingEngine');
 
 const ADMIN_TOKEN = process.env.ADMIN_TOKEN || 'admin';
 
@@ -1652,6 +1653,16 @@ app.get('/api/admin/subscription-metrics', adminCheck, async (req, res) => {
   }
 });
 
+app.get('/api/admin/scaling-events', adminCheck, async (req, res) => {
+  try {
+    const events = await db.getScalingEvents(50);
+    res.json(events);
+  } catch (err) {
+    logError(err);
+    res.status(500).json({ error: 'Failed to fetch events' });
+  }
+});
+
 /**
  * POST /api/create-order
  * Create a Stripe Checkout session
@@ -2003,6 +2014,10 @@ if (require.main === module) {
   initDailyPrintsSold();
   checkCompetitionStart();
   setInterval(checkCompetitionStart, 3600000);
+  runScalingEngine().catch((err) => logError('Scaling engine failed', err));
+  setInterval(() => {
+    runScalingEngine().catch((err) => logError('Scaling engine failed', err));
+  }, 3600000);
   syncMailingList().catch((err) => logError('Mail sync failed', err));
   setInterval(
     () => {

--- a/backend/tests/scalingEngine.test.js
+++ b/backend/tests/scalingEngine.test.js
@@ -1,0 +1,44 @@
+process.env.REDDIT_ADS_API_URL = 'http://ads';
+process.env.REDDIT_ADS_API_TOKEN = 't';
+process.env.PROFIT_PER_SALE_CENTS = '500';
+
+jest.mock('../db', () => ({
+  query: jest.fn(),
+  insertScalingEvent: jest.fn(),
+}));
+const db = require('../db');
+
+jest.mock('axios');
+const axios = require('axios');
+
+const run = require('../scalingEngine');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('increases budget when CAC below threshold', async () => {
+  axios.get.mockResolvedValueOnce({
+    data: [{ subreddit: 'fun', campaign_id: '1', spend_cents: 100, budget_cents: 1000 }],
+  });
+  db.query.mockResolvedValueOnce({ rows: [{ count: '10' }] });
+  axios.post.mockResolvedValue({});
+  await run();
+  expect(axios.post).toHaveBeenCalledWith(
+    'http://ads/campaigns/1/budget',
+    { budget_cents: 1100 },
+    expect.any(Object)
+  );
+  expect(db.insertScalingEvent).toHaveBeenCalledWith('fun', 1000, 1100, 'increase');
+});
+
+test('pauses when CAC far above threshold', async () => {
+  axios.get.mockResolvedValueOnce({
+    data: [{ subreddit: 'fun', campaign_id: '1', spend_cents: 2000, budget_cents: 1000 }],
+  });
+  db.query.mockResolvedValueOnce({ rows: [{ count: '1' }] });
+  axios.post.mockResolvedValue({});
+  await run();
+  expect(axios.post).toHaveBeenCalledWith('http://ads/campaigns/1/pause', null, expect.any(Object));
+  expect(db.insertScalingEvent).toHaveBeenCalledWith('fun', 1000, 0, 'pause');
+});


### PR DESCRIPTION
## Summary
- create `scaling_events` table
- add scaling engine script to adjust ad budgets
- expose `/api/admin/scaling-events` endpoint
- schedule scaling engine hourly
- include tests for scaling engine

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852c67923a0832d8d286adee4e554cd