### PR TITLE
Add dynamic usernames for purchase popups

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -499,6 +499,18 @@ app.get("/api/stats", (req, res) => {
   }
 });
 
+app.get("/api/usernames", async (req, res) => {
+  try {
+    const { rows } = await db.query(
+      "SELECT username FROM users ORDER BY RANDOM() LIMIT 10",
+    );
+    res.json(rows.map((r) => r.username));
+  } catch (err) {
+    logError(err);
+    res.status(500).json({ error: "Failed to fetch usernames" });
+  }
+});
+
 app.get("/api/campaign", (req, res) => {
   res.json(campaigns);
 });

--- a/backend/tests/additionalApi.test.js
+++ b/backend/tests/additionalApi.test.js
@@ -649,3 +649,12 @@ test('GET /api/competitions/winners returns list', async () => {
   const res = await request(app).get('/api/competitions/winners');
   expect([200, 404]).toContain(res.status);
 });
+
+test('GET /api/usernames returns list', async () => {
+  db.query.mockResolvedValueOnce({ rows: [{ username: 'alice' }, { username: 'bob' }] });
+  const res = await request(app).get('/api/usernames');
+  expect(res.status).toBe(200);
+  expect(Array.isArray(res.body)).toBe(true);
+  const call = db.query.mock.calls.find((c) => c[0].includes('SELECT username'));
+  expect(call).toBeDefined();
+});

--- a/js/index.js
+++ b/js/index.js
@@ -1029,10 +1029,27 @@ async function init() {
   setInterval(updateCutoff, 60000);
 
   const popupEl = document.getElementById("purchase-popups");
-  const popupMsgs = [
-    "Anna from NY just purchased",
-    "Tom from London bought a print",
+  let popupMsgs = [
+    "Someone recently bought a print",
+    "Someone recently created a model",
   ];
+  async function loadPopupNames() {
+    try {
+      const res = await fetch(`${API_BASE}/usernames`);
+      if (res.ok) {
+        const names = await res.json();
+        if (Array.isArray(names) && names.length >= 2) {
+          popupMsgs = [
+            `${names[0]} recently bought a print`,
+            `${names[1]} recently created a model`,
+          ];
+        }
+      }
+    } catch {
+      /* ignore errors */
+    }
+  }
+  loadPopupNames();
   let popupIdx = 0;
   function showPopup() {
     if (!popupEl) return;


### PR DESCRIPTION
## Summary
- add `/api/usernames` endpoint to fetch random usernames
- show recent user activity in index page popups
- test new endpoint

## Testing
- `npx prettier --write backend/server.js js/index.js backend/tests/additionalApi.test.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856d8b070c0832da7089fe488b80db3