### PR TITLE
Add quantity pill hover effect

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -94,6 +94,15 @@
         box-shadow: 0 0 10px rgba(48, 213, 200, 0.6),
           0 6px 10px rgba(0, 0, 0, 0.6);
       }
+
+      /* Hover effect for quantity selector */
+      #qty-pill {
+        transition: transform 0.2s ease;
+      }
+      #qty-pill:hover,
+      #qty-pill:focus-within {
+        transform: scale(1.04);
+      }
     </style>
   </head>
 


### PR DESCRIPTION
## Summary
- add a hover/active scale effect for the quantity selector on the payment page

## Testing
- `npm run format` in `backend`
- `npm test` in `backend`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_6857d5b80318832d9211f15be6958eec