### PR TITLE
Add engagement leaderboard & achievements

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -153,6 +153,34 @@ async function adjustRewardPoints(userId, delta) {
   return parseInt(rows[0].points, 10);
 }
 
+async function getLeaderboard(limit = 10) {
+  const { rows } = await query(
+    `SELECT u.username, rp.points
+     FROM reward_points rp
+     JOIN users u ON rp.user_id=u.id
+     ORDER BY rp.points DESC
+     LIMIT $1`,
+    [limit],
+  );
+  return rows;
+}
+
+async function getAchievements(userId) {
+  const { rows } = await query(
+    "SELECT name, created_at FROM achievements WHERE user_id=$1 ORDER BY created_at DESC",
+    [userId],
+  );
+  return rows;
+}
+
+async function addAchievement(userId, name) {
+  const { rows } = await query(
+    "INSERT INTO achievements(user_id, name) VALUES($1,$2) RETURNING id",
+    [userId, name],
+  );
+  return rows[0];
+}
+
 async function getUserIdForReferral(code) {
   const { rows } = await query(
     "SELECT user_id FROM referral_links WHERE code=$1",
@@ -828,6 +856,9 @@ module.exports = {
   getOrCreateReferralLink,
   getRewardPoints,
   adjustRewardPoints,
+  getLeaderboard,
+  getAchievements,
+  addAchievement,
   getUserIdForReferral,
   insertReferralEvent,
   getOrCreateOrderReferralLink,

--- a/backend/migrations/054_create_achievements.sql
+++ b/backend/migrations/054_create_achievements.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS achievements (
+  id SERIAL PRIMARY KEY,
+  user_id TEXT REFERENCES users(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);

--- a/backend/server.js
+++ b/backend/server.js
@@ -1091,6 +1091,27 @@ app.post("/api/rewards/redeem", authRequired, async (req, res) => {
   }
 });
 
+app.get("/api/leaderboard", async (req, res) => {
+  const limit = parseInt(req.query.limit, 10) || 10;
+  try {
+    const board = await db.getLeaderboard(limit);
+    res.json(board);
+  } catch (err) {
+    logError(err);
+    res.status(500).json({ error: "Failed to fetch leaderboard" });
+  }
+});
+
+app.get("/api/achievements", authRequired, async (req, res) => {
+  try {
+    const achievements = await db.getAchievements(req.user.id);
+    res.json({ achievements });
+  } catch (err) {
+    logError(err);
+    res.status(500).json({ error: "Failed to fetch achievements" });
+  }
+});
+
 app.post("/api/gifts/:id/claim", async (req, res) => {
   if (!giftsAllowed(req))
     return res.status(403).json({ error: "Gifting not enabled" });

--- a/backend/tests/engagement.test.js
+++ b/backend/tests/engagement.test.js
@@ -1,0 +1,44 @@
+process.env.STRIPE_SECRET_KEY = "test";
+process.env.STRIPE_WEBHOOK_SECRET = "whsec";
+process.env.DB_URL = "postgres://user:pass@localhost/db";
+process.env.HUNYUAN_API_KEY = "test";
+process.env.HUNYUAN_SERVER_URL = "http://localhost:4000";
+
+jest.mock("../db", () => ({
+  query: jest.fn().mockResolvedValue({ rows: [] }),
+  getLeaderboard: jest.fn(),
+  getAchievements: jest.fn(),
+}));
+const db = require("../db");
+
+const request = require("supertest");
+const jwt = require("jsonwebtoken");
+const app = require("../server");
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test("GET /api/leaderboard returns list", async () => {
+  db.getLeaderboard.mockResolvedValue([{ username: "alice", points: 5 }]);
+  const res = await request(app).get("/api/leaderboard?limit=5");
+  expect(res.status).toBe(200);
+  expect(res.body[0].username).toBe("alice");
+  expect(db.getLeaderboard).toHaveBeenCalledWith(5);
+});
+
+test("GET /api/achievements requires auth", async () => {
+  const res = await request(app).get("/api/achievements");
+  expect(res.status).toBe(401);
+});
+
+test("GET /api/achievements returns list", async () => {
+  db.getAchievements.mockResolvedValue([{ name: "First Print" }]);
+  const token = jwt.sign({ id: "u1" }, "secret");
+  const res = await request(app)
+    .get("/api/achievements")
+    .set("authorization", `Bearer ${token}`);
+  expect(res.status).toBe(200);
+  expect(res.body.achievements).toHaveLength(1);
+  expect(db.getAchievements).toHaveBeenCalledWith("u1");
+});

--- a/docs/task_list.md
+++ b/docs/task_list.md
@@ -218,7 +218,6 @@
   - Featured member spotlights showcasing subscriber creations.
   - Monthly design challenges with member voting.
   - In-person or virtual meetups.
-  - Leaderboard and achievements for engagement.
   - Badge system on profiles.
 
 - **Referral and affiliate programs**

--- a/js/my_profile.js
+++ b/js/my_profile.js
@@ -53,21 +53,23 @@ async function loadPrintOfWeek() {
 }
 
 function startOfWeek(d = new Date()) {
-  const date = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+  const date = new Date(
+    Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()),
+  );
   const day = date.getUTCDay();
   const diff = date.getUTCDate() - day;
   return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), diff));
 }
 
 function showCountdown() {
-  const el = document.getElementById('next-free-print');
+  const el = document.getElementById("next-free-print");
   if (!el) return;
   const now = new Date();
   const weekStart = startOfWeek(now);
   const nextWeek = new Date(weekStart.getTime() + 7 * 24 * 60 * 60 * 1000);
   const diff = nextWeek - now;
   if (diff <= 0) {
-    el.textContent = '';
+    el.textContent = "";
     return;
   }
   const days = Math.floor(diff / (24 * 60 * 60 * 1000));
@@ -379,6 +381,46 @@ async function loadCredits() {
   }
 }
 
+async function loadLeaderboard() {
+  try {
+    const res = await fetch(`${API_BASE}/leaderboard?limit=10`);
+    if (!res.ok) return;
+    const data = await res.json();
+    const body = document.getElementById("leaderboard-body");
+    if (!body) return;
+    body.innerHTML = "";
+    data.forEach((e) => {
+      const tr = document.createElement("tr");
+      tr.innerHTML = `<td class="px-2 py-1">${e.username}</td><td class="px-2 py-1">${e.points}</td>`;
+      body.appendChild(tr);
+    });
+  } catch (err) {
+    console.error("Failed to load leaderboard", err);
+  }
+}
+
+async function loadAchievements() {
+  const token = localStorage.getItem("token");
+  if (!token) return;
+  try {
+    const res = await fetch(`${API_BASE}/achievements`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) return;
+    const { achievements } = await res.json();
+    const list = document.getElementById("achievements-list");
+    if (!list) return;
+    list.innerHTML = "";
+    achievements.forEach((a) => {
+      const li = document.createElement("li");
+      li.textContent = a.name;
+      list.appendChild(li);
+    });
+  } catch (err) {
+    console.error("Failed to load achievements", err);
+  }
+}
+
 function createObserver() {
   const sentinel = document.getElementById("models-sentinel");
   if (!sentinel) return;
@@ -420,4 +462,6 @@ document.addEventListener("DOMContentLoaded", () => {
   loadMore();
   loadDashboard();
   loadPrintOfWeek();
+  loadLeaderboard();
+  loadAchievements();
 });

--- a/my_profile.html
+++ b/my_profile.html
@@ -235,7 +235,10 @@
       >
         <h2 class="text-lg font-semibold mb-2">Time Capsule</h2>
         <p id="time-capsule-text" class="mb-2"></p>
-        <button id="time-capsule-action" class="px-3 py-1 bg-blue-600 rounded-3xl"></button>
+        <button
+          id="time-capsule-action"
+          class="px-3 py-1 bg-blue-600 rounded-3xl"
+        ></button>
       </div>
 
       <div
@@ -244,8 +247,12 @@
       >
         <h2 class="text-lg font-semibold mb-2">Subscriber Previews</h2>
         <div class="grid grid-cols-2 gap-4">
-          <div class="h-24 bg-[#1A1A1D] flex items-center justify-center">Preview 1</div>
-          <div class="h-24 bg-[#1A1A1D] flex items-center justify-center">Preview 2</div>
+          <div class="h-24 bg-[#1A1A1D] flex items-center justify-center">
+            Preview 1
+          </div>
+          <div class="h-24 bg-[#1A1A1D] flex items-center justify-center">
+            Preview 2
+          </div>
         </div>
       </div>
 
@@ -273,6 +280,24 @@
           </thead>
           <tbody id="orders-body"></tbody>
         </table>
+      </div>
+
+      <div
+        id="engagement"
+        class="bg-[#2A2A2E] border border-white/10 p-6 rounded-3xl w-96 mb-6"
+      >
+        <h2 class="text-lg font-semibold mb-2">Community Leaderboard</h2>
+        <table class="w-full text-sm mb-4">
+          <thead>
+            <tr>
+              <th class="text-left">User</th>
+              <th class="text-left">Points</th>
+            </tr>
+          </thead>
+          <tbody id="leaderboard-body"></tbody>
+        </table>
+        <h3 class="text-lg font-semibold mb-2">Achievements</h3>
+        <ul id="achievements-list" class="list-disc list-inside text-sm"></ul>
       </div>
       <button id="delete-account" class="bg-red-600 px-3 py-1 rounded-xl mb-6">
         Delete Account
@@ -330,7 +355,8 @@
       <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center">
         <h2 class="text-2xl font-semibold mb-2">print2 pro</h2>
         <p class="mb-4">
-          Get two prints (single or multicolour tiers) every week for £149.99/month.
+          Get two prints (single or multicolour tiers) every week for
+          £149.99/month.
         </p>
         <button
           id="printclub-close"


### PR DESCRIPTION
## Summary
- implement achievements table and DB helpers
- expose `/api/leaderboard` and `/api/achievements`
- show leaderboard and achievements on `my_profile.html`
- add frontend calls for new endpoints
- remove completed task from docs
- add backend tests

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_6857be2967cc832da4805bf6f09ec394