### PR TITLE
Fix wizard slot count placeholder

### DIFF
--- a/index.html
+++ b/index.html
@@ -476,7 +476,7 @@
         <span
           id="wizard-slots"
           class="hidden text-[#30D5C8] mr-2 whitespace-nowrap"
-          >Only 4 print slots remaining:</span
+        ></span
         >
         <span>Purchase model</span>
       </div>


### PR DESCRIPTION
## Summary
- remove hardcoded slot count on `index.html`

## Testing
- `npm run format`
- `npm test`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_6855e9642914832db5b374761c0f8fb4