### PR TITLE
Animate purchase popup fade

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,6 +122,23 @@
       model-viewer {
         touch-action: none;
       }
+      @keyframes purchaseFade {
+        0% {
+          opacity: 0;
+        }
+        20% {
+          opacity: 1;
+        }
+        80% {
+          opacity: 1;
+        }
+        100% {
+          opacity: 0;
+        }
+      }
+      .purchase-fade {
+        animation: purchaseFade 10s forwards;
+      }
     </style>
   </head>
 
@@ -620,7 +637,7 @@
     <script type="module" src="js/rewardBadge.js"></script>
     <div
       id="purchase-popups"
-      class="fixed bottom-28 left-4 bg-black/80 text-white px-3 py-1 rounded hidden text-sm flex items-center space-x-2"
+      class="fixed bottom-28 left-4 bg-black/80 text-white px-3 py-1 rounded hidden opacity-0 text-sm flex items-center space-x-2"
     ></div>
     <img src="/pixel" alt="" width="1" height="1" style="display: none" />
   </body>

--- a/js/index.js
+++ b/js/index.js
@@ -1022,7 +1022,13 @@ async function init() {
       popupEl.appendChild(img);
     }
     popupEl.classList.remove("hidden");
-    setTimeout(() => popupEl.classList.add("hidden"), 5000);
+    popupEl.classList.remove("purchase-fade");
+    void popupEl.offsetWidth;
+    popupEl.classList.add("purchase-fade");
+    setTimeout(() => {
+      popupEl.classList.add("hidden");
+      popupEl.classList.remove("purchase-fade");
+    }, 10000);
     popupIdx++;
   }
   setInterval(showPopup, 15000);


### PR DESCRIPTION
## Summary
- add purchase fade animation in index page
- trigger CSS animation from `showPopup` in index.js

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_68567421f214832d9657827d40d87c95