### PR TITLE
Add seller credit tasks

### DIFF
--- a/docs/task_list.md
+++ b/docs/task_list.md
@@ -289,3 +289,13 @@
   - Custom print requests for higher tiers.
   - Private sales or auctions for rare prints.
   - Merchandising discounts on apparel or accessories.
+
+## Seller Credits
+
+- Add migration introducing a table or column for `sale_credits` tied to `user_id`.
+- Implement `getSaleCredit` and `adjustSaleCredit` helpers in the backend.
+- Award sellers £5 credit in the checkout webhook when a job is paid.
+- Provide `GET /api/credits` and `POST /api/credits/redeem` endpoints.
+- Display credit balance on profile pages and allow applying credit at checkout.
+- Add Jest tests for credit accrual and redemption.
+- Document the feature in the README.

--- a/login.html
+++ b/login.html
@@ -31,7 +31,11 @@
             stroke-width="2"
             viewBox="0 0 24 24"
           >
-            <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M15 19l-7-7 7-7"
+            />
           </svg>
           Back
         </a>
@@ -91,6 +95,11 @@
     </header>
     <main class="flex-1 flex items-center justify-center">
       <div class="relative w-96">
+        <p class="text-center mb-4 text-gray-400">
+          <span class="text-white">Earn £5</span>
+          credit everytime someone orders one of your prints: log in to your
+          profile to claim
+        </p>
         <form
           id="loginForm"
           class="space-y-4 bg-[#2A2A2E] border border-white/10 p-6 rounded-3xl"
@@ -133,7 +142,7 @@
     </main>
     <script type="module" src="js/login.js"></script>
     <script type="module">
-      import { shareOn } from './js/share.js';
+      import { shareOn } from "./js/share.js";
       window.shareOn = shareOn;
     </script>
     <div
@@ -143,7 +152,8 @@
       <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center">
         <h2 class="text-2xl font-semibold mb-2">Print Club</h2>
         <p class="mb-4">
-          Get two prints (single or multicolour tiers) every week for £149.99/month.
+          Get two prints (single or multicolour tiers) every week for
+          £149.99/month.
         </p>
         <button
           id="printclub-close"

--- a/signup.html
+++ b/signup.html
@@ -95,6 +95,11 @@
     </header>
     <main class="flex-1 flex items-center justify-center">
       <div class="relative w-96">
+        <p class="text-center mb-4 text-gray-400">
+          <span class="text-white">Earn £5</span>
+          credit everytime someone orders one of your prints: log in to your
+          profile to claim
+        </p>
         <form
           id="signupForm"
           class="space-y-4 bg-[#2A2A2E] border border-white/10 p-6 rounded-3xl"
@@ -156,7 +161,8 @@
       <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center">
         <h2 class="text-2xl font-semibold mb-2">Print Club</h2>
         <p class="mb-4">
-          Get two prints (single or multicolour tiers) every week for £149.99/month.
+          Get two prints (single or multicolour tiers) every week for
+          £149.99/month.
         </p>
         <button
           id="printclub-close"


### PR DESCRIPTION
## Summary
- document tasks for new seller credits feature
- notify potential sellers about £5 credit on login and signup pages

## Testing
- `npm ci` in `backend/`
- `npm ci` in `backend/hunyuan_server`
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_6855e59f8a50832db6961fc4d4df7754