### PR TITLE
Add utils tests to raise coverage

### DIFF
--- a/backend/tests/utils/generateAdCopy.test.js
+++ b/backend/tests/utils/generateAdCopy.test.js
@@ -1,0 +1,44 @@
+const axios = require("axios");
+jest.mock("axios");
+
+// mock templates
+jest.mock("../../ad_templates.json", () => [
+  { template: "Ad for {subreddit}" },
+]);
+
+const generateAdCopy = require("../../utils/generateAdCopy");
+
+describe("generateAdCopy", () => {
+  const originalEnv = process.env.LLM_API_URL;
+
+  afterEach(() => {
+    process.env.LLM_API_URL = originalEnv;
+    jest.clearAllMocks();
+  });
+
+  test("returns template text when API url not set", async () => {
+    delete process.env.LLM_API_URL;
+    Math.random = jest.fn(() => 0); // pick first template
+    const text = await generateAdCopy("foo");
+    expect(text).toBe("Ad for foo");
+  });
+
+  test("uses API when url set", async () => {
+    process.env.LLM_API_URL = "http://api";
+    axios.post.mockResolvedValue({ data: { text: " Hello " } });
+    const text = await generateAdCopy("bar", "context");
+    expect(axios.post).toHaveBeenCalledWith("http://api", {
+      prompt: "Write a short advert for r/bar. Context: context",
+    });
+    expect(text).toBe("Hello");
+  });
+
+  test("falls back to template on error", async () => {
+    process.env.LLM_API_URL = "http://api";
+    axios.post.mockRejectedValue(new Error("fail"));
+    Math.random = jest.fn(() => 0);
+    console.error.mockImplementation(() => {});
+    const text = await generateAdCopy("baz");
+    expect(text).toBe("Ad for baz");
+  });
+});

--- a/backend/tests/utils/generateTitle.test.js
+++ b/backend/tests/utils/generateTitle.test.js
@@ -1,0 +1,21 @@
+const generateTitle = require("../../utils/generateTitle");
+
+describe("generateTitle", () => {
+  test('returns "Untitled Model" for non-string input', () => {
+    expect(generateTitle(null)).toBe("Untitled Model");
+    expect(generateTitle(123)).toBe("Untitled Model");
+  });
+
+  test('returns "Untitled Model" when no words', () => {
+    expect(generateTitle("!!! ???")).toBe("Untitled Model");
+  });
+
+  test("deduplicates and limits to three words", () => {
+    const result = generateTitle("cat cat dog fish bird");
+    expect(result).toBe("Cat Dog Fish");
+  });
+
+  test("capitalizes and trims words", () => {
+    expect(generateTitle(" hello world ")).toBe("Hello World");
+  });
+});

--- a/backend/tests/utils/validateStl.test.js
+++ b/backend/tests/utils/validateStl.test.js
@@ -1,0 +1,38 @@
+const fs = require("fs");
+const path = require("path");
+const validateStl = require("../../utils/validateStl");
+
+describe("validateStl", () => {
+  const tmpDir = fs.mkdtempSync(path.join(__dirname, "stl-"));
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("returns true for valid ASCII STL", () => {
+    const file = path.join(tmpDir, "model_ascii.stl");
+    const ascii = `solid test\nfacet normal 0 0 0\nouter loop\nvertex 0 0 0\nvertex 1 0 0\nvertex 0 1 0\nendloop\nendfacet\nendsolid test`;
+    fs.writeFileSync(file, ascii);
+    expect(validateStl(file)).toBe(true);
+  });
+
+  test("returns true for valid binary STL", () => {
+    const file = path.join(tmpDir, "model_bin.stl");
+    const buf = Buffer.alloc(84);
+    buf.write("BINARY", 0, "ascii");
+    buf.writeUInt32LE(1, 80);
+    fs.writeFileSync(file, buf);
+    expect(validateStl(file)).toBe(true);
+  });
+
+  test("returns false for invalid file", () => {
+    const file = path.join(tmpDir, "invalid.stl");
+    fs.writeFileSync(file, "bad");
+    expect(validateStl(file)).toBe(false);
+  });
+
+  test("returns false when file missing", () => {
+    const file = path.join(tmpDir, "missing.stl");
+    expect(validateStl(file)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for generateTitle utility
- cover generateAdCopy fallback and API behavior
- add validateStl tests

## Testing
- `npm run format`
- `npm test`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_68556329b9b8832d8a6afaed63f108b0