### PR TITLE
Add procurement order tracking and overdue alerts

### DIFF
--- a/backend/migrations/051_create_procurement_orders.sql
+++ b/backend/migrations/051_create_procurement_orders.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS procurement_orders (
+  id SERIAL PRIMARY KEY,
+  hub_id INTEGER REFERENCES printer_hubs(id) ON DELETE CASCADE,
+  vendor TEXT,
+  model TEXT,
+  quantity INTEGER,
+  status TEXT DEFAULT 'sent',
+  ack_date DATE,
+  est_arrival_date DATE,
+  flagged_overdue BOOLEAN DEFAULT FALSE,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);

--- a/backend/package.json
+++ b/backend/package.json
@@ -28,7 +28,8 @@
     "check-capacity": "node scripts/check-capacity.js",
     "send-intel-report": "node scripts/send-intel-report.js",
     "notify-clearing": "node scripts/notify-manual-clearing.js",
-    "send-ops-report": "node scripts/send-ops-report.js"
+    "send-ops-report": "node scripts/send-ops-report.js",
+    "flag-overdue-printers": "node scripts/flag-overdue-procurement-orders.js"
   },
   "keywords": [],
   "author": "",

--- a/backend/scripts/auto-procure-printers.js
+++ b/backend/scripts/auto-procure-printers.js
@@ -41,6 +41,11 @@ async function run() {
           `Ship to ${hub.name} in ${hub.location}`,
           outPath,
         );
+        await client.query(
+          `INSERT INTO procurement_orders(hub_id, vendor, model, quantity)
+           VALUES($1,$2,$3,$4)`,
+          [row.hub_id, PRINTER_VENDOR, PRINTER_MODEL, QUANTITY],
+        );
         const targetDate = new Date(Date.now() + 30 * 86400000)
           .toISOString()
           .slice(0, 10);

--- a/backend/scripts/flag-overdue-procurement-orders.js
+++ b/backend/scripts/flag-overdue-procurement-orders.js
@@ -1,0 +1,39 @@
+require("dotenv").config();
+const { Client } = require("pg");
+const { sendMail } = require("../mail");
+
+const ALERT_EMAIL = process.env.PROCUREMENT_ALERT_EMAIL || "";
+
+async function run() {
+  const client = new Client({ connectionString: process.env.DB_URL });
+  await client.connect();
+  try {
+    const { rows } = await client.query(
+      `SELECT id, hub_id, vendor, model, quantity, est_arrival_date
+         FROM procurement_orders
+        WHERE est_arrival_date IS NOT NULL
+          AND est_arrival_date < CURRENT_DATE
+          AND flagged_overdue=FALSE`,
+    );
+    for (const row of rows) {
+      const msg = `Order #${row.id} for hub ${row.hub_id} is overdue (expected ${row.est_arrival_date.toISOString().slice(0, 10)})`;
+      if (ALERT_EMAIL) {
+        await sendMail(ALERT_EMAIL, "Overdue printer delivery", msg);
+      } else {
+        console.log(msg);
+      }
+      await client.query(
+        "UPDATE procurement_orders SET flagged_overdue=TRUE WHERE id=$1",
+        [row.id],
+      );
+    }
+  } finally {
+    await client.end();
+  }
+}
+
+if (require.main === module) {
+  run();
+}
+
+module.exports = run;

--- a/backend/tests/autoProcurePrinters.test.js
+++ b/backend/tests/autoProcurePrinters.test.js
@@ -24,10 +24,11 @@ test("creates purchase order when saturation high", async () => {
   mClient.query
     .mockResolvedValueOnce({ rows: [{ hub_id: 1, avg_sat: "0.9" }] })
     .mockResolvedValueOnce({ rows: [{ name: "Hub", location: "US" }] })
+    .mockResolvedValueOnce({})
     .mockResolvedValueOnce({});
   await run();
   expect(emailVendorApproval).toHaveBeenCalled();
-  expect(mClient.query).toHaveBeenCalledTimes(3);
+  expect(mClient.query).toHaveBeenCalledTimes(4);
 });
 
 test("no order when saturation below threshold", async () => {

--- a/backend/tests/flagOverdueProcurementOrders.test.js
+++ b/backend/tests/flagOverdueProcurementOrders.test.js
@@ -1,0 +1,52 @@
+process.env.DB_URL = "postgres://user:pass@localhost/db";
+process.env.PROCUREMENT_ALERT_EMAIL = "ops@example.com";
+
+jest.mock("pg");
+const { Client } = require("pg");
+const mClient = { connect: jest.fn(), end: jest.fn(), query: jest.fn() };
+Client.mockImplementation(() => mClient);
+
+jest.mock("../mail", () => ({ sendMail: jest.fn() }));
+const { sendMail } = require("../mail");
+
+const run = require("../scripts/flag-overdue-procurement-orders");
+
+beforeEach(() => {
+  mClient.connect.mockClear();
+  mClient.end.mockClear();
+  mClient.query.mockClear();
+  sendMail.mockClear();
+});
+
+test("sends alert for overdue orders", async () => {
+  mClient.query
+    .mockResolvedValueOnce({
+      rows: [
+        {
+          id: 1,
+          hub_id: 2,
+          vendor: "ACME",
+          model: "MVP",
+          quantity: 2,
+          est_arrival_date: new Date("2024-01-01"),
+        },
+      ],
+    })
+    .mockResolvedValueOnce({});
+  await run();
+  expect(sendMail).toHaveBeenCalledWith(
+    "ops@example.com",
+    "Overdue printer delivery",
+    expect.stringContaining("Order #1"),
+  );
+  expect(mClient.query).toHaveBeenCalledWith(
+    "UPDATE procurement_orders SET flagged_overdue=TRUE WHERE id=$1",
+    [1],
+  );
+});
+
+test("does nothing when none overdue", async () => {
+  mClient.query.mockResolvedValueOnce({ rows: [] });
+  await run();
+  expect(sendMail).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- create `procurement_orders` table
- log purchase orders in `auto-procure-printers.js`
- alert when procurement orders are overdue
- test new script and update procurement tests

## Testing
- `npm run format`
- `npm test`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_6855cb57459c832d8912384a2dfb7448