### PR TITLE
Fix print-run slots text and remove stray label

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -324,8 +324,7 @@ async function updatePrintRunInfo() {
     /* ignore */
   }
   hoursEl.textContent = computePrintRunHours();
-  if (slotsEl)
-    slotsEl.textContent = `<${adjustedSlots(baseSlots) + 1} slots remain`;
+  if (slotsEl) slotsEl.textContent = adjustedSlots(baseSlots) + 1;
   if (info) info.classList.remove("invisible");
   if (typeof window.positionQuote === "function") {
     requestAnimationFrame(() => window.positionQuote());

--- a/payment.html
+++ b/payment.html
@@ -370,8 +370,6 @@
                 Use Print Club credit (<span id="credits-remaining">0</span> left this week)
               </label>
             </div>
-
-              </label>
             </div>
 
             <div id="payment-element" class="text-center text-gray-400">


### PR DESCRIPTION
## Summary
- correct dynamic text for print run slots
- remove extraneous closing `</label>` in `payment.html`

## Testing
- `npm run format`
- `npm test`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_68566cbdd190832dabc8d3d5129ba100