### PR TITLE
Remove gift recipient fields

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -374,8 +374,6 @@ async function initPaymentPage() {
   const discountMsg = document.getElementById('discount-msg');
   const seasonalBundleEl = document.getElementById('seasonal-bundle');
   const applyBtn = document.getElementById('apply-discount');
-  const surpriseToggle = document.getElementById('surprise-toggle');
-  const recipientFields = document.getElementById('recipient-fields');
   fetchCampaignBundle();
   loadCheckoutCredits();
   if (referralId && discountMsg) {
@@ -408,14 +406,6 @@ async function initPaymentPage() {
     subscriptionRadios.forEach((r) => {
       if (r.value === 'join') r.checked = true;
     });
-  }
-  if (surpriseToggle && recipientFields) {
-    const toggle = () => {
-      if (surpriseToggle.checked) recipientFields.classList.add('hidden');
-      else recipientFields.classList.remove('hidden');
-    };
-    surpriseToggle.addEventListener('change', toggle);
-    toggle();
   }
   const payBtn = document.getElementById('submit-payment');
   const singleLabel = document.getElementById('single-label');
@@ -750,11 +740,9 @@ async function initPaymentPage() {
     });
     const giftDiv = document.getElementById('gift-options');
     const giftBtn = document.getElementById('gift-order');
-    if (giftDiv && giftBtn && surpriseToggle && recipientFields) {
+    if (giftDiv && giftBtn) {
       giftDiv.classList.remove('hidden');
       giftBtn.addEventListener('click', () => {
-        surpriseToggle.checked = false;
-        recipientFields.classList.remove('hidden');
         document.getElementById('checkout-form')?.scrollIntoView({
           behavior: 'smooth',
         });
@@ -870,8 +858,6 @@ async function initPaymentPage() {
       city: document.getElementById('ship-city').value,
       zip: document.getElementById('ship-zip').value,
       email: emailEl.value,
-      surprise: document.getElementById('surprise-toggle')?.checked || false,
-      recipientEmail: document.getElementById('recipient-email')?.value || '',
     };
     let etchName = '';
     if (etchInput && !etchInput.disabled) {

--- a/payment.html
+++ b/payment.html
@@ -300,20 +300,6 @@
                 aria-label="Email"
               />
             </div>
-            <label class="flex items-center gap-2 text-sm my-2">
-              <input type="checkbox" id="surprise-toggle" class="accent-[#30D5C8]" />
-              This is a surprise
-            </label>
-            <div id="recipient-fields" class="mb-2">
-              <input
-                id="recipient-email"
-                type="email"
-                class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10"
-                placeholder="Recipient Email (optional)"
-                autocomplete="email"
-                aria-label="Recipient Email"
-              />
-            </div>
             <div>
               <input
                 id="ship-address"


### PR DESCRIPTION
## Summary
- remove surprise checkbox and recipient email input
- stop toggling gift fields in payment.js
- trim gift field data from shipping info

## Testing
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_6855e241c154832dad5f401b0487946c