### PR TITLE
Implement weekly order streaks

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -188,6 +188,42 @@ async function insertReferredOrder(orderId, referrerId) {
     [orderId, referrerId],
   );
 }
+
+async function updateWeeklyOrderStreak(userId, date = new Date()) {
+  const week = startOfWeek(date);
+  const weekStr = week.toISOString().slice(0, 10);
+  const { rows } = await query(
+    "SELECT last_week_start, streak FROM order_streaks WHERE user_id=$1",
+    [userId],
+  );
+  if (rows.length === 0) {
+    await query(
+      "INSERT INTO order_streaks(user_id, last_week_start, streak) VALUES($1,$2,1)",
+      [userId, weekStr],
+    );
+    return 1;
+  }
+  const lastWeek = rows[0].last_week_start
+    ? new Date(rows[0].last_week_start)
+    : null;
+  let streak = rows[0].streak || 1;
+  if (rows[0].last_week_start === weekStr) {
+    return streak;
+  }
+  if (
+    lastWeek &&
+    week.getTime() - lastWeek.getTime() === 7 * 24 * 60 * 60 * 1000
+  ) {
+    streak += 1;
+  } else {
+    streak = 1;
+  }
+  await query(
+    "UPDATE order_streaks SET last_week_start=$2, streak=$3 WHERE user_id=$1",
+    [userId, weekStr, streak],
+  );
+  return streak;
+}
 async function insertAdClick(subreddit, sessionId) {
   await query(
     "INSERT INTO ad_clicks(subreddit, session_id, timestamp) VALUES($1,$2,NOW())",
@@ -687,6 +723,7 @@ module.exports = {
   ensureCurrentWeekCredits,
   getCurrentWeekCredits,
   incrementCreditsUsed,
+  updateWeeklyOrderStreak,
   getOrCreateReferralLink,
   getRewardPoints,
   adjustRewardPoints,

--- a/backend/migrations/049_create_order_streaks.sql
+++ b/backend/migrations/049_create_order_streaks.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS order_streaks (
+  user_id UUID PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+  last_week_start DATE NOT NULL,
+  streak INTEGER NOT NULL DEFAULT 1,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TRIGGER order_streaks_set_updated
+BEFORE UPDATE ON order_streaks
+FOR EACH ROW EXECUTE PROCEDURE set_updated_at();

--- a/backend/server.js
+++ b/backend/server.js
@@ -2660,6 +2660,21 @@ app.post(
               );
             }
           }
+
+          const streak = await db.updateWeeklyOrderStreak(userId);
+          if (streak % 4 === 0) {
+            const type = `weekly_streak_${streak}`;
+            const { rows: existing } = await db.query(
+              "SELECT 1 FROM incentives WHERE user_id=$1 AND type=$2",
+              [userId, type],
+            );
+            if (existing.length === 0) {
+              await db.query(
+                "INSERT INTO incentives(user_id, type) VALUES($1,$2)",
+                [userId, type],
+              );
+            }
+          }
         }
       } catch (err) {
         logError(err);

--- a/backend/tests/api.test.js
+++ b/backend/tests/api.test.js
@@ -24,6 +24,7 @@ jest.mock("../db", () => ({
   getUserIdForReferral: jest.fn(),
   getOrCreateOrderReferralLink: jest.fn(),
   insertReferredOrder: jest.fn(),
+  updateWeeklyOrderStreak: jest.fn(),
 }));
 const db = require("../db");
 
@@ -310,6 +311,30 @@ test("Stripe webhook updates order and awards badge", async () => {
   );
   expect(incentive).toBeTruthy();
   expect(incentive[1][1]).toMatch(/^three_orders_/);
+});
+
+test("Stripe webhook awards weekly streak badge", async () => {
+  db.query
+    .mockResolvedValueOnce({})
+    .mockResolvedValueOnce({
+      rows: [{ job_id: "job1", user_id: "u1", shipping_info: { name: "A" } }],
+    })
+    .mockResolvedValueOnce({ rows: [{ model_url: "/tmp/model.stl" }] })
+    .mockResolvedValueOnce({ rows: [{ count: "1" }] });
+  db.updateWeeklyOrderStreak.mockResolvedValueOnce(4);
+  db.query.mockResolvedValueOnce({ rows: [] }).mockResolvedValueOnce({});
+  const payload = JSON.stringify({});
+  const res = await request(app)
+    .post("/api/webhook/stripe")
+    .set("stripe-signature", "sig")
+    .set("Content-Type", "application/json")
+    .send(payload);
+  expect(res.status).toBe(200);
+  const incentiveCalls = db.query.mock.calls.filter((c) =>
+    c[0].includes("INSERT INTO incentives"),
+  );
+  const last = incentiveCalls[incentiveCalls.length - 1];
+  expect(last[1][1]).toBe("weekly_streak_4");
 });
 
 test("Stripe webhook invalid signature", async () => {

--- a/docs/task_list.md
+++ b/docs/task_list.md
@@ -26,10 +26,6 @@
 - Add real photo of printed object or user-generated image to hero section to reinforce the physical product.
 - Display pricing info near the prompt field such as "From $X / print" to reduce hesitation.
 
-## Repeat Purchase Incentives
-
-- Track consecutive weekly orders and badge streaks.
-
 ## 3D Model Loading Performance
 
 - Optimize the `.glb` file used on `index.html` and `payment.html`.


### PR DESCRIPTION
## Summary
- add `order_streaks` table
- update database helpers with `updateWeeklyOrderStreak`
- award weekly streak badges after multiples of four weeks
- test weekly streak incentive
- remove completed task from task list

## Testing
- `npx prettier docs/task_list.md backend/db.js backend/tests/api.test.js -w`
- `npm test` *(fails: Identifier 'rows' has already been declared)*
- `npm run ci` *(fails: Unexpected token parsing server.js)*

------
https://chatgpt.com/codex/tasks/task_e_68543908c6c0832d89ed503faad1c23c