### PR TITLE
Fix delivery warning layout on checkout

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -582,7 +582,7 @@
         <div
           id="delivery-warning"
           style="position: absolute; right: calc(100% + 0.55cm); bottom: 1rem;"
-          class="max-w-xs text-sm text-gray-200/90 text-left"
+          class="w-fit text-sm text-gray-200/90 text-left"
         >
           <p>
             Due to incredibly high demand, delivery may take 3+ weeks.<br />


### PR DESCRIPTION
## Summary
- keep delivery warning single line with `w-fit`
- ran formatting and tests per AGENTS.md

## Testing
- `npm run format`
- `npm test`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_6855cb8c77a8832da335781ad162ce7a