### PR TITLE
feat: add abandoned checkout discount emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,13 @@ This repository contains the early MVP code for print2's website and backend.
    npm run send-reminders  # inside backend/
    ```
 
-8. (Optional) Clean up expired password reset tokens periodically:
+8. (Optional) Send discount offers to abandoned checkouts:
+
+   ```bash
+   npm run send-abandoned-offers  # inside backend/
+   ```
+
+9. (Optional) Clean up expired password reset tokens periodically:
 
    ```bash
    npm run cleanup-tokens  # inside backend/

--- a/backend/email_templates/discount_offer.txt
+++ b/backend/email_templates/discount_offer.txt
@@ -1,0 +1,5 @@
+We noticed you started checkout but didn't finish. Here's a $5 discount code good for the next 48 hours:
+
+{{code}}
+
+Use it at checkout before it expires!

--- a/backend/migrations/054_add_abandoned_offer_flag.sql
+++ b/backend/migrations/054_add_abandoned_offer_flag.sql
@@ -1,0 +1,2 @@
+ALTER TABLE orders
+  ADD COLUMN IF NOT EXISTS abandoned_offer_sent BOOLEAN DEFAULT FALSE;

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,6 +13,7 @@
     "create-admin": "node scripts/create-admin.js",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "send-reminders": "node scripts/send-purchase-reminders.js",
+    "send-abandoned-offers": "node scripts/send-abandoned-offers.js",
     "send-followups": "node scripts/send-post-purchase-followups.js",
     "send-delay-notifications": "node scripts/send-delay-notifications.js",
     "send-shipping-confirmations": "node scripts/send-shipping-confirmations.js",

--- a/backend/scripts/send-abandoned-offers.js
+++ b/backend/scripts/send-abandoned-offers.js
@@ -1,0 +1,50 @@
+require("dotenv").config();
+const { Client } = require("pg");
+const { sendTemplate } = require("../mail");
+const { createTimedCode } = require("../discountCodes");
+
+const DELAY_HOURS = parseInt(
+  process.env.ABANDONED_OFFER_DELAY_HOURS || "24",
+  10,
+);
+
+async function sendAbandonedOffers() {
+  const client = new Client({ connectionString: process.env.DB_URL });
+  await client.connect();
+  try {
+    const { rows } = await client.query(
+      `SELECT session_id, shipping_info->>'email' AS email
+         FROM orders
+        WHERE status='pending'
+          AND shipping_info ? 'email'
+          AND COALESCE(abandoned_offer_sent, FALSE)=FALSE
+          AND created_at < NOW() - INTERVAL '${DELAY_HOURS} hours'`,
+    );
+    for (const row of rows) {
+      if (!row.email) continue;
+      try {
+        const code = await createTimedCode(500, 48);
+        await sendTemplate(
+          row.email,
+          "Complete Your Purchase",
+          "discount_offer.txt",
+          { code },
+        );
+        await client.query(
+          "UPDATE orders SET abandoned_offer_sent=TRUE WHERE session_id=$1",
+          [row.session_id],
+        );
+      } catch (err) {
+        console.error("Failed to send offer for", row.session_id, err);
+      }
+    }
+  } finally {
+    await client.end();
+  }
+}
+
+if (require.main === module) {
+  sendAbandonedOffers();
+}
+
+module.exports = sendAbandonedOffers;

--- a/backend/tests/abandonedOffers.test.js
+++ b/backend/tests/abandonedOffers.test.js
@@ -1,0 +1,40 @@
+process.env.DB_URL = "postgres://user:pass@localhost/db";
+
+jest.mock("pg");
+const { Client } = require("pg");
+const mClient = { connect: jest.fn(), end: jest.fn(), query: jest.fn() };
+Client.mockImplementation(() => mClient);
+
+jest.mock("../mail", () => ({ sendTemplate: jest.fn() }));
+const { sendTemplate } = require("../mail");
+
+jest.mock("../discountCodes", () => ({
+  createTimedCode: jest.fn().mockResolvedValue("DISC5"),
+}));
+const { createTimedCode } = require("../discountCodes");
+
+const run = require("../scripts/send-abandoned-offers");
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+test("sends offers for abandoned checkouts", async () => {
+  mClient.query.mockResolvedValueOnce({
+    rows: [{ session_id: "s1", email: "a@a.com" }],
+  });
+  mClient.query.mockResolvedValueOnce({});
+  await run();
+  expect(createTimedCode).toHaveBeenCalledWith(500, 48);
+  expect(sendTemplate).toHaveBeenCalledWith(
+    "a@a.com",
+    "Complete Your Purchase",
+    "discount_offer.txt",
+    { code: "DISC5" },
+  );
+  expect(mClient.query).toHaveBeenCalledWith(
+    expect.stringContaining("UPDATE orders"),
+    ["s1"],
+  );
+  expect(mClient.end).toHaveBeenCalled();
+});

--- a/backend/translations.json
+++ b/backend/translations.json
@@ -21,6 +21,8 @@
   "post_purchase_followup.body": "Hi {{username}},\n\nWe hope you're enjoying your recent print. If you'd like another copy or want to share the experience with a friend, you can easily reorder below:\n\n{{reorder_url}}\n\nThanks for supporting our community!",
   "purchase_reminder.subject": "Complete your purchase",
   "purchase_reminder.body": "Hi {{username}},\n\nWe noticed you haven't finished your purchase yet. If you'd like to complete it, just return to your jobs page and finalize the order.\n\nLet us know if you need any help!",
+  "discount_offer.subject": "Complete your purchase",
+  "discount_offer.body": "We noticed you started checkout but didn't finish. Here's a $5 discount code good for the next 48 hours:\n\n{{code}}\n\nUse it at checkout before it expires!",
   "reminder.subject": "print2 pro Reminder",
   "reminder.body": "Hi {{username}},\n\nYou still have unused print2 pro credits this month. Be sure to redeem your prints before they reset!\n\nThanks for being a member.",
   "rental_agreement.subject": "Rental Agreement",
@@ -30,4 +32,3 @@
   "shipping_update.subject": "Package update: {{status}}",
   "shipping_update.body": "Hi {{username}},\n\nYour order {{order_id}} status update: {{status}}\n\nWe'll keep you posted until it's delivered."
 }
-


### PR DESCRIPTION
## Summary
- add script to email a discount for abandoned carts
- add email template and translations
- expose new npm script and migration
- document how to run the job
- test abandoned cart emails

## Testing
- `npx prettier --write backend/package.json backend/translations.json README.md backend/scripts/send-abandoned-offers.js backend/tests/abandonedOffers.test.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857be9d89dc832dbe272abea6c55168