### PR TITLE
Update .prettierignore for Prettier check

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -10,3 +10,9 @@ coverage
 backend/coverage
 **/coverage/**
 backend/generated_ads.json
+
+# --- ignore generated output ------------------------------
+coverage
+coverage/**
+# (optional) you can list more generated folders here, e.g. build, dist
+# ----------------------------------------------------------


### PR DESCRIPTION
## Summary
- ignore coverage output in `.prettierignore`

## Testing
- `npm ci` in `backend/`
- `npm ci` in `backend/hunyuan_server`
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `npm run ci`
- `npx prettier --check "**/*.{js,jsx,json,md,html}"`


------
https://chatgpt.com/codex/tasks/task_e_685553f2d898832db32285d9933eeb37