### PR TITLE
Fix color menu closing behavior

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -624,6 +624,8 @@ async function initPaymentPage() {
     colorMenu.addEventListener("click", (ev) => {
       const btn = ev.target.closest("button[data-color]");
       if (btn) {
+        // Prevent click from bubbling and reopening the menu
+        ev.stopPropagation();
         const color = btn.dataset.color;
         singleButton.style.backgroundColor = color;
 


### PR DESCRIPTION
## Summary
- close the single-color menu once a color is chosen on the payment page

## Testing
- `npm run format` in `backend`
- `npm test` in `backend`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_6857bfbe9840832d9b93105efafa53cd