### PR TITLE
Update quantity selection behavior

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -376,6 +376,8 @@ async function initPaymentPage() {
   const applyBtn = document.getElementById('apply-discount');
   const surpriseToggle = document.getElementById('surprise-toggle');
   const recipientFields = document.getElementById('recipient-fields');
+  const qtySelect = document.getElementById('print-qty');
+  const bulkMsg = document.getElementById('bulk-discount-msg');
   fetchCampaignBundle();
   loadCheckoutCredits();
   if (referralId && discountMsg) {
@@ -528,7 +530,10 @@ async function initPaymentPage() {
       const suffix = hasReferral ? ' first month' : '';
       payBtn.textContent = `Join Print Club – Pay £${price.toFixed(2)}${suffix}`;
     } else {
-      payBtn.textContent = `Pay £${(selectedPrice / 100).toFixed(2)}`;
+      const qty = Math.max(1, parseInt(qtySelect?.value || '2', 10));
+      let total = selectedPrice * qty;
+      if (qty >= 2) total -= Math.round(selectedPrice * 0.1);
+      payBtn.textContent = `Pay £${(total / 100).toFixed(2)}`;
     }
   }
 
@@ -560,6 +565,13 @@ async function initPaymentPage() {
 
   subscriptionRadios.forEach((r) => {
     r.addEventListener('change', updatePayButton);
+  });
+
+  qtySelect?.addEventListener('change', () => {
+    updatePayButton();
+    if (!bulkMsg) return;
+    if (qtySelect.value === '1') bulkMsg.classList.remove('hidden');
+    else bulkMsg.classList.add('hidden');
   });
 
   if (singleInput && colorMenu && singleButton) {
@@ -845,7 +857,7 @@ async function initPaymentPage() {
         body: JSON.stringify({ sessionId, subreddit, step: 'start' }),
       }).catch(() => {});
     }
-    const qty = Math.max(1, parseInt(document.getElementById('print-qty')?.value || '1', 10));
+    const qty = Math.max(1, parseInt(document.getElementById('print-qty')?.value || '2', 10));
     let discount = 0;
     const end = parseInt(localStorage.getItem('flashDiscountEnd'), 10) || 0;
     if (end && end > Date.now()) {
@@ -860,9 +872,6 @@ async function initPaymentPage() {
     }
     if (qty >= 2) {
       discount += Math.round(selectedPrice * 0.1);
-      document.getElementById('bulk-discount-msg')?.classList.remove('hidden');
-    } else {
-      document.getElementById('bulk-discount-msg')?.classList.add('hidden');
     }
     const shippingInfo = {
       name: document.getElementById('ship-name').value,

--- a/payment.html
+++ b/payment.html
@@ -349,10 +349,13 @@
                 aria-label="Quantity"
               >
                 <option value="1">1</option>
-                <option value="2">2</option>
+                <option value="2" selected>2</option>
+                <option value="3">3</option>
+                <option value="4">4</option>
+                <option value="5">5</option>
               </select>
               <span id="bulk-discount-msg" class="text-[#30D5C8] hidden"
-                >10% off second print!</span
+                >10% off 2nd print!</span
               >
             </div>
 


### PR DESCRIPTION
## Summary
- default to quantity of two on the payment page and extend quantity options
- update pay button total when quantity changes
- show discount hint when quantity is changed to one

## Testing
- `npm test`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_6855e45872cc832dac860e9ab02cf5d4