### PR TITLE
Implement basic operations dashboard

### DIFF
--- a/admin/operations.html
+++ b/admin/operations.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Operations Dashboard</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body class="bg-[#1A1A1D] text-white font-sans flex flex-col min-h-screen">
+    <header class="relative flex items-center justify-between py-4 px-6">
+      <a
+        href="../index.html"
+        class="bg-[#2A2A2E] border border-white/10 rounded-3xl px-4 py-2 hover:bg-[#3A3A3E] transition-shape"
+        >Back</a
+      >
+      <h1 class="absolute inset-x-0 top-1/2 -translate-y-1/2 text-center text-2xl font-semibold">
+        Operations Dashboard
+      </h1>
+      <span class="w-16"></span>
+    </header>
+    <main class="flex-1 p-4 space-y-4">
+      <div class="space-x-2">
+        <input
+          id="token"
+          type="password"
+          placeholder="Admin token"
+          class="bg-[#2A2A2E] border border-white/10 rounded px-2 py-1"
+        />
+        <button id="set-token" class="bg-[#30D5C8] text-[#1A1A1D] px-3 py-1 rounded">
+          Set Token
+        </button>
+      </div>
+      <div id="ops" class="space-y-4"></div>
+    </main>
+    <script type="module" src="../js/adminOperations.js"></script>
+  </body>
+</html>

--- a/backend/db.js
+++ b/backend/db.js
@@ -281,6 +281,17 @@ async function getRewardOption(points) {
   return rows[0] || null;
 }
 
