### PR TITLE
Fix ESLint warnings

### DIFF
--- a/upload/processThumbnail.js
+++ b/upload/processThumbnail.js
@@ -14,7 +14,8 @@ const sharp = require("sharp");
 /**
  * Process an uploaded thumbnail image according to repository standards.
  * @param {Buffer} fileBuffer Raw image data
- * @returns {Promise<{ok: boolean, buffer?: Buffer, error?: string}>}
+ * @returns {Promise<{ok: boolean, buffer?: Buffer, error?: string}>} Result
+ * object containing the processed buffer or an error message.
  */
 async function processThumbnail(fileBuffer) {
   try {


### PR DESCRIPTION
## Summary
- add missing JSDoc return description in `processThumbnail`

## Validation
- `npm run format` in `backend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_685804b75b44832db1b01b38ef4ec153