### PR TITLE
Implement daily hub saturation summary

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -1,8 +1,8 @@
 // backend/db.js
-require('dotenv').config();
-const { Pool } = require('pg');
-const { v4: uuidv4 } = require('uuid');
-const { dbUrl } = require('./config');
+require("dotenv").config();
+const { Pool } = require("pg");
+const { v4: uuidv4 } = require("uuid");
+const { dbUrl } = require("./config");
 const pool = new Pool({ connectionString: dbUrl });
 
 function query(text, params) {
@@ -10,19 +10,22 @@ function query(text, params) {
 }
 
 async function insertShare(jobId, userId, slug) {
-  return query('INSERT INTO shares(job_id, user_id, slug) VALUES($1,$2,$3) RETURNING *', [
-    jobId,
-    userId,
-    slug,
-  ]).then((res) => res.rows[0]);
+  return query(
+    "INSERT INTO shares(job_id, user_id, slug) VALUES($1,$2,$3) RETURNING *",
+    [jobId, userId, slug],
+  ).then((res) => res.rows[0]);
 }
 
 async function getShareBySlug(slug) {
-  return query('SELECT * FROM shares WHERE slug=$1', [slug]).then((res) => res.rows[0]);
+  return query("SELECT * FROM shares WHERE slug=$1", [slug]).then(
+    (res) => res.rows[0],
+  );
 }
 
 async function getShareByJobId(jobId) {
-  return query('SELECT * FROM shares WHERE job_id=$1', [jobId]).then((res) => res.rows[0]);
+  return query("SELECT * FROM shares WHERE job_id=$1", [jobId]).then(
+    (res) => res.rows[0],
+  );
 }
 
 async function insertCommission(
@@ -31,23 +34,25 @@ async function insertCommission(
   sellerUserId,
   buyerUserId,
   commissionCents,
-  status = 'pending'
+  status = "pending",
 ) {
   return query(
-    'INSERT INTO model_commissions(order_id, model_id, seller_user_id, buyer_user_id, commission_cents, status) VALUES($1,$2,$3,$4,$5,$6) RETURNING *',
-    [orderId, modelId, sellerUserId, buyerUserId, commissionCents, status]
+    "INSERT INTO model_commissions(order_id, model_id, seller_user_id, buyer_user_id, commission_cents, status) VALUES($1,$2,$3,$4,$5,$6) RETURNING *",
+    [orderId, modelId, sellerUserId, buyerUserId, commissionCents, status],
   ).then((res) => res.rows[0]);
 }
 
 async function getCommissionsForUser(userId) {
   return query(
-    'SELECT * FROM model_commissions WHERE seller_user_id=$1 OR buyer_user_id=$1 ORDER BY created_at DESC',
-    [userId]
+    "SELECT * FROM model_commissions WHERE seller_user_id=$1 OR buyer_user_id=$1 ORDER BY created_at DESC",
+    [userId],
   ).then((res) => res.rows);
 }
 
 function startOfWeek(d = new Date()) {
-  const date = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+  const date = new Date(
+    Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()),
+  );
   const day = date.getUTCDay();
   const diff = date.getUTCDate() - day;
   return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), diff));
@@ -59,7 +64,7 @@ async function upsertSubscription(
   periodStart,
   periodEnd,
   customerId,
-  subscriptionId
+  subscriptionId,
 ) {
   return query(
     `INSERT INTO subscriptions(user_id, status, current_period_start, current_period_end, stripe_customer_id, stripe_subscription_id)
@@ -67,18 +72,21 @@ async function upsertSubscription(
      ON CONFLICT (user_id) DO UPDATE
      SET status=$2, current_period_start=$3, current_period_end=$4, stripe_customer_id=$5, stripe_subscription_id=$6, updated_at=NOW()
      RETURNING *`,
-    [userId, status, periodStart, periodEnd, customerId, subscriptionId]
+    [userId, status, periodStart, periodEnd, customerId, subscriptionId],
   ).then((res) => res.rows[0]);
 }
 
 async function cancelSubscription(userId) {
-  return query(`UPDATE subscriptions SET status='canceled' WHERE user_id=$1 RETURNING *`, [
-    userId,
-  ]).then((res) => res.rows[0]);
+  return query(
+    `UPDATE subscriptions SET status='canceled' WHERE user_id=$1 RETURNING *`,
+    [userId],
+  ).then((res) => res.rows[0]);
 }
 
 async function getSubscription(userId) {
-  return query('SELECT * FROM subscriptions WHERE user_id=$1', [userId]).then((res) => res.rows[0]);
+  return query("SELECT * FROM subscriptions WHERE user_id=$1", [userId]).then(
+    (res) => res.rows[0],
+  );
 }
 
 async function ensureCurrentWeekCredits(userId, defaultCredits = 0) {
@@ -88,7 +96,7 @@ async function ensureCurrentWeekCredits(userId, defaultCredits = 0) {
     `INSERT INTO subscription_credits(user_id, week_start, total_credits)
      VALUES($1,$2,$3)
      ON CONFLICT (user_id, week_start) DO NOTHING`,
-    [userId, weekStr, defaultCredits]
+    [userId, weekStr, defaultCredits],
   );
 }
 
