### PR TITLE
Fix hour label when one hour remains

### DIFF
--- a/index.html
+++ b/index.html
@@ -357,7 +357,8 @@
           <p class="whitespace-nowrap" style="margin-right: 0.5cm">
             Next print run closes in
             <span id="print-run-hours">6</span>
-            hours &mdash;
+            <span id="print-run-hours-label">hours</span>
+            &mdash;
             &lt;<span id="print-run-slots"></span> slots remain
           </p>
         </div>

--- a/js/index.js
+++ b/js/index.js
@@ -310,6 +310,7 @@ function computePrintRunHours() {
 
 async function updatePrintRunInfo() {
   const hoursEl = document.getElementById("print-run-hours");
+  const hoursLabelEl = document.getElementById("print-run-hours-label");
   const slotsEl = document.getElementById("print-run-slots");
   const info = document.getElementById("print-run-info");
   if (!hoursEl && !slotsEl) return;
@@ -325,7 +326,9 @@ async function updatePrintRunInfo() {
   } catch {
     /* ignore */
   }
-  hoursEl.textContent = computePrintRunHours();
+  const hours = computePrintRunHours();
+  hoursEl.textContent = hours;
+  if (hoursLabelEl) hoursLabelEl.textContent = hours === 1 ? "hour" : "hours";
   if (slotsEl) slotsEl.textContent = `${adjustedSlots(baseSlots) + 1}`;
 
   if (info) info.classList.remove("invisible");


### PR DESCRIPTION
## Summary
- adjust print run info to show `hour` when one hour remains
- update client JS to set the correct label

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_68567852af0c832daff1018d76ae472b