### PR TITLE
chore(ci): add Snyk token check, conditional scans, and npm audit fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,14 +43,38 @@ jobs:
             npm audit --prefix backend/hunyuan_server --audit-level=high
           fi
 
-      - name: Run Snyk security scan
-        run: |
-          npx snyk test --severity-threshold=high
-          npx snyk test --severity-threshold=high --file=backend/package.json
-          if [ -f backend/hunyuan_server/package.json ]; then
-            npx snyk test --severity-threshold=high --file=backend/hunyuan_server/package.json
-          fi
+      - name: Validate SNYK_TOKEN
+        if: ${{ secrets.SNYK_TOKEN }}
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        run: |
+          if ! npx snyk auth --token="$SNYK_TOKEN" >/dev/null 2>&1; then
+            echo "❌ Invalid SNYK_TOKEN; please update your GitHub secret"
+            exit 1
+          fi
+
+      - name: Snyk security scan
+        if: ${{ secrets.SNYK_TOKEN }}
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        run: npx snyk test --severity-threshold=high --file=backend/package.json
+
+      - name: Fallback to npm audit
+        if: ${{ !secrets.SNYK_TOKEN }}
+        run: |
+          echo "⚠️ SNYK_TOKEN not set; running npm audit instead"
+          npm audit --audit-level=high --prefix backend
+
+      - name: Snyk hunyuan scan
+        if: ${{ secrets.SNYK_TOKEN && hashFiles('backend/hunyuan_server/package.json') != '' }}
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        run: npx snyk test --severity-threshold=high --file=backend/hunyuan_server/package.json
+
+      - name: Fallback hunyuan npm audit
+        if: ${{ !secrets.SNYK_TOKEN && hashFiles('backend/hunyuan_server/package.json') != '' }}
+        run: |
+          echo "⚠️ SNYK_TOKEN not set; running npm audit instead"
+          npm audit --audit-level=high --prefix backend/hunyuan_server
 
       # ← you can add additional steps here, like your tests

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -49,11 +49,36 @@ jobs:
             npm audit --audit-level=high --prefix backend/hunyuan_server
           fi
 
-      - name: Run Snyk security scan
-        run: |
-          npx snyk test --severity-threshold=high --file=backend/package.json
-          if [ -f backend/hunyuan_server/package.json ]; then
-            npx snyk test --severity-threshold=high --file=backend/hunyuan_server/package.json
-          fi
+      - name: Validate SNYK_TOKEN
+        if: ${{ secrets.SNYK_TOKEN }}
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        run: |
+          if ! npx snyk auth --token="$SNYK_TOKEN" >/dev/null 2>&1; then
+            echo "❌ Invalid SNYK_TOKEN; please update your GitHub secret"
+            exit 1
+          fi
+
+      - name: Snyk security scan
+        if: ${{ secrets.SNYK_TOKEN }}
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        run: npx snyk test --severity-threshold=high --file=backend/package.json
+
+      - name: Fallback to npm audit
+        if: ${{ !secrets.SNYK_TOKEN }}
+        run: |
+          echo "⚠️ SNYK_TOKEN not set; running npm audit instead"
+          npm audit --audit-level=high --prefix backend
+
+      - name: Snyk hunyuan scan
+        if: ${{ secrets.SNYK_TOKEN && hashFiles('backend/hunyuan_server/package.json') != '' }}
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        run: npx snyk test --severity-threshold=high --file=backend/hunyuan_server/package.json
+
+      - name: Fallback hunyuan npm audit
+        if: ${{ !secrets.SNYK_TOKEN && hashFiles('backend/hunyuan_server/package.json') != '' }}
+        run: |
+          echo "⚠️ SNYK_TOKEN not set; running npm audit instead"
+          npm audit --audit-level=high --prefix backend/hunyuan_server

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,7 @@
+### Snyk Scans
+
+This workflow uses Snyk to test for high-severity vulnerabilities.
+
+- **To enable**: add your Snyk API token as the `SNYK_TOKEN` secret in GitHub repo settings.
+- **Fallback**: if `SNYK_TOKEN` is missing, CI will automatically run `npm audit --audit-level=high`.
+- **Validation**: invalid tokens will error early with a clear message.


### PR DESCRIPTION
## Summary
- validate `SNYK_TOKEN` before running Snyk
- skip Snyk scans when the token is missing and run `npm audit` instead
- document how Snyk scanning works

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_6855b5c4d270832d82f5923f2b0c60b2