### PR TITLE
chore(ci): enforce minimum test coverage threshold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,4 +25,7 @@ jobs:
       - name: Run CI
         run: npm run ci
 
+      - name: Run coverage
+        run: npm run coverage
+
       # ← you can add additional steps here, like your tests

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ backend/hunyuan_server/uploads/
 *.log
 .DS_Store
 reports/
+backend/coverage/

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -6,4 +6,14 @@ module.exports = {
   testEnvironment: 'node',
   testMatch: ['<rootDir>/tests/**/*.test.js'],
   testTimeout: 10000,
+  coverageDirectory: 'coverage',
+  coverageReporters: ['text', 'lcov'],
+  coverageThreshold: {
+    global: {
+      branches: 80,
+      functions: 80,
+      lines: 80,
+      statements: 80,
+    },
+  },
 };

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -29,13 +29,14 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.28.0",
+        "@types/jest": "^30.0.0",
+        "coverage-badges-cli": "^2.1.0",
         "eslint": "^9.28.0",
         "eslint-config-prettier": "^10.1.5",
         "eslint-plugin-promise": "^7.2.1",
         "globals": "^16.2.0",
         "htmlparser2": "^9.0.0",
         "jest": "^30.0.0",
-        "@types/jest": "^30.0.0",
         "jest-environment-jsdom": "^30.0.0-beta.3",
         "jest-localstorage-mock": "^2.4.26",
         "jsdom": "^26.1.0",
@@ -1896,6 +1897,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/fs-extra": {
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.4.tgz",
+      "integrity": "sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/jsonfile": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
@@ -1950,6 +1962,23 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/jsonfile": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.1.4.tgz",
+      "integrity": "sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==",
       "dev": true,
       "license": "MIT"
     },
@@ -2658,6 +2687,13 @@
       "peerDependencies": {
         "@babel/core": "^7.11.0"
       }
+    },
+    "node_modules/badgen": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/badgen/-/badgen-3.2.3.tgz",
+      "integrity": "sha512-svDuwkc63E/z0ky3drpUppB83s/nlgDciH9m+STwwQoWyq7yCgew1qEfJ+9axkKdNq7MskByptWUN9j1PGMwFA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -3425,6 +3461,33 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/coverage-badges-cli": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/coverage-badges-cli/-/coverage-badges-cli-2.1.0.tgz",
+      "integrity": "sha512-akV7OQ+qvv7BFeN+T+n4MQNrghAlvbJ1NY+1bcYF4H9Dv68J4ohMOjs5RerX2yVGHPUjebQE0lUnuaICuW0pnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/fs-extra": "~11.0.0",
+        "@types/minimist": "~1.2.2",
+        "badgen": "~3.2.3",
+        "fs-extra": "~11.2.0",
+        "lodash.get": "^4.4.2",
+        "mini-svg-data-uri": "^1.4.4",
+        "minimist": "~1.2.5"
+      },
+      "bin": {
+        "coverage-badges": "bin/cli",
+        "coverage-badges-cli": "bin/cli"
+      },
+      "engines": {
+        "node": ">=v20.11.0",
+        "npm": ">=10.2.4"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
       }
     },
     "node_modules/cross-spawn": {
@@ -4673,6 +4736,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/fs.realpath": {
@@ -6299,6 +6377,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "node_modules/jsonwebtoken": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
@@ -6568,6 +6659,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -6790,6 +6889,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/mini-svg-data-uri": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.4.4.tgz",
+      "integrity": "sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mini-svg-data-uri": "cli.js"
       }
     },
     "node_modules/minimatch": {
@@ -9052,6 +9161,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/unpipe": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "test": "jest",
     "test-ci": "jest --ci --maxWorkers=2 --detectOpenHandles --forceExit",
+    "coverage": "jest --ci --coverage --maxWorkers=2 --detectOpenHandles --forceExit && npx coverage-badges-cli --source coverage/coverage-summary.json --output coverage/badge.svg",
     "start": "node server.js",
     "init-db": "node scripts/init-db.js",
     "migrate": "node scripts/run-migrations.js",
@@ -60,7 +61,8 @@
     "lighthouse": "^12.6.1",
     "prettier": "^3.1.0",
     "supertest": "^7.1.1",
-    "htmlparser2": "^9.0.0"
+    "htmlparser2": "^9.0.0",
+    "coverage-badges-cli": "^2.1.0"
   },
   "engines": {
     "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint:fix": "eslint . --fix",
     "check-conflicts": "! grep -R --include=*.js --include=*.jsx --include=*.ts --include=*.tsx '^(<{7}|={7}|>{7})' .",
     "test": "npm test --prefix backend",
+    "coverage": "npm run coverage --prefix backend",
     "typecheck": "tsc --noEmit",
     "ci": "npm run format && npm run lint && npm run typecheck && npm run test-ci --prefix backend"
   },


### PR DESCRIPTION
## Summary
- add global coverage threshold to Jest config
- add coverage script and badge generation
- ignore coverage output
- run coverage check in CI

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: GET /api/admin/spaces requires admin)*
- `npm run ci` *(fails: GET /api/admin/spaces requires admin)*
- `npm run coverage` *(fails: coverage below threshold)*

------
https://chatgpt.com/codex/tasks/task_e_685411c68214832db17ee730dc7fbbd2