### PR TITLE
Fix wizard slot count mismatch

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -983,10 +983,8 @@ async function init() {
 
   setInterval(updateStats, 3600000);
 
-  if (window.setWizardSlotCount) {
-    const slots = Math.floor(Math.random() * 6) + 3;
-    window.setWizardSlotCount(slots);
-  }
+  // Keep the wizard UI in sync with the payment page
+  updateWizardSlotCount();
 
   const cutoffEl = document.getElementById("shipping-cutoff");
   function updateCutoff() {


### PR DESCRIPTION
## Summary
- synchronize wizard step with payment slot count by calling `updateWizardSlotCount`

## Testing
- `npm test --prefix backend`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_68566e93b118832dab0e0e37d41e11d4