+async function getOperationsMetrics() {
+  const backlogRes = await query("SELECT COUNT(*) FROM print_jobs WHERE status!='complete'");
+  const errorsRes = await query(
+    "SELECT job_id, error FROM jobs WHERE error IS NOT NULL AND error<>'' ORDER BY updated_at DESC LIMIT 5"
+  );
+  return {
+    backlog: parseInt(backlogRes.rows[0].count, 10),
+    errors: errorsRes.rows,
+  };
+}
+
 async function getUserCreations(userId, limit = 10, offset = 0) {
   const { rows } = await query(
     `SELECT c.id, c.title, c.category, j.job_id, j.model_url
@@ -353,4 +364,5 @@ module.exports = {
   getCommunityComments,
   getRewardOptions,
   getRewardOption,
+  getOperationsMetrics,
 };

--- a/backend/scripts/send-printclub-reminders.js
+++ b/backend/scripts/send-printclub-reminders.js
@@ -9,7 +9,6 @@ function startOfWeek(d = new Date()) {
   return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), diff));
 }
 
-
 function daysUntilNextReset() {
   const today = new Date();
   const nextWeekStart = new Date(startOfWeek(today).getTime() + 7 * 24 * 60 * 60 * 1000);
@@ -19,14 +18,11 @@ function daysUntilNextReset() {
 async function sendReminders() {
   if (daysUntilNextReset() > 2) return;
 
-
   const client = new Client({ connectionString: process.env.DB_URL });
   await client.connect();
   const week = startOfWeek();
   const weekStr = week.toISOString().slice(0, 10);
   try {
-    const week = startOfWeek(now);
-    const weekStr = week.toISOString().slice(0, 10);
     const { rows } = await client.query(
       `SELECT u.email, u.username
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -1652,6 +1652,24 @@ app.get('/api/admin/subscription-metrics', adminCheck, async (req, res) => {
   }
 });
 
+app.get('/api/admin/operations', adminCheck, async (req, res) => {
+  try {
+    const metrics = await db.getOperationsMetrics();
+    const capacity = 20;
+    const hub = {
+      name: 'Main',
+      backlog: metrics.backlog,
+      capacity,
+      load: metrics.backlog / capacity,
+    };
+    const scaling = hub.load > 0.8 ? 'Demand high - consider scaling' : 'Capacity OK';
+    res.json({ hubs: [hub], errors: metrics.errors, scaling });
+  } catch (err) {
+    logError(err);
+    res.status(500).json({ error: 'Failed to fetch metrics' });
+  }
+});
+
 /**
  * POST /api/create-order
  * Create a Stripe Checkout session

--- a/backend/tests/operations.test.js
+++ b/backend/tests/operations.test.js
@@ -1,0 +1,33 @@
+process.env.STRIPE_SECRET_KEY = 'test';
+process.env.STRIPE_WEBHOOK_SECRET = 'whsec';
+process.env.DB_URL = 'postgres://user:pass@localhost/db';
+process.env.HUNYUAN_API_KEY = 'test';
+process.env.HUNYUAN_SERVER_URL = 'http://localhost:4000';
+
+jest.mock('../db', () => ({
+  query: jest.fn(),
+  insertCommission: jest.fn(),
+  getOperationsMetrics: jest.fn(),
+  getOrCreateOrderReferralLink: jest.fn(),
+  insertReferredOrder: jest.fn(),
+}));
+const db = require('../db');
+
+const request = require('supertest');
+const app = require('../server');
+
+beforeEach(() => {
+  db.getOperationsMetrics.mockClear();
+});
+
+test('GET /api/admin/operations requires admin', async () => {
+  const res = await request(app).get('/api/admin/operations');
+  expect(res.status).toBe(401);
+});
+
+test('GET /api/admin/operations returns data', async () => {
+  db.getOperationsMetrics.mockResolvedValueOnce({ backlog: 3, errors: [] });
+  const res = await request(app).get('/api/admin/operations').set('x-admin-token', 'admin');
+  expect(res.status).toBe(200);
+  expect(res.body.hubs[0].backlog).toBe(3);
+});

--- a/js/adminOperations.js
+++ b/js/adminOperations.js
@@ -1,0 +1,60 @@
+function getToken() {
+  return localStorage.getItem('adminToken') || localStorage.getItem('token') || '';
+}
+
+function setToken(token) {
+  localStorage.setItem('adminToken', token);
+}
+
+function authHeaders() {
+  const admin = localStorage.getItem('adminToken');
+  if (admin) return { 'x-admin-token': admin };
+  const user = localStorage.getItem('token');
+  if (user) return { Authorization: `Bearer ${user}` };
+  return {};
+}
+
+const API_BASE = (window.API_ORIGIN || '') + '/api';
+
+async function load() {
+  const container = document.getElementById('ops');
+  container.textContent = 'Loading...';
+  try {
+    const resp = await fetch(`${API_BASE}/admin/operations`, { headers: authHeaders() });
+    if (!resp.ok) throw new Error('Failed');
+    const data = await resp.json();
+    container.innerHTML = '';
+    const div = document.createElement('div');
+    div.className = 'space-y-2';
+    const hub = data.hubs[0];
+    div.innerHTML = `
+      <p>Backlog: ${hub.backlog}</p>
+      <p>Daily Capacity: ${hub.capacity}</p>
+      <p>Load: ${(hub.load * 100).toFixed(0)}%</p>
+      <p>Scaling: ${data.scaling}</p>
+    `;
+    container.appendChild(div);
+    if (data.errors && data.errors.length) {
+      const errList = document.createElement('ul');
+      errList.className = 'list-disc ml-4';
+      data.errors.forEach((e) => {
+        const li = document.createElement('li');
+        li.textContent = `${e.job_id}: ${e.error}`;
+        errList.appendChild(li);
+      });
+      container.appendChild(errList);
+    }
+  } catch (err) {
+    container.textContent = 'Failed to load dashboard';
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const tokenInput = document.getElementById('token');
+  tokenInput.value = localStorage.getItem('adminToken') || '';
+  document.getElementById('set-token').addEventListener('click', () => {
+    setToken(tokenInput.value.trim());
+    load();
+  });
+  if (getToken()) load();
+});


### PR DESCRIPTION
## Summary
- add an operations dashboard page and JS
- expose `/api/admin/operations` endpoint
- support operations metrics in db layer
- fix print club reminder script
- provide tests for the new endpoint

## Validation
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6852c6b494c8832d842e50db15b19961