### PR TITLE
Improve purchase popup fade

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,6 +124,9 @@
       }
       @keyframes purchaseFade {
         0% {
+          opacity: 0;
+        }
+        25% {
           opacity: 1;
         }
         75% {


### PR DESCRIPTION
## Summary
- animate purchase popup from 0% to 100% opacity over 2s and shorten visible time

## Testing
- `npm run format` (backend)
- `npm test` (backend)


------
https://chatgpt.com/codex/tasks/task_e_6856df64f5f0832d86c600ca892420ef