### PR TITLE
Automated scaling engine docs cleanup

### DIFF
--- a/backend/tests/scalingEngine.test.js
+++ b/backend/tests/scalingEngine.test.js
@@ -42,3 +42,18 @@ test('pauses when CAC far above threshold', async () => {
   expect(axios.post).toHaveBeenCalledWith('http://ads/campaigns/1/pause', null, expect.any(Object));
   expect(db.insertScalingEvent).toHaveBeenCalledWith('fun', 1000, 0, 'pause');
 });
+
+test('decreases budget when CAC slightly above threshold', async () => {
+  axios.get.mockResolvedValueOnce({
+    data: [{ subreddit: 'fun', campaign_id: '1', spend_cents: 700, budget_cents: 1000 }],
+  });
+  db.query.mockResolvedValueOnce({ rows: [{ count: '1' }] });
+  axios.post.mockResolvedValue({});
+  await run();
+  expect(axios.post).toHaveBeenCalledWith(
+    'http://ads/campaigns/1/budget',
+    { budget_cents: 800 },
+    expect.any(Object)
+  );
+  expect(db.insertScalingEvent).toHaveBeenCalledWith('fun', 1000, 800, 'decrease');
+});

--- a/docs/task_list.md
+++ b/docs/task_list.md
@@ -163,16 +163,6 @@
 - Display aggregated profit by subreddit in an admin dashboard.
 - Add unit tests covering profit calculations and data import.
 
-## Automated Scaling Engine
-
-- Fetch campaign performance hourly via cron.
-- Compute marginal CAC per subreddit.
-- Compare CAC to profit per sale with thresholds.
-- Increase or decrease budgets via Reddit Ads API accordingly.
-- Pause campaigns when CAC exceeds profit threshold.
-- Log each budget change to a `scaling_events` table.
-- Expose an admin endpoint listing recent scaling actions.
-
 ## Autonomous 3D Printing
 
 - Create `print_jobs` table with order ID, printer ID, status, and G-code path.


### PR DESCRIPTION
## Summary
- add unit test for decrease budget path in scaling engine
- remove completed scaling engine section from task list

## Testing
- `npm run format` in `backend/`
- `npm test -- -i`

------
https://chatgpt.com/codex/tasks/task_e_685329a28704832dbf2ebc6840b7cc11