### PR TITLE
Fix viewer preview clipping

### DIFF
--- a/index.html
+++ b/index.html
@@ -225,7 +225,7 @@
       <div class="relative flex justify-center w-full max-w-lg">
         <section
           id="preview-wrapper"
-          class="relative w-full max-w-lg h-80 bg-[#2A2A2E] border border-white/10 rounded-3xl overflow-visible"
+          class="relative w-full max-w-lg h-80 bg-[#2A2A2E] border border-white/10 rounded-3xl overflow-hidden"
         >
           <!-- fallback still-image (hidden) -->
           <img

--- a/js/index.js
+++ b/js/index.js
@@ -146,6 +146,7 @@ const FALLBACK_GLB_LOW =
 const FALLBACK_GLB_HIGH =
   "https://modelviewer.dev/shared-assets/models/Astronaut.glb";
 const FALLBACK_GLB = FALLBACK_GLB_LOW;
+const LOW_POLY_GLB = FALLBACK_GLB_LOW;
 
 const EXAMPLES = [
   "cute robot figurine",


### PR DESCRIPTION
## Summary
- define `LOW_POLY_GLB` for the viewer
- ensure preview loader respects rounded edges

## Testing
- `npm test`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_6855d6325f60832d8f7a9933c32508d4