### PR TITLE
Implement gifting option and update tasks

### DIFF
--- a/docs/task_list.md
+++ b/docs/task_list.md
@@ -93,33 +93,19 @@
 - Record sign-up and cancellation events in `subscription_events` table.
 - Display a "Manage subscription" button on the profile page linking to the Stripe customer portal.
 - Add unit tests for credit deduction and weekly reset.
-
 ## Repeat Purchase Incentives
-
-- Show gifting options at checkout and on delivery confirmation.
-  - Add a "This is a surprise" toggle for recipient details.
-  - Offer a discount when ordering two prints of the same model.
-  - Rotate limited-time seasonal bundles for gifting.
-- Run theme campaigns such as "Sci-fi month" or "D&D drop".
-
   - Award a badge when someone purchases three times in a month.
   - Offer an optional monthly "time capsule" print.
   - Showcase other users' creations for inspiration.
-
 - Add loyalty features to the account area.
-  - Grant a badge after four total purchases.
   - Highlight a "Print of the week" for quick purchase.
   - For subscribers, show a countdown to their next free print.
   - Provide subscriber-only design previews.
   - Track consecutive weekly orders and badge streaks.
-
 ## Mailing List Automation
-
 - Add unit tests for confirm, webhook handling and sync logic.
-
 ## Competitions Profit Drivers
 
-- Show purchase buttons for past winners.
   - Add a "Buy Print" button below each winning model in `competitions.html`.
   - Pre-fill `print3Model` and `print3JobId` in local storage when the button is clicked.
 - Offer a discount for printing your competition entry.

--- a/js/payment.js
+++ b/js/payment.js
@@ -721,6 +721,18 @@ async function initPaymentPage() {
     reorderBtn?.addEventListener('click', () => {
       window.location.href = 'payment.html';
     });
+    const giftDiv = document.getElementById('gift-options');
+    const giftBtn = document.getElementById('gift-order');
+    if (giftDiv && giftBtn && surpriseToggle && recipientFields) {
+      giftDiv.classList.remove('hidden');
+      giftBtn.addEventListener('click', () => {
+        surpriseToggle.checked = false;
+        recipientFields.classList.remove('hidden');
+        document.getElementById('checkout-form')?.scrollIntoView({
+          behavior: 'smooth',
+        });
+      });
+    }
     const nextModal = document.getElementById('next-print-modal');
     const nextBtn = document.getElementById('next-print-btn');
     const nextText = document.getElementById('next-print-text');

--- a/payment.html
+++ b/payment.html
@@ -105,6 +105,10 @@
           </div>
         </div>
         <button id="reorder-color" class="underline">Order another color</button>
+        <div id="gift-options" class="hidden space-y-1">
+          <span>Want to send this as a gift?</span>
+          <button id="gift-order" class="underline">Gift this print</button>
+        </div>
       </div>
       <div id="cancel" class="hidden text-red-400 text-center">Payment cancelled.</div>
       <div


### PR DESCRIPTION
## Summary
- add gift-order button after purchase success
- show the button via JS and scroll to form
- remove completed items from Repeat Purchase Incentives list

## Testing
- `npm run format`
- `npm test`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_68532960ef74832da7e5e3073f3dfa93