### PR TITLE
Add print purchase flows for past winners

### DIFF
--- a/competitions.html
+++ b/competitions.html
@@ -62,7 +62,8 @@
           href="printclub.html"
           id="print-club-badge"
           class="bg-gradient-to-r from-purple-500 to-pink-500 text-white rounded-3xl px-3 py-2 text-sm transition-shape"
-          >Print Club £140/mo</a>
+          >Print Club £140/mo</a
+        >
         <div class="flex space-x-2">
           <button
             class="w-9 h-9 flex-shrink-0 flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-full hover:bg-[#3A3A3E] transition-shape"
@@ -103,10 +104,7 @@
       </div>
     </header>
     <main class="flex-1 p-4 space-y-6">
-      <div
-        id="printclub-banner"
-        class="bg-blue-600 text-white p-3 rounded-xl text-center hidden"
-      >
+      <div id="printclub-banner" class="bg-blue-600 text-white p-3 rounded-xl text-center hidden">
         Join <strong>Print Club</strong> for weekly prints.
         <a href="#" id="printclub-banner-link" class="underline">Learn more</a>
       </div>
@@ -138,56 +136,95 @@
       <div id="entry-success" class="hidden text-green-400 mt-2"></div>
       <h2 class="text-2xl mt-8">Past Winners</h2>
       <div id="winners-grid" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 mt-4">
-        <div
-          class="model-card relative h-32 bg-[#2A2A2E] border border-white/10 rounded-xl hover:bg-[#3A3A3E] transition-shape flex items-center justify-center cursor-pointer"
-          data-model="https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/DamagedHelmet/glTF-Binary/DamagedHelmet.glb"
-          data-job="helmet"
-        >
-          <img
-            src="https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/DamagedHelmet/screenshot/screenshot.png"
-            alt="Damaged Helmet"
-            class="w-full h-full object-contain pointer-events-none"
-          />
-          <span class="absolute top-1 left-1 bg-black/60 text-xs px-1 rounded">Ended 05/25</span>
-          <button class="like absolute bottom-1 right-1 text-xs bg-red-600 px-1 rounded">♥</button>
-          <span class="absolute bottom-8 right-1 text-xs bg-black/50 px-1 rounded" id="votes-helmet">0</span>
-          <button class="purchase absolute bottom-1 left-1 font-bold text-lg py-2 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]">Buy</button>
+        <div class="space-y-2 flex flex-col items-center">
+          <div
+            class="model-card relative h-32 bg-[#2A2A2E] border border-white/10 rounded-xl hover:bg-[#3A3A3E] transition-shape flex items-center justify-center cursor-pointer"
+            data-model="https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/DamagedHelmet/glTF-Binary/DamagedHelmet.glb"
+            data-job="helmet"
+          >
+            <img
+              src="https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/DamagedHelmet/screenshot/screenshot.png"
+              alt="Damaged Helmet"
+              class="w-full h-full object-contain pointer-events-none"
+            />
+            <span class="absolute top-1 left-1 bg-black/60 text-xs px-1 rounded">Ended 05/25</span>
+            <button class="like absolute bottom-1 right-1 text-xs bg-red-600 px-1 rounded">
+              ♥
+            </button>
+            <span
+              class="absolute bottom-1 right-1 translate-y-[-1.5rem] text-xs bg-black/50 px-1 rounded"
+              id="votes-helmet"
+              >0</span
+            >
+          </div>
+          <button
+            class="purchase font-bold text-lg py-2 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]"
+          >
+            Buy Print
+          </button>
         </div>
-        <div
-          class="model-card relative h-32 bg-[#2A2A2E] border border-white/10 rounded-xl hover:bg-[#3A3A3E] transition-shape flex items-center justify-center cursor-pointer"
-          data-model="https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Fox/glTF-Binary/Fox.glb"
-          data-job="fox"
-        >
-          <img
-            src="https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Fox/screenshot/screenshot.jpg"
-            alt="Fox"
-            class="w-full h-full object-contain pointer-events-none"
-          />
-          <span class="absolute top-1 left-1 bg-black/60 text-xs px-1 rounded">Ended 03/24</span>
-          <button class="like absolute bottom-1 right-1 text-xs bg-red-600 px-1 rounded">♥</button>
-          <span class="absolute bottom-8 right-1 text-xs bg-black/50 px-1 rounded" id="votes-fox">0</span>
-          <button class="purchase absolute bottom-1 left-1 font-bold text-lg py-2 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]">Buy</button>
+        <div class="space-y-2 flex flex-col items-center">
+          <div
+            class="model-card relative h-32 bg-[#2A2A2E] border border-white/10 rounded-xl hover:bg-[#3A3A3E] transition-shape flex items-center justify-center cursor-pointer"
+            data-model="https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Fox/glTF-Binary/Fox.glb"
+            data-job="fox"
+          >
+            <img
+              src="https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Fox/screenshot/screenshot.jpg"
+              alt="Fox"
+              class="w-full h-full object-contain pointer-events-none"
+            />
+            <span class="absolute top-1 left-1 bg-black/60 text-xs px-1 rounded">Ended 03/24</span>
+            <button class="like absolute bottom-1 right-1 text-xs bg-red-600 px-1 rounded">
+              ♥
+            </button>
+            <span
+              class="absolute bottom-1 right-1 translate-y-[-1.5rem] text-xs bg-black/50 px-1 rounded"
+              id="votes-fox"
+              >0</span
+            >
+          </div>
+          <button
+            class="purchase font-bold text-lg py-2 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]"
+          >
+            Buy Print
+          </button>
         </div>
