### PR TITLE
Hide shipping cutoff countdown

### DIFF
--- a/docs/task_list.md
+++ b/docs/task_list.md
@@ -147,6 +147,7 @@
 - Log reprint events for reporting and analytics.
 - Send a delivery confirmation email containing a satisfaction survey link.
 - Store survey responses in the database and surface metrics on the dashboard.
+- Reintroduce next-day delivery countdown on the site when logistics allow.
 
 ## Gifting Flow Integration
 

--- a/index.html
+++ b/index.html
@@ -280,7 +280,7 @@
             id="checkout-container"
             class="absolute bottom-4 right-4 flex flex-col items-end"
           >
-            <div id="shipping-cutoff" class="text-xs text-gray-200 mb-1"></div>
+              <!-- <div id="shipping-cutoff" class="text-xs text-gray-200 mb-1"></div> -->
             <a
               id="checkout-button"
               href="payment.html"


### PR DESCRIPTION
## Summary
- hide the "Order in Xh Xm for same-day processing" message
- note future next-day delivery in the task list

## Testing
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_6855e3a1e5ec832d994981fa30cb2d0c