### PR TITLE
Add reward points summary in header

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -54,17 +54,24 @@
             stroke-width="2"
             viewBox="0 0 24 24"
           >
-            <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M15 19l-7-7 7-7"
+            />
           </svg>
           Back
         </a>
-        <h1 class="flex-1 text-center text-3xl font-semibold">Community Creations</h1>
+        <h1 class="flex-1 text-center text-3xl font-semibold">
+          Community Creations
+        </h1>
         <a
           href="earn-rewards.html"
           id="earn-rewards-badge"
           class="bg-gradient-to-r from-purple-500 to-pink-500 text-white rounded-3xl px-3 py-2 text-sm transition-shape"
           >[🎉 NEW] Earn Rewards</a
         >
+        <span id="header-points" class="ml-1"></span>
       </div>
       <div class="flex items-center space-x-4 ml-4">
         <a
@@ -147,7 +154,10 @@
       <!-- Popular Creations -->
       <section class="mb-12">
         <h2 class="text-xl font-semibold mb-4">Popular Now</h2>
-        <div id="popular-grid" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4"></div>
+        <div
+          id="popular-grid"
+          class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4"
+        ></div>
         <div id="popular-sentinel" class="h-8"></div>
         <button
           id="popular-load"
@@ -160,7 +170,10 @@
       <!-- Recent Creations -->
       <section>
         <h2 class="text-xl font-semibold mb-4">Recent</h2>
-        <div id="recent-grid" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4"></div>
+        <div
+          id="recent-grid"
+          class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4"
+        ></div>
         <div id="recent-sentinel" class="h-8"></div>
         <button
           id="recent-load"
@@ -258,16 +271,31 @@
         >
           Add to Basket
         </button>
-        <div id="modal-copy-container" class="absolute bottom-4 left-40 flex items-center gap-2">
-          <button id="modal-copy-link" class="font-bold py-2 px-4 rounded-full shadow-md bg-[#2A2A2E] border border-white/20">Copy Link</button>
+        <div
+          id="modal-copy-container"
+          class="absolute bottom-4 left-40 flex items-center gap-2"
+        >
+          <button
+            id="modal-copy-link"
+            class="font-bold py-2 px-4 rounded-full shadow-md bg-[#2A2A2E] border border-white/20"
+          >
+            Copy Link
+          </button>
           <span id="modal-copy-help" class="relative cursor-pointer text-lg">
             <i class="fas fa-question-circle"></i>
-            <span id="modal-copy-tooltip" class="absolute hidden bottom-full mb-2 left-1/2 -translate-x-1/2 bg-[#2A2A2E] border border-white/10 rounded p-2 text-xs whitespace-nowrap">Click to copy the shareable link</span>
+            <span
+              id="modal-copy-tooltip"
+              class="absolute hidden bottom-full mb-2 left-1/2 -translate-x-1/2 bg-[#2A2A2E] border border-white/10 rounded p-2 text-xs whitespace-nowrap"
+              >Click to copy the shareable link</span
+            >
           </span>
           <span id="modal-copy-msg" class="ml-2 text-sm hidden">Copied!</span>
         </div>
         <div class="mt-4 bg-[#2A2A2E] p-4 rounded-xl">
-          <ul id="comments-list" class="space-y-1 max-h-48 overflow-y-auto text-sm"></ul>
+          <ul
+            id="comments-list"
+            class="space-y-1 max-h-48 overflow-y-auto text-sm"
+          ></ul>
           <div id="comment-form" class="flex gap-2 mt-2">
             <input
               type="text"
@@ -275,56 +303,66 @@
               placeholder="Add a comment..."
               class="flex-1 bg-[#1A1A1D] border border-white/20 rounded px-2 py-1"
             />
-            <button id="comment-submit" class="px-3 py-1 bg-blue-600 rounded">Post</button>
+            <button id="comment-submit" class="px-3 py-1 bg-blue-600 rounded">
+              Post
+            </button>
           </div>
         </div>
       </div>
     </div>
     <script type="module">
-      import { shareOn } from './js/share.js';
-      import { init, closeModel, restoreOpenModel } from './js/community.js';
+      import { shareOn } from "./js/share.js";
+      import { loadRewardSummary } from "./js/rewards.js";
+      import { init, closeModel, restoreOpenModel } from "./js/community.js";
       window.shareOn = shareOn;
+      loadRewardSummary();
 
