### PR TITLE
chore(ci): enforce security scans

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,4 +35,22 @@ jobs:
           git diff --exit-code backend/package-lock.json
           git diff --exit-code backend/hunyuan_server/package-lock.json
 
+      - name: Audit dependencies
+        run: |
+          npm audit --audit-level=high
+          npm audit --prefix backend --audit-level=high
+          if [ -f backend/hunyuan_server/package.json ]; then
+            npm audit --prefix backend/hunyuan_server --audit-level=high
+          fi
+
+      - name: Run Snyk security scan
+        run: |
+          npx snyk test --severity-threshold=high
+          npx snyk test --severity-threshold=high --file=backend/package.json
+          if [ -f backend/hunyuan_server/package.json ]; then
+            npx snyk test --severity-threshold=high --file=backend/hunyuan_server/package.json
+          fi
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+
       # ← you can add additional steps here, like your tests

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -41,3 +41,19 @@ jobs:
 
       - run: npx prettier --check "**/*.{js,jsx,json,md,html}"
         working-directory: backend
+
+      - name: Audit dependencies
+        run: |
+          npm audit --audit-level=high --prefix backend
+          if [ -f backend/hunyuan_server/package.json ]; then
+            npm audit --audit-level=high --prefix backend/hunyuan_server
+          fi
+
+      - name: Run Snyk security scan
+        run: |
+          npx snyk test --severity-threshold=high --file=backend/package.json
+          if [ -f backend/hunyuan_server/package.json ]; then
+            npx snyk test --severity-threshold=high --file=backend/hunyuan_server/package.json
+          fi
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
+npm audit --audit-level=high
 npx lint-staged


### PR DESCRIPTION
## Summary
- run `npm audit` and `snyk test` during CI
- add `npm audit` to the pre-commit hook to block committing vulnerable code

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_685530fcc4ac832d9eb90c7a87838aba