### PR TITLE
Fix shipping cutoff position

### DIFF
--- a/index.html
+++ b/index.html
@@ -280,6 +280,7 @@
             id="checkout-container"
             class="absolute bottom-4 right-4 flex flex-col items-center"
           >
+            <div id="shipping-cutoff" class="text-xs text-gray-200 mb-1"></div>
             <a
               id="checkout-button"
               href="payment.html"
@@ -290,7 +291,6 @@
             >
               Print from £29.99 →
             </a>
-            <div id="shipping-cutoff" class="text-xs text-gray-200 mt-1"></div>
           </div>
           <button
             id="add-basket-button"


### PR DESCRIPTION
## Summary
- move shipping cutoff text above the checkout button so users see processing time before purchase

## Testing
- `npm test`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_6855e20d7010832d925e6536e1d41bce