### PR TITLE
Fix checkout summary layout

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -155,11 +155,11 @@
 
         <!-- Checkout Form -->
         <div
-          class="relative w-full md:w-1/2 max-w-md bg-[#2A2A2E] border border-white/10 rounded-3xl p-6"
+          class="relative w-full md:w-1/2 max-w-md bg-[#2A2A2E] border border-white/10 rounded-3xl p-6 flex flex-col h-full"
         >
           <h2 class="text-2xl font-semibold mb-2 text-center">Checkout</h2>
           <div id="bundle-banner" class="text-[#30D5C8] text-center text-sm mb-2 hidden"></div>
-          <form id="checkout-form" class="space-y-[0.33rem]">
+          <form id="checkout-form" class="space-y-[0.33rem] flex-1">
             <!-- Material/Size Options -->
             <fieldset id="material-options" class="flex w-full justify-between my-4">
               <label
@@ -386,7 +386,7 @@
               Pay &pound;39.99 (2 prints)
             </button>
           </form>
-          <div class="mt-2 flex flex-wrap items-center justify-between text-xs gap-2">
+          <div class="mt-auto flex flex-wrap items-center justify-between text-xs gap-2">
             <p class="text-red-300">
               Only <span id="slot-count" style="visibility: hidden"></span> prints left
             </p>


### PR DESCRIPTION
## Summary
- ensure checkout container is a flex column
- allow the form to grow within the card
- pin the payment summary elements to the bottom

## Testing
- `npm run ci`
- `npm run format` (in `backend/`)
- `npm test` (in `backend/`)

------
https://chatgpt.com/codex/tasks/task_e_685680fcabf0832d90a847464340f255