### PR TITLE
Disable Spring Bloom bundle

### DIFF
--- a/docs/task_list.md
+++ b/docs/task_list.md
@@ -10,6 +10,7 @@
 ## Purchase & Checkout
 
 - Offer multiple payment methods including Apple Pay and Google Pay.
+- Reconfigure seasonal order bundles once promotions resume.
 
 ## Decreasing CAC
 

--- a/js/payment.js
+++ b/js/payment.js
@@ -31,7 +31,6 @@ const SEASONAL_BUNDLES = [
     name: 'Winter Wonderland Bundle',
     detail: 'Free snowman stand with gift prints',
   },
-  { name: 'Spring Bloom Bundle', detail: 'Includes floral gift wrap' },
   { name: 'Summer Fun Bundle', detail: 'Beach-themed gift card included' },
   { name: 'Autumn Harvest Bundle', detail: 'Leaf pattern gift wrap' },
 ];


### PR DESCRIPTION
## Summary
- remove Spring Bloom bundle from seasonal rotation
- note to reconfigure seasonal orders in the future

## Testing
- `npx prettier --write docs/task_list.md js/payment.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855e36a91dc832d8fcc533d7e28c286