### PR TITLE
chore: ensure Docker CLI & daemon support in devcontainer and CI

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,7 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu
+
+RUN apt-get update && \
+    apt-get install -y docker.io && \
+    rm -rf /var/lib/apt/lists/*
+
+CMD ["sleep", "infinity"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,10 @@
+{
+  "name": "MVP Dev Container",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "runArgs": ["--privileged"],
+  "mounts": [
+    "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind"
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,16 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    services:
+      docker:
+        image: docker:dind
+        options: --privileged
     steps:
+      - name: Ensure Docker CLI
+        run: |
+          if ! command -v docker >/dev/null; then
+            sudo apt-get update && sudo apt-get install -y docker.io
+          fi
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,6 @@
+version: '3.8'
+services:
+  app:
+    privileged: true
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
## Summary
- add devcontainer with Docker and socket passthrough
- support docker socket in docker-compose override
- allow CI to run docker builds via docker:dind and CLI install fallback

## Testing
- `npm run format`
- `npm run test-ci`

------
https://chatgpt.com/codex/tasks/task_e_6857f21fd4f4832d9f9fa3a47c4bc85b