### PR TITLE
Fix checkout message alignment

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -449,7 +449,9 @@
             <p>&#128666; Free UK Shipping</p>
           </div>
 
-          <div class="mt-4 w-full md:w-1/2 max-w-lg text-center text-sm text-gray-200/90">
+          <div
+            class="absolute left-0 bottom-4 w-full md:w-1/2 max-w-lg text-center text-sm text-gray-200/90"
+          >
             <p>
               Due to incredibly high demand, delivery may take 3+ weeks.<br />
               Please allow for this. &ndash;


### PR DESCRIPTION
## Summary
- restore message layout on payment page so notice sits outside checkout box

## Testing
- `npm run format` (shows prettier output)
- `npm test` *(fails: Identifier 'createSpace' has already been declared)*
- `npm run ci` *(fails: eslint Parsing error)*

------
https://chatgpt.com/codex/tasks/task_e_68542a635b44832dab1dde4bcc99f9d3