### PR TITLE
Implement countdown to next free print

### DIFF
--- a/docs/task_list.md
+++ b/docs/task_list.md
@@ -45,7 +45,6 @@
 - Showcase other users' creations for inspiration.
 - Add loyalty features to the account area.
   - Highlight a "Print of the week" for quick purchase.
-  - For subscribers, show a countdown to their next free print.
   - Provide subscriber-only design previews.
   - Track consecutive weekly orders and badge streaks.
 

--- a/js/my_profile.js
+++ b/js/my_profile.js
@@ -2,6 +2,29 @@ import { captureSnapshots } from './snapshot.js';
 
 const API_BASE = (window.API_ORIGIN || '') + '/api';
 
+function startOfWeek(d = new Date()) {
+  const date = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+  const day = date.getUTCDay();
+  const diff = date.getUTCDate() - day;
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), diff));
+}
+
+function showCountdown() {
+  const el = document.getElementById('next-free-print');
+  if (!el) return;
+  const now = new Date();
+  const weekStart = startOfWeek(now);
+  const nextWeek = new Date(weekStart.getTime() + 7 * 24 * 60 * 60 * 1000);
+  const diff = nextWeek - now;
+  if (diff <= 0) {
+    el.textContent = '';
+    return;
+  }
+  const days = Math.floor(diff / (24 * 60 * 60 * 1000));
+  const hours = Math.floor((diff % (24 * 60 * 60 * 1000)) / (60 * 60 * 1000));
+  el.textContent = `Next free prints refresh in ${days}d ${hours}h`;
+}
+
 function createCard(model) {
   const div = document.createElement('div');
   div.className =
@@ -300,4 +323,6 @@ document.addEventListener('DOMContentLoaded', () => {
   createObserver();
   loadMore();
   loadDashboard();
+  showCountdown();
+  setInterval(showCountdown, 60 * 60 * 1000);
 });

--- a/my_profile.html
+++ b/my_profile.html
@@ -193,6 +193,7 @@
           <div id="progress-bar" class="bg-blue-600 h-full rounded" style="width: 0%"></div>
         </div>
         <p id="progress-text" class="text-sm mt-2"></p>
+        <p id="next-free-print" class="text-sm"></p>
         <button
           id="upgrade-cta"
           class="hidden mt-2 px-3 py-1 bg-gradient-to-r from-purple-500 to-pink-500 rounded-3xl"


### PR DESCRIPTION
## Summary
- show subscription refresh countdown on profile page
- trigger countdown via JavaScript
- remove completed subtask from docs

## Testing
- `npm test` *(fails: GET /api/admin/spaces returns 404)*
- `npm run ci` *(fails: tsconfig-strictest/tsconfig.base.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854120caa18832db1112d13bbcd9297