### PR TITLE
Add gift email templates and migration

### DIFF
--- a/backend/email_templates/gift_claim.txt
+++ b/backend/email_templates/gift_claim.txt
@@ -1,0 +1,3 @@
+Hi {{recipient}},
+You've received a 3D print from {{sender}}! Click the link below to claim your gift and provide shipping details:
+{{claimUrl}}

--- a/backend/email_templates/gift_printing.txt
+++ b/backend/email_templates/gift_printing.txt
@@ -1,0 +1,1 @@
+Good news! Your gift print is now being produced. We'll notify you once it's on the way.

--- a/backend/email_templates/gift_upsell.txt
+++ b/backend/email_templates/gift_upsell.txt
@@ -1,0 +1,1 @@
+We hope you loved your recent gift print! Did you know you can send a custom print back to the giver? Check out our models and surprise them.

--- a/backend/migrations/048_create_gifts.sql
+++ b/backend/migrations/048_create_gifts.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS gifts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  order_id TEXT REFERENCES orders(session_id),
+  sender_id UUID REFERENCES users(id),
+  recipient_email TEXT,
+  message TEXT,
+  shipping_info JSONB,
+  etch_name TEXT,
+  claimed_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);


### PR DESCRIPTION
## Summary
- add migration for `gifts` table
- add email templates for gift claim, printing and upsell

## Testing
- `npm run format` *(fails: formatting step modifies unrelated files)*
- `npm test` *(fails due to upstream lint error)*
- `npm run ci` *(fails due to upstream lint error)*

------
https://chatgpt.com/codex/tasks/task_e_685426e8e4c8832db3f89cc4ce310478