### PR TITLE
Improve copy link UI

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -258,12 +258,14 @@
         >
           Add to Basket
         </button>
-        <button
-          id="modal-copy-link"
-          class="absolute bottom-4 left-40 font-bold py-2 px-4 rounded-full shadow-md bg-[#2A2A2E] border border-white/20"
-        >
-          Copy Link
-        </button>
+        <div id="modal-copy-container" class="absolute bottom-4 left-40 flex items-center gap-2">
+          <button id="modal-copy-link" class="font-bold py-2 px-4 rounded-full shadow-md bg-[#2A2A2E] border border-white/20">Copy Link</button>
+          <span id="modal-copy-help" class="relative cursor-pointer text-lg">
+            <i class="fas fa-question-circle"></i>
+            <span id="modal-copy-tooltip" class="absolute hidden bottom-full mb-2 left-1/2 -translate-x-1/2 bg-[#2A2A2E] border border-white/10 rounded p-2 text-xs whitespace-nowrap">Click to copy the shareable link</span>
+          </span>
+          <span id="modal-copy-msg" class="ml-2 text-sm hidden">Copied!</span>
+        </div>
         <div class="mt-4 bg-[#2A2A2E] p-4 rounded-xl">
           <ul id="comments-list" class="space-y-1 max-h-48 overflow-y-auto text-sm"></ul>
           <div id="comment-form" class="flex gap-2 mt-2">
@@ -336,12 +338,28 @@
         });
 
         const copyBtn = document.getElementById('modal-copy-link');
+        const copyMsg = document.getElementById('modal-copy-msg');
+        const help = document.getElementById('modal-copy-help');
+        const tooltip = document.getElementById('modal-copy-tooltip');
         copyBtn?.addEventListener('click', () => {
           const id = copyBtn.dataset.id;
           if (!id) return;
           const url = `${window.location.origin}/community/model/${id}`;
-          navigator.clipboard.writeText(url).then(() => alert('Link copied'));
+          navigator.clipboard.writeText(url).then(() => {
+            if (copyMsg) {
+              copyMsg.classList.remove('hidden');
+              setTimeout(() => copyMsg.classList.add('hidden'), 2000);
+            }
+          });
         });
+        if (help && tooltip) {
+          ['mouseenter', 'focus'].forEach((ev) =>
+            help.addEventListener(ev, () => tooltip.classList.remove('hidden'))
+          );
+          ['mouseleave', 'blur'].forEach((ev) =>
+            help.addEventListener(ev, () => tooltip.classList.add('hidden'))
+          );
+        }
 
         closeBtn.addEventListener('click', close);
         document.addEventListener('keydown', (e) => {

--- a/js/myCreations.js
+++ b/js/myCreations.js
@@ -82,6 +82,9 @@ document.addEventListener('DOMContentLoaded', () => {
   const modal = document.getElementById('model-modal');
   const closeBtn = document.getElementById('close-modal');
   const copyBtn = document.getElementById('modal-copy-link');
+  const copyMsg = document.getElementById('modal-copy-msg');
+  const help = document.getElementById('modal-copy-help');
+  const tooltip = document.getElementById('modal-copy-tooltip');
   function close() {
     modal.classList.add('hidden');
     document.body.classList.remove('overflow-hidden');
@@ -94,8 +97,21 @@ document.addEventListener('DOMContentLoaded', () => {
     const id = copyBtn.dataset.id;
     if (!id) return;
     const url = `${window.location.origin}/community/model/${id}`;
-    navigator.clipboard.writeText(url).then(() => alert('Link copied'));
+    navigator.clipboard.writeText(url).then(() => {
+      if (copyMsg) {
+        copyMsg.classList.remove('hidden');
+        setTimeout(() => copyMsg.classList.add('hidden'), 2000);
+      }
+    });
   });
+  if (help && tooltip) {
+    ['mouseenter', 'focus'].forEach((ev) =>
+      help.addEventListener(ev, () => tooltip.classList.remove('hidden'))
+    );
+    ['mouseleave', 'blur'].forEach((ev) =>
+      help.addEventListener(ev, () => tooltip.classList.add('hidden'))
+    );
+  }
   createObserver();
   loadMore();
 });

--- a/my_creations.html
+++ b/my_creations.html
@@ -58,7 +58,14 @@
           <span class="sr-only">Close</span>
         </button>
         <model-viewer src="" alt="3D model preview" environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr" camera-controls auto-rotate class="w-full h-96 bg-[#2A2A2E] rounded-xl"></model-viewer>
-        <button id="modal-copy-link" class="absolute bottom-4 left-4 font-bold py-2 px-4 rounded-full shadow-md bg-[#2A2A2E] border border-white/20 text-white">Copy Link</button>
+        <div class="absolute bottom-4 left-4 flex items-center gap-2">
+          <button id="modal-copy-link" class="font-bold py-2 px-4 rounded-full shadow-md bg-[#2A2A2E] border border-white/20 text-white">Copy Link</button>
+          <span id="modal-copy-help" class="relative cursor-pointer text-lg">
+            <i class="fas fa-question-circle"></i>
+            <span id="modal-copy-tooltip" class="absolute hidden bottom-full mb-2 left-1/2 -translate-x-1/2 bg-[#2A2A2E] border border-white/10 rounded p-2 text-xs whitespace-nowrap">Click to copy the shareable link</span>
+          </span>
+          <span id="modal-copy-msg" class="ml-2 text-sm hidden">Copied!</span>
+        </div>
       </div>
     </div>
     <script type="module" src="js/myCreations.js"></script>


### PR DESCRIPTION
## Summary
- enhance copy link button UI with tooltip and confirmation message
- add hover info for sharing guidance

## Testing
- `npm ci` in backend
- `npm ci` in backend/hunyuan_server
- `npm run format` in backend
- `npm test` *(fails: SyntaxError in server.js)*
- `npm run ci` *(fails during formatting step)*

------
https://chatgpt.com/codex/tasks/task_e_68542e02c774832da5de76499a2c3e2e