### PR TITLE
Adjust print run info string

### DIFF
--- a/index.html
+++ b/index.html
@@ -348,7 +348,7 @@
             Next print run closes in
             <span id="print-run-hours">6</span>
             hours &mdash;
-            <span id="print-run-slots"></span>
+            &lt;<span id="print-run-slots"></span> slots remain
           </p>
         </div>
       </div>
@@ -559,7 +559,7 @@
         if (info && basket) {
           const infoWidth = info.getBoundingClientRect().width;
           const basketRect = basket.getBoundingClientRect();
-          const infoLeft = basketRect.right - wrapperRect.left - infoWidth - 31;
+          const infoLeft = basketRect.right - wrapperRect.left - infoWidth - 19;
           info.style.left = `${infoLeft}px`;
           info.style.top = `${top}px`;
           info.classList.remove("invisible");

--- a/js/index.js
+++ b/js/index.js
@@ -324,7 +324,8 @@ async function updatePrintRunInfo() {
     /* ignore */
   }
   hoursEl.textContent = computePrintRunHours();
-  if (slotsEl) slotsEl.textContent = adjustedSlots(baseSlots);
+  if (slotsEl)
+    slotsEl.textContent = `<${adjustedSlots(baseSlots) + 1} slots remain`;
   if (info) info.classList.remove("invisible");
   if (typeof window.positionQuote === "function") {
     requestAnimationFrame(() => window.positionQuote());


### PR DESCRIPTION
## Summary
- show remaining print slots as `<n slots remain>`
- shift print-run info closer to logo

## Testing
- `npm run format` in `backend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_68566590d4f0832dbe2fc45fad76efe4