### PR TITLE
Persist community model viewer across reloads

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -282,7 +282,7 @@
     </div>
     <script type="module">
       import { shareOn } from './js/share.js';
-      import { init } from './js/community.js';
+      import { init, closeModel, restoreOpenModel } from './js/community.js';
       window.shareOn = shareOn;
 
       document.addEventListener('DOMContentLoaded', () => {
@@ -314,10 +314,7 @@
           if (btn) setTier(btn.dataset.tier);
         });
 
-        function close() {
-          modal.classList.add('hidden');
-          document.body.classList.remove('overflow-hidden');
-        }
+        const close = closeModel;
 
         checkoutBtn.addEventListener('click', () => {
           sessionStorage.setItem('fromCommunity', '1');
@@ -377,6 +374,7 @@
 
         setTier('silver');
         init();
+        restoreOpenModel();
       });
     </script>
     <div


### PR DESCRIPTION
## Summary
- remember which community model was open in the modal
- reopen the viewer after reload and clear state on navigation

## Testing
- `npm run format`
- `npm test`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_68550d816b58832d9c92895b2ac4dfa7