### PR TITLE
Add weekly ops report

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -27,7 +27,8 @@
     "check-inventory": "node scripts/check-inventory.js",
     "check-capacity": "node scripts/check-capacity.js",
     "send-intel-report": "node scripts/send-intel-report.js",
-    "notify-clearing": "node scripts/notify-manual-clearing.js"
+    "notify-clearing": "node scripts/notify-manual-clearing.js",
+    "send-ops-report": "node scripts/send-ops-report.js"
   },
   "keywords": [],
   "author": "",

--- a/backend/scripts/send-ops-report.js
+++ b/backend/scripts/send-ops-report.js
@@ -1,0 +1,98 @@
+require("dotenv").config();
+const { Client } = require("pg");
+const fs = require("fs");
+const path = require("path");
+const PDFDocument = require("pdfkit");
+const { sendMailWithAttachment } = require("../mail");
+
+async function run() {
+  const client = new Client({ connectionString: process.env.DB_URL });
+  await client.connect();
+  try {
+    const hubRes = await client.query(`
+      SELECT h.id, h.name, COUNT(p.id) AS printers
+        FROM printer_hubs h
+        LEFT JOIN printers p ON p.hub_id=h.id
+       GROUP BY h.id, h.name
+       ORDER BY h.id`);
+    const orderRes = await client.query(
+      "SELECT status, COUNT(*) FROM orders GROUP BY status",
+    );
+    const errorRes = await client.query(`
+      SELECT h.id, COUNT(*) AS errors
+        FROM printer_hubs h
+        JOIN printers p ON p.hub_id=h.id
+        JOIN printer_metrics m ON m.printer_id=p.id
+       WHERE m.created_at >= NOW() - INTERVAL '7 days'
+         AND (m.status='offline' OR m.error IS NOT NULL)
+       GROUP BY h.id`);
+    const errorMap = {};
+    for (const r of errorRes.rows) {
+      errorMap[r.id] = parseInt(r.errors, 10);
+    }
+    const hubs = hubRes.rows.map((r) => ({
+      id: r.id,
+      name: r.name,
+      printers: parseInt(r.printers, 10),
+      errors: errorMap[r.id] || 0,
+    }));
+    const orders = orderRes.rows.reduce((acc, r) => {
+      acc[r.status] = parseInt(r.count, 10);
+      return acc;
+    }, {});
+    const date = new Date().toISOString().slice(0, 10);
+    const outDir = path.join(__dirname, "..", "..", "reports");
+    fs.mkdirSync(outDir, { recursive: true });
+    const outPath = path.join(outDir, `ops_report_${date}.pdf`);
+    await new Promise((resolve) => {
+      const doc = new PDFDocument();
+      doc.pipe(fs.createWriteStream(outPath).on("finish", resolve));
+      doc.fontSize(18).text("State of Company", { align: "center" });
+      doc.moveDown();
+      doc.fontSize(12).text(`Date: ${date}`);
+      doc.moveDown();
+      doc.text("Orders:");
+      for (const [status, count] of Object.entries(orders)) {
+        doc.text(`- ${status}: ${count}`);
+      }
+      doc.moveDown();
+      doc.text("Hubs:");
+      hubs.forEach((h) => {
+        const mark = h.errors > 0 ? ` (errors: ${h.errors})` : "";
+        doc.text(`- ${h.name} - printers: ${h.printers}${mark}`);
+      });
+      doc.end();
+    });
+    if (process.env.OPS_REPORT_ARCHIVE) {
+      const dest = path.join(
+        process.env.OPS_REPORT_ARCHIVE,
+        path.basename(outPath),
+      );
+      fs.copyFileSync(outPath, dest);
+    }
+    if (process.env.OPS_EMAILS) {
+      const emails = process.env.OPS_EMAILS.split(",")
+        .map((e) => e.trim())
+        .filter(Boolean);
+      for (const e of emails) {
+        await sendMailWithAttachment(
+          e,
+          "Weekly Operations Report",
+          "See attached report",
+          outPath,
+        );
+      }
+    }
+  } finally {
+    await client.end();
+  }
+}
+
+if (require.main === module) {
+  run().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}
+
+module.exports = run;

--- a/backend/tests/opsReport.test.js
+++ b/backend/tests/opsReport.test.js
@@ -1,0 +1,37 @@
+process.env.DB_URL = "postgres://user:pass@localhost/db";
+process.env.OPS_EMAILS = "ops@test.com";
+process.env.OPS_REPORT_ARCHIVE = "/tmp";
+
+jest.mock("pg");
+const { Client } = require("pg");
+const mClient = { connect: jest.fn(), end: jest.fn(), query: jest.fn() };
+Client.mockImplementation(() => mClient);
+
+jest.mock("../mail", () => ({ sendMailWithAttachment: jest.fn() }));
+const { sendMailWithAttachment } = require("../mail");
+
+const fs = require("fs");
+const run = require("../scripts/send-ops-report");
+
+describe("send ops report", () => {
+  beforeEach(() => {
+    mClient.connect.mockClear();
+    mClient.end.mockClear();
+    mClient.query.mockClear();
+    sendMailWithAttachment.mockClear();
+  });
+
+  test("emails report and archives file", async () => {
+    mClient.query
+      .mockResolvedValueOnce({ rows: [{ id: 1, name: "Hub", printers: "2" }] })
+      .mockResolvedValueOnce({ rows: [{ status: "paid", count: "5" }] })
+      .mockResolvedValueOnce({ rows: [{ id: 1, errors: "4" }] });
+    const copy = jest.spyOn(fs, "copyFileSync").mockImplementation(() => {});
+    await run();
+    expect(mClient.connect).toHaveBeenCalled();
+    expect(sendMailWithAttachment).toHaveBeenCalled();
+    expect(copy).toHaveBeenCalled();
+    expect(mClient.end).toHaveBeenCalled();
+    copy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- script to generate operations report and email to ops team
- archive reports
- expose command via npm scripts
- test weekly ops report script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685531cc96c0832d872e93e640ace1b2