### PR TITLE
UI tweak for quantity spinner

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -367,6 +367,8 @@ async function initPaymentPage() {
   const surpriseToggle = document.getElementById('surprise-toggle');
   const recipientFields = document.getElementById('recipient-fields');
   const qtySelect = document.getElementById('print-qty');
+  const qtyDec = document.getElementById('qty-decrement');
+  const qtyInc = document.getElementById('qty-increment');
   const bulkMsg = document.getElementById('bulk-discount-msg');
 
   fetchCampaignBundle();
@@ -549,6 +551,22 @@ async function initPaymentPage() {
     if (!bulkMsg) return;
     if (qtySelect.value === '1') bulkMsg.classList.remove('hidden');
     else bulkMsg.classList.add('hidden');
+  });
+
+  qtyDec?.addEventListener('click', () => {
+    if (!qtySelect) return;
+    let val = parseInt(qtySelect.value, 10) || 1;
+    val = Math.max(1, val - 1);
+    qtySelect.value = String(val);
+    qtySelect.dispatchEvent(new Event('change'));
+  });
+
+  qtyInc?.addEventListener('click', () => {
+    if (!qtySelect) return;
+    let val = parseInt(qtySelect.value, 10) || 1;
+    val = Math.min(5, val + 1);
+    qtySelect.value = String(val);
+    qtySelect.dispatchEvent(new Event('change'));
   });
 
   if (singleInput && colorMenu && singleButton) {

--- a/payment.html
+++ b/payment.html
@@ -399,18 +399,32 @@
             </p>
             <div class="flex items-center gap-2">
               <label for="print-qty">Quantity</label>
-              <select
-                id="print-qty"
-                class="p-1 rounded-md bg-[#1A1A1D] border border-white/10"
-                aria-label="Quantity"
+              <button
+                id="qty-decrement"
+                type="button"
+                class="px-2 py-1 rounded-md bg-[#1A1A1D] border border-white/10"
+                aria-label="Decrease quantity"
               >
-                <option value="1">1</option>
-                <option value="2" selected>2</option>
-                <option value="3">3</option>
-                <option value="4">4</option>
-                <option value="5">5</option>
-              </select>
-              <span id="bulk-discount-msg" class="text-[#30D5C8] hidden">10% off 2nd print!</span>
+                &ndash;
+              </button>
+              <input
+                id="print-qty"
+                type="number"
+                min="1"
+                max="5"
+                value="2"
+                class="w-12 text-center p-1 rounded-md bg-[#1A1A1D] border border-white/10"
+                aria-label="Quantity"
+              />
+              <button
+                id="qty-increment"
+                type="button"
+                class="px-2 py-1 rounded-md bg-[#1A1A1D] border border-white/10"
+                aria-label="Increase quantity"
+              >
+                +
+              </button>
+              <span id="bulk-discount-msg" class="text-[#30D5C8] hidden">Popular: 2 prints &ndash; save 10 %</span>
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- replace quantity dropdown with +/- spinner on payment page
- show new text `Popular: 2 prints – save 10 %`
- update payment script to handle spinner buttons

## Testing
- `npm run format` in backend
- `npm test` in backend
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_68565dbc2880832d951d64fb84434d9c