### PR TITLE
Fix quantity layout on payment page

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -289,9 +289,9 @@
             </label>
 
             </fieldset>
-            <div class="flex flex-col items-center mt-2 text-white text-sm">
+            <div class="flex items-center gap-2 mt-2 text-white text-sm">
               <span>Quantity:</span>
-              <div class="flex items-center gap-2 mt-1">
+              <div class="flex items-center gap-2">
                 <button
                   type="button"
                   id="qty-increment"
@@ -316,7 +316,7 @@
                   class="w-12 text-center bg-[#1A1A1D] border border-white/20 rounded"
                 />
               </div>
-              <p id="bulk-discount-msg" class="text-xs mt-1 hidden"></p>
+              <p id="bulk-discount-msg" class="text-xs hidden whitespace-nowrap ml-2"></p>
             </div>
 
             <div>


### PR DESCRIPTION
## Summary
- keep the quantity selector and promo message on one line in **payment.html**

## Testing
- `npm run format` in `backend/`
- `npm test` in `backend/` *(all 60 tests passed)*
- `npm run ci` *(fails: ESLint couldn't find a config file)*

------
https://chatgpt.com/codex/tasks/task_e_6856dd555814832d880cc51313074383