### PR TITLE
Extend viewer in fullscreen

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,6 +139,11 @@
       .purchase-fade {
         animation: purchaseFade 10s forwards;
       }
+
+      /* Taller preview when browser UI is hidden */
+      #preview-wrapper.fullscreen-height {
+        height: 24rem; /* h-96 */
+      }
     </style>
   </head>
 
@@ -350,7 +355,6 @@
           </p>
         </div>
         <div
-
           id="print-run-info"
           class="absolute text-right text-sm text-red-400 leading-snug invisible"
         >
@@ -358,8 +362,7 @@
             Next print run closes in
             <span id="print-run-hours">6</span>
             <span id="print-run-hours-label">hours</span>
-            &mdash;
-            &lt;<span id="print-run-slots"></span> slots remain
+            &mdash; &lt;<span id="print-run-slots"></span> slots remain
           </p>
         </div>
       </div>
@@ -582,8 +585,6 @@
           info.style.transform = "translateY(-50%)";
         }
 
-
-
         quote.classList.remove("invisible");
       }
 
@@ -628,5 +629,20 @@
       class="fixed bottom-28 left-4 bg-black/80 text-white px-3 py-1 rounded hidden opacity-0 text-sm flex items-center space-x-2"
     ></div>
     <img src="/pixel" alt="" width="1" height="1" style="display: none" />
+    <script type="module">
+      function adjustViewerHeight() {
+        const wrapper = document.getElementById("preview-wrapper");
+        if (!wrapper) return;
+        const fullscreen = Math.abs(window.innerHeight - screen.height) < 5;
+        if (fullscreen) {
+          wrapper.classList.add("fullscreen-height");
+        } else {
+          wrapper.classList.remove("fullscreen-height");
+        }
+      }
+
+      window.addEventListener("DOMContentLoaded", adjustViewerHeight);
+      window.addEventListener("resize", adjustViewerHeight);
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add fullscreen-height class to extend 3D viewer when browser chrome is hidden
- toggle the class on resize to keep the upload controls closer to the wizard

## Testing
- `npm run format`
- `npm test`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_6856815b6cf8832dacdee77895245b21