### PR TITLE
Update competitions signup text

### DIFF
--- a/competitions.html
+++ b/competitions.html
@@ -123,16 +123,10 @@
       <h2 class="text-2xl">Active Competitions</h2>
       <h3 id="current-theme" class="text-lg text-[#30D5C8] mt-1"></h3>
       <div id="list" class="space-y-4"></div>
-      <form id="comp-subscribe" class="flex space-x-2 mt-4 max-w-sm">
-        <input
-          type="email"
-          id="comp-email"
-          class="flex-1 bg-[#1A1A1D] border border-white/10 rounded px-2"
-          placeholder="Email for updates"
-          aria-label="Email address"
-        />
-        <button class="bg-[#30D5C8] text-[#1A1A1D] px-3 rounded">Subscribe</button>
-      </form>
+      <p class="mt-4">
+        <a href="signup.html" class="font-bold text-[#30D5C8]">Sign Up</a>
+        to hear when competitions/prizes are available.
+      </p>
       <div id="comp-subscribe-msg" class="text-sm"></div>
       <div id="entry-success" class="hidden text-green-400 mt-2"></div>
       <h2 class="text-2xl mt-8">Past Winners</h2>


### PR DESCRIPTION
## Summary
- replace competitions email form with signup link text

## Testing
- `npm run format`
- `npm test`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_6855d58b30c4832db9130be23f45bf26