### PR TITLE
chore(ci): enforce staging preview deploy validations

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -1,0 +1,33 @@
+name: Preview Deploy
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci --prefix backend
+      - run: |
+          if [ -f backend/hunyuan_server/package.json ]; then
+            npm ci --prefix backend/hunyuan_server
+          fi
+      - run: npm install -g netlify-cli
+      - name: Deploy preview
+        id: netlify
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        run: |
+          netlify deploy --dir=. --site $NETLIFY_SITE_ID --auth $NETLIFY_AUTH_TOKEN --json > deploy.json
+          echo "PREVIEW_URL=$(jq -r '.deploy_url' deploy.json)" >> $GITHUB_ENV
+      - name: Run smoke tests
+        env:
+          PLAYWRIGHT_BASE_URL: ${{ env.PREVIEW_URL }}
+        run: npx playwright test e2e/smoke.test.js

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,10 +1,14 @@
 const { defineConfig } = require('@playwright/test');
+const baseURL = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3000';
+
 module.exports = defineConfig({
   testDir: 'e2e',
-  use: { baseURL: 'http://localhost:3000', headless: true },
-  webServer: {
-    command: 'npx http-server -c-1 -p 3000',
-    port: 3000,
-    timeout: 120 * 1000,
-  },
+  use: { baseURL, headless: true },
+  webServer: process.env.PLAYWRIGHT_BASE_URL
+    ? undefined
+    : {
+        command: 'npx http-server -c-1 -p 3000',
+        port: 3000,
+        timeout: 120 * 1000,
+      },
 });


### PR DESCRIPTION
## Summary
- integrate Netlify preview deploys for PR validation
- allow Playwright tests to target remote URLs

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_6857ed332ed8832d8504e89830be3e5a