### PR TITLE
Add rainbow shimmer effect to multi-colour payment option

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -45,6 +45,32 @@
       src="https://cdn.jsdelivr.net/npm/@google/model-viewer@1.12.0/dist/model-viewer-legacy.js"
       defer
     ></script>
+    <style>
+      /* Add rainbow shimmer effect used on the index submit arrow */
+      #multi-color-button {
+        position: relative;
+        overflow: hidden;
+      }
+      #multi-color-button::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(
+          120deg,
+          rgba(255, 255, 255, 0) 0%,
+          rgba(255, 0, 255, 0.3) 15%,
+          rgba(0, 255, 255, 0.3) 85%,
+          rgba(255, 255, 255, 0) 100%
+        );
+        transform: translateX(-100%);
+        animation: shimmer 3s ease-in-out infinite;
+      }
+      @keyframes shimmer {
+        to {
+          transform: translateX(100%);
+        }
+      }
+    </style>
   </head>
 
   <body class="bg-[#1A1A1D] text-white font-sans min-h-screen flex flex-col">
@@ -180,6 +206,7 @@
                   checked
                 />
                 <span
+                  id="multi-color-button"
                   class="w-28 h-28 flex flex-col items-center justify-center rounded-full border-4 border-white/20 shadow-xl peer-checked:border-[#30D5C8]"
                 >
                   <span class="font-semibold leading-none">£39.99</span>


### PR DESCRIPTION
## Summary
- apply old rainbow shimmer animation from the index arrow to the £39.99 multi-colour payment option

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6856c6d34d30832d9fef38913812d554