@@ -96,8 +104,8 @@ async function getCurrentWeekCredits(userId) {
   const week = startOfWeek();
   const weekStr = week.toISOString().slice(0, 10);
   return query(
-    'SELECT total_credits, used_credits FROM subscription_credits WHERE user_id=$1 AND week_start=$2',
-    [userId, weekStr]
+    "SELECT total_credits, used_credits FROM subscription_credits WHERE user_id=$1 AND week_start=$2",
+    [userId, weekStr],
   ).then((res) => res.rows[0]);
 }
 
@@ -107,20 +115,29 @@ async function incrementCreditsUsed(userId, amount = 1) {
   await ensureCurrentWeekCredits(userId, 0);
   return query(
     `UPDATE subscription_credits SET used_credits=used_credits + $3 WHERE user_id=$1 AND week_start=$2`,
-    [userId, weekStr, amount]
+    [userId, weekStr, amount],
   );
 }
 
 async function getOrCreateReferralLink(userId) {
-  const { rows } = await query('SELECT code FROM referral_links WHERE user_id=$1', [userId]);
+  const { rows } = await query(
+    "SELECT code FROM referral_links WHERE user_id=$1",
+    [userId],
+  );
   if (rows.length) return rows[0].code;
-  const code = uuidv4().replace(/-/g, '').slice(0, 8);
-  await query('INSERT INTO referral_links(user_id, code) VALUES($1,$2)', [userId, code]);
+  const code = uuidv4().replace(/-/g, "").slice(0, 8);
+  await query("INSERT INTO referral_links(user_id, code) VALUES($1,$2)", [
+    userId,
+    code,
+  ]);
   return code;
 }
 
 async function getRewardPoints(userId) {
-  const { rows } = await query('SELECT points FROM reward_points WHERE user_id=$1', [userId]);
+  const { rows } = await query(
+    "SELECT points FROM reward_points WHERE user_id=$1",
+    [userId],
+  );
   return rows.length ? parseInt(rows[0].points, 10) : 0;
 }
 
