### PR TITLE
Fix header stats color

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,9 +130,9 @@
     <header class="relative flex items-center justify-between py-4 px-6">
       <div class="flex flex-col items-start">
         <img src="img/textlogo.png" alt="print3" class="h-10 w-auto" />
-        <div class="mt-1 flex flex-col text-sm text-gray-200 opacity-90">
-          <p><span class="text-white">5400+</span> prints</p>
-          <p>delivered already</p>
+        <div class="mt-1 flex flex-col text-sm opacity-90">
+          <p class="text-gray-200"><span class="text-white">5400+</span> prints</p>
+          <p class="text-gray-200">delivered already</p>
           <p id="stats-ticker" class="text-[#30D5C8] text-left" style="min-height: 2.5rem"></p>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- keep '5400+' text white
- make surrounding text gray

## Testing
- `npm run format`
- `npm test`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_685510529794832da6d3a99f8303923e