### PR TITLE
Add Print Club marketing tasks

### DIFF
--- a/docs/task_list.md
+++ b/docs/task_list.md
@@ -197,3 +197,90 @@
   - Offer a minimal gift-wrap upsell toggle in the modal.
   - Use subtle gift icons on product thumbnails instead of large banners.
   - A/B test concise versus detailed gift copy to avoid clutter.
+
+## Increasing Print Club subscriptions
+
+- **Pricing incentives**
+  - Introductory discounts – offer a discounted first month or a "first print free" promotion.
+  - Annual plans – provide a lower effective price when subscribers pay for a full year upfront.
+  - Family or group tiers – discounted rates for multiple members under one plan.
+  - Loyalty discounts – reduce the price or grant bonus prints for members who reach milestones (3-month, 6-month, 1-year).
+  - Upgrade credits – allow unused credits to roll over or convert into higher-tier prints after a period.
+  - Pause functionality – let members pause their subscription for a short time without canceling.
+  - "Founders rate" – limited-time, lifetime pricing for early adopters.
+
+- **Exclusive content & features**
+  - Early access to new designs – give subscribers a preview window or ability to order upcoming prints first.
+  - "Print of the Week" specials – curated weekly designs only available to members.
+  - Limited-edition runs – exclusive prints that are never offered to non-members.
+  - Digital extras – provide STL files, wallpapers, or design behind-the-scenes content.
+  - Priority printing – members' orders jump the queue for faster turnaround.
+  - Member-only giveaways – occasional free extras such as filament samples or display stands.
+  - Time Capsule prints – monthly or quarterly themed prints available only to continuing members.
+  - Livestreaming your print being created.
+
+- **Community building**
+  - Members-only forum or Discord for discussion and sharing.
+  - Featured member spotlights showcasing subscriber creations.
+  - Monthly design challenges with member voting.
+  - In-person or virtual meetups.
+  - Leaderboard and achievements for engagement.
+  - Badge system on profiles.
+
+- **Referral and affiliate programs**
+  - Referral points that credit members for bringing in new subscribers.
+  - Social sharing incentives for posting referral links.
+  - Affiliate partnerships offering commissions to influencers or partners.
+
+- **Marketing & promotion**
+  - Retargeted ads reminding past visitors about the club.
+  - Email drip campaigns highlighting perks and success stories.
+  - Testimonials and user-generated content.
+  - Limited-time countdown banners to create urgency.
+  - Cross-promotion with competitions.
+  - Bundled deals with other offerings.
+
+- **Service and support enhancements**
+  - Dedicated support channel for club members.
+  - Printed instructions and tips in shipments.
+  - Shipping perks such as free or faster delivery.
+  - Quality guarantee with free reprints if needed.
+
+- **Operational / technical improvements**
+  - Auto-renew reminders before billing.
+  - Usage progress bar to track available prints.
+  - Personalized recommendations based on past orders.
+  - Mobile app with push notifications.
+  - Integrated wish list to remember desired prints.
+  - One-click reorder of past favorites.
+  - API access for makers to integrate uploads.
+
+- **Long-term engagement ideas**
+  - Subscription anniversary gifts.
+  - Member surveys to gather feedback.
+  - Customizable print options such as colors or sizes.
+  - Points for interaction in forums or reviews.
+  - Collaborations with design artists for exclusive models.
+
+- **Partnerships & cross-industry tie-ins**
+  - Educational partners like schools or maker spaces.
+  - Hardware bundles offering a printer plus membership.
+  - Filament manufacturer collaborations with special colors.
+  - Charity collaborations donating a portion of fees.
+
+- **Content & media strategies**
+  - Behind-the-scenes videos of the printing process.
+  - Livestream design sessions.
+  - Printable accessory packs as digital files.
+  - Guest artist series with new designers each month.
+
+- **Stability & trust**
+  - Transparent credit tracking and rollover.
+  - Money-back guarantee for new members.
+  - Clear terms of service.
+
+- **Upsell / add-on opportunities**
+  - "Super Subscriber" tier with more prints and perks.
+  - Custom print requests for higher tiers.
+  - Private sales or auctions for rare prints.
+  - Merchandising discounts on apparel or accessories.


### PR DESCRIPTION
## Summary
- extend the `task_list` with a new section on ideas to increase Print Club subscriptions

## Testing
- `npm run format`
- `npm test`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_6855cbd65b4c832db4469d740296d682