@@ -131,75 +148,93 @@ async function adjustRewardPoints(userId, delta) {
      ON CONFLICT (user_id)
      DO UPDATE SET points = reward_points.points + EXCLUDED.points
      RETURNING points`,
-    [userId, delta]
+    [userId, delta],
   );
   return parseInt(rows[0].points, 10);
 }
 
 async function getUserIdForReferral(code) {
-  const { rows } = await query('SELECT user_id FROM referral_links WHERE code=$1', [code]);
+  const { rows } = await query(
+    "SELECT user_id FROM referral_links WHERE code=$1",
+    [code],
+  );
   return rows.length ? rows[0].user_id : null;
 }
 
 async function insertReferralEvent(referrerId, type) {
-  await query('INSERT INTO referral_events(referrer_id, type) VALUES($1,$2)', [referrerId, type]);
+  await query("INSERT INTO referral_events(referrer_id, type) VALUES($1,$2)", [
+    referrerId,
+    type,
+  ]);
 }
 
 async function getOrCreateOrderReferralLink(orderId) {
-  const { rows } = await query('SELECT code FROM order_referral_links WHERE order_id=$1', [
-    orderId,
-  ]);
+  const { rows } = await query(
+    "SELECT code FROM order_referral_links WHERE order_id=$1",
+    [orderId],
+  );
   if (rows.length) return rows[0].code;
-  const code = uuidv4().replace(/-/g, '').slice(0, 8);
-  await query('INSERT INTO order_referral_links(order_id, code) VALUES($1,$2)', [orderId, code]);
+  const code = uuidv4().replace(/-/g, "").slice(0, 8);
+  await query(
+    "INSERT INTO order_referral_links(order_id, code) VALUES($1,$2)",
+    [orderId, code],
+  );
   return code;
 }
 
 async function insertReferredOrder(orderId, referrerId) {
-  await query('INSERT INTO referred_orders(order_id, referrer_id) VALUES($1,$2)', [
-    orderId,
-    referrerId,
-  ]);
+  await query(
+    "INSERT INTO referred_orders(order_id, referrer_id) VALUES($1,$2)",
+    [orderId, referrerId],
+  );
 }
 async function insertAdClick(subreddit, sessionId) {
-  await query('INSERT INTO ad_clicks(subreddit, session_id, timestamp) VALUES($1,$2,NOW())', [
-    subreddit,
-    sessionId,
-  ]);
+  await query(
+    "INSERT INTO ad_clicks(subreddit, session_id, timestamp) VALUES($1,$2,NOW())",
+    [subreddit, sessionId],
+  );
 }
 
 async function insertCartEvent(sessionId, modelId, subreddit) {
   await query(
-    'INSERT INTO cart_events(session_id, model_id, subreddit, timestamp) VALUES($1,$2,$3,NOW())',
-    [sessionId, modelId, subreddit]
+    "INSERT INTO cart_events(session_id, model_id, subreddit, timestamp) VALUES($1,$2,$3,NOW())",
+    [sessionId, modelId, subreddit],
   );
 }
 
 async function insertCheckoutEvent(sessionId, subreddit, step) {
   await query(
-    'INSERT INTO checkout_events(session_id, subreddit, step, timestamp) VALUES($1,$2,$3,NOW())',
-    [sessionId, subreddit, step]
+    "INSERT INTO checkout_events(session_id, subreddit, step, timestamp) VALUES($1,$2,$3,NOW())",
+    [sessionId, subreddit, step],
   );
 }
 
-async function insertPageView(sessionId, subreddit, utmSource, utmMedium, utmCampaign) {
+async function insertPageView(
+  sessionId,
+  subreddit,
+  utmSource,
+  utmMedium,
+  utmCampaign,
+) {
   await query(
-    'INSERT INTO page_views(session_id, subreddit, utm_source, utm_medium, utm_campaign, timestamp) VALUES($1,$2,$3,$4,$5,NOW())',
-    [sessionId, subreddit, utmSource, utmMedium, utmCampaign]
+    "INSERT INTO page_views(session_id, subreddit, utm_source, utm_medium, utm_campaign, timestamp) VALUES($1,$2,$3,$4,$5,NOW())",
+    [sessionId, subreddit, utmSource, utmMedium, utmCampaign],
   );
 }
 
 async function insertSubscriptionEvent(userId, event, variant, priceCents) {
   await query(
-    'INSERT INTO subscription_events(user_id, event, variant, price_cents) VALUES($1,$2,$3,$4)',
-    [userId, event, variant, priceCents]
+    "INSERT INTO subscription_events(user_id, event, variant, price_cents) VALUES($1,$2,$3,$4)",
+    [userId, event, variant, priceCents],
   );
 }
 
 async function getSubscriptionMetrics() {
-  const active = await query("SELECT COUNT(*) FROM subscriptions WHERE status='active'");
+  const active = await query(
+    "SELECT COUNT(*) FROM subscriptions WHERE status='active'",
+  );
   const churn = await query(
-    "SELECT COUNT(*) FROM subscription_events WHERE event='cancel' AND created_at >= NOW() - INTERVAL '30 days'"
+    "SELECT COUNT(*) FROM subscription_events WHERE event='cancel' AND created_at >= NOW() - INTERVAL '30 days'",
   );
   return {
     active: parseInt(active.rows[0].count, 10),
@@ -208,27 +243,43 @@ async function getSubscriptionMetrics() {
 }
 
 async function insertShareEvent(shareId, network) {
-  await query('INSERT INTO share_events(share_id, network, timestamp) VALUES($1,$2,NOW())', [
-    shareId,
-    network,
-  ]);
+  await query(
+    "INSERT INTO share_events(share_id, network, timestamp) VALUES($1,$2,NOW())",
+    [shareId, network],
+  );
 }
 
 async function getConversionMetrics() {
-  const clicks = await query('SELECT subreddit, COUNT(*) AS c FROM ad_clicks GROUP BY subreddit');
-  const carts = await query('SELECT subreddit, COUNT(*) AS c FROM cart_events GROUP BY subreddit');
+  const clicks = await query(
+    "SELECT subreddit, COUNT(*) AS c FROM ad_clicks GROUP BY subreddit",
+  );
+  const carts = await query(
+    "SELECT subreddit, COUNT(*) AS c FROM cart_events GROUP BY subreddit",
+  );
   const completes = await query(
-    "SELECT subreddit, COUNT(*) FILTER (WHERE step='complete') AS c FROM checkout_events GROUP BY subreddit"
+    "SELECT subreddit, COUNT(*) FILTER (WHERE step='complete') AS c FROM checkout_events GROUP BY subreddit",
   );
   const map = {};
   for (const row of clicks.rows)
-    map[row.subreddit] = { clicks: parseInt(row.c, 10), carts: 0, completes: 0 };
+    map[row.subreddit] = {
+      clicks: parseInt(row.c, 10),
+      carts: 0,
+      completes: 0,
+    };
   for (const row of carts.rows) {
-    map[row.subreddit] = map[row.subreddit] || { clicks: 0, carts: 0, completes: 0 };
+    map[row.subreddit] = map[row.subreddit] || {
+      clicks: 0,
+      carts: 0,
+      completes: 0,
+    };
     map[row.subreddit].carts = parseInt(row.c, 10);
   }
   for (const row of completes.rows) {
-    map[row.subreddit] = map[row.subreddit] || { clicks: 0, carts: 0, completes: 0 };
+    map[row.subreddit] = map[row.subreddit] || {
+      clicks: 0,
+      carts: 0,
+      completes: 0,
+    };
     map[row.subreddit].completes = parseInt(row.c, 10);
   }
   return Object.entries(map).map(([subreddit, d]) => ({
@@ -245,13 +296,14 @@ async function getProfitMetrics() {
             SUM(pc.cost_cents * o.quantity) AS cost_cents
        FROM orders o
        LEFT JOIN pricing_costs pc ON pc.product_type = o.product_type
-      GROUP BY o.subreddit`
+      GROUP BY o.subreddit`,
   );
   return rows.map((r) => ({
     subreddit: r.subreddit,
     revenue: parseInt(r.revenue_cents, 10) || 0,
     cost: parseInt(r.cost_cents, 10) || 0,
-    profit: (parseInt(r.revenue_cents, 10) || 0) - (parseInt(r.cost_cents, 10) || 0),
+    profit:
+      (parseInt(r.revenue_cents, 10) || 0) - (parseInt(r.cost_cents, 10) || 0),
   }));
 }
 
@@ -260,41 +312,48 @@ async function upsertMailingListEntry(email, token) {
     `INSERT INTO mailing_list(email, token)
      VALUES($1,$2)
      ON CONFLICT (email) DO UPDATE SET token=$2, unsubscribed=FALSE`,
-    [email, token]
+    [email, token],
   );
 }
 
 async function confirmMailingListEntry(token) {
-  await query('UPDATE mailing_list SET confirmed=TRUE WHERE token=$1', [token]);
+  await query("UPDATE mailing_list SET confirmed=TRUE WHERE token=$1", [token]);
 }
 
 async function unsubscribeMailingListEntry(token) {
-  await query('UPDATE mailing_list SET unsubscribed=TRUE WHERE token=$1', [token]);
+  await query("UPDATE mailing_list SET unsubscribed=TRUE WHERE token=$1", [
+    token,
+  ]);
 }
 
 async function insertSocialShare(userId, orderId, url) {
   const { rows } = await query(
-    'INSERT INTO social_shares(user_id, order_id, post_url) VALUES($1,$2,$3) RETURNING id, verified',
-    [userId, orderId, url]
+    "INSERT INTO social_shares(user_id, order_id, post_url) VALUES($1,$2,$3) RETURNING id, verified",
+    [userId, orderId, url],
   );
   return rows[0];
 }
 
 async function verifySocialShare(id, discountCode) {
   const { rows } = await query(
-    'UPDATE social_shares SET verified=TRUE, discount_code=$2 WHERE id=$1 RETURNING user_id',
-    [id, discountCode]
+    "UPDATE social_shares SET verified=TRUE, discount_code=$2 WHERE id=$1 RETURNING user_id",
+    [id, discountCode],
   );
   return rows[0];
 }
 
 async function getRewardOptions() {
-  const { rows } = await query('SELECT points, amount_cents FROM reward_options ORDER BY points');
+  const { rows } = await query(
+    "SELECT points, amount_cents FROM reward_options ORDER BY points",
+  );
   return rows;
 }
 
 async function getRewardOption(points) {
-  const { rows } = await query('SELECT amount_cents FROM reward_options WHERE points=$1', [points]);
+  const { rows } = await query(
+    "SELECT amount_cents FROM reward_options WHERE points=$1",
+    [points],
+  );
   return rows[0] || null;
 }
 
@@ -303,21 +362,27 @@ async function insertAdSpend(subreddit, date, spendCents) {
     `INSERT INTO ad_spend(subreddit, date, spend_cents)
      VALUES($1,$2,$3)
      ON CONFLICT (subreddit, date) DO UPDATE SET spend_cents=$3`,
-    [subreddit, date, spendCents]
+    [subreddit, date, spendCents],
   );
 }
 
 async function getBusinessIntelligenceMetrics() {
   const profits = await getProfitMetrics();
   const spend = await query(
-    'SELECT subreddit, SUM(spend_cents) AS spend_cents FROM ad_spend GROUP BY subreddit'
+    "SELECT subreddit, SUM(spend_cents) AS spend_cents FROM ad_spend GROUP BY subreddit",
   );
   const orders = await query(
-    "SELECT subreddit, COUNT(*) AS count FROM orders WHERE status='paid' GROUP BY subreddit"
+    "SELECT subreddit, COUNT(*) AS count FROM orders WHERE status='paid' GROUP BY subreddit",
   );
   const map = {};
   for (const p of profits) {
-    map[p.subreddit] = { revenue: p.revenue, cost: p.cost, profit: p.profit, spend: 0, orders: 0 };
+    map[p.subreddit] = {
+      revenue: p.revenue,
+      cost: p.cost,
+      profit: p.profit,
+      spend: 0,
+      orders: 0,
+    };
   }
   for (const row of spend.rows) {
     map[row.subreddit] = map[row.subreddit] || {
@@ -349,15 +414,15 @@ async function getBusinessIntelligenceMetrics() {
 
 async function insertScalingEvent(subreddit, oldBudget, newBudget, reason) {
   await query(
-    'INSERT INTO scaling_events(subreddit, old_budget_cents, new_budget_cents, reason) VALUES($1,$2,$3,$4)',
-    [subreddit, oldBudget, newBudget, reason]
+    "INSERT INTO scaling_events(subreddit, old_budget_cents, new_budget_cents, reason) VALUES($1,$2,$3,$4)",
+    [subreddit, oldBudget, newBudget, reason],
   );
 }
 
 async function getScalingEvents(limit = 50) {
   const { rows } = await query(
-    'SELECT subreddit, old_budget_cents, new_budget_cents, reason, created_at FROM scaling_events ORDER BY created_at DESC LIMIT $1',
-    [limit]
+    "SELECT subreddit, old_budget_cents, new_budget_cents, reason, created_at FROM scaling_events ORDER BY created_at DESC LIMIT $1",
+    [limit],
   );
   return rows;
 }
@@ -370,15 +435,15 @@ async function getUserCreations(userId, limit = 10, offset = 0) {
      WHERE c.user_id=$1
      ORDER BY c.created_at DESC
      LIMIT $2 OFFSET $3`,
-    [userId, limit, offset]
+    [userId, limit, offset],
   );
   return rows;
 }
 
 async function insertCommunityComment(modelId, userId, text) {
   const { rows } = await query(
-    'INSERT INTO community_comments(model_id, user_id, text) VALUES($1,$2,$3) RETURNING id, text, created_at',
-    [modelId, userId, text]
+    "INSERT INTO community_comments(model_id, user_id, text) VALUES($1,$2,$3) RETURNING id, text, created_at",
+    [modelId, userId, text],
   );
   return rows[0];
 }
