### PR TITLE
feat(signup): enable contact field expansion

### DIFF
--- a/signup.html
+++ b/signup.html
@@ -181,6 +181,14 @@
         }
       }
 
+      document
+        .getElementById("emailStub")
+        .addEventListener("click", () => expand("emailStub", "emailGroup"));
+
+      document
+        .getElementById("addressStub")
+        .addEventListener("click", () => expand("addressStub", "addressGroup"));
+
       import { shareOn } from "./js/share.js";
       window.shareOn = shareOn;
     </script>

--- a/upload/processThumbnail.js
+++ b/upload/processThumbnail.js
@@ -14,7 +14,7 @@ const sharp = require("sharp");
 /**
  * Process an uploaded thumbnail image according to repository standards.
  * @param {Buffer} fileBuffer Raw image data
- * @returns {Promise<{ok: boolean, buffer?: Buffer, error?: string}>}
+ * @returns {Promise<{ok: boolean, buffer?: Buffer, error?: string}>} Processed image result
  */
 async function processThumbnail(fileBuffer) {
   try {


### PR DESCRIPTION
## Summary
- enable collapse group expansion on the signup page when clicking stubs
- clarify return description for thumbnail processor

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_6858009c7a2c832d9897b937532be8f5