### PR TITLE
Fix image thumbnail persistence

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -643,7 +643,11 @@ function renderThumbnails(arr) {
     btn.onclick = () => {
       arr.splice(i, 1);
       uploadedFiles.splice(i, 1);
-      localStorage.setItem("print3Images", JSON.stringify(arr));
+      try {
+        localStorage.setItem("print3Images", JSON.stringify(arr));
+      } catch {
+        /* ignore storage errors */
+      }
       renderThumbnails(arr);
       updateWizardFromInputs();
     };
@@ -682,7 +686,11 @@ async function processFiles(files) {
   uploadedFiles = [...files];
   const thumbs = await Promise.all(uploadedFiles.map((f) => getThumbnail(f)));
 
-  localStorage.setItem("print3Images", JSON.stringify(thumbs));
+  try {
+    localStorage.setItem("print3Images", JSON.stringify(thumbs));
+  } catch {
+    /* ignore storage errors */
+  }
   renderThumbnails(thumbs);
   editsPending = true;
   refs.buyNowBtn?.classList.add("hidden");


### PR DESCRIPTION
## Summary
- catch localStorage errors so image thumbnail previews still render when storage is unavailable

## Testing
- `npm test`
- `npx prettier --write js/index.js`


------
https://chatgpt.com/codex/tasks/task_e_6857f15c85a8832da1ff2c8bda8fc315