@@ -391,34 +456,36 @@ async function getCommunityComments(modelId, limit = 20) {
      WHERE cc.model_id=$1
      ORDER BY cc.created_at ASC
      LIMIT $2`,
-    [modelId, limit]
+    [modelId, limit],
   );
   return rows;
 }
 
 async function createPrinterHub(name, location, operator) {
   const { rows } = await query(
-    'INSERT INTO printer_hubs(name, location, operator) VALUES($1,$2,$3) RETURNING *',
-    [name, location, operator]
+    "INSERT INTO printer_hubs(name, location, operator) VALUES($1,$2,$3) RETURNING *",
+    [name, location, operator],
   );
   return rows[0];
 }
 
 async function listPrinterHubs() {
-  const { rows } = await query('SELECT * FROM printer_hubs ORDER BY id');
+  const { rows } = await query("SELECT * FROM printer_hubs ORDER BY id");
   return rows;
 }
 
 async function addPrinter(serial, hubId) {
-  const { rows } = await query('INSERT INTO printers(serial, hub_id) VALUES($1,$2) RETURNING *', [
-    serial,
-    hubId,
-  ]);
+  const { rows } = await query(
+    "INSERT INTO printers(serial, hub_id) VALUES($1,$2) RETURNING *",
+    [serial, hubId],
+  );
   return rows[0];
 }
 
 async function getPrintersByHub(hubId) {
-  const { rows } = await query('SELECT * FROM printers WHERE hub_id=$1', [hubId]);
+  const { rows } = await query("SELECT * FROM printers WHERE hub_id=$1", [
+    hubId,
+  ]);
   return rows;
 }
 
@@ -429,10 +496,10 @@ async function insertPrinterMetric(
   error,
   utilization = null,
   idleSeconds = null,
-  avgCompletionSeconds = null
+  avgCompletionSeconds = null,
 ) {
   await query(
-    'INSERT INTO printer_metrics(printer_id, status, queue_length, error, utilization, idle_seconds, avg_completion_seconds) VALUES($1,$2,$3,$4,$5,$6,$7)',
+    "INSERT INTO printer_metrics(printer_id, status, queue_length, error, utilization, idle_seconds, avg_completion_seconds) VALUES($1,$2,$3,$4,$5,$6,$7)",
     [
       printerId,
       status,
@@ -441,7 +508,7 @@ async function insertPrinterMetric(
       utilization,
       idleSeconds,
       avgCompletionSeconds,
-    ]
+    ],
   );
 }
 
@@ -449,22 +516,22 @@ async function getLatestPrinterMetrics() {
   const { rows } = await query(
     `SELECT DISTINCT ON (printer_id) printer_id, status, queue_length, error, utilization, idle_seconds, avg_completion_seconds, created_at
      FROM printer_metrics
-     ORDER BY printer_id, created_at DESC`
+     ORDER BY printer_id, created_at DESC`,
   );
   return rows;
 }
 
 async function getAverageJobCompletionSeconds() {
   const { rows } = await query(
-    "SELECT AVG(EXTRACT(EPOCH FROM (updated_at - created_at))) AS avg FROM jobs WHERE status='sent'"
+    "SELECT AVG(EXTRACT(EPOCH FROM (updated_at - created_at))) AS avg FROM jobs WHERE status='sent'",
   );
   return rows[0] && rows[0].avg ? parseFloat(rows[0].avg) : null;
 }
 
 async function insertHubShipment(hubId, carrier, trackingNumber, status) {
   const { rows } = await query(
-    'INSERT INTO hub_shipments(hub_id, carrier, tracking_number, status) VALUES($1,$2,$3,$4) RETURNING *',
-    [hubId, carrier, trackingNumber, status]
+    "INSERT INTO hub_shipments(hub_id, carrier, tracking_number, status) VALUES($1,$2,$3,$4) RETURNING *",
+    [hubId, carrier, trackingNumber, status],
   );
   return rows[0];
 }
