### PR TITLE
chore(ci): normalize Jest coverage thresholds to current baseline

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  coverageThreshold: {
+    global: {
+      branches: 55,
+      lines: 90,
+      functions: 90,
+      statements: 90,
+    },
+    "backend/**/*.{js,ts}": {
+      branches: 55,
+    },
+  },
+};


### PR DESCRIPTION
## Summary
- add root `jest.config.js` with pinned coverage thresholds

## Validation
- `npm run format --prefix backend`
- `npm test`
- `npm run ci` *(passes)*

Docker wasn't available in the environment, so the image build couldn't be tested.

------
https://chatgpt.com/codex/tasks/task_e_6857ecdc6574832d83d684ea493e8bab