-        <div
-          class="model-card relative h-32 bg-[#2A2A2E] border border-white/10 rounded-xl hover:bg-[#3A3A3E] transition-shape flex items-center justify-center cursor-pointer"
-          data-model="https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoomBox/glTF-Binary/BoomBox.glb"
-          data-job="boombox"
-        >
-          <img
-            src="https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoomBox/screenshot/screenshot.jpg"
-            alt="BoomBox"
-            class="w-full h-full object-contain pointer-events-none"
-          />
-          <span class="absolute top-1 left-1 bg-black/60 text-xs px-1 rounded">Ended 01/23</span>
-          <button class="like absolute bottom-1 right-1 text-xs bg-red-600 px-1 rounded">♥</button>
-          <span class="absolute bottom-8 right-1 text-xs bg-black/50 px-1 rounded" id="votes-boombox">0</span>
-          <button class="purchase absolute bottom-1 left-1 font-bold text-lg py-2 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]">Buy</button>
+        <div class="space-y-2 flex flex-col items-center">
+          <div
+            class="model-card relative h-32 bg-[#2A2A2E] border border-white/10 rounded-xl hover:bg-[#3A3A3E] transition-shape flex items-center justify-center cursor-pointer"
+            data-model="https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoomBox/glTF-Binary/BoomBox.glb"
+            data-job="boombox"
+          >
+            <img
+              src="https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoomBox/screenshot/screenshot.jpg"
+              alt="BoomBox"
+              class="w-full h-full object-contain pointer-events-none"
+            />
+            <span class="absolute top-1 left-1 bg-black/60 text-xs px-1 rounded">Ended 01/23</span>
+            <button class="like absolute bottom-1 right-1 text-xs bg-red-600 px-1 rounded">
+              ♥
+            </button>
+            <span
+              class="absolute bottom-1 right-1 translate-y-[-1.5rem] text-xs bg-black/50 px-1 rounded"
+              id="votes-boombox"
+              >0</span
+            >
+          </div>
+          <button
+            class="purchase font-bold text-lg py-2 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]"
+          >
+            Buy Print
+          </button>
         </div>
       </div>
       <h2 class="text-2xl mt-8">Winner Interviews</h2>
       <div id="winner-interviews" class="space-y-4 mt-4"></div>
       <h2 class="text-2xl mt-8">Trending Prints</h2>
-      <div id="trending-prints" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 mt-4"></div>
+      <div
+        id="trending-prints"
+        class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 mt-4"
+      ></div>
     </main>
     <div
       id="enter-modal"
@@ -285,7 +322,7 @@
             id="modal-checkout"
             href="payment.html"
             class="font-bold py-3 px-5 rounded-full shadow-md transition border-2 border-black"
-            style="background-color: #30D5C8; color: #1A1A1D"
+            style="background-color: #30d5c8; color: #1a1a1d"
             onmouseover="this.style.opacity='0.85'"
             onmouseout="this.style.opacity='1'"
           >
@@ -340,8 +377,6 @@
           document.body.classList.remove('overflow-hidden');
         }
 