@@ -476,15 +543,35 @@ async function upsertOrderLocationSummary(date, state, count, hours) {
      ON CONFLICT (summary_date, state)
      DO UPDATE SET order_count=$3, estimated_hours=$4, updated_at=NOW()
      RETURNING *`,
-    [date, state, count, hours]
+    [date, state, count, hours],
   );
   return rows[0];
 }
 
 async function getOrderLocationSummary(date) {
   const { rows } = await query(
-    'SELECT state, order_count, estimated_hours FROM order_location_summary WHERE summary_date=$1 ORDER BY state',
-    [date]
+    "SELECT state, order_count, estimated_hours FROM order_location_summary WHERE summary_date=$1 ORDER BY state",
+    [date],
+  );
+  return rows;
+}
+
+async function upsertHubSaturationSummary(date, hubId, saturation) {
+  const { rows } = await query(
+    `INSERT INTO hub_saturation_summary(summary_date, hub_id, avg_queue_saturation)
+     VALUES($1,$2,$3)
+     ON CONFLICT (summary_date, hub_id)
+     DO UPDATE SET avg_queue_saturation=$3, updated_at=NOW()
+     RETURNING *`,
+    [date, hubId, saturation],
+  );
+  return rows[0];
+}
+
+async function getHubSaturationSummary(date) {
+  const { rows } = await query(
+    "SELECT hub_id, avg_queue_saturation FROM hub_saturation_summary WHERE summary_date=$1 ORDER BY hub_id",
+    [date],
   );
   return rows;
 }
@@ -539,6 +626,8 @@ module.exports = {
   insertHubShipment,
   upsertOrderLocationSummary,
   getOrderLocationSummary,
+  upsertHubSaturationSummary,
+  getHubSaturationSummary,
   // newly exposed helpers
   insertAdSpend,
   getAverageJobCompletionSeconds,

--- a/backend/migrations/046_create_hub_saturation_summary.sql
+++ b/backend/migrations/046_create_hub_saturation_summary.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS hub_saturation_summary (
+  id SERIAL PRIMARY KEY,
+  summary_date DATE NOT NULL,
+  hub_id INTEGER REFERENCES printer_hubs(id) ON DELETE CASCADE,
+  avg_queue_saturation REAL DEFAULT 0,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(summary_date, hub_id)
+);
+
+CREATE INDEX IF NOT EXISTS hub_saturation_summary_date_idx ON hub_saturation_summary(summary_date);
+
+CREATE TRIGGER hub_saturation_summary_set_updated
+BEFORE UPDATE ON hub_saturation_summary
+FOR EACH ROW EXECUTE PROCEDURE set_updated_at();

--- a/backend/scripts/update-hub-saturation.js
+++ b/backend/scripts/update-hub-saturation.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+require("dotenv").config();
+const { Client } = require("pg");
+const db = require("../db");
+
+async function update(date = new Date(Date.now() - 86400000)) {
+  const summaryDate = date.toISOString().slice(0, 10);
+  const start = summaryDate;
+  const end = new Date(Date.parse(summaryDate) + 86400000)
+    .toISOString()
+    .slice(0, 10);
+  const client = new Client({ connectionString: process.env.DB_URL });
+  await client.connect();
+  try {
+    const res = await client.query(
+      `SELECT h.id AS hub_id, AVG(m.queue_length) AS avg_queue
+         FROM printer_hubs h
+         JOIN printers p ON p.hub_id=h.id
+         JOIN printer_metrics m ON m.printer_id=p.id
+        WHERE m.created_at>= $1 AND m.created_at< $2
+        GROUP BY h.id`,
+      [start, end],
+    );
+    for (const row of res.rows) {
+      await db.upsertHubSaturationSummary(
+        summaryDate,
+        row.hub_id,
+        parseFloat(row.avg_queue),
+      );
+    }
+    console.log("Updated hub saturation for", summaryDate);
+  } finally {
+    await client.end();
+  }
+}
+
+if (require.main === module) {
+  update().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}
+
+module.exports = update;

--- a/docs/task_list.md
+++ b/docs/task_list.md
@@ -86,7 +86,6 @@
 
 ## Scaling Triggers & Procurement
 
-- Calculate average queue saturation per hub daily.
 - Generate purchase orders when saturation stays above threshold.
 - Email vendors with pre-filled printer order details.
 - Integrate vendor APIs to place orders automatically.


### PR DESCRIPTION
## Summary
- add `hub_saturation_summary` table and migration
- provide DB helpers to upsert/query hub saturation
- script to compute average queue saturation per hub each day
- remove completed task from the to‑do list

## Testing
- `npm run format`
- `npm test` *(fails: GET /api/admin/spaces returns 404)*
- `npm run ci` *(fails: tsconfig-strictest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685412524874832d9ca5165cf79df3c5