### PR TITLE
chore(ci): add Docker build parity check

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,15 @@
+name: Docker Build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build Docker image
+        run: docker build .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:20
+WORKDIR /app
+COPY package*.json ./
+COPY backend/package*.json backend/
+COPY backend/hunyuan_server/package*.json backend/hunyuan_server/
+COPY . .
+RUN npm ci && npm ci --prefix backend && if [ -f backend/hunyuan_server/package.json ]; then npm ci --prefix backend/hunyuan_server; fi
+RUN npm run ci
+CMD ["npm", "start", "--prefix", "backend"]


### PR DESCRIPTION
## Summary
- add Dockerfile for local build and tests
- add workflow to build Docker image on CI

## Validation
- `npm run format` output:
```
utils/generateAdCopy.js 17ms
utils/generateShareCard.js 2ms (unchanged)
utils/generateTitle.js 3ms (unchanged)
utils/routing.js 5ms (unchanged)
utils/validateStl.js 2ms (unchanged)
```
- `npm test` output snippet:
```
Test Suites: 58 passed, 58 total
Tests:       303 passed, 303 total
Snapshots:   0 total
Time:        7.19 s
Ran all test suites.
```


------
https://chatgpt.com/codex/tasks/task_e_6855caf9efe8832dabfa98f13cc7f4cf