-
-
         checkoutBtn.addEventListener('click', () => {
           sessionStorage.setItem('fromCommunity', '1');
           const model = checkoutBtn.dataset.model;
@@ -390,7 +425,13 @@
         <p class="mb-4">
           Get two prints every week for just £140/month. Unused credits expire weekly.
         </p>
-        <button id="printclub-close" class="mt-2 px-4 py-2 bg-blue-600 rounded-3xl" aria-label="Close Print Club modal">Close</button>
+        <button
+          id="printclub-close"
+          class="mt-2 px-4 py-2 bg-blue-600 rounded-3xl"
+          aria-label="Close Print Club modal"
+        >
+          Close
+        </button>
       </div>
     </div>
     <script type="module" src="js/printclub.js"></script>

--- a/docs/task_list.md
+++ b/docs/task_list.md
@@ -119,15 +119,9 @@
 
 ## Competitions Profit Drivers
 
-- Show purchase buttons for past winners.
-  - Add a "Buy Print" button below each winning model in `competitions.html`.
-  - Pre-fill `print3Model` and `print3JobId` in local storage when the button is clicked.
 - Offer a discount for printing your competition entry.
   - Generate a one-time code after an entry is submitted.
   - Display the code in the success message.
-- Add "Order Print" button under each past winner card on the competitions page.
-  - When clicked, open the model modal with the winner's model and job ID.
-  - Save the model ID to localStorage when proceeding to checkout.
 - After a user enters a competition, display a one-time discount code for printing their entry.
   - Provide `/api/competitions/:id/discount` endpoint to generate and return the code.
 - Create a "Trending Prints" section at the bottom that fetches models from `/api/trending` and shows Add to Basket buttons.

--- a/js/competitions.js
+++ b/js/competitions.js
@@ -15,7 +15,6 @@ function prefetchModel(url) {
   prefetchedModels.add(url);
 }
 
-
 function openViewer(modelUrl, jobId, snapshot = '') {
   const modal = document.getElementById('model-modal');
   const viewer = modal.querySelector('model-viewer');
@@ -267,13 +266,10 @@ async function submitEntry(e) {
     const msg = document.getElementById('entry-success');
     if (msg) {
       try {
-        const resp = await fetch(
-          `${API_BASE}/competitions/${currentId}/discount`,
-          {
-            method: 'POST',
-            headers: { Authorization: `Bearer ${token}` },
-          }
-        );
+        const resp = await fetch(`${API_BASE}/competitions/${currentId}/discount`, {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${token}` },
+        });
         if (resp.ok) {
           const data = await resp.json();
           msg.textContent = `Discount code: ${data.code}`;
@@ -331,14 +327,14 @@ async function loadPast() {
     div.innerHTML = `<h3 class="text-lg">${c.name}</h3>
       <div class="model-card relative h-32 border border-white/10 rounded-xl flex items-center justify-center cursor-pointer" data-model="${c.model_url}" data-job="${c.winner_model_id}">
         <img src="${c.snapshot || ''}" alt="Winning model" class="w-full h-full object-contain pointer-events-none" />
-        <button class="order absolute bottom-1 left-1 font-bold text-lg py-2 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]">Buy Print</button>
-      </div>`;
+      </div>
+      <button class="order font-bold text-lg py-2 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]">Order Print</button>`;
     container.appendChild(div);
     const card = div.querySelector('.model-card');
     const btn = div.querySelector('.order');
     btn.addEventListener('click', (e) => {
       e.stopPropagation();
-      purchase(c.model_url, c.winner_model_id);
+      openModelModal(c.model_url, c.winner_model_id, c.snapshot || '');
     });
     card.addEventListener('click', () => {
       openModelModal(c.model_url, c.winner_model_id, c.snapshot || '');
@@ -355,14 +351,16 @@ async function loadTrending() {
   const items = await res.json();
   items.forEach((i) => {
     const card = document.createElement('div');
-    card.className = 'relative h-32 bg-[#2A2A2E] border border-white/10 rounded-xl flex items-center justify-center cursor-pointer';
+    card.className =
+      'relative h-32 bg-[#2A2A2E] border border-white/10 rounded-xl flex items-center justify-center cursor-pointer';
     card.dataset.model = i.model_url;
     card.dataset.job = i.job_id;
     if (i.snapshot) {
       card.innerHTML = `<img src="${i.snapshot}" alt="Model" class="w-full h-full object-contain pointer-events-none" />`;
     }
     const btn = document.createElement('button');
-    btn.className = 'add absolute bottom-1 left-1 font-bold text-lg py-2 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]';
+    btn.className =
+      'add absolute bottom-1 left-1 font-bold text-lg py-2 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]';
     btn.textContent = 'Add to Basket';
     btn.addEventListener('click', (e) => {
       e.stopPropagation();
@@ -404,7 +402,7 @@ document.addEventListener('DOMContentLoaded', () => {
   });
   document.querySelectorAll('#winners-grid .model-card').forEach((card) => {
     const likeBtn = card.querySelector('.like');
-    const buyBtn = card.querySelector('.purchase');
+    const buyBtn = card.parentElement.querySelector('.purchase');
     if (likeBtn) {
       likeBtn.addEventListener('click', (e) => {
         e.stopPropagation();
@@ -414,7 +412,8 @@ document.addEventListener('DOMContentLoaded', () => {
     if (buyBtn) {
       buyBtn.addEventListener('click', (e) => {
         e.stopPropagation();
-        purchase(card.dataset.model, card.dataset.job);
+        const img = card.querySelector('img');
+        openModelModal(card.dataset.model, card.dataset.job, img ? img.src : '');
       });
     }
     card.addEventListener('click', (e) => {
@@ -427,7 +426,6 @@ document.addEventListener('DOMContentLoaded', () => {
     card.addEventListener('click', () =>
       openViewer(card.dataset.model, card.dataset.job, card.querySelector('img')?.src || '')
     );
-
   });
   load();
   loadPast();


### PR DESCRIPTION
## Summary
- show Buy Print buttons under past winners and open model modal when clicked
- enable same behavior for dynamically loaded past winners
- update competitions.js accordingly
- clean up Competitions Profit Drivers checklist

## Testing
- `npm run format` within `backend`
- `npm test` within `backend`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_6853297c8814832dad52b7cbe4bd21f9