### PR TITLE
Add placeholder image box to Print Club page

### DIFF
--- a/docs/task_list.md
+++ b/docs/task_list.md
@@ -18,6 +18,7 @@
 ## Competitions & Print Club
 
 - Add images to the competitions page and Print Club with participant quotes to show social proof.
+- Replace the placeholder "Real life image here" box on the Print Club page with an actual photo.
 
 ## Hub Deployment Kit
 

--- a/printclub.html
+++ b/printclub.html
@@ -90,18 +90,23 @@
       </div>
     </header>
     <main class="flex-1 flex items-center justify-center px-4">
-      <div class="max-w-lg text-center space-y-4">
-        <p class="text-lg">
-          Join Print Club for £149.99 per month to receive 2 prints (single or multicolour tiers) every week.
-        </p>
-        <p class="text-lg">
-          Members also get early access to new designs and exclusive promotions.
-        </p>
-        <a
-          href="payment.html?plan=printclub"
-          class="inline-block bg-[#30D5C8] text-[#1A1A1D] px-6 py-3 rounded-xl font-semibold hover:bg-[#28b7a8] transition"
-          >Subscribe Now</a
-        >
+      <div class="max-w-4xl w-full flex flex-col md:flex-row items-center justify-between space-y-6 md:space-y-0 md:space-x-8">
+        <div class="text-center space-y-4 md:max-w-lg">
+          <p class="text-lg">
+            Join Print Club for £149.99 per month to receive 2 prints (single or multicolour tiers) every week.
+          </p>
+          <p class="text-lg">
+            Members also get early access to new designs and exclusive promotions.
+          </p>
+          <a
+            href="payment.html?plan=printclub"
+            class="inline-block bg-[#30D5C8] text-[#1A1A1D] px-6 py-3 rounded-xl font-semibold hover:bg-[#28b7a8] transition"
+            >Subscribe Now</a
+          >
+        </div>
+        <div class="w-full md:w-80 h-60 flex items-center justify-center border border-white/20 rounded-xl bg-[#2A2A2E] text-sm">
+          Real life image here
+        </div>
       </div>
     </main>
     <script type="module">


### PR DESCRIPTION
## Summary
- add a right-hand side image placeholder to `printclub.html`
- note in task list to replace placeholder with real photo later

## Testing
- `npm run format`
- `npm test`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_6855e561014c832d972f6e25a97496ab