### PR TITLE
Add trophy icon to payment page

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -432,6 +432,7 @@
 
               <span id="bulk-discount-msg" class="text-[#30D5C8] hidden">
                 Popular choice: keep one, gift one – save 10% (<span id="popular-savings"></span>)
+                <i class="fas fa-trophy ml-1" aria-hidden="true"></i>
               </span>
 
             </div>


### PR DESCRIPTION
## Summary
- add a trophy icon next to the bulk discount text on the payment page

## Validation
- `npm run format`
- `npm test --silent --runInBand`
- `npm run ci --silent`


------
https://chatgpt.com/codex/tasks/task_e_685666c3cca8832db868a64ae8e19b71