### PR TITLE
Add login reminder on rewards page

### DIFF
--- a/earn-rewards.html
+++ b/earn-rewards.html
@@ -5,7 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Earn Rewards</title>
     <meta property="og:title" content="Earn Rewards – print2" />
-    <meta property="og:description" content="Learn how to earn rewards on print2." />
+    <meta
+      property="og:description"
+      content="Learn how to earn rewards on print2."
+    />
     <meta property="og:image" content="img/boxlogo.png" />
     <script src="js/applyColorScheme.js"></script>
     <script src="https://cdn.tailwindcss.com"></script>
@@ -28,12 +31,15 @@
             stroke-width="2"
             viewBox="0 0 24 24"
           >
-            <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M15 19l-7-7 7-7"
+            />
           </svg>
           Back
         </a>
         <h1 class="flex-1 text-center text-3xl font-semibold">Earn Rewards</h1>
-
       </div>
       <div class="flex items-center space-x-4 ml-4">
         <a
@@ -83,12 +89,22 @@
     </header>
     <main class="flex-1 flex items-center justify-center px-4">
       <div class="max-w-lg space-y-4 text-center">
+        <p>
+          You must
+          <a href="login.html" class="font-bold text-[#30D5C8]">Log In</a>
+          or
+          <a href="signup.html" class="font-bold text-[#30D5C8]">Sign Up</a>
+          to get rewards.
+        </p>
         <p class="text-lg">
-          Invite friends to try print2 using your personal link below. When they sign up and place
-          orders you'll earn points that can be redeemed for discounts on future prints.
+          Invite friends to try print2 using your personal link below. When they
+          sign up and place orders you'll earn points that can be redeemed for
+          discounts on future prints.
         </p>
         <div>
-          <label for="referral-link" class="block text-sm mb-1">Your referral link</label>
+          <label for="referral-link" class="block text-sm mb-1"
+            >Your referral link</label
+          >
           <div class="flex">
             <input
               id="referral-link"
@@ -106,20 +122,32 @@
           </div>
         </div>
         <div>
-          <label class="block text-sm mb-1">Points: <span id="reward-points">0</span> ⭐</label>
-          <progress id="reward-progress" value="0" max="100" class="w-full h-3"></progress>
+          <label class="block text-sm mb-1"
+            >Points: <span id="reward-points">0</span> ⭐</label
+          >
+          <progress
+            id="reward-progress"
+            value="0"
+            max="100"
+            class="w-full h-3"
+          ></progress>
           <div class="mt-3 flex">
             <select
               id="reward-select"
               class="bg-[#2A2A2E] border border-white/10 rounded-l-xl px-2 py-1 flex-1"
             ></select>
-            <button class="bg-blue-600 px-3 rounded-r-xl" onclick="redeemReward()">Redeem</button>
+            <button
+              class="bg-blue-600 px-3 rounded-r-xl"
+              onclick="redeemReward()"
+            >
+              Redeem
+            </button>
           </div>
         </div>
       </div>
     </main>
     <script type="module">
-      import { shareOn } from './js/share.js';
+      import { shareOn } from "./js/share.js";
       window.shareOn = shareOn;
     </script>
     <script type="module" src="js/rewards.js"></script>
@@ -130,7 +158,8 @@
       <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center">
         <h2 class="text-2xl font-semibold mb-2">print2 pro</h2>
         <p class="mb-4">
-          Get two prints (single or multicolour tiers) every week for £149.99/month.
+          Get two prints (single or multicolour tiers) every week for
+          £149.99/month.
         </p>
         <button
           id="printclub-close"


### PR DESCRIPTION
## Summary
- prompt users to log in or sign up before they can use rewards

## Testing
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_6857bf782124832d98950238e2dd4744