### PR TITLE
Add highlight for selected pricing tier

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -80,6 +80,20 @@
       #print-qty {
         -moz-appearance: textfield;
       }
+
+      /* Highlight the selected pricing tier */
+      #material-options label span {
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+      }
+      #material-options label:hover span,
+      #material-options input:active + span {
+        transform: scale(1.04);
+      }
+      #material-options input:checked + span {
+        transform: scale(1.04);
+        box-shadow: 0 0 10px rgba(48, 213, 200, 0.6),
+          0 6px 10px rgba(0, 0, 0, 0.6);
+      }
     </style>
   </head>
 


### PR DESCRIPTION
## Summary
- style the pricing tier buttons so the chosen option scales and glows

## Testing
- `npm run format` in `backend`
- `npm test` in `backend`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_6857c13ec1bc832da830ea9303827547