### PR TITLE
Implement daily ops report

### DIFF
--- a/backend/scripts/generate-ops-report.js
+++ b/backend/scripts/generate-ops-report.js
@@ -1,0 +1,41 @@
+require('dotenv').config();
+const { Client } = require('pg');
+
+async function generateOpsReport() {
+  const client = new Client({ connectionString: process.env.DB_URL });
+  await client.connect();
+  try {
+    const hubRes = await client.query(`
+      SELECT h.id, h.name, COUNT(p.id) AS printers
+        FROM printer_hubs h
+        LEFT JOIN printers p ON p.hub_id=h.id
+       GROUP BY h.id, h.name
+       ORDER BY h.id`);
+    const orderRes = await client.query('SELECT status, COUNT(*) FROM orders GROUP BY status');
+    const orders = orderRes.rows.reduce((acc, r) => {
+      acc[r.status] = parseInt(r.count, 10);
+      return acc;
+    }, {});
+    const report = {
+      date: new Date().toISOString().slice(0, 10),
+      hubs: hubRes.rows.map((r) => ({
+        id: r.id,
+        name: r.name,
+        printers: parseInt(r.printers, 10),
+      })),
+      orders,
+    };
+    console.log(JSON.stringify(report, null, 2));
+  } finally {
+    await client.end();
+  }
+}
+
+if (require.main === module) {
+  generateOpsReport().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}
+
+module.exports = generateOpsReport;

--- a/backend/tests/generateOpsReport.test.js
+++ b/backend/tests/generateOpsReport.test.js
@@ -1,0 +1,28 @@
+process.env.DB_URL = 'postgres://user:pass@localhost/db';
+
+jest.mock('pg');
+const { Client } = require('pg');
+const mClient = { connect: jest.fn(), end: jest.fn(), query: jest.fn() };
+Client.mockImplementation(() => mClient);
+
+const run = require('../scripts/generate-ops-report');
+
+beforeEach(() => {
+  mClient.connect.mockClear();
+  mClient.end.mockClear();
+  mClient.query.mockClear();
+});
+
+test('outputs hub and order summary', async () => {
+  mClient.query
+    .mockResolvedValueOnce({ rows: [{ id: 1, name: 'Hub A', printers: '3' }] })
+    .mockResolvedValueOnce({ rows: [{ status: 'paid', count: '5' }] });
+  const log = jest.spyOn(console, 'log').mockImplementation(() => {});
+  await run();
+  expect(mClient.connect).toHaveBeenCalled();
+  expect(mClient.query).toHaveBeenNthCalledWith(1, expect.stringContaining('FROM printer_hubs'));
+  expect(mClient.query).toHaveBeenNthCalledWith(2, expect.stringContaining('FROM orders'));
+  expect(log).toHaveBeenCalledWith(expect.stringContaining('"hubs"'));
+  expect(mClient.end).toHaveBeenCalled();
+  log.mockRestore();
+});

--- a/docs/task_list.md
+++ b/docs/task_list.md
@@ -407,8 +407,6 @@
 
 ## Global Operations Reporting
 
-- Produce a daily capacity report summarizing each hub.
-- Summarize orders pending vs fulfilled.
 - Email a weekly "state of company" PDF with key metrics.
 - Highlight hubs with repeated errors or downtime.
 - Archive all reports in cloud storage.


### PR DESCRIPTION
## Summary
- add script to create daily hub/order report
- test ops report generation
- remove completed tasks from operations list

## Testing
- `npm run format`
- `npm test`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_685329fadd5c832da50df806324d077c