### PR TITLE
Fix progress bar flash on homepage

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -398,10 +398,10 @@ const hideAll = () => {
     refs.viewer.pause();
   }
 };
-const showLoader = () => {
+const showLoader = (withProgress = true) => {
   hideAll();
   refs.loader.style.display = 'flex';
-  startProgress();
+  if (withProgress) startProgress();
 };
 const showModel = () => {
   hideAll();
@@ -707,7 +707,7 @@ async function init() {
   window.addEventListener('resize', syncUploadHeights);
   setStep('prompt');
   if (window.setWizardStage) window.setWizardStage('prompt');
-  showLoader();
+  showLoader(false);
   fetchCampaign();
   const initData = await fetchInitData();
   if (initData) {


### PR DESCRIPTION
## Summary
- add `withProgress` flag to `showLoader` and disable it on initial page load

## Testing
- `npm run format`
- `npm test` *(fails: Identifier 'rows' has already been declared)*
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_685439be4844832da2467504c1ef6636