### PR TITLE
Fix print club modal layout

### DIFF
--- a/competitions.html
+++ b/competitions.html
@@ -410,16 +410,16 @@
         <p class="mb-4">
           Get two prints (single or multicolour tiers) every week for £149.99/month. Unused credits expire weekly.
         </p>
-        <div class="mt-4 flex justify-center space-x-2">
+        <div class="mt-4 grid grid-cols-4 gap-2 w-full">
           <a
             href="printclub.html"
             id="printclub-learn"
-            class="bg-gradient-to-r from-purple-500 to-pink-500 text-white rounded-3xl px-3 py-2 text-sm transition-shape"
+            class="col-span-3 flex items-center justify-center bg-gradient-to-r from-purple-500 to-pink-500 text-white rounded-3xl px-3 py-2 text-sm transition-shape"
             >Learn More</a
           >
           <button
             id="printclub-close"
-            class="inline-flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-3xl px-5 py-2 text-lg font-medium hover:bg-[#3A3A3E] transition-shape"
+            class="col-span-1 flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-3xl px-4 py-2 text-lg font-medium hover:bg-[#3A3A3E] transition-shape"
             aria-label="Close Print Club modal"
           >
             Close


### PR DESCRIPTION
## Summary
- tweak "Learn More" modal layout in competitions page

## Testing
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_6855d4025814832d8f42ee4b25a7f529