### PR TITLE
Switch fallback model to astronaut

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -151,7 +151,7 @@ const upload = multer({ dest: uploadsDir });
 
 const PORT = config.port;
 const FALLBACK_GLB =
-  "https://modelviewer.dev/shared-assets/models/RobotExpressive.glb";
+  "https://modelviewer.dev/shared-assets/models/Astronaut.glb";
 
 function computePrintSlots(date = new Date()) {
   const dtf = new Intl.DateTimeFormat("en-US", {

--- a/backend/tests/api.test.js
+++ b/backend/tests/api.test.js
@@ -606,7 +606,7 @@ test("/api/generate falls back on server failure", async () => {
   const res = await request(app).post("/api/generate").send({ prompt: "t" });
   expect(res.status).toBe(200);
   expect(res.body.glb_url).toBe(
-    "https://modelviewer.dev/shared-assets/models/RobotExpressive.glb",
+    "https://modelviewer.dev/shared-assets/models/Astronaut.glb",
   );
 });
 

--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@
     <!-- Preload default model assets -->
     <link
       rel="preload"
-      href="https://modelviewer.dev/shared-assets/models/RobotExpressive.glb"
+      href="https://modelviewer.dev/shared-assets/models/Astronaut.glb"
       as="fetch"
       type="model/gltf-binary"
       crossorigin
@@ -239,7 +239,7 @@
           <!-- 3-D Astronaut (always visible) -->
           <model-viewer
             id="viewer"
-            src="https://modelviewer.dev/shared-assets/models/RobotExpressive.glb"
+            src="https://modelviewer.dev/shared-assets/models/Astronaut.glb"
             alt="3D astronaut"
             environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
             camera-controls

--- a/js/index.js
+++ b/js/index.js
@@ -142,7 +142,7 @@ const TZ = "America/New_York";
 // Local fallback model used when generation fails or the viewer hasn't loaded a model yet.
 
 const FALLBACK_GLB_LOW =
-  "https://modelviewer.dev/shared-assets/models/RobotExpressive.glb";
+  "https://modelviewer.dev/shared-assets/models/Astronaut.glb";
 const FALLBACK_GLB_HIGH =
   "https://modelviewer.dev/shared-assets/models/Astronaut.glb";
 const FALLBACK_GLB = FALLBACK_GLB_LOW;
@@ -718,7 +718,7 @@ async function init() {
   await ensureModelViewerLoaded();
   if (window.customElements?.whenDefined) {
     try {
-      await customElements.whenDefined('model-viewer');
+      await customElements.whenDefined("model-viewer");
     } catch {}
   }
   syncUploadHeights();

--- a/js/payment.js
+++ b/js/payment.js
@@ -4,7 +4,7 @@
 let stripe = null;
 
 // Use a lightweight fallback model and upgrade to the high detail version after load.
-const FALLBACK_GLB_LOW = 'https://modelviewer.dev/shared-assets/models/RobotExpressive.glb';
+const FALLBACK_GLB_LOW = 'https://modelviewer.dev/shared-assets/models/Astronaut.glb';
 const FALLBACK_GLB_HIGH = 'https://modelviewer.dev/shared-assets/models/Astronaut.glb';
 const FALLBACK_GLB = FALLBACK_GLB_LOW;
 const PRICES = {

--- a/payment.html
+++ b/payment.html
@@ -15,7 +15,7 @@
     <!-- Preload 3D assets -->
     <link
       rel="preload"
-      href="https://modelviewer.dev/shared-assets/models/RobotExpressive.glb"
+      href="https://modelviewer.dev/shared-assets/models/Astronaut.glb"
       as="fetch"
       crossorigin
     />

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,6 +1,6 @@
 const CACHE_NAME = 'model-cache-v1';
 const ASSETS = [
-  'https://modelviewer.dev/shared-assets/models/RobotExpressive.glb',
+  'https://modelviewer.dev/shared-assets/models/Astronaut.glb',
   'https://modelviewer.dev/shared-assets/environments/neutral.hdr'
 ];
 


### PR DESCRIPTION
## Summary
- revert default viewer model from RobotExpressive to Astronaut
- update tests expecting fallback GLB

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855d89f1c1c832db783a6b19cba1ac3