### PR TITLE
Implement clearing alert script

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -26,7 +26,8 @@
     "import-ad-spend": "node scripts/import-ad-spend.js",
     "check-inventory": "node scripts/check-inventory.js",
     "check-capacity": "node scripts/check-capacity.js",
-    "send-intel-report": "node scripts/send-intel-report.js"
+    "send-intel-report": "node scripts/send-intel-report.js",
+    "notify-clearing": "node scripts/notify-manual-clearing.js"
   },
   "keywords": [],
   "author": "",

--- a/backend/scripts/notify-manual-clearing.js
+++ b/backend/scripts/notify-manual-clearing.js
@@ -1,0 +1,36 @@
+require("dotenv").config();
+const { Client } = require("pg");
+const { sendMail } = require("../mail");
+
+async function notifyManualClearing() {
+  const client = new Client({ connectionString: process.env.DB_URL });
+  await client.connect();
+  try {
+    const { rows } = await client.query(
+      `SELECT p.serial, h.operator, m.error
+         FROM printers p
+         JOIN printer_hubs h ON p.hub_id=h.id
+         JOIN LATERAL (
+           SELECT error
+             FROM printer_metrics
+            WHERE printer_id=p.id
+         ORDER BY created_at DESC
+            LIMIT 1
+         ) m ON TRUE
+        WHERE m.error ILIKE '%clear%'`,
+    );
+    for (const row of rows) {
+      if (!row.operator) continue;
+      const message = `Printer ${row.serial} requires manual clearing: ${row.error}`;
+      await sendMail(row.operator, "Printer requires manual clearing", message);
+    }
+  } finally {
+    await client.end();
+  }
+}
+
+if (require.main === module) {
+  notifyManualClearing();
+}
+
+module.exports = notifyManualClearing;

--- a/backend/tests/notifyManualClearing.test.js
+++ b/backend/tests/notifyManualClearing.test.js
@@ -1,0 +1,37 @@
+process.env.DB_URL = "postgres://user:pass@localhost/db";
+
+jest.mock("pg");
+const { Client } = require("pg");
+const mClient = { connect: jest.fn(), end: jest.fn(), query: jest.fn() };
+Client.mockImplementation(() => mClient);
+
+jest.mock("../mail", () => ({ sendMail: jest.fn() }));
+const { sendMail } = require("../mail");
+
+const run = require("../scripts/notify-manual-clearing");
+
+beforeEach(() => {
+  mClient.connect.mockClear();
+  mClient.end.mockClear();
+  mClient.query.mockClear();
+  sendMail.mockClear();
+});
+
+test("sends alert for printers needing clearing", async () => {
+  mClient.query.mockResolvedValueOnce({
+    rows: [{ serial: "p1", operator: "op@example.com", error: "needs clear" }],
+  });
+  await run();
+  expect(sendMail).toHaveBeenCalledWith(
+    "op@example.com",
+    "Printer requires manual clearing",
+    expect.stringContaining("p1"),
+  );
+  expect(mClient.end).toHaveBeenCalled();
+});
+
+test("no alert when no printers need clearing", async () => {
+  mClient.query.mockResolvedValueOnce({ rows: [] });
+  await run();
+  expect(sendMail).not.toHaveBeenCalled();
+});

--- a/docs/task_list.md
+++ b/docs/task_list.md
@@ -39,8 +39,6 @@
 
 ## Autonomous 3D Printing
 
-- Notify operator when a printer requires manual clearing.
-
 ## Fulfillment Capacity Forecasting
 
 - Graph forecasted demand vs. capacity in the admin panel.


### PR DESCRIPTION
## Summary
- add notify-manual-clearing script
- expose script via npm in backend/package.json
- test notifying operators about printers that need clearing
- remove completed manual-clearing task from docs

## Testing
- `npm test -- -i`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_68550ef81498832db616c45747521256