### PR TITLE
chore(commit): enforce conventional commits

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,22 @@
-module.exports = { extends: ['@commitlint/config-conventional'] };
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'type-enum': [
+      2,
+      'always',
+      [
+        'build',
+        'ci',
+        'docs',
+        'feat',
+        'fix',
+        'chore',
+        'refactor',
+        'test',
+        'style',
+        'perf',
+        'revert'
+      ]
+    ]
+  }
+};


### PR DESCRIPTION
## Summary
- configure commitlint with allowed commit types

## Validation
- `npm run format` (backend)
- `npm test` (backend)

```
tests/rewards.test.js 14ms
...
utils/validateStl.js 2ms (unchanged)
```

```
  generateTitle.js                   |     100 |    84.61 |     100 |     100 |
...
  validateStl.js                     |     100 |      100 |     100 |     100 |
```


------
https://chatgpt.com/codex/tasks/task_e_6857c4420a38832d99d18fdbe1052fc7