### PR TITLE
Add most popular tag to payment page

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -192,6 +192,7 @@
                   Only <span id="color-slot-count" style="visibility: hidden"></span> coloured
                   prints left
                 </span>
+                <span class="block text-xs mt-1 text-white w-28">(most popular)</span>
               </label>
 
                          <label


### PR DESCRIPTION
## Summary
- update payment page to show a new '(most popular)' notice below the multi-colour option
- ran formatting and backend tests

## Testing
- `npm run format` in `backend/`
- `npm test` in `backend/`

------
https://chatgpt.com/codex/tasks/task_e_6856c63453f4832d85807c677bcf2159