-      document.addEventListener('DOMContentLoaded', () => {
-        const modal = document.getElementById('model-modal');
-        const checkoutBtn = document.getElementById('modal-checkout');
-        const addBasketBtn = document.getElementById('modal-add-basket');
-        const closeBtn = document.getElementById('close-modal');
-        const tierToggle = document.getElementById('tier-toggle');
+      document.addEventListener("DOMContentLoaded", () => {
+        const modal = document.getElementById("model-modal");
+        const checkoutBtn = document.getElementById("modal-checkout");
+        const addBasketBtn = document.getElementById("modal-add-basket");
+        const closeBtn = document.getElementById("close-modal");
+        const tierToggle = document.getElementById("tier-toggle");
 
         function setTier(tier) {
-          tierToggle?.querySelectorAll('button[data-tier]').forEach((btn) => {
+          tierToggle?.querySelectorAll("button[data-tier]").forEach((btn) => {
             const active = btn.dataset.tier === tier;
 
-            btn.classList.toggle('ring-2', active);
-            btn.classList.toggle('ring-white', active);
-            btn.classList.toggle('opacity-100', active);
-            btn.classList.toggle('opacity-50', !active);
+            btn.classList.toggle("ring-2", active);
+            btn.classList.toggle("ring-white", active);
+            btn.classList.toggle("opacity-100", active);
+            btn.classList.toggle("opacity-50", !active);
           });
           if (checkoutBtn) {
-            const price = tier === 'bronze' ? 29.99 : tier === 'gold' ? 79.99 : 39.99;
+            const price =
+              tier === "bronze" ? 29.99 : tier === "gold" ? 79.99 : 39.99;
             checkoutBtn.textContent = `Print for £${price.toFixed(2)} →`;
           }
-          const material = tier === 'bronze' ? 'single' : tier === 'gold' ? 'premium' : 'multi';
-          localStorage.setItem('print3Material', material);
+          const material =
+            tier === "bronze"
+              ? "single"
+              : tier === "gold"
+                ? "premium"
+                : "multi";
+          localStorage.setItem("print3Material", material);
         }
 
-        tierToggle?.addEventListener('click', (ev) => {
-          const btn = ev.target.closest('button[data-tier]');
+        tierToggle?.addEventListener("click", (ev) => {
+          const btn = ev.target.closest("button[data-tier]");
           if (btn) setTier(btn.dataset.tier);
         });
 
         const close = closeModel;
 
-        checkoutBtn.addEventListener('click', () => {
-          sessionStorage.setItem('fromCommunity', '1');
+        checkoutBtn.addEventListener("click", () => {
+          sessionStorage.setItem("fromCommunity", "1");
           const model = checkoutBtn.dataset.model;
           const job = checkoutBtn.dataset.job;
-          if (model) localStorage.setItem('print3Model', model);
-          if (job) localStorage.setItem('print3JobId', job);
+          if (model) localStorage.setItem("print3Model", model);
+          if (job) localStorage.setItem("print3JobId", job);
         });
 
-        addBasketBtn?.addEventListener('click', () => {
+        addBasketBtn?.addEventListener("click", () => {
           if (!window.addToBasket) return;
           const model = addBasketBtn.dataset.model;
           const job = addBasketBtn.dataset.job;
@@ -334,45 +372,48 @@
           }
         });
 
-        const copyBtn = document.getElementById('modal-copy-link');
-        const copyMsg = document.getElementById('modal-copy-msg');
-        const help = document.getElementById('modal-copy-help');
-        const tooltip = document.getElementById('modal-copy-tooltip');
-        copyBtn?.addEventListener('click', () => {
+        const copyBtn = document.getElementById("modal-copy-link");
+        const copyMsg = document.getElementById("modal-copy-msg");
+        const help = document.getElementById("modal-copy-help");
+        const tooltip = document.getElementById("modal-copy-tooltip");
+        copyBtn?.addEventListener("click", () => {
           const id = copyBtn.dataset.id;
           if (!id) return;
           const url = `${window.location.origin}/community/model/${id}`;
           navigator.clipboard.writeText(url).then(() => {
             if (copyMsg) {
-              copyMsg.classList.remove('hidden');
-              setTimeout(() => copyMsg.classList.add('hidden'), 2000);
+              copyMsg.classList.remove("hidden");
+              setTimeout(() => copyMsg.classList.add("hidden"), 2000);
             }
           });
         });
         if (help && tooltip) {
-          ['mouseenter', 'focus'].forEach((ev) =>
-            help.addEventListener(ev, () => tooltip.classList.remove('hidden'))
+          ["mouseenter", "focus"].forEach((ev) =>
+            help.addEventListener(ev, () => tooltip.classList.remove("hidden")),
           );
-          ['mouseleave', 'blur'].forEach((ev) =>
-            help.addEventListener(ev, () => tooltip.classList.add('hidden'))
+          ["mouseleave", "blur"].forEach((ev) =>
+            help.addEventListener(ev, () => tooltip.classList.add("hidden")),
           );
         }
 
-        closeBtn.addEventListener('click', close);
-        document.addEventListener('keydown', (e) => {
-          if (e.key === 'Escape') close();
+        closeBtn.addEventListener("click", close);
+        document.addEventListener("keydown", (e) => {
+          if (e.key === "Escape") close();
         });
 
-        document.addEventListener('click', (e) => {
-          if (modal.classList.contains('hidden')) return;
-          const container = modal.querySelector('div');
-          const basketBtn = document.getElementById('basket-button');
-          if (!container.contains(e.target) && !(basketBtn && basketBtn.contains(e.target))) {
+        document.addEventListener("click", (e) => {
+          if (modal.classList.contains("hidden")) return;
+          const container = modal.querySelector("div");
+          const basketBtn = document.getElementById("basket-button");
+          if (
+            !container.contains(e.target) &&
+            !(basketBtn && basketBtn.contains(e.target))
+          ) {
             close();
           }
         });
 
-        setTier('silver');
+        setTier("silver");
         init();
         restoreOpenModel();
       });
@@ -384,7 +425,8 @@
       <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center">
         <h2 class="text-2xl font-semibold mb-2">Print Club</h2>
         <p class="mb-4">
-          Get two prints (single or multicolour tiers) every week for £149.99/month. Unused credits expire weekly.
+          Get two prints (single or multicolour tiers) every week for
+          £149.99/month. Unused credits expire weekly.
         </p>
         <button
           id="printclub-close"

--- a/competitions.html
+++ b/competitions.html
@@ -5,7 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Competitions</title>
     <meta property="og:title" content="Competitions – print3" />
-    <meta property="og:description" content="Join print3 contests and showcase your 3D designs." />
+    <meta
+      property="og:description"
+      content="Join print3 contests and showcase your 3D designs."
+    />
     <meta property="og:image" content="img/boxlogo.png" />
     <script src="js/applyColorScheme.js"></script>
     <link rel="preconnect" href="https://modelviewer.dev" crossorigin />
@@ -45,7 +48,11 @@
             stroke-width="2"
             viewBox="0 0 24 24"
           >
-            <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M15 19l-7-7 7-7"
+            />
           </svg>
           Back
         </a>
@@ -56,6 +63,7 @@
           class="bg-gradient-to-r from-purple-500 to-pink-500 text-white rounded-3xl px-3 py-2 text-sm transition-shape"
           >[🎉 NEW] Earn Rewards</a
         >
+        <span id="header-points" class="ml-1"></span>
       </div>
       <div class="flex items-center space-x-4 ml-4">
         <a
@@ -104,14 +112,17 @@
       </div>
     </header>
     <main class="flex-1 p-4 space-y-6">
-      <div id="printclub-banner" class="bg-blue-600 text-white p-3 rounded-xl text-center hidden">
+      <div
+        id="printclub-banner"
+        class="bg-blue-600 text-white p-3 rounded-xl text-center hidden"
+      >
         Join <strong>Print Club</strong> for weekly prints.
         <a href="#" id="printclub-banner-link" class="underline">Learn more</a>
       </div>
       <section class="bg-[#2A2A2E] p-4 rounded-xl">
         <p class="mb-2">
-          Put your modelling skills to the test! Enter our themed contests, climb the leaderboard
-          and win free prints.
+          Put your modelling skills to the test! Enter our themed contests,
+          climb the leaderboard and win free prints.
         </p>
         <p>
           <a href="signup.html" class="font-bold text-[#30D5C8]">Sign Up</a>
@@ -131,12 +142,17 @@
           placeholder="Email for updates"
           aria-label="Email address"
         />
-        <button class="bg-[#30D5C8] text-[#1A1A1D] px-3 rounded">Subscribe</button>
+        <button class="bg-[#30D5C8] text-[#1A1A1D] px-3 rounded">
+          Subscribe
+        </button>
       </form>
       <div id="comp-subscribe-msg" class="text-sm"></div>
       <div id="entry-success" class="hidden text-green-400 mt-2"></div>
       <h2 class="text-2xl mt-8">Past Winners</h2>
-      <div id="winners-grid" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 mt-4">
+      <div
+        id="winners-grid"
+        class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 mt-4"
+      >
         <div
           class="model-card relative h-32 bg-[#2A2A2E] border border-white/10 rounded-xl hover:bg-[#3A3A3E] transition-shape flex items-center justify-center cursor-pointer"
           data-model="https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/DamagedHelmet/glTF-Binary/DamagedHelmet.glb"
@@ -147,9 +163,17 @@
             alt="Damaged Helmet"
             class="w-full h-full object-contain pointer-events-none"
           />
-          <span class="absolute top-1 left-1 bg-black/60 text-xs px-1 rounded">Ended 05/25</span>
-          <button class="like absolute bottom-1 right-1 text-xs bg-red-600 px-1 rounded">♥</button>
-          <span class="absolute bottom-8 right-1 text-xs bg-black/50 px-1 rounded" id="votes-helmet"
+          <span class="absolute top-1 left-1 bg-black/60 text-xs px-1 rounded"
+            >Ended 05/25</span
+          >
+          <button
+            class="like absolute bottom-1 right-1 text-xs bg-red-600 px-1 rounded"
+          >
+            ♥
+          </button>
+          <span
+            class="absolute bottom-8 right-1 text-xs bg-black/50 px-1 rounded"
+            id="votes-helmet"
             >0</span
           >
           <button
@@ -168,9 +192,17 @@
             alt="Fox"
             class="w-full h-full object-contain pointer-events-none"
           />
-          <span class="absolute top-1 left-1 bg-black/60 text-xs px-1 rounded">Ended 03/24</span>
-          <button class="like absolute bottom-1 right-1 text-xs bg-red-600 px-1 rounded">♥</button>
-          <span class="absolute bottom-8 right-1 text-xs bg-black/50 px-1 rounded" id="votes-fox"
+          <span class="absolute top-1 left-1 bg-black/60 text-xs px-1 rounded"
+            >Ended 03/24</span
+          >
+          <button
+            class="like absolute bottom-1 right-1 text-xs bg-red-600 px-1 rounded"
+          >
+            ♥
+          </button>
+          <span
+            class="absolute bottom-8 right-1 text-xs bg-black/50 px-1 rounded"
+            id="votes-fox"
             >0</span
           >
           <button
@@ -189,8 +221,14 @@
             alt="BoomBox"
             class="w-full h-full object-contain pointer-events-none"
           />
-          <span class="absolute top-1 left-1 bg-black/60 text-xs px-1 rounded">Ended 01/23</span>
-          <button class="like absolute bottom-1 right-1 text-xs bg-red-600 px-1 rounded">♥</button>
+          <span class="absolute top-1 left-1 bg-black/60 text-xs px-1 rounded"
+            >Ended 01/23</span
+          >
+          <button
+            class="like absolute bottom-1 right-1 text-xs bg-red-600 px-1 rounded"
+          >
+            ♥
+          </button>
           <span
             class="absolute bottom-8 right-1 text-xs bg-black/50 px-1 rounded"
             id="votes-boombox"
@@ -224,10 +262,17 @@
         />
         <div id="enter-error" class="text-red-400 text-sm"></div>
         <div class="flex justify-end space-x-2">
-          <button id="enter-cancel" type="button" class="px-4 py-2 bg-gray-500 rounded">
+          <button
+            id="enter-cancel"
+            type="button"
+            class="px-4 py-2 bg-gray-500 rounded"
+          >
             Cancel
           </button>
-          <button type="submit" class="px-4 py-2 bg-[#30D5C8] text-[#1A1A1D] rounded">
+          <button
+            type="submit"
+            class="px-4 py-2 bg-[#30D5C8] text-[#1A1A1D] rounded"
+          >
             Submit
           </button>
         </div>
@@ -324,53 +369,61 @@
     </div>
     <script type="module" src="js/competitions.js"></script>
     <script type="module">
-      import { shareOn } from './js/share.js';
+      import { shareOn } from "./js/share.js";
+      import { loadRewardSummary } from "./js/rewards.js";
       window.shareOn = shareOn;
+      loadRewardSummary();
 
-      document.addEventListener('DOMContentLoaded', () => {
-        const modal = document.getElementById('model-modal');
-        const viewer = modal.querySelector('model-viewer');
-        const checkoutBtn = document.getElementById('modal-checkout');
-        const addBasketBtn = document.getElementById('modal-add-basket');
-        const closeBtn = document.getElementById('close-modal');
-        const tierToggle = document.getElementById('tier-toggle');
+      document.addEventListener("DOMContentLoaded", () => {
+        const modal = document.getElementById("model-modal");
+        const viewer = modal.querySelector("model-viewer");
+        const checkoutBtn = document.getElementById("modal-checkout");
+        const addBasketBtn = document.getElementById("modal-add-basket");
+        const closeBtn = document.getElementById("close-modal");
+        const tierToggle = document.getElementById("tier-toggle");
 
         function setTier(tier) {
-          tierToggle?.querySelectorAll('button[data-tier]').forEach((btn) => {
+          tierToggle?.querySelectorAll("button[data-tier]").forEach((btn) => {
             const active = btn.dataset.tier === tier;
 
-            btn.classList.toggle('ring-2', active);
-            btn.classList.toggle('ring-white', active);
-            btn.classList.toggle('opacity-100', active);
-            btn.classList.toggle('opacity-50', !active);
+            btn.classList.toggle("ring-2", active);
+            btn.classList.toggle("ring-white", active);
+            btn.classList.toggle("opacity-100", active);
+            btn.classList.toggle("opacity-50", !active);
           });
           if (checkoutBtn) {
-            const price = tier === 'bronze' ? 29.99 : tier === 'gold' ? 79.99 : 39.99;
+            const price =
+              tier === "bronze" ? 29.99 : tier === "gold" ? 79.99 : 39.99;
             checkoutBtn.textContent = `Print for £${price.toFixed(2)} →`;
           }
-          const material = tier === 'bronze' ? 'single' : tier === 'gold' ? 'premium' : 'multi';
-          localStorage.setItem('print3Material', material);
+          const material =
+            tier === "bronze"
+              ? "single"
+              : tier === "gold"
+                ? "premium"
+                : "multi";
+          localStorage.setItem("print3Material", material);
         }
 
-        tierToggle?.addEventListener('click', (ev) => {
-          const btn = ev.target.closest('button[data-tier]');
+        tierToggle?.addEventListener("click", (ev) => {
+          const btn = ev.target.closest("button[data-tier]");
           if (btn) setTier(btn.dataset.tier);
         });
 
         function close() {
-          modal.classList.add('hidden');
-          document.body.classList.remove('overflow-hidden');
+          modal.classList.add("hidden");
+          document.body.classList.remove("overflow-hidden");
         }
 
-        checkoutBtn.addEventListener('click', () => {
-          sessionStorage.setItem('fromCompetitions', '1');
+        checkoutBtn.addEventListener("click", () => {
+          sessionStorage.setItem("fromCompetitions", "1");
           const model = checkoutBtn.dataset.model;
           const job = checkoutBtn.dataset.job;
-          if (model) localStorage.setItem('print3Model', model);
-          if (job) localStorage.setItem('print3JobId', job);
+          if (model) localStorage.setItem("print3Model", model);
+          if (job) localStorage.setItem("print3JobId", job);
         });
 
-        addBasketBtn?.addEventListener('click', () => {
+        addBasketBtn?.addEventListener("click", () => {
           if (!window.addToBasket) return;
           const model = addBasketBtn.dataset.model;
           const job = addBasketBtn.dataset.job;
@@ -380,25 +433,28 @@
           }
         });
 
-        closeBtn.addEventListener('click', close);
+        closeBtn.addEventListener("click", close);
 
-        document.addEventListener('keydown', (e) => {
-          if (e.key === 'Escape') close();
+        document.addEventListener("keydown", (e) => {
+          if (e.key === "Escape") close();
         });
 
-        document.addEventListener('click', (e) => {
-          if (modal.classList.contains('hidden')) return;
-          const container = modal.querySelector('div');
-          const basketBtn = document.getElementById('basket-button');
-          if (!container.contains(e.target) && !(basketBtn && basketBtn.contains(e.target))) {
+        document.addEventListener("click", (e) => {
+          if (modal.classList.contains("hidden")) return;
+          const container = modal.querySelector("div");
+          const basketBtn = document.getElementById("basket-button");
+          if (
+            !container.contains(e.target) &&
+            !(basketBtn && basketBtn.contains(e.target))
+          ) {
             close();
           }
         });
 
-        document.addEventListener('keydown', (e) => {
-          if (e.key === 'Escape') close();
+        document.addEventListener("keydown", (e) => {
+          if (e.key === "Escape") close();
         });
-        setTier('silver');
+        setTier("silver");
       });
     </script>
     <div
@@ -408,7 +464,8 @@
       <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center">
         <h2 class="text-2xl font-semibold mb-2">Print Club</h2>
         <p class="mb-4">
-          Get two prints (single or multicolour tiers) every week for £149.99/month. Unused credits expire weekly.
+          Get two prints (single or multicolour tiers) every week for
+          £149.99/month. Unused credits expire weekly.
         </p>
         <div class="mt-4 flex justify-center space-x-2">
           <a

--- a/earn-rewards.html
+++ b/earn-rewards.html
@@ -5,7 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Earn Rewards</title>
     <meta property="og:title" content="Earn Rewards – print2" />
-    <meta property="og:description" content="Learn how to earn rewards on print2." />
+    <meta
+      property="og:description"
+      content="Learn how to earn rewards on print2."
+    />
     <meta property="og:image" content="img/boxlogo.png" />
     <script src="js/applyColorScheme.js"></script>
     <script src="https://cdn.tailwindcss.com"></script>
@@ -28,7 +31,11 @@
             stroke-width="2"
             viewBox="0 0 24 24"
           >
-            <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M15 19l-7-7 7-7"
+            />
           </svg>
           Back
         </a>
@@ -39,6 +46,7 @@
           class="bg-gradient-to-r from-purple-500 to-pink-500 text-white rounded-3xl px-3 py-2 text-sm transition-shape"
           >[🎉 NEW] Earn Rewards</a
         >
+        <span id="header-points" class="ml-1"></span>
       </div>
       <div class="flex items-center space-x-4 ml-4">
         <a
@@ -89,11 +97,14 @@
     <main class="flex-1 flex items-center justify-center px-4">
       <div class="max-w-lg space-y-4 text-center">
         <p class="text-lg">
-          Invite friends to try print2 using your personal link below. When they sign up and place
-          orders you'll earn points that can be redeemed for discounts on future prints.
+          Invite friends to try print2 using your personal link below. When they
+          sign up and place orders you'll earn points that can be redeemed for
+          discounts on future prints.
         </p>
         <div>
-          <label for="referral-link" class="block text-sm mb-1">Your referral link</label>
+          <label for="referral-link" class="block text-sm mb-1"
+            >Your referral link</label
+          >
           <div class="flex">
             <input
               id="referral-link"
@@ -111,21 +122,35 @@
           </div>
         </div>
         <div>
-          <label class="block text-sm mb-1">Reward Points: <span id="reward-points">0</span></label>
-          <progress id="reward-progress" value="0" max="100" class="w-full h-3"></progress>
+          <label class="block text-sm mb-1"
+            >Reward Points: <span id="reward-points">0</span></label
+          >
+          <progress
+            id="reward-progress"
+            value="0"
+            max="100"
+            class="w-full h-3"
+          ></progress>
           <div class="mt-3 flex">
             <select
               id="reward-select"
               class="bg-[#2A2A2E] border border-white/10 rounded-l-xl px-2 py-1 flex-1"
             ></select>
-            <button class="bg-blue-600 px-3 rounded-r-xl" onclick="redeemReward()">Redeem</button>
+            <button
+              class="bg-blue-600 px-3 rounded-r-xl"
+              onclick="redeemReward()"
+            >
+              Redeem
+            </button>
           </div>
         </div>
       </div>
     </main>
     <script type="module">
-      import { shareOn } from './js/share.js';
+      import { shareOn } from "./js/share.js";
+      import { loadRewardSummary } from "./js/rewards.js";
       window.shareOn = shareOn;
+      loadRewardSummary();
     </script>
     <script type="module" src="js/rewards.js"></script>
     <div
@@ -135,7 +160,8 @@
       <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center">
         <h2 class="text-2xl font-semibold mb-2">Print Club</h2>
         <p class="mb-4">
-          Get two prints (single or multicolour tiers) every week for £149.99/month. Unused credits expire weekly.
+          Get two prints (single or multicolour tiers) every week for
+          £149.99/month. Unused credits expire weekly.
         </p>
         <button
           id="printclub-close"

--- a/index.html
+++ b/index.html
@@ -137,10 +137,15 @@
       <div class="flex flex-col items-start">
         <img src="img/textlogo.png" alt="print3" class="h-10 w-auto" />
         <div class="mt-1 flex flex-col text-sm opacity-90">
-
-          <p class="text-gray-300"><span class="text-white">5400+</span> prints</p>
+          <p class="text-gray-300">
+            <span class="text-white">5400+</span> prints
+          </p>
           <p class="text-gray-300">delivered already</p>
-          <p id="stats-ticker" class="text-[#30D5C8] text-left" style="min-height: 2.5rem"></p>
+          <p
+            id="stats-ticker"
+            class="text-[#30D5C8] text-left"
+            style="min-height: 2.5rem"
+          ></p>
         </div>
       </div>
 
@@ -167,6 +172,7 @@
           class="bg-gradient-to-r from-purple-500 to-pink-500 text-white rounded-3xl px-3 py-2 text-sm transition-shape"
           >[🎉 NEW] Earn Rewards</a
         >
+        <span id="header-points" class="ml-1"></span>
 
         <a
           href="printclub.html"
@@ -496,6 +502,7 @@
     <script type="module" src="js/exitDiscount.js" defer></script>
     <script type="module" src="js/printclub.js" defer></script>
     <script type="module">
+      import { loadRewardSummary } from "./js/rewards.js";
       document
         .getElementById("profile-link")
         ?.addEventListener("click", function (e) {
@@ -504,6 +511,7 @@
             window.location.href = "login.html";
           }
         });
+      loadRewardSummary();
     </script>
 
     <!-- Position the subreddit quote next to the checkout button and keep

--- a/js/rewards.js
+++ b/js/rewards.js
@@ -1,73 +1,94 @@
-const API_BASE = (window.API_ORIGIN || '') + '/api';
+const API_BASE = (window.API_ORIGIN || "") + "/api";
 
 async function loadRewardOptions() {
   try {
     const res = await fetch(`${API_BASE}/rewards/options`);
     if (res.ok) {
       const { options } = await res.json();
-      const sel = document.getElementById('reward-select');
+      const sel = document.getElementById("reward-select");
       if (sel) {
-        sel.innerHTML = '';
+        sel.innerHTML = "";
         options.forEach((o) => {
-          const opt = document.createElement('option');
+          const opt = document.createElement("option");
           opt.value = o.points;
-          opt.textContent = `${o.points} pts - $${(o.amount_cents / 100).toFixed(
-            2
-          )} off`;
+          opt.textContent = `${o.points} pts - $${(
+            o.amount_cents / 100
+          ).toFixed(2)} off`;
           sel.appendChild(opt);
         });
       }
     }
   } catch (err) {
-    console.error('Failed to load reward options', err);
+    console.error("Failed to load reward options", err);
   }
 }
 
 async function loadRewards() {
-  const token = localStorage.getItem('token');
+  const token = localStorage.getItem("token");
   if (!token) return;
   const headers = { authorization: `Bearer ${token}` };
   try {
     const resLink = await fetch(`${API_BASE}/referral-link`, { headers });
     if (resLink.ok) {
       const { code } = await resLink.json();
-      const input = document.getElementById('referral-link');
+      const input = document.getElementById("referral-link");
       if (input) input.value = `${window.location.origin}?ref=${code}`;
     }
   } catch (err) {
-    console.error('Failed to load referral link', err);
+    console.error("Failed to load referral link", err);
   }
   try {
     const resPts = await fetch(`${API_BASE}/rewards`, { headers });
     if (resPts.ok) {
       const { points } = await resPts.json();
-      const ptsEl = document.getElementById('reward-points');
+      const ptsEl = document.getElementById("reward-points");
       if (ptsEl) ptsEl.textContent = points;
-      const bar = document.getElementById('reward-progress');
+      const bar = document.getElementById("reward-progress");
       if (bar) bar.value = points;
     }
   } catch (err) {
-    console.error('Failed to load rewards', err);
+    console.error("Failed to load rewards", err);
+  }
+}
+
+async function loadRewardSummary() {
+  const ptsEl = document.getElementById("header-points");
+  if (!ptsEl) return;
+  const token = localStorage.getItem("token");
+  if (!token) {
+    ptsEl.textContent = "0";
+    return;
+  }
+  try {
+    const res = await fetch(`${API_BASE}/rewards`, {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    if (res.ok) {
+      const { points } = await res.json();
+      ptsEl.textContent = points;
+    }
+  } catch (err) {
+    console.error("Failed to load reward summary", err);
   }
 }
 
 function copyReferral() {
-  const input = document.getElementById('referral-link');
+  const input = document.getElementById("referral-link");
   input?.select();
-  document.execCommand('copy');
+  document.execCommand("copy");
 }
 
 async function redeemReward() {
-  const sel = document.getElementById('reward-select');
+  const sel = document.getElementById("reward-select");
   if (!sel) return;
   const points = parseInt(sel.value, 10);
-  const token = localStorage.getItem('token');
+  const token = localStorage.getItem("token");
   if (!token || !points) return;
   try {
     const res = await fetch(`${API_BASE}/rewards/redeem`, {
-      method: 'POST',
+      method: "POST",
       headers: {
-        'Content-Type': 'application/json',
+        "Content-Type": "application/json",
         authorization: `Bearer ${token}`,
       },
       body: JSON.stringify({ points }),
@@ -78,12 +99,16 @@ async function redeemReward() {
       loadRewards();
     }
   } catch (err) {
-    console.error('Failed to redeem', err);
+    console.error("Failed to redeem", err);
   }
 }
 
 window.copyReferral = copyReferral;
 window.redeemReward = redeemReward;
-window.addEventListener('DOMContentLoaded', () => {
-  loadRewardOptions().then(loadRewards);
+window.loadRewardSummary = loadRewardSummary;
+window.addEventListener("DOMContentLoaded", () => {
+  loadRewardOptions().then(() => {
+    loadRewards();
+    loadRewardSummary();
+  });
 });

--- a/login.html
+++ b/login.html
@@ -31,7 +31,11 @@
             stroke-width="2"
             viewBox="0 0 24 24"
           >
-            <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M15 19l-7-7 7-7"
+            />
           </svg>
           Back
         </a>
@@ -42,6 +46,7 @@
           class="bg-gradient-to-r from-purple-500 to-pink-500 text-white rounded-3xl px-3 py-2 text-sm transition-shape"
           >[🎉 NEW] Earn Rewards</a
         >
+        <span id="header-points" class="ml-1"></span>
       </div>
       <div class="flex items-center space-x-4 ml-4">
         <a
@@ -133,8 +138,10 @@
     </main>
     <script type="module" src="js/login.js"></script>
     <script type="module">
-      import { shareOn } from './js/share.js';
+      import { shareOn } from "./js/share.js";
+      import { loadRewardSummary } from "./js/rewards.js";
       window.shareOn = shareOn;
+      loadRewardSummary();
     </script>
     <div
       id="printclub-modal"
@@ -143,7 +150,8 @@
       <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center">
         <h2 class="text-2xl font-semibold mb-2">Print Club</h2>
         <p class="mb-4">
-          Get two prints (single or multicolour tiers) every week for £149.99/month. Unused credits expire weekly.
+          Get two prints (single or multicolour tiers) every week for
+          £149.99/month. Unused credits expire weekly.
         </p>
         <button
           id="printclub-close"

--- a/my_profile.html
+++ b/my_profile.html
@@ -58,6 +58,7 @@
           class="bg-gradient-to-r from-purple-500 to-pink-500 text-white rounded-3xl px-3 py-2 text-sm transition-shape"
           >[🎉 NEW] Earn Rewards</a
         >
+        <span id="header-points" class="ml-1"></span>
 
         <a
           href="printclub.html"
@@ -235,7 +236,10 @@
       >
         <h2 class="text-lg font-semibold mb-2">Time Capsule</h2>
         <p id="time-capsule-text" class="mb-2"></p>
-        <button id="time-capsule-action" class="px-3 py-1 bg-blue-600 rounded-3xl"></button>
+        <button
+          id="time-capsule-action"
+          class="px-3 py-1 bg-blue-600 rounded-3xl"
+        ></button>
       </div>
 
       <div
@@ -244,8 +248,12 @@
       >
         <h2 class="text-lg font-semibold mb-2">Subscriber Previews</h2>
         <div class="grid grid-cols-2 gap-4">
-          <div class="h-24 bg-[#1A1A1D] flex items-center justify-center">Preview 1</div>
-          <div class="h-24 bg-[#1A1A1D] flex items-center justify-center">Preview 2</div>
+          <div class="h-24 bg-[#1A1A1D] flex items-center justify-center">
+            Preview 1
+          </div>
+          <div class="h-24 bg-[#1A1A1D] flex items-center justify-center">
+            Preview 2
+          </div>
         </div>
       </div>
 
@@ -321,7 +329,9 @@
     <script type="module" src="js/my_profile.js"></script>
     <script type="module">
       import { shareOn } from "./js/share.js";
+      import { loadRewardSummary } from "./js/rewards.js";
       window.shareOn = shareOn;
+      loadRewardSummary();
     </script>
     <div
       id="printclub-modal"
@@ -330,7 +340,8 @@
       <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center">
         <h2 class="text-2xl font-semibold mb-2">Print Club</h2>
         <p class="mb-4">
-          Get two prints (single or multicolour tiers) every week for £149.99/month. Unused credits expire weekly.
+          Get two prints (single or multicolour tiers) every week for
+          £149.99/month. Unused credits expire weekly.
         </p>
         <button
           id="printclub-close"

--- a/printclub.html
+++ b/printclub.html
@@ -31,7 +31,11 @@
             stroke-width="2"
             viewBox="0 0 24 24"
           >
-            <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M15 19l-7-7 7-7"
+            />
           </svg>
           Back
         </a>
@@ -42,6 +46,7 @@
           class="bg-gradient-to-r from-purple-500 to-pink-500 text-white rounded-3xl px-3 py-2 text-sm transition-shape"
           >[🎉 NEW] Earn Rewards</a
         >
+        <span id="header-points" class="ml-1"></span>
       </div>
       <div class="flex items-center space-x-4 ml-4">
         <a
@@ -92,10 +97,12 @@
     <main class="flex-1 flex items-center justify-center px-4">
       <div class="max-w-lg text-center space-y-4">
         <p class="text-lg">
-          Join Print Club for £149.99 per month to receive 2 prints (single or multicolour tiers) every week.
+          Join Print Club for £149.99 per month to receive 2 prints (single or
+          multicolour tiers) every week.
         </p>
         <p class="text-lg">
-          Unused credits expire weekly, so be sure to print your favourite models.
+          Unused credits expire weekly, so be sure to print your favourite
+          models.
         </p>
         <p class="text-lg">
           Members also get early access to new designs and exclusive promotions.
@@ -108,8 +115,10 @@
       </div>
     </main>
     <script type="module">
-      import { shareOn } from './js/share.js';
+      import { shareOn } from "./js/share.js";
+      import { loadRewardSummary } from "./js/rewards.js";
       window.shareOn = shareOn;
+      loadRewardSummary();
     </script>
     <div
       id="printclub-modal"
@@ -118,7 +127,8 @@
       <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center">
         <h2 class="text-2xl font-semibold mb-2">Print Club</h2>
         <p class="mb-4">
-          Get two prints (single or multicolour tiers) every week for £149.99/month. Unused credits expire weekly.
+          Get two prints (single or multicolour tiers) every week for
+          £149.99/month. Unused credits expire weekly.
         </p>
         <button
           id="printclub-close"

--- a/profile.html
+++ b/profile.html
@@ -5,7 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Profile</title>
     <meta property="og:title" content="Profile – print3" />
-    <meta property="og:description" content="View your generated models and past orders." />
+    <meta
+      property="og:description"
+      content="View your generated models and past orders."
+    />
     <meta property="og:image" content="img/boxlogo.png" />
     <script src="js/applyColorScheme.js"></script>
     <link rel="preconnect" href="https://modelviewer.dev" crossorigin />
@@ -39,7 +42,11 @@
           stroke-width="2"
           viewBox="0 0 24 24"
         >
-          <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M15 19l-7-7 7-7"
+          />
         </svg>
         Back
       </a>
@@ -56,6 +63,7 @@
           class="bg-gradient-to-r from-purple-500 to-pink-500 text-white rounded-3xl px-3 py-2 text-sm transition-shape"
           >[🎉 NEW] Earn Rewards</a
         >
+        <span id="header-points" class="ml-1"></span>
 
         <a
           href="printclub.html"
@@ -116,10 +124,17 @@
     </header>
     <main class="flex-1 px-6 py-4">
       <div id="profile-header" class="text-center mb-6">
-        <img id="profile-avatar" class="w-24 h-24 rounded-full mx-auto mb-2" alt="Profile avatar" />
+        <img
+          id="profile-avatar"
+          class="w-24 h-24 rounded-full mx-auto mb-2"
+          alt="Profile avatar"
+        />
         <h2 id="profile-display" class="text-xl font-semibold"></h2>
       </div>
-      <div id="models" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4"></div>
+      <div
+        id="models"
+        class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4"
+      ></div>
       <div id="auth-options" class="text-center mt-8 hidden">
         <a
           href="login.html"
@@ -204,8 +219,10 @@
     </div>
     <script type="module" src="js/profile.js"></script>
     <script type="module">
-      import { shareOn } from './js/share.js';
+      import { shareOn } from "./js/share.js";
+      import { loadRewardSummary } from "./js/rewards.js";
       window.shareOn = shareOn;
+      loadRewardSummary();
     </script>
     <div
       id="printclub-modal"
@@ -214,7 +231,8 @@
       <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center">
         <h2 class="text-2xl font-semibold mb-2">Print Club</h2>
         <p class="mb-4">
-          Get two prints (single or multicolour tiers) every week for £149.99/month. Unused credits expire weekly.
+          Get two prints (single or multicolour tiers) every week for
+          £149.99/month. Unused credits expire weekly.
         </p>
         <button
           id="printclub-close"

--- a/request-reset.html
+++ b/request-reset.html
@@ -26,7 +26,11 @@
           stroke-width="2"
           viewBox="0 0 24 24"
         >
-          <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M15 19l-7-7 7-7"
+          />
         </svg>
         Back
       </a>
@@ -42,6 +46,7 @@
           class="bg-gradient-to-r from-purple-500 to-pink-500 text-white rounded-3xl px-3 py-2 text-sm transition-shape"
           >[🎉 NEW] Earn Rewards</a
         >
+        <span id="header-points" class="ml-1"></span>
 
         <a
           href="printclub.html"
@@ -112,8 +117,10 @@
     </main>
     <script type="module" src="js/requestReset.js"></script>
     <script type="module">
-      import { shareOn } from './js/share.js';
+      import { shareOn } from "./js/share.js";
+      import { loadRewardSummary } from "./js/rewards.js";
       window.shareOn = shareOn;
+      loadRewardSummary();
     </script>
     <div
       id="printclub-modal"
@@ -122,7 +129,8 @@
       <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center">
         <h2 class="text-2xl font-semibold mb-2">Print Club</h2>
         <p class="mb-4">
-          Get two prints (single or multicolour tiers) every week for £149.99/month. Unused credits expire weekly.
+          Get two prints (single or multicolour tiers) every week for
+          £149.99/month. Unused credits expire weekly.
         </p>
         <button
           id="printclub-close"

--- a/reset-password.html
+++ b/reset-password.html
@@ -26,7 +26,11 @@
           stroke-width="2"
           viewBox="0 0 24 24"
         >
-          <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M15 19l-7-7 7-7"
+          />
         </svg>
         Back
       </a>
@@ -42,6 +46,7 @@
           class="bg-gradient-to-r from-purple-500 to-pink-500 text-white rounded-3xl px-3 py-2 text-sm transition-shape"
           >[🎉 NEW] Earn Rewards</a
         >
+        <span id="header-points" class="ml-1"></span>
 
         <a
           href="printclub.html"
@@ -112,8 +117,10 @@
     </main>
     <script type="module" src="js/resetPassword.js"></script>
     <script type="module">
-      import { shareOn } from './js/share.js';
+      import { shareOn } from "./js/share.js";
+      import { loadRewardSummary } from "./js/rewards.js";
       window.shareOn = shareOn;
+      loadRewardSummary();
     </script>
     <div
       id="printclub-modal"
@@ -122,7 +129,8 @@
       <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center">
         <h2 class="text-2xl font-semibold mb-2">Print Club</h2>
         <p class="mb-4">
-          Get two prints (single or multicolour tiers) every week for £149.99/month. Unused credits expire weekly.
+          Get two prints (single or multicolour tiers) every week for
+          £149.99/month. Unused credits expire weekly.
         </p>
         <button
           id="printclub-close"

--- a/signup.html
+++ b/signup.html
@@ -31,7 +31,11 @@
             stroke-width="2"
             viewBox="0 0 24 24"
           >
-            <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M15 19l-7-7 7-7"
+            />
           </svg>
           Back
         </a>
@@ -42,6 +46,7 @@
           class="bg-gradient-to-r from-purple-500 to-pink-500 text-white rounded-3xl px-3 py-2 text-sm transition-shape"
           >[🎉 NEW] Earn Rewards</a
         >
+        <span id="header-points" class="ml-1"></span>
       </div>
       <div class="flex items-center space-x-4 ml-4">
         <a
@@ -148,8 +153,10 @@
     </main>
     <script type="module" src="js/signup.js"></script>
     <script type="module">
-      import { shareOn } from './js/share.js';
+      import { shareOn } from "./js/share.js";
+      import { loadRewardSummary } from "./js/rewards.js";
       window.shareOn = shareOn;
+      loadRewardSummary();
     </script>
     <div
       id="printclub-modal"
@@ -158,7 +165,8 @@
       <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center">
         <h2 class="text-2xl font-semibold mb-2">Print Club</h2>
         <p class="mb-4">
-          Get two prints (single or multicolour tiers) every week for £149.99/month. Unused credits expire weekly.
+          Get two prints (single or multicolour tiers) every week for
+          £149.99/month. Unused credits expire weekly.
         </p>
         <button
           id="printclub-close"


### PR DESCRIPTION
## Summary
- show reward points next to the Earn Rewards badge on all pages
- fetch points via new `loadRewardSummary()` helper
- update scripts to import and call the new function

## Testing
- `npm ci` in `backend/` and `backend/hunyuan_server`
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_6855d662dc30832daf04067b5daab349