### PR TITLE
Fix branding typos

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -414,7 +414,7 @@
             <div id="credit-option" class="my-2 text-sm hidden">
               <label class="flex items-center gap-1">
                 <input type="checkbox" id="use-credit" class="accent-[#30D5C8]" />
-                Use Print Club credit (<span id="credits-remaining">0</span> left this week)
+                Use print2 pro credit (<span id="credits-remaining">0</span> left this week)
               </label>
             </div>
 

--- a/print2pro-checkout.html
+++ b/print2pro-checkout.html
@@ -57,7 +57,7 @@
         <p class="text-center text-white mb-6">
           You must first
           <a href="signup.html" class="font-bold text-[#30D5C8]">Sign Up</a>
-          before joining Print Club.
+          before joining print2 pro.
         </p>
         <form id="checkout-form" class="space-y-2 w-full mt-4">
           <div>
@@ -119,8 +119,7 @@
               <span id="printclub-price">Join print2 pro &pound;149.99/mo</span>
             </label>
           </fieldset>
-          <div id="payment-element" class="text-center text-gray-400">
-          </div>
+          <div id="payment-element" class="text-center text-gray-400"></div>
           <button
             id="submit-payment"
             type="button"


### PR DESCRIPTION
## Summary
- replace last 'Print Club' branding references

## Testing
- `npm run format`
- `npm test --prefix backend`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_6857bde941c8832d871cceb2d5dd7a0e