### PR TITLE
Implement collapsible contact section on signup

### DIFF
--- a/signup.html
+++ b/signup.html
@@ -104,13 +104,32 @@
           class="space-y-4 bg-[#2A2A2E] border border-white/10 p-6 rounded-3xl"
           aria-label="Sign up form"
         >
-          <input
-            id="su-email"
-            type="email"
-            class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10 text-gray-200"
-            placeholder="Email"
-            aria-label="Email"
-          />
+          <div class="flex flex-col" id="emailStub">
+            <label for="email" class="font-medium">Contact</label>
+            <input
+              id="emailStubInput"
+              type="text"
+              placeholder="Tap to add…"
+              class="bg-gray-800 rounded-lg h-12 px-3 text-gray-400 cursor-pointer"
+              readonly
+            />
+          </div>
+          <div id="emailGroup" class="collapsible collapsed">
+            <input
+              id="su-email"
+              type="email"
+              class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10 text-gray-200"
+              placeholder="Email"
+              aria-label="Email"
+            />
+            <input
+              id="phone"
+              type="tel"
+              class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10 text-gray-200 mt-2"
+              placeholder="Phone"
+              aria-label="Phone"
+            />
+          </div>
           <input
             id="su-name"
             class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10 text-gray-200"


### PR DESCRIPTION
## Summary
- add an Email & Phone collapsible section on the signup page

## Testing
- `npx prettier --write signup.html`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857ec26e548832da79dccd7983d0fc3