### PR TITLE
Add loyalty milestones for print2 pro

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -119,6 +119,16 @@ async function incrementCreditsUsed(userId, amount = 1) {
   );
 }
 
+async function getSubscriptionDurationMonths(userId) {
+  const { rows } = await query(
+    `SELECT EXTRACT(year FROM age(NOW(), created_at)) * 12 + EXTRACT(month FROM age(NOW(), created_at)) AS months
+       FROM subscriptions WHERE user_id=$1`,
+    [userId],
+  );
+  if (!rows.length || rows[0].months === null) return 0;
+  return Math.floor(Number(rows[0].months));
+}
+
 async function getOrCreateReferralLink(userId) {
   const { rows } = await query(
     "SELECT code FROM referral_links WHERE user_id=$1",
@@ -824,6 +834,7 @@ module.exports = {
   ensureCurrentWeekCredits,
   getCurrentWeekCredits,
   incrementCreditsUsed,
+  getSubscriptionDurationMonths,
   updateWeeklyOrderStreak,
   getOrCreateReferralLink,
   getRewardPoints,

--- a/backend/server.js
+++ b/backend/server.js
@@ -848,16 +848,20 @@ app.get("/api/subscription/credits", authRequired, async (req, res) => {
 app.get("/api/subscription/summary", authRequired, async (req, res) => {
   try {
     await db.ensureCurrentWeekCredits(req.user.id, 2);
-    const [sub, credits] = await Promise.all([
+    const [sub, credits, months] = await Promise.all([
       db.getSubscription(req.user.id),
       db.getCurrentWeekCredits(req.user.id),
+      db.getSubscriptionDurationMonths(req.user.id),
     ]);
+    const milestone = months >= 12 ? 12 : months >= 6 ? 6 : months >= 3 ? 3 : 0;
     res.json({
       subscription: sub || { active: false },
       credits: {
         remaining: credits.total_credits - credits.used_credits,
         total: credits.total_credits,
       },
+      months_subscribed: months,
+      milestone,
     });
   } catch (err) {
     logError(err);

--- a/backend/tests/subscriptions.test.js
+++ b/backend/tests/subscriptions.test.js
@@ -1,33 +1,40 @@
-process.env.STRIPE_SECRET_KEY = 'test';
-process.env.STRIPE_WEBHOOK_SECRET = 'whsec';
-process.env.DB_URL = 'postgres://user:pass@localhost/db';
-process.env.HUNYUAN_API_KEY = 'test';
-process.env.HUNYUAN_SERVER_URL = 'http://localhost:4000';
+process.env.STRIPE_SECRET_KEY = "test";
+process.env.STRIPE_WEBHOOK_SECRET = "whsec";
+process.env.DB_URL = "postgres://user:pass@localhost/db";
+process.env.HUNYUAN_API_KEY = "test";
+process.env.HUNYUAN_SERVER_URL = "http://localhost:4000";
 
-jest.mock('../db', () => ({
+jest.mock("../db", () => ({
   query: jest.fn().mockResolvedValue({ rows: [] }),
   insertCommission: jest.fn().mockResolvedValue({}),
-  upsertSubscription: jest.fn().mockResolvedValue({ id: 's1', status: 'active' }),
-  cancelSubscription: jest.fn().mockResolvedValue({ id: 's1', status: 'canceled' }),
-  getSubscription: jest.fn().mockResolvedValue({ id: 's1', status: 'active' }),
+  upsertSubscription: jest
+    .fn()
+    .mockResolvedValue({ id: "s1", status: "active" }),
+  cancelSubscription: jest
+    .fn()
+    .mockResolvedValue({ id: "s1", status: "canceled" }),
+  getSubscription: jest.fn().mockResolvedValue({ id: "s1", status: "active" }),
   ensureCurrentWeekCredits: jest.fn(),
-  getCurrentWeekCredits: jest.fn().mockResolvedValue({ total_credits: 2, used_credits: 1 }),
+  getCurrentWeekCredits: jest
+    .fn()
+    .mockResolvedValue({ total_credits: 2, used_credits: 1 }),
   incrementCreditsUsed: jest.fn(),
+  getSubscriptionDurationMonths: jest.fn().mockResolvedValue(0),
   insertSubscriptionEvent: jest.fn(),
   getSubscriptionMetrics: jest.fn(),
   getOrCreateOrderReferralLink: jest.fn(),
   insertReferredOrder: jest.fn(),
 }));
-const db = require('../db');
+const db = require("../db");
 
-jest.mock('stripe');
-const Stripe = require('stripe');
+jest.mock("stripe");
+const Stripe = require("stripe");
 const stripeMock = { billingPortal: { sessions: { create: jest.fn() } } };
 Stripe.mockImplementation(() => stripeMock);
 
-const request = require('supertest');
-const app = require('../server');
-const jwt = require('jsonwebtoken');
+const request = require("supertest");
+const app = require("../server");
+const jwt = require("jsonwebtoken");
 
 beforeEach(() => {
   db.upsertSubscription.mockClear();
@@ -39,73 +46,78 @@ beforeEach(() => {
   db.getSubscriptionMetrics.mockClear();
 });
 
-test('GET /api/subscription returns subscription', async () => {
-  const token = jwt.sign({ id: 'u1' }, 'secret');
-  const res = await request(app).get('/api/subscription').set('authorization', `Bearer ${token}`);
+test("GET /api/subscription returns subscription", async () => {
+  const token = jwt.sign({ id: "u1" }, "secret");
+  const res = await request(app)
+    .get("/api/subscription")
+    .set("authorization", `Bearer ${token}`);
   expect(res.status).toBe(200);
-  expect(res.body.status).toBe('active');
+  expect(res.body.status).toBe("active");
 });
 
-test('POST /api/subscription creates record', async () => {
-  const token = jwt.sign({ id: 'u1' }, 'secret');
+test("POST /api/subscription creates record", async () => {
+  const token = jwt.sign({ id: "u1" }, "secret");
   const res = await request(app)
-    .post('/api/subscription')
-    .set('authorization', `Bearer ${token}`)
+    .post("/api/subscription")
+    .set("authorization", `Bearer ${token}`)
     .send({});
   expect(res.status).toBe(200);
   expect(db.upsertSubscription).toHaveBeenCalled();
 });
 
-test('GET /api/subscription/credits returns remaining', async () => {
-  const token = jwt.sign({ id: 'u1' }, 'secret');
+test("GET /api/subscription/credits returns remaining", async () => {
+  const token = jwt.sign({ id: "u1" }, "secret");
   const res = await request(app)
-    .get('/api/subscription/credits')
-    .set('authorization', `Bearer ${token}`);
+    .get("/api/subscription/credits")
+    .set("authorization", `Bearer ${token}`);
   expect(res.status).toBe(200);
   expect(res.body.remaining).toBe(1);
 });
 
-test('GET /api/subscription/summary returns subscription and credits', async () => {
-  const token = jwt.sign({ id: 'u1' }, 'secret');
+test("GET /api/subscription/summary returns subscription and credits", async () => {
+  const token = jwt.sign({ id: "u1" }, "secret");
   const res = await request(app)
-    .get('/api/subscription/summary')
-    .set('authorization', `Bearer ${token}`);
+    .get("/api/subscription/summary")
+    .set("authorization", `Bearer ${token}`);
   expect(res.status).toBe(200);
-  expect(res.body.subscription.status).toBe('active');
+  expect(res.body.subscription.status).toBe("active");
   expect(res.body.credits.remaining).toBe(1);
 });
 
-test('POST /api/subscription/portal returns url', async () => {
-  db.getSubscription.mockResolvedValueOnce({ stripe_customer_id: 'cus_1' });
-  stripeMock.billingPortal.sessions.create.mockResolvedValueOnce({ url: 'u' });
-  const token = jwt.sign({ id: 'u1' }, 'secret');
+test("POST /api/subscription/portal returns url", async () => {
+  db.getSubscription.mockResolvedValueOnce({ stripe_customer_id: "cus_1" });
+  stripeMock.billingPortal.sessions.create.mockResolvedValueOnce({ url: "u" });
+  const token = jwt.sign({ id: "u1" }, "secret");
   const res = await request(app)
-    .post('/api/subscription/portal')
-    .set('authorization', `Bearer ${token}`);
+    .post("/api/subscription/portal")
+    .set("authorization", `Bearer ${token}`);
   expect(res.status).toBe(200);
-  expect(res.body.url).toBe('u');
+  expect(res.body.url).toBe("u");
   expect(stripeMock.billingPortal.sessions.create).toHaveBeenCalled();
 });
 
-test('POST /api/subscription/portal 404 without customer', async () => {
+test("POST /api/subscription/portal 404 without customer", async () => {
   db.getSubscription.mockResolvedValueOnce(null);
-  const token = jwt.sign({ id: 'u1' }, 'secret');
+  const token = jwt.sign({ id: "u1" }, "secret");
   const res = await request(app)
-    .post('/api/subscription/portal')
-    .set('authorization', `Bearer ${token}`);
+    .post("/api/subscription/portal")
+    .set("authorization", `Bearer ${token}`);
   expect(res.status).toBe(404);
 });
 
-test('GET /api/admin/subscription-metrics requires admin', async () => {
-  const res = await request(app).get('/api/admin/subscription-metrics');
+test("GET /api/admin/subscription-metrics requires admin", async () => {
+  const res = await request(app).get("/api/admin/subscription-metrics");
   expect(res.status).toBe(401);
 });
 
-test('GET /api/admin/subscription-metrics returns data', async () => {
-  db.getSubscriptionMetrics.mockResolvedValueOnce({ active: 5, churn_last_30_days: 2 });
+test("GET /api/admin/subscription-metrics returns data", async () => {
+  db.getSubscriptionMetrics.mockResolvedValueOnce({
+    active: 5,
+    churn_last_30_days: 2,
+  });
   const res = await request(app)
-    .get('/api/admin/subscription-metrics')
-    .set('x-admin-token', 'admin');
+    .get("/api/admin/subscription-metrics")
+    .set("x-admin-token", "admin");
   expect(res.status).toBe(200);
   expect(res.body.active).toBe(5);
   expect(res.body.churn_last_30_days).toBe(2);

--- a/js/account.js
+++ b/js/account.js
@@ -1,94 +1,111 @@
-import { fetchWithCache } from './apiCache.js';
+import { fetchWithCache } from "./apiCache.js";
 
-const API_BASE = (window.API_ORIGIN || '') + '/api';
+const API_BASE = (window.API_ORIGIN || "") + "/api";
 
 async function loadProfile() {
-  const token = localStorage.getItem('token');
+  const token = localStorage.getItem("token");
   if (!token) {
-    window.location.href = 'login.html';
+    window.location.href = "login.html";
     return;
   }
   const data = await fetchWithCache(
     `${API_BASE}/me`,
     { headers: { Authorization: `Bearer ${token}` } },
-    'me'
+    "me",
   );
-  document.getElementById('mp-username').textContent = data.username;
-  document.getElementById('mp-email').textContent = data.email;
-  const displayEl = document.getElementById('mp-display');
-  if (displayEl) displayEl.textContent = data.displayName || '';
+  document.getElementById("mp-username").textContent = data.username;
+  document.getElementById("mp-email").textContent = data.email;
+  const displayEl = document.getElementById("mp-display");
+  if (displayEl) displayEl.textContent = data.displayName || "";
 }
 
 async function loadSubscription() {
-  const token = localStorage.getItem('token');
+  const token = localStorage.getItem("token");
   if (!token) return;
   try {
-    const { subscription: sub, credits } = await fetchWithCache(
+    const {
+      subscription: sub,
+      credits,
+      months_subscribed: months,
+      milestone,
+    } = await fetchWithCache(
       `${API_BASE}/subscription/summary`,
       { headers: { Authorization: `Bearer ${token}` } },
-      'subscription-summary'
+      "subscription-summary",
     );
-    const container = document.getElementById('subscription-progress');
-    const previews = document.getElementById('design-previews');
-    const tcStatus = document.getElementById('time-capsule-status');
-    const manage = document.getElementById('manage-subscription');
-    if (!sub || sub.active === false || sub.status === 'canceled') {
+    const container = document.getElementById("subscription-progress");
+    const previews = document.getElementById("design-previews");
+    const tcStatus = document.getElementById("time-capsule-status");
+    const manage = document.getElementById("manage-subscription");
+    if (!sub || sub.active === false || sub.status === "canceled") {
       if (manage) {
-        manage.textContent = 'Join print2 pro';
+        manage.textContent = "Join print2 pro";
         manage.onclick = () => {
-          window.location.href = 'print2pro-checkout.html';
+          window.location.href = "print2pro-checkout.html";
         };
       }
-      previews?.classList.add('hidden');
+      previews?.classList.add("hidden");
       return;
     }
-    if (container) container.classList.remove('hidden');
-    previews?.classList.remove('hidden');
+    if (container) container.classList.remove("hidden");
+    previews?.classList.remove("hidden");
     const used = credits.total - credits.remaining;
     const pct = credits.total ? (used / credits.total) * 100 : 0;
-    const bar = document.getElementById('credit-bar');
+    const bar = document.getElementById("credit-bar");
     if (bar) bar.style.width = `${pct}%`;
-    document.getElementById('credits-used').textContent = used;
-    document.getElementById('credits-total').textContent = credits.total;
+    document.getElementById("credits-used").textContent = used;
+    document.getElementById("credits-total").textContent = credits.total;
+    const loyalty = document.getElementById("loyalty-info");
+    if (loyalty) {
+      if (milestone >= 12)
+        loyalty.textContent = "1-year member! +4 bonus prints each week";
+      else if (milestone >= 6)
+        loyalty.textContent = "6-month member! +2 bonus prints each week";
+      else if (milestone >= 3)
+        loyalty.textContent = "3-month member! +1 bonus print each week";
+      else
+        loyalty.textContent = `Member for ${months} month${months === 1 ? "" : "s"}`;
+    }
     if (manage) {
-      manage.textContent = 'Manage subscription';
+      manage.textContent = "Manage subscription";
       manage.onclick = openPortal;
     }
 
     if (tcStatus) {
-      const text = tcStatus.querySelector('#time-capsule-text');
-      const btn = tcStatus.querySelector('#time-capsule-action');
-      const active = localStorage.getItem('timeCapsuleActive') === 'true';
-      tcStatus.classList.remove('hidden');
+      const text = tcStatus.querySelector("#time-capsule-text");
+      const btn = tcStatus.querySelector("#time-capsule-action");
+      const active = localStorage.getItem("timeCapsuleActive") === "true";
+      tcStatus.classList.remove("hidden");
       if (active) {
-        text.textContent = 'Monthly Time Capsule prints are active.';
-        btn.textContent = 'Disable';
+        text.textContent = "Monthly Time Capsule prints are active.";
+        btn.textContent = "Disable";
         btn.onclick = () => {
-          localStorage.removeItem('timeCapsuleActive');
+          localStorage.removeItem("timeCapsuleActive");
           loadSubscription();
         };
       } else {
-        text.textContent = 'Add a monthly Time Capsule print to your subscription.';
-        btn.textContent = 'Activate';
+        text.textContent =
+          "Add a monthly Time Capsule print to your subscription.";
+        btn.textContent = "Activate";
         btn.onclick = () => {
-          localStorage.setItem('timeCapsuleActive', 'true');
+          localStorage.setItem("timeCapsuleActive", "true");
           loadSubscription();
         };
       }
     }
   } catch (err) {
-    console.error('Failed to load subscription info', err);
+    console.error("Failed to load subscription info", err);
   }
 }
 
 async function openPortal() {
-  const token = localStorage.getItem('token');
+  const token = localStorage.getItem("token");
   if (!token) {
-    window.location.href = 'login.html';
+    window.location.href = "login.html";
     return;
   }
   const res = await fetch(`${API_BASE}/subscription/portal`, {
-    method: 'POST',
+    method: "POST",
     headers: { Authorization: `Bearer ${token}` },
   });
   if (res.ok) {
@@ -97,7 +114,7 @@ async function openPortal() {
   }
 }
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener("DOMContentLoaded", () => {
   loadProfile();
   loadSubscription();
 });

--- a/my_profile.html
+++ b/my_profile.html
@@ -216,6 +216,7 @@
           ></div>
         </div>
         <p id="progress-text" class="text-sm mt-2"></p>
+        <p id="loyalty-info" class="text-sm mt-1"></p>
 
         <button
           id="upgrade-cta"
@@ -235,7 +236,10 @@
       >
         <h2 class="text-lg font-semibold mb-2">Time Capsule</h2>
         <p id="time-capsule-text" class="mb-2"></p>
-        <button id="time-capsule-action" class="px-3 py-1 bg-blue-600 rounded-3xl"></button>
+        <button
+          id="time-capsule-action"
+          class="px-3 py-1 bg-blue-600 rounded-3xl"
+        ></button>
       </div>
 
       <div
@@ -244,8 +248,12 @@
       >
         <h2 class="text-lg font-semibold mb-2">Subscriber Previews</h2>
         <div class="grid grid-cols-2 gap-4">
-          <div class="h-24 bg-[#1A1A1D] flex items-center justify-center">Preview 1</div>
-          <div class="h-24 bg-[#1A1A1D] flex items-center justify-center">Preview 2</div>
+          <div class="h-24 bg-[#1A1A1D] flex items-center justify-center">
+            Preview 1
+          </div>
+          <div class="h-24 bg-[#1A1A1D] flex items-center justify-center">
+            Preview 2
+          </div>
         </div>
       </div>
 
@@ -330,7 +338,8 @@
       <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center">
         <h2 class="text-2xl font-semibold mb-2">print2 pro</h2>
         <p class="mb-4">
-          Get two prints (single or multicolour tiers) every week for £149.99/month.
+          Get two prints (single or multicolour tiers) every week for
+          £149.99/month.
         </p>
         <button
           id="printclub-close"

--- a/printclub.html
+++ b/printclub.html
@@ -32,7 +32,11 @@
             stroke-width="2"
             viewBox="0 0 24 24"
           >
-            <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M15 19l-7-7 7-7"
+            />
           </svg>
           Back
         </a>
@@ -85,28 +89,44 @@
       </div>
     </header>
     <main class="flex-1 flex items-center justify-center px-4">
-      <div class="max-w-4xl w-full flex flex-col md:flex-row items-center justify-between space-y-6 md:space-y-0 md:space-x-8">
+      <div
+        class="max-w-4xl w-full flex flex-col md:flex-row items-center justify-between space-y-6 md:space-y-0 md:space-x-8"
+      >
         <div class="text-center space-y-4 md:max-w-lg">
           <p class="text-lg">
-
-            Join print2 pro for £149.99 per month to receive 2 prints (single or multicolour tiers) every week, and unlimited £20 off premium tier (£79.99 -> £59.99).
+            Join print2 pro for £149.99 per month to receive 2 prints (single or
+            multicolour tiers) every week, and unlimited £20 off premium tier
+            (£79.99 -> £59.99).
           </p>
           <p class="text-lg">
-            Members also get early access to new designs and exclusive promotions.
+            Members also get early access to new designs and exclusive
+            promotions.
           </p>
+          <div class="text-left text-sm mt-4" id="loyalty-benefits">
+            <h3 class="text-lg font-semibold mb-1 text-center">
+              Loyalty Rewards
+            </h3>
+            <ul class="list-disc list-inside space-y-1">
+              <li>3 months – 1 bonus print each week</li>
+              <li>6 months – 2 bonus prints each week</li>
+              <li>12 months – 4 bonus prints and 25% off</li>
+            </ul>
+          </div>
           <a
             href="print2pro-checkout.html"
             class="inline-block bg-[#30D5C8] text-[#1A1A1D] px-6 py-3 rounded-xl font-semibold hover:bg-[#28b7a8] transition"
             >Subscribe Now</a
           >
         </div>
-        <div class="w-full md:w-80 h-60 flex items-center justify-center border border-white/20 rounded-xl bg-[#2A2A2E] text-sm">
+        <div
+          class="w-full md:w-80 h-60 flex items-center justify-center border border-white/20 rounded-xl bg-[#2A2A2E] text-sm"
+        >
           Real life image here
         </div>
       </div>
     </main>
     <script type="module">
-      import { shareOn } from './js/share.js';
+      import { shareOn } from "./js/share.js";
       window.shareOn = shareOn;
     </script>
     <div
@@ -116,7 +136,9 @@
       <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center">
         <h2 class="text-2xl font-semibold mb-2">print2 pro</h2>
         <p class="mb-4">
-          Get two prints (single or multicolour tiers) every week for £149.99/month, plus save £20 off the premium price (£79.99 ==> £59.99).
+          Get two prints (single or multicolour tiers) every week for
+          £149.99/month, plus save £20 off the premium price (£79.99 ==>
+          £59.99).
         </p>
         <button
           id="printclub-close"
@@ -130,14 +152,20 @@
     <script type="module" src="js/printclub.js"></script>
     <script type="module" src="js/rewardBadge.js"></script>
     <script>
-      document.addEventListener('DOMContentLoaded', () => {
-        const link = document.getElementById('back-link');
+      document.addEventListener("DOMContentLoaded", () => {
+        const link = document.getElementById("back-link");
         if (!link) return;
         try {
           const ref = new URL(document.referrer);
-          if (ref.origin === window.location.origin && !ref.pathname.endsWith('printclub.html')) {
-            link.setAttribute('href', ref.pathname.replace(/^\//, '') + ref.search + ref.hash);
-            link.addEventListener('click', (e) => {
+          if (
+            ref.origin === window.location.origin &&
+            !ref.pathname.endsWith("printclub.html")
+          ) {
+            link.setAttribute(
+              "href",
+              ref.pathname.replace(/^\//, "") + ref.search + ref.hash,
+            );
+            link.addEventListener("click", (e) => {
               e.preventDefault();
               history.back();
             });


### PR DESCRIPTION
## Summary
- compute subscription duration in the backend
- expose months subscribed and milestone in `/api/subscription/summary`
- display milestone progress on the profile page
- show loyalty rewards on the print2 pro page
- adjust tests for new API fields

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857bed74cdc832da66ef7c6e023c33f