### PR TITLE
Remove Share tooltip icon

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -260,10 +260,6 @@
         </button>
         <div id="modal-copy-container" class="absolute bottom-4 left-40 flex items-center gap-2">
           <button id="modal-copy-link" class="font-bold py-2 px-4 rounded-full shadow-md bg-[#2A2A2E] border border-white/20">Share</button>
-          <span id="modal-copy-help" class="relative cursor-pointer text-lg">
-            <i class="fas fa-question-circle"></i>
-            <span id="modal-copy-tooltip" class="absolute hidden bottom-full mb-2 left-1/2 -translate-x-1/2 bg-[#2A2A2E] border border-white/10 rounded p-2 text-xs whitespace-nowrap">Click to copy the shareable link</span>
-          </span>
           <span id="modal-copy-msg" class="ml-2 text-sm opacity-0 transition-opacity">Link copied</span>
         </div>
         <div class="mt-4 bg-[#2A2A2E] p-4 rounded-xl">


### PR DESCRIPTION
## Summary
- remove the question mark tooltip from CommunityCreations

## Testing
- `npm run format` in `backend`
- `npm test` in `backend`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_6855e1e287a0832dafe06a82387bc3e0