### PR TITLE
Remove display name from signup

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -194,8 +194,8 @@ function authRequired(req, res, next) {
 }
 
 app.post("/api/register", async (req, res) => {
-  const { username, displayName, email, password } = req.body;
-  if (!username || !displayName || !email || !password) {
+  const { username, email, password } = req.body;
+  if (!username || !email || !password) {
     return res.status(400).json({ error: "Missing fields" });
   }
   if (!isValidEmail(email)) {
@@ -209,7 +209,7 @@ app.post("/api/register", async (req, res) => {
     );
     await db.query(
       "INSERT INTO user_profiles(user_id, display_name) VALUES($1,$2)",
-      [rows[0].id, displayName],
+      [rows[0].id, username],
     );
     const mlToken = uuidv4();
     await db.upsertMailingListEntry(email, mlToken);

--- a/backend/tests/api.test.js
+++ b/backend/tests/api.test.js
@@ -258,7 +258,6 @@ test("POST /api/register returns token", async () => {
   db.query.mockResolvedValueOnce({ rows: [{ id: "u1", username: "alice" }] });
   const res = await request(app).post("/api/register").send({
     username: "alice",
-    displayName: "Alice",
     email: "a@a.com",
     password: "p",
   });
@@ -541,35 +540,27 @@ test("Admin create competition unauthorized", async () => {
 test("registration missing username", async () => {
   const res = await request(app)
     .post("/api/register")
-    .send({ displayName: "Alice", email: "a@a.com", password: "p" });
+    .send({ email: "a@a.com", password: "p" });
   expect(res.status).toBe(400);
 });
 
 test("registration missing email", async () => {
   const res = await request(app)
     .post("/api/register")
-    .send({ username: "a", displayName: "Alice", password: "p" });
+    .send({ username: "a", password: "p" });
   expect(res.status).toBe(400);
 });
 
 test("registration missing password", async () => {
   const res = await request(app)
     .post("/api/register")
-    .send({ username: "a", displayName: "Alice", email: "a@a.com" });
-  expect(res.status).toBe(400);
-});
-
-test("registration missing displayName", async () => {
-  const res = await request(app)
-    .post("/api/register")
-    .send({ username: "a", email: "a@a.com", password: "p" });
+    .send({ username: "a", email: "a@a.com" });
   expect(res.status).toBe(400);
 });
 
 test("registration invalid email", async () => {
   const res = await request(app).post("/api/register").send({
     username: "a",
-    displayName: "Alice",
     email: "invalid",
     password: "p",
   });
@@ -581,7 +572,6 @@ test("registration duplicate username", async () => {
   db.query.mockRejectedValueOnce(new Error("duplicate key"));
   const res = await request(app).post("/api/register").send({
     username: "a",
-    displayName: "Alice",
     email: "a@a.com",
     password: "p",
   });

--- a/backend/tests/frontend/signup.test.js
+++ b/backend/tests/frontend/signup.test.js
@@ -1,35 +1,48 @@
 /** @jest-environment node */
-const fs = require('fs');
-const path = require('path');
-const { JSDOM } = require('jsdom');
+const fs = require("fs");
+const path = require("path");
+const { JSDOM } = require("jsdom");
 
-let html = fs.readFileSync(path.join(__dirname, '../../../signup.html'), 'utf8');
+let html = fs.readFileSync(
+  path.join(__dirname, "../../../signup.html"),
+  "utf8",
+);
 html = html
-  .replace(/<script[^>]+tailwind[^>]*><\/script>/, '')
-  .replace(/<link[^>]+font-awesome[^>]+>/, '');
+  .replace(/<script[^>]+tailwind[^>]*><\/script>/, "")
+  .replace(/<link[^>]+font-awesome[^>]+>/, "");
 
-describe('signup form', () => {
-  test('shows error on failed signup', async () => {
+describe("signup form", () => {
+  test("shows error on failed signup", async () => {
     const dom = new JSDOM(html, {
-      runScripts: 'dangerously',
-      resources: 'usable',
-      url: 'http://localhost/signup.html',
+      runScripts: "dangerously",
+      resources: "usable",
+      url: "http://localhost/signup.html",
     });
-    dom.window.document.querySelectorAll('script[src*="tailwind"]').forEach((s) => s.remove());
+    dom.window.document
+      .querySelectorAll('script[src*="tailwind"]')
+      .forEach((s) => s.remove());
     global.window = dom.window;
     global.document = dom.window.document;
-    const scriptSrc = fs.readFileSync(path.join(__dirname, '../../../js/signup.js'), 'utf8');
+    const scriptSrc = fs.readFileSync(
+      path.join(__dirname, "../../../js/signup.js"),
+      "utf8",
+    );
     dom.window.eval(scriptSrc);
-    const fetchMock = jest.fn(() => Promise.resolve({ json: () => ({ error: 'fail' }) }));
+    const fetchMock = jest.fn(() =>
+      Promise.resolve({ json: () => ({ error: "fail" }) }),
+    );
     dom.window.fetch = fetchMock;
     global.fetch = fetchMock;
-    dom.window.document.getElementById('su-name').value = 'u';
-    dom.window.document.getElementById('su-display').value = 'User';
-    dom.window.document.getElementById('su-email').value = 'e';
-    dom.window.document.getElementById('su-pass').value = 'p';
-    dom.window.document.getElementById('signupForm').dispatchEvent(new dom.window.Event('submit'));
+    dom.window.document.getElementById("su-name").value = "u";
+    dom.window.document.getElementById("su-email").value = "e";
+    dom.window.document.getElementById("su-pass").value = "p";
+    dom.window.document
+      .getElementById("signupForm")
+      .dispatchEvent(new dom.window.Event("submit"));
     await new Promise((r) => setTimeout(r, 0));
-    expect(dom.window.document.getElementById('error').textContent).toBe('Invalid email format');
+    expect(dom.window.document.getElementById("error").textContent).toBe(
+      "Invalid email format",
+    );
     expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/js/signup.js
+++ b/js/signup.js
@@ -1,4 +1,4 @@
-const API_BASE = (window.API_ORIGIN || '') + '/api';
+const API_BASE = (window.API_ORIGIN || "") + "/api";
 
 function isValidEmail(email) {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
@@ -6,45 +6,42 @@ function isValidEmail(email) {
 
 async function signup(e) {
   e.preventDefault();
-  const nameEl = document.getElementById('su-name');
-  const displayEl = document.getElementById('su-display');
-  const emailEl = document.getElementById('su-email');
-  const passEl = document.getElementById('su-pass');
-  const optInEl = document.getElementById('signup-mailing');
-  [nameEl, displayEl, emailEl, passEl].forEach((el) =>
-    el.classList.remove('border-red-500')
+  const nameEl = document.getElementById("su-name");
+  const emailEl = document.getElementById("su-email");
+  const passEl = document.getElementById("su-pass");
+  const optInEl = document.getElementById("signup-mailing");
+  [nameEl, emailEl, passEl].forEach((el) =>
+    el.classList.remove("border-red-500"),
   );
   const username = nameEl.value.trim();
-  const displayName = displayEl.value.trim();
   const email = emailEl.value.trim();
   const password = passEl.value.trim();
   const optIn = optInEl && optInEl.checked;
-  if (!username || !displayName || !email || !password) {
-    document.getElementById('error').textContent = 'All fields required';
-    if (!username) nameEl.classList.add('border-red-500');
-    if (!displayName) displayEl.classList.add('border-red-500');
-    if (!email) emailEl.classList.add('border-red-500');
-    if (!password) passEl.classList.add('border-red-500');
+  if (!username || !email || !password) {
+    document.getElementById("error").textContent = "All fields required";
+    if (!username) nameEl.classList.add("border-red-500");
+    if (!email) emailEl.classList.add("border-red-500");
+    if (!password) passEl.classList.add("border-red-500");
     return;
   }
   if (!isValidEmail(email)) {
-    document.getElementById('error').textContent = 'Invalid email format';
-    emailEl.classList.add('border-red-500');
+    document.getElementById("error").textContent = "Invalid email format";
+    emailEl.classList.add("border-red-500");
     return;
   }
   const res = await fetch(`${API_BASE}/register`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ username, displayName, email, password }),
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ username, email, password }),
   });
   const data = await res.json();
   if (data.token) {
-    localStorage.setItem('token', data.token);
-    const ref = localStorage.getItem('referrerId');
+    localStorage.setItem("token", data.token);
+    const ref = localStorage.getItem("referrerId");
     if (ref) {
       fetch(`${API_BASE}/referral-signup`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ code: ref }),
       })
         .then((r) => r.json())
@@ -57,16 +54,19 @@ async function signup(e) {
     }
     if (optIn) {
       fetch(`${API_BASE}/subscribe`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email }),
       });
     }
-    window.location.href = 'profile.html';
+    window.location.href = "profile.html";
   } else {
-    document.getElementById('error').textContent = data.error || 'Signup failed';
-    [nameEl, emailEl, passEl].forEach((el) => el.classList.add('border-red-500'));
+    document.getElementById("error").textContent =
+      data.error || "Signup failed";
+    [nameEl, emailEl, passEl].forEach((el) =>
+      el.classList.add("border-red-500"),
+    );
   }
 }
 
-document.getElementById('signupForm').addEventListener('submit', signup);
+document.getElementById("signupForm").addEventListener("submit", signup);

--- a/signup.html
+++ b/signup.html
@@ -31,7 +31,11 @@
             stroke-width="2"
             viewBox="0 0 24 24"
           >
-            <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M15 19l-7-7 7-7"
+            />
           </svg>
           Back
         </a>
@@ -110,12 +114,6 @@
             aria-label="Username"
           />
           <input
-            id="su-display"
-            class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10 text-gray-200"
-            placeholder="Display Name"
-            aria-label="Display Name"
-          />
-          <input
             id="su-pass"
             type="password"
             class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10 text-gray-200"
@@ -148,7 +146,7 @@
     </main>
     <script type="module" src="js/signup.js"></script>
     <script type="module">
-      import { shareOn } from './js/share.js';
+      import { shareOn } from "./js/share.js";
       window.shareOn = shareOn;
     </script>
     <div
@@ -158,7 +156,8 @@
       <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center">
         <h2 class="text-2xl font-semibold mb-2">Print Club</h2>
         <p class="mb-4">
-          Get two prints (single or multicolour tiers) every week for £149.99/month. Unused credits expire weekly.
+          Get two prints (single or multicolour tiers) every week for
+          £149.99/month. Unused credits expire weekly.
         </p>
         <button
           id="printclub-close"


### PR DESCRIPTION
## Summary
- remove display name field from signup page
- simplify signup script
- adjust registration endpoint to drop display name requirement
- update backend and frontend tests accordingly

## Testing
- `npx prettier --write server.js tests/api.test.js tests/frontend/signup.test.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855d428b9ac832dadef267654ca7a16