### PR TITLE
Refine Dockerfile for Node 20 build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,60 +1,70 @@
 # syntax=docker/dockerfile:1
 
-### Builder stage
+# -------- builder stage
 FROM node:20 AS builder
-WORKDIR /app
 
-# Accept proxy build arguments
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 
-# Disable Husky hooks and npm lifecycle scripts
+WORKDIR /app
+
+# Disable Husky and npm lifecycle scripts
 ENV HUSKY=0 NPM_CONFIG_IGNORE_SCRIPTS=true
 
-# Install root dependencies
+# -------- install root dependencies
 COPY package.json package-lock.json ./
-RUN unset NPM_CONFIG_HTTP_PROXY NPM_CONFIG_HTTPS_PROXY || true && \
-    if [ -n "$HTTP_PROXY" ]; then npm config set proxy "$HTTP_PROXY"; fi && \
-    if [ -n "$HTTPS_PROXY" ]; then npm config set https-proxy "$HTTPS_PROXY"; fi && \
-    npm install && npm ci --omit=dev
+RUN unset NPM_CONFIG_HTTP_PROXY NPM_CONFIG_HTTPS_PROXY || true \
+    && if [ -n "$HTTP_PROXY" ]; then npm config set proxy "$HTTP_PROXY"; fi \
+    && if [ -n "$HTTPS_PROXY" ]; then npm config set https-proxy "$HTTPS_PROXY"; fi \
+    && npm ci --no-audit --no-fund
 
-# Install backend dependencies
+# -------- install backend dependencies
 COPY backend/package.json backend/package-lock.json ./backend/
-RUN unset NPM_CONFIG_HTTP_PROXY NPM_CONFIG_HTTPS_PROXY || true && \
-    if [ -n "$HTTP_PROXY" ]; then npm config set proxy "$HTTP_PROXY"; fi && \
-    if [ -n "$HTTPS_PROXY" ]; then npm config set https-proxy "$HTTPS_PROXY"; fi && \
-    npm install --prefix backend && npm ci --omit=dev --prefix backend
+RUN unset NPM_CONFIG_HTTP_PROXY NPM_CONFIG_HTTPS_PROXY || true \
+    && if [ -n "$HTTP_PROXY" ]; then npm config set proxy "$HTTP_PROXY"; fi \
+    && if [ -n "$HTTPS_PROXY" ]; then npm config set https-proxy "$HTTPS_PROXY"; fi \
+    && npm ci --no-audit --no-fund --prefix backend
 
-# Install hunyuan_server dependencies
+# -------- install hunyuan_server dependencies if present
 COPY backend/hunyuan_server/package.json backend/hunyuan_server/package-lock.json ./backend/hunyuan_server/
-RUN unset NPM_CONFIG_HTTP_PROXY NPM_CONFIG_HTTPS_PROXY || true && \
-    if [ -n "$HTTP_PROXY" ]; then npm config set proxy "$HTTP_PROXY"; fi && \
-    if [ -n "$HTTPS_PROXY" ]; then npm config set https-proxy "$HTTPS_PROXY"; fi && \
-    npm install --prefix backend/hunyuan_server && npm ci --omit=dev --prefix backend/hunyuan_server
+RUN if [ -f backend/hunyuan_server/package-lock.json ]; then \
+        unset NPM_CONFIG_HTTP_PROXY NPM_CONFIG_HTTPS_PROXY || true && \
+        if [ -n "$HTTP_PROXY" ]; then npm config set proxy "$HTTP_PROXY"; fi && \
+        if [ -n "$HTTPS_PROXY" ]; then npm config set https-proxy "$HTTPS_PROXY"; fi && \
+        npm ci --no-audit --no-fund --prefix backend/hunyuan_server; \
+    fi
 
-# Copy the rest of the source and run the build script
+# -------- copy source and run CI
 COPY . .
 RUN npm run ci
 
-### Runtime stage
-FROM node:20 AS runner
-WORKDIR /app
+# -------- prune dev dependencies
+RUN npm prune --production \
+    && npm prune --production --prefix backend \
+    && if [ -f backend/hunyuan_server/package-lock.json ]; then npm prune --production --prefix backend/hunyuan_server; fi
 
-# Accept the same proxy build arguments
+# -------- runtime stage
+FROM node:20
+
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 
-# Disable lifecycle scripts during install
+WORKDIR /app
+
 ENV HUSKY=0 NPM_CONFIG_IGNORE_SCRIPTS=true
 
-# Configure npm proxy if provided
-RUN unset NPM_CONFIG_HTTP_PROXY NPM_CONFIG_HTTPS_PROXY || true && \
-    if [ -n "$HTTP_PROXY" ]; then npm config set proxy "$HTTP_PROXY"; fi && \
-    if [ -n "$HTTPS_PROXY" ]; then npm config set https-proxy "$HTTPS_PROXY"; fi
+RUN unset NPM_CONFIG_HTTP_PROXY NPM_CONFIG_HTTPS_PROXY || true
 
-# Bring over built source and install production deps
+# Copy production dependencies and built app
+COPY --from=builder /app/package.json /app/package-lock.json ./
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/backend/package.json /app/backend/package-lock.json ./backend/
+COPY --from=builder /app/backend/node_modules ./backend/node_modules
+COPY --from=builder /app/backend/hunyuan_server/package.json /app/backend/hunyuan_server/package-lock.json ./backend/hunyuan_server/
+COPY --from=builder /app/backend/hunyuan_server/node_modules ./backend/hunyuan_server/node_modules
+
 COPY --from=builder /app .
-RUN npm ci --only=production && npm ci --only=production --prefix backend && npm ci --only=production --prefix backend/hunyuan_server
 
-# Start the backend by default
+EXPOSE 3000
+
 CMD ["npm","start","--prefix","backend"]


### PR DESCRIPTION
## Summary
- rework Dockerfile to follow two-stage build for monorepo

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_6856cd6ceb50832d97b98cd4acc39919