### PR TITLE
Add weekly ops report workflow

### DIFF
--- a/.github/workflows/ops-report.yml
+++ b/.github/workflows/ops-report.yml
@@ -1,0 +1,21 @@
+name: Weekly Operations Report
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+          cache-dependency-path: 'backend/package-lock.json'
+      - run: npm ci
+        working-directory: backend
+      - run: npm run send-ops-report
+        working-directory: backend

--- a/docs/task_list.md
+++ b/docs/task_list.md
@@ -133,9 +133,7 @@
 
 ## Global Operations Reporting
 
-- Email a weekly "state of company" PDF with key metrics.
-- Highlight hubs with repeated errors or downtime.
-- Archive all reports in cloud storage.
+(completed)
 
 ## Carrier Pickup Integration
 


### PR DESCRIPTION
## Summary
- create a GitHub Action to send the ops report every Monday
- mark Global Operations Reporting tasks as complete

## Testing
- `npm run format` *(backend)*
- `npm test` *(backend)*
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_6855cb2aee9c832db543a0f7e10bc7c0