### PR TITLE
Fix signup error message placement

### DIFF
--- a/signup.html
+++ b/signup.html
@@ -125,28 +125,22 @@
             aria-label="Password"
           />
           <div class="flex items-center">
-            <div class="relative flex flex-col items-start">
+            <div class="flex flex-col items-start">
               <button
                 class="bg-[#30D5C8] text-[#1A1A1D] font-semibold px-4 py-2 rounded-xl hover:bg-[#28b7a8] transition"
                 type="submit"
               >
                 Sign Up
               </button>
-
-              <div
-                id="error"
-                class="absolute top-full left-0 ml-4 mt-1 text-red-400 whitespace-nowrap"
-                aria-live="assertive"
-              ></div>
             </div>
           </div>
         </form>
-        <div
-          id="error"
-          class="absolute top-full left-0 ml-4 mt-1 text-red-400 whitespace-nowrap"
-          aria-live="assertive"
-        ></div>
       </div>
+      <div
+        id="error"
+        class="mt-2 text-red-400 text-center"
+        aria-live="assertive"
+      ></div>
     </main>
     <script type="module" src="js/signup.js"></script>
     <script type="module">


### PR DESCRIPTION
## Summary
- show signup error message below signup box outside the form

## Testing
- `npm run format` (backend)
- `npm test` (backend)


------
https://chatgpt.com/codex/tasks/task_e_68567fdfb864832d95779d346b1406d1