### PR TITLE
Remove pricing note from header

### DIFF
--- a/index.html
+++ b/index.html
@@ -213,9 +213,6 @@
             <i class="fab fa-instagram"></i>
           </button>
         </div>
-        <div id="price-info" class="text-sm text-gray-400 mt-1">
-          From £29.99 per print
-        </div>
       </div>
     </header>
 


### PR DESCRIPTION
## Summary
- remove `From £29.99 per print` text from the index page header

## Testing
- `npm run format`
- `npm test`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_6855d4a3dd2c832d9a6a091778963ae1