### PR TITLE
Fix model viewer initialization

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -706,6 +706,11 @@ refs.submitBtn.addEventListener('click', async () => {
 
 async function init() {
   await ensureModelViewerLoaded();
+  if (window.customElements?.whenDefined) {
+    try {
+      await customElements.whenDefined('model-viewer');
+    } catch {}
+  }
   syncUploadHeights();
   window.addEventListener('resize', syncUploadHeights);
   setStep('prompt');


### PR DESCRIPTION
## Summary
- ensure the `<model-viewer>` custom element is defined before using it

## Testing
- `npm run format`
- `npm test`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_68555af2c6dc832dbc98c85e466f65b8