### PR TITLE
Fix cross-env lock file mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ This repository contains the early MVP code for print2's website and backend.
 
 ## Development Container
 
+After changing dependencies run:
+  npm install --package-lock-only
+
 You can build a dev container from the included `Dockerfile`. The image now
 installs the Docker CLI so commands like `docker --version` work inside the
 container. If you want to skip running full CI inside the container, build with

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@types/jest": "^30.0.0",
         "@typescript-eslint/eslint-plugin": "^8.34.1",
         "@typescript-eslint/parser": "^8.34.1",
+        "cross-env": "7.0.3",
         "eslint": "^9.29.0",
         "eslint-config-prettier": "^8.10.0",
         "eslint-plugin-jsdoc": "^51.1.1",
@@ -4602,6 +4603,25 @@
         "@types/node": "*",
         "cosmiconfig": ">=9",
         "typescript": ">=5"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {
@@ -17360,6 +17380,15 @@
       "dev": true,
       "requires": {
         "jiti": "^2.4.1"
+      }
+    },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
       }
     },
     "cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@types/jest": "^30.0.0",
     "@typescript-eslint/eslint-plugin": "^8.34.1",
     "@typescript-eslint/parser": "^8.34.1",
-    "cross-env": "^7.0.3",
+    "cross-env": "7.0.3",
     "eslint": "^9.29.0",
     "eslint-config-prettier": "^8.10.0",
     "eslint-plugin-jsdoc": "^51.1.1",


### PR DESCRIPTION
## Summary
- declare `cross-env` only in devDependencies
- add `cross-env` entry to package-lock
- document how to keep the lock file current

## Testing
- `npm run format` (backend)
- `npm test` (backend)


------
https://chatgpt.com/codex/tasks/task_e_685801222cc4832db385967c4b45a450