### PR TITLE
Fix color menu open bug

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -650,6 +650,8 @@ async function initPaymentPage() {
       if (btn) {
         // Prevent click from bubbling and reopening the menu
         ev.stopPropagation();
+        // Prevent the label from re-triggering the input's click handler
+        ev.preventDefault();
         const color = btn.dataset.color;
         singleButton.style.backgroundColor = color;
 


### PR DESCRIPTION
## Summary
- ensure single-color palette closes after a color is selected

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857dfc10740832d806926304b7bf2a6