### PR TITLE
Fix discount popup link

### DIFF
--- a/index.html
+++ b/index.html
@@ -484,11 +484,10 @@
           Sale ends tonight! Use code
           <span class="text-white font-mono px-1">SAVE5</span> for 5% off.
         </p>
-        <p class="text-gray-200 text-sm">
-          <a href="signup.html" class="font-bold text-[#30D5C8]"
-            >Sign up to hear when discounts are available</a
-          >
-        </p>
+          <p class="text-gray-200 text-sm">
+            <a href="signup.html" class="font-bold text-[#30D5C8]">Sign up</a>
+            to hear when discounts are available
+          </p>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- update exit discount popup so only **Sign up** is blue and clickable

## Testing
- `npm run format`
- `npm test`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_68568c7866cc832dbd69d43f49e856df