### PR TITLE
Implement daily order summary job

### DIFF
--- a/backend/migrations/040_create_order_summaries.sql
+++ b/backend/migrations/040_create_order_summaries.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS order_summaries (
+  day DATE NOT NULL,
+  location TEXT NOT NULL,
+  order_count INTEGER NOT NULL,
+  printer_hours INTEGER NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  PRIMARY KEY (day, location)
+);

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,6 +18,7 @@
     "cleanup-tokens": "node scripts/cleanup-password-resets.js",
     "measure-load": "node scripts/measure-load.js",
     "generate-referral-qr": "node scripts/generate-referral-qr.js",
+    "summarize-orders": "node scripts/summarize-orders.js",
     "lint": "eslint . --max-warnings=0"
   },
   "keywords": [],

--- a/backend/scripts/send-printclub-reminders.js
+++ b/backend/scripts/send-printclub-reminders.js
@@ -9,7 +9,6 @@ function startOfWeek(d = new Date()) {
   return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), diff));
 }
 
-
 function daysUntilNextReset() {
   const today = new Date();
   const nextWeekStart = new Date(startOfWeek(today).getTime() + 7 * 24 * 60 * 60 * 1000);
@@ -19,14 +18,11 @@ function daysUntilNextReset() {
 async function sendReminders() {
   if (daysUntilNextReset() > 2) return;
 
-
   const client = new Client({ connectionString: process.env.DB_URL });
   await client.connect();
   const week = startOfWeek();
   const weekStr = week.toISOString().slice(0, 10);
   try {
-    const week = startOfWeek(now);
-    const weekStr = week.toISOString().slice(0, 10);
     const { rows } = await client.query(
       `SELECT u.email, u.username
 

--- a/backend/scripts/summarize-orders.js
+++ b/backend/scripts/summarize-orders.js
@@ -1,0 +1,47 @@
+require('dotenv').config();
+const { Client } = require('pg');
+const { sendMail } = require('../mail');
+
+const HOURS_PER_ORDER = parseFloat(process.env.PRINTER_HOURS_PER_ORDER || '2');
+const DAILY_CAPACITY = parseFloat(process.env.DAILY_CAPACITY_HOURS || '24');
+const ALERT_EMAIL = process.env.CAPACITY_ALERT_EMAIL || '';
+
+async function summarizeOrders() {
+  const client = new Client({ connectionString: process.env.DB_URL });
+  await client.connect();
+  try {
+    const { rows } = await client.query(
+      `SELECT DATE(created_at) AS day,
+              COALESCE(shipping_info->>'country', 'Unknown') AS location,
+              COUNT(*)::int AS order_count
+         FROM orders
+        WHERE created_at >= NOW() - INTERVAL '1 day'
+        GROUP BY day, location`
+    );
+    for (const row of rows) {
+      const hours = row.order_count * HOURS_PER_ORDER;
+      await client.query(
+        `INSERT INTO order_summaries(day, location, order_count, printer_hours)
+         VALUES($1,$2,$3,$4)
+         ON CONFLICT (day, location)
+         DO UPDATE SET order_count=$3, printer_hours=$4`,
+        [row.day, row.location, row.order_count, hours]
+      );
+      if (hours > DAILY_CAPACITY && ALERT_EMAIL) {
+        await sendMail(
+          ALERT_EMAIL,
+          'Capacity at risk',
+          `Orders for ${row.location} on ${row.day} require ${hours} printer hours but capacity is ${DAILY_CAPACITY}.`
+        );
+      }
+    }
+  } finally {
+    await client.end();
+  }
+}
+
+if (require.main === module) {
+  summarizeOrders();
+}
+
+module.exports = summarizeOrders;

--- a/backend/tests/summarizeOrders.test.js
+++ b/backend/tests/summarizeOrders.test.js
@@ -1,0 +1,45 @@
+process.env.DB_URL = 'postgres://user:pass@localhost/db';
+process.env.PRINTER_HOURS_PER_ORDER = '2';
+process.env.DAILY_CAPACITY_HOURS = '5';
+process.env.CAPACITY_ALERT_EMAIL = 'ops@test.com';
+
+jest.mock('pg');
+const { Client } = require('pg');
+const mClient = { connect: jest.fn(), end: jest.fn(), query: jest.fn() };
+Client.mockImplementation(() => mClient);
+
+jest.mock('../mail', () => ({ sendMail: jest.fn() }));
+const { sendMail } = require('../mail');
+
+const run = require('../scripts/summarize-orders');
+
+beforeEach(() => {
+  mClient.connect.mockClear();
+  mClient.end.mockClear();
+  mClient.query.mockClear();
+  sendMail.mockClear();
+});
+
+test('inserts summary and sends alert when capacity exceeded', async () => {
+  mClient.query.mockResolvedValueOnce({
+    rows: [{ day: '2024-01-01', location: 'US', order_count: 3 }],
+  });
+  mClient.query.mockResolvedValueOnce({});
+  await run();
+  expect(mClient.connect).toHaveBeenCalled();
+  expect(mClient.query).toHaveBeenCalledWith(
+    expect.stringContaining('INSERT INTO order_summaries'),
+    ['2024-01-01', 'US', 3, 6]
+  );
+  expect(sendMail).toHaveBeenCalled();
+  expect(mClient.end).toHaveBeenCalled();
+});
+
+test('no alert when under capacity', async () => {
+  mClient.query.mockResolvedValueOnce({
+    rows: [{ day: '2024-01-01', location: 'US', order_count: 1 }],
+  });
+  mClient.query.mockResolvedValueOnce({});
+  await run();
+  expect(sendMail).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- create `order_summaries` table
- add script to summarise orders and email alerts when capacity is exceeded
- expose `summarize-orders` npm script
- fix duplicate week calculation in print club reminder script
- test new summarise-orders script

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6852c69e0014832d855ae3264ede3a6a