### PR TITLE
Add thumbnail to purchase popup

### DIFF
--- a/index.html
+++ b/index.html
@@ -586,7 +586,7 @@
     <script type="module" src="js/basket.js" defer></script>
     <div
       id="purchase-popups"
-      class="fixed bottom-28 left-4 bg-black/80 text-white px-3 py-1 rounded hidden text-sm"
+      class="fixed bottom-28 left-4 bg-black/80 text-white px-3 py-1 rounded hidden text-sm flex items-center space-x-2"
     ></div>
   </body>
 </html>

--- a/js/index.js
+++ b/js/index.js
@@ -234,6 +234,7 @@ let editsPending = false;
 let progressInterval = null;
 let progressStart = null;
 let usingViewerProgress = false;
+let lastSnapshot = null;
 
 function getCycleKey() {
   const now = new Date();
@@ -700,7 +701,10 @@ refs.submitBtn.addEventListener("click", async () => {
       if (!snapshot || snapshot.includes("placehold.co")) {
         snapshot = await captureModelSnapshot(url);
       }
+      lastSnapshot = snapshot;
       window.addAutoItem({ jobId: lastJobId, modelUrl: url, snapshot });
+    } else {
+      lastSnapshot = await captureModelSnapshot(url);
     }
     setStep("model");
     if (window.setWizardStage) window.setWizardStage("purchase");
@@ -810,6 +814,9 @@ async function init() {
       { once: true },
     );
     await refs.viewer.updateComplete;
+    try {
+      lastSnapshot = await captureModelSnapshot(refs.viewer.src);
+    } catch {}
   }
   showModel();
   fetchProfile().then(() => {
@@ -885,6 +892,7 @@ async function init() {
     if (!snapshot || snapshot.includes("placehold.co")) {
       snapshot = await captureModelSnapshot(refs.viewer.src);
     }
+    lastSnapshot = snapshot;
     const item = { jobId: lastJobId, modelUrl: refs.viewer.src, snapshot };
     if (
       window.manualizeItem &&
@@ -963,7 +971,17 @@ async function init() {
   let popupIdx = 0;
   function showPopup() {
     if (!popupEl) return;
-    popupEl.textContent = popupMsgs[popupIdx % popupMsgs.length];
+    const msg = popupMsgs[popupIdx % popupMsgs.length];
+    popupEl.innerHTML = "";
+    const span = document.createElement("span");
+    span.textContent = msg;
+    popupEl.appendChild(span);
+    if (popupIdx % popupMsgs.length === 0 && lastSnapshot) {
+      const img = document.createElement("img");
+      img.src = lastSnapshot;
+      img.className = "w-10 h-10 ml-2 rounded";
+      popupEl.appendChild(img);
+    }
     popupEl.classList.remove("hidden");
     setTimeout(() => popupEl.classList.add("hidden"), 5000);
     popupIdx++;


### PR DESCRIPTION
## Summary
- display popup as flex container
- capture model snapshot when generating
- attach snapshot image in purchase popups

## Testing
- `npm ci` in `backend/`
- `npm ci` in `backend/hunyuan_server`
- `npx prettier --write js/index.js`
- `npm test` *(results excerpt)*
- `npm run ci` *(results excerpt)*

------
https://chatgpt.com/codex/tasks/task_e_6855da078670832d90cd8ad0f3762d99