### PR TITLE
Fix wizard slot colon

### DIFF
--- a/js/wizard.js
+++ b/js/wizard.js
@@ -46,6 +46,6 @@ document.addEventListener('DOMContentLoaded', updateWizard);
 window.setWizardStage = setWizardStage;
 export function setWizardSlotCount(n) {
   const el = document.getElementById('wizard-slots');
-  if (el) el.textContent = `Only ${n} print slots remaining;`;
+  if (el) el.textContent = `Only ${n} print slots remaining:`;
 }
 window.setWizardSlotCount = setWizardSlotCount;


### PR DESCRIPTION
## Summary
- change the semicolon in the slot count message to a colon

## Testing
- `npm run format` within `backend/`
- `npm test` *(fails: GET /api/admin/spaces returns 404)*
- `npm run ci` *(fails: tsconfig.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68541471530c832d9918cfba2dae21f3