### PR TITLE
Fix TypeScript config path

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+
+  "compilerOptions": {
+    "allowUnusedLabels": false,
+    "allowUnreachableCode": false,
+    "checkJs": true,
+    "downlevelIteration": true,
+    "esModuleInterop": true,
+    "exactOptionalPropertyTypes": true,
+    "forceConsistentCasingInFileNames": true,
+    "importHelpers": true,
+    "isolatedModules": true,
+    "noErrorTruncation": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "useDefineForClassFields": true,
+    "verbatimModuleSyntax": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "tsconfig-strictest/tsconfig.base.json",
+  "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "allowJs": true,
     "checkJs": true,


### PR DESCRIPTION
## Summary
- vendor the strictest base tsconfig
- reference the vendored base config from the project tsconfig

## Testing
- `npm run format` in `backend`
- `npm test` in `backend` *(fails: GET /api/admin/spaces requires admin)*
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_68541b351fe8832db9c4df4c5b6f59db