### PR TITLE
Fix loyalty rewards placement

### DIFF
--- a/printclub.html
+++ b/printclub.html
@@ -102,21 +102,19 @@
             Members also get early access to new designs and exclusive
             promotions.
           </p>
+          <a
+            href="print2pro-checkout.html"
+            class="inline-block bg-[#30D5C8] text-[#1A1A1D] px-6 py-3 rounded-xl font-semibold hover:bg-[#28b7a8] transition"
+            >Subscribe Now £149.99/mo</a
+          >
           <div class="text-left text-sm mt-4" id="loyalty-benefits">
-            <h3 class="text-lg font-semibold mb-1 text-center">
-              Loyalty Rewards
-            </h3>
+            <h3 class="text-lg underline mb-1 text-center">Loyalty Rewards</h3>
             <ul class="list-disc list-inside space-y-1">
               <li>3 months – 1 bonus print each week</li>
               <li>6 months – 2 bonus prints each week</li>
               <li>12 months – 4 bonus prints and 25% off</li>
             </ul>
           </div>
-          <a
-            href="print2pro-checkout.html"
-            class="inline-block bg-[#30D5C8] text-[#1A1A1D] px-6 py-3 rounded-xl font-semibold hover:bg-[#28b7a8] transition"
-            >Subscribe Now</a
-          >
         </div>
         <div
           class="w-full md:w-80 h-60 flex items-center justify-center border border-white/20 rounded-xl bg-[#2A2A2E] text-sm"


### PR DESCRIPTION
## Summary
- move loyalty rewards below the subscribe button on the printclub page
- underline the loyalty rewards heading
- show the £149.99/mo price on the button

## Testing
- `npm run format`
- `npm test`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_6857fa44a588832da799bac3a1ef3ee9