### PR TITLE
Improve competitions page message

### DIFF
--- a/competitions.html
+++ b/competitions.html
@@ -123,10 +123,6 @@
       <h2 class="text-2xl">Active Competitions</h2>
       <h3 id="current-theme" class="text-lg text-[#30D5C8] mt-1"></h3>
       <div id="list" class="space-y-4"></div>
-      <p class="mt-4">
-        <a href="signup.html" class="font-bold text-[#30D5C8]">Sign Up</a>
-        to hear when competitions/prizes are available.
-      </p>
       <div id="comp-subscribe-msg" class="text-sm"></div>
       <div id="entry-success" class="hidden text-green-400 mt-2"></div>
       <h2 class="text-2xl mt-8">Past Winners</h2>

--- a/js/competitions.js
+++ b/js/competitions.js
@@ -79,13 +79,14 @@ async function load() {
   const list = document.getElementById('list');
   if (!res.ok) {
     // When the competitions API fails, show a friendly message
-    list.textContent = 'No ongoing competitions right now';
+    list.innerHTML =
+      '<p class="text-center text-white/80">No ongoing competitions right now. <a href="signup.html" class="font-bold text-[#30D5C8]">Sign Up</a> to hear when competitions/prizes are available.</p>';
     return;
   }
   const comps = await res.json();
   if (comps.length === 0) {
     list.innerHTML =
-      '<p class="text-center text-white/80">No active competitions. Check back soon!</p>';
+      '<p class="text-center text-white/80">No ongoing competitions right now. <a href="signup.html" class="font-bold text-[#30D5C8]">Sign Up</a> to hear when competitions/prizes are available.</p>';
     return;
   }
   const themeEl = document.getElementById('current-theme');


### PR DESCRIPTION
## Summary
- merge the missing competitions message and sign-up link
- remove redundant signup note from competitions page

## Testing
- `npm run format`
- `npm test --silent`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_6855d8ddc77c832d9a24576f2ffad20f