### PR TITLE
Fix delivery warning layout

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -574,7 +574,7 @@
         <div
           id="delivery-warning"
           style="position: absolute; right: calc(100% + 0.55cm); bottom: 1rem;"
-          class="w-fit text-sm text-gray-200/90 text-left"
+          class="text-sm text-gray-200/90 text-left max-w-xs whitespace-normal"
         >
           <p>
             Due to incredibly high demand, delivery may take 3+ weeks. Please


### PR DESCRIPTION
## Summary
- adjust layout of delivery warning text for better wrapping

## Testing
- `npm ci` in `backend/`
- `npm ci` in `backend/hunyuan_server`
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_6855e8088144832da19a71cc9875c641