### PR TITLE
Remove shift tracking from task list

### DIFF
--- a/docs/task_list.md
+++ b/docs/task_list.md
@@ -76,13 +76,6 @@
   - Mark tasks complete via `POST /tasks/:id/complete`.
   - Summarise hub progress in the admin dashboard.
 
-- **Shift tracking**
-
-  - Add `shifts` table storing operator, hub, start and end times.
-  - Start shift timer on login or manual "Start shift".
-  - End shift on logout or manual "End shift".
-  - Display shift history and total hours per operator.
-
 - **Alerts for incomplete tasks**
 
   - Nightly job checks for tasks not completed by shift end.


### PR DESCRIPTION
## Summary
- update `docs/task_list.md` to remove the obsolete *Shift tracking* section

## Testing
- `npm test`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_6855e32a0564832d87f9d8cccf97cf2a