### PR TITLE
Add CI watchdog

### DIFF
--- a/.github/workflows/ci-watchdog.yml
+++ b/.github/workflows/ci-watchdog.yml
@@ -1,0 +1,26 @@
+name: CI Watchdog
+on:
+  workflow_run:
+    workflows: ["CI", "build", "test"]
+    types: [completed]
+  schedule:
+    - cron:  '0 */3 * * *'
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  scan:
+    if: ${{ github.repository_owner == 'print3git' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm install --no-audit --no-fund
+      - run: node scripts/ci_watchdog.js
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -17,6 +17,7 @@ module.exports = [
       "docs",
       "e2e",
       "backend",
+      "scripts/ci_watchdog.ts",
     ],
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@eslint-community/eslint-utils": "^4.7.0",
         "@eslint/js": "^9.29.0",
         "@lhci/cli": "^0.15.0",
+        "@octokit/action": "^6",
         "@percy/cli": "^1.31.0",
         "@percy/playwright": "^1.0.8",
         "@playwright/test": "^1.53.1",
@@ -23,6 +24,7 @@
         "@types/jest": "^30.0.0",
         "@typescript-eslint/eslint-plugin": "^8.34.1",
         "@typescript-eslint/parser": "^8.34.1",
+        "cross-env": "^7.0.3",
         "eslint": "^9.29.0",
         "eslint-config-prettier": "^8.10.0",
         "eslint-plugin-jsdoc": "^51.1.1",
@@ -1801,6 +1803,288 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@octokit/action": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/action/-/action-6.1.0.tgz",
+      "integrity": "sha512-lo+nHx8kAV86bxvOVOI3vFjX3gXPd/L7guAUbvs3pUvnR2KC+R7yjBkA1uACt4gYhs4LcWP3AXSGQzsbeN2XXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-action": "^4.0.0",
+        "@octokit/core": "^5.0.0",
+        "@octokit/plugin-paginate-rest": "^9.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "^10.0.0",
+        "@octokit/types": "^12.0.0",
+        "undici": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/action/node_modules/undici": {
+      "version": "6.21.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/@octokit/auth-action": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-action/-/auth-action-4.1.0.tgz",
+      "integrity": "sha512-m+3t7K46IYyMk7Bl6/lF4Rv09GqDZjYmNg8IWycJ2Fa3YE3DE7vQcV6G2hUPmR9NDqenefNJwVtlisMjzymPiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^4.0.0",
+        "@octokit/types": "^13.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/auth-action/node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/auth-action/node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+      "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.1.tgz",
+      "integrity": "sha512-dKYCMuPO1bmrpuogcjQ8z7ICCH3FP6WmxpwC03yjzGfZhj9fTJg6+bS1+UAplekbN2C+M61UNllGOOoAfGCrdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^4.0.0",
+        "@octokit/graphql": "^7.1.0",
+        "@octokit/request": "^8.4.1",
+        "@octokit/request-error": "^5.1.1",
+        "@octokit/types": "^13.0.0",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/core/node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/core/node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.6.tgz",
+      "integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/endpoint/node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/endpoint/node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.1.tgz",
+      "integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^8.4.1",
+        "@octokit/types": "^13.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/graphql/node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/graphql/node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+      "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.2.tgz",
+      "integrity": "sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^12.6.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "5"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.4.1.tgz",
+      "integrity": "sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^12.6.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": "5"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
+      "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^9.0.6",
+        "@octokit/request-error": "^5.1.1",
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
+      "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.1.0",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/request-error/node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/request-error/node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@octokit/request/node_modules/@octokit/openapi-types": {
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@octokit/request/node_modules/@octokit/types": {
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^24.2.0"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "12.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+      "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^20.0.0"
+      }
+    },
     "node_modules/@paulirish/trace_engine": {
       "version": "0.0.53",
       "resolved": "https://registry.npmjs.org/@paulirish/trace_engine/-/trace_engine-0.0.53.tgz",
@@ -3577,6 +3861,13 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/before-after-hook": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+      "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/bl": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
@@ -4604,6 +4895,25 @@
         "typescript": ">=5"
       }
     },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -4924,6 +5234,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/destroy": {
       "version": "1.2.0",
@@ -13641,6 +13958,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/universal-user-agent": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
+      "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/universalify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
@@ -15481,6 +15805,238 @@
       "dev": true,
       "peer": true
     },
+    "@octokit/action": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/action/-/action-6.1.0.tgz",
+      "integrity": "sha512-lo+nHx8kAV86bxvOVOI3vFjX3gXPd/L7guAUbvs3pUvnR2KC+R7yjBkA1uACt4gYhs4LcWP3AXSGQzsbeN2XXw==",
+      "dev": true,
+      "requires": {
+        "@octokit/auth-action": "^4.0.0",
+        "@octokit/core": "^5.0.0",
+        "@octokit/plugin-paginate-rest": "^9.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "^10.0.0",
+        "@octokit/types": "^12.0.0",
+        "undici": "^6.0.0"
+      },
+      "dependencies": {
+        "undici": {
+          "version": "6.21.3",
+          "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+          "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
+          "dev": true
+        }
+      }
+    },
+    "@octokit/auth-action": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-action/-/auth-action-4.1.0.tgz",
+      "integrity": "sha512-m+3t7K46IYyMk7Bl6/lF4Rv09GqDZjYmNg8IWycJ2Fa3YE3DE7vQcV6G2hUPmR9NDqenefNJwVtlisMjzymPiQ==",
+      "dev": true,
+      "requires": {
+        "@octokit/auth-token": "^4.0.0",
+        "@octokit/types": "^13.0.0"
+      },
+      "dependencies": {
+        "@octokit/openapi-types": {
+          "version": "24.2.0",
+          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+          "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+          "dev": true
+        },
+        "@octokit/types": {
+          "version": "13.10.0",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+          "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+          "dev": true,
+          "requires": {
+            "@octokit/openapi-types": "^24.2.0"
+          }
+        }
+      }
+    },
+    "@octokit/auth-token": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+      "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+      "dev": true
+    },
+    "@octokit/core": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.1.tgz",
+      "integrity": "sha512-dKYCMuPO1bmrpuogcjQ8z7ICCH3FP6WmxpwC03yjzGfZhj9fTJg6+bS1+UAplekbN2C+M61UNllGOOoAfGCrdQ==",
+      "dev": true,
+      "requires": {
+        "@octokit/auth-token": "^4.0.0",
+        "@octokit/graphql": "^7.1.0",
+        "@octokit/request": "^8.4.1",
+        "@octokit/request-error": "^5.1.1",
+        "@octokit/types": "^13.0.0",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "dependencies": {
+        "@octokit/openapi-types": {
+          "version": "24.2.0",
+          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+          "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+          "dev": true
+        },
+        "@octokit/types": {
+          "version": "13.10.0",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+          "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+          "dev": true,
+          "requires": {
+            "@octokit/openapi-types": "^24.2.0"
+          }
+        }
+      }
+    },
+    "@octokit/endpoint": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.6.tgz",
+      "integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "dependencies": {
+        "@octokit/openapi-types": {
+          "version": "24.2.0",
+          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+          "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+          "dev": true
+        },
+        "@octokit/types": {
+          "version": "13.10.0",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+          "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+          "dev": true,
+          "requires": {
+            "@octokit/openapi-types": "^24.2.0"
+          }
+        }
+      }
+    },
+    "@octokit/graphql": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.1.tgz",
+      "integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
+      "dev": true,
+      "requires": {
+        "@octokit/request": "^8.4.1",
+        "@octokit/types": "^13.0.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "dependencies": {
+        "@octokit/openapi-types": {
+          "version": "24.2.0",
+          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+          "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+          "dev": true
+        },
+        "@octokit/types": {
+          "version": "13.10.0",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+          "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+          "dev": true,
+          "requires": {
+            "@octokit/openapi-types": "^24.2.0"
+          }
+        }
+      }
+    },
+    "@octokit/openapi-types": {
+      "version": "20.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+      "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
+      "dev": true
+    },
+    "@octokit/plugin-paginate-rest": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.2.tgz",
+      "integrity": "sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^12.6.0"
+      }
+    },
+    "@octokit/plugin-rest-endpoint-methods": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.4.1.tgz",
+      "integrity": "sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^12.6.0"
+      }
+    },
+    "@octokit/request": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
+      "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
+      "dev": true,
+      "requires": {
+        "@octokit/endpoint": "^9.0.6",
+        "@octokit/request-error": "^5.1.1",
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^6.0.0"
+      },
+      "dependencies": {
+        "@octokit/openapi-types": {
+          "version": "24.2.0",
+          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+          "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+          "dev": true
+        },
+        "@octokit/types": {
+          "version": "13.10.0",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+          "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+          "dev": true,
+          "requires": {
+            "@octokit/openapi-types": "^24.2.0"
+          }
+        }
+      }
+    },
+    "@octokit/request-error": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
+      "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
+      "dev": true,
+      "requires": {
+        "@octokit/types": "^13.1.0",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      },
+      "dependencies": {
+        "@octokit/openapi-types": {
+          "version": "24.2.0",
+          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+          "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+          "dev": true
+        },
+        "@octokit/types": {
+          "version": "13.10.0",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+          "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+          "dev": true,
+          "requires": {
+            "@octokit/openapi-types": "^24.2.0"
+          }
+        }
+      }
+    },
+    "@octokit/types": {
+      "version": "12.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+      "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+      "dev": true,
+      "requires": {
+        "@octokit/openapi-types": "^20.0.0"
+      }
+    },
     "@paulirish/trace_engine": {
       "version": "0.0.53",
       "resolved": "https://registry.npmjs.org/@paulirish/trace_engine/-/trace_engine-0.0.53.tgz",
@@ -16655,6 +17211,12 @@
       "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
       "dev": true
     },
+    "before-after-hook": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+      "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
+      "dev": true
+    },
     "bl": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
@@ -17362,6 +17924,15 @@
         "jiti": "^2.4.1"
       }
     },
+    "cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      }
+    },
     "cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -17569,6 +18140,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true
+    },
+    "deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
       "dev": true
     },
     "destroy": {
@@ -23524,6 +24101,12 @@
       "requires": {
         "crypto-random-string": "^2.0.0"
       }
+    },
+    "universal-user-agent": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
+      "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
+      "dev": true
     },
     "universalify": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "lhci": "lhci autorun",
-    "prepare": "husky install",
+    "prepare": "husky install && tsc -p scripts/tsconfig.json",
     "format": "prettier --write \"**/*.{js,jsx,json,md,html}\"",
     "format:check": "prettier --check \"**/*.{js,jsx,json,md,html}\"",
     "lint": "npm run check-conflicts && eslint . --max-warnings=0 && npm run lint --prefix backend",
@@ -66,6 +66,7 @@
     "size-limit": "^11.2.0",
     "tsconfig-strictest": "^1.0.0-beta.1",
     "typescript": "^5.8.3",
+    "@octokit/action": "^6",
     "wait-on": "^8.0.3"
   },
   "lint-staged": {

--- a/scripts/ci_watchdog.js
+++ b/scripts/ci_watchdog.js
@@ -1,0 +1,176 @@
+"use strict";
+var __importDefault =
+  (this && this.__importDefault) ||
+  function (mod) {
+    return mod && mod.__esModule ? mod : { default: mod };
+  };
+Object.defineProperty(exports, "__esModule", { value: true });
+const action_1 = require("@octokit/action");
+const node_child_process_1 = require("node:child_process");
+const promises_1 = __importDefault(require("node:fs/promises"));
+const node_path_1 = __importDefault(require("node:path"));
+const octo = new action_1.Octokit();
+const repoSlug = process.env.GITHUB_REPOSITORY || "";
+const [owner, repo] = repoSlug.split("/");
+// --- parameters ---
+const WINDOW_HOURS = 4;
+const MIN_HITS = 5;
+const MAX_RUNS = 25;
+// helper
+const sinceIso = new Date(Date.now() - WINDOW_HOURS * 3600_000).toISOString();
+async function main() {
+  const runs = await octo.paginate(octo.rest.actions.listWorkflowRunsForRepo, {
+    owner,
+    repo,
+    per_page: 100,
+    status: "failure",
+    event: "pull_request",
+    created: `>${sinceIso}`,
+  });
+  const clusters = {};
+  for (const r of runs.slice(0, MAX_RUNS)) {
+    const log = await octo.rest.actions.downloadWorkflowRunLogs({
+      owner,
+      repo,
+      run_id: r.id,
+      request: { raw: true },
+    });
+    const firstLine =
+      Buffer.from(log.data).toString("utf8").split("\n").find(Boolean) ??
+      "unknown error";
+    const key = firstLine.trim().slice(0, 120);
+    clusters[key] ??= { msg: key, runs: [], prs: [] };
+    clusters[key].runs.push(r.id);
+    clusters[key].prs.push(r.pull_requests?.[0]?.number ?? -1);
+  }
+  const systemic = Object.values(clusters).filter(
+    (c) => c.prs.length >= MIN_HITS,
+  );
+  if (!systemic.length) {
+    console.log("No systemic failure detected");
+    return;
+  }
+  for (const cluster of systemic) {
+    const slug = cluster.msg
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .slice(0, 40);
+    await handleCluster(slug, cluster);
+  }
+}
+async function handleCluster(slug, cluster) {
+  const branch = `ci/auto-fix/${slug}`;
+  const issueTitle = `CI auto-fix: ${cluster.msg}`;
+  // --- attempt fix recipes ---
+  let changed = false;
+  if (cluster.msg.includes("npm ci can only install packages")) {
+    console.log("Patching npm ci → npm install");
+    changed ||= await patchFiles(
+      /npm ci --no-audit --no-fund/g,
+      "npm install --no-audit --no-fund",
+    );
+  }
+  if (cluster.msg.includes("Unauthorized: could not retrieve project")) {
+    console.log("Adding secret guard to Netlify step");
+    changed ||= await patchFiles(
+      /netlify deploy [^\n]+/g,
+      `if [[ -n "$NETLIFY_AUTH_TOKEN" && -n "$NETLIFY_SITE_ID" ]]; then
+  netlify deploy --dir=. --site $NETLIFY_SITE_ID --auth $NETLIFY_AUTH_TOKEN --json > deploy.json
+  echo "PREVIEW_URL=$(jq -r '.deploy_url' deploy.json)" >> $GITHUB_ENV
+else
+  echo "ℹ️ Skipping Netlify deploy – secrets missing"
+fi`,
+    );
+  }
+  if (!changed) {
+    console.log("No recipe matched, just filing issue/comments");
+    await upsertIssue(issueTitle, cluster);
+    await commentOnPRs(cluster);
+    return;
+  }
+  // Commit branch & PR
+  (0, node_child_process_1.execSync)(`git checkout -B ${branch}`);
+  (0, node_child_process_1.execSync)('git config user.name "ci-watchdog[bot]"');
+  (0, node_child_process_1.execSync)(
+    'git config user.email "ci-watchdog@users.noreply.github.com"',
+  );
+  (0, node_child_process_1.execSync)(
+    'git commit -am "ci: auto-fix systemic failure"',
+  );
+  (0, node_child_process_1.execSync)(`git push -f origin ${branch}`);
+  await octo.rest.pulls.create({
+    owner,
+    repo,
+    head: branch,
+    base: "main",
+    title: `ci: auto-fix for "${cluster.msg}"`,
+    body: "This PR was opened automatically by the CI watchdog.",
+  });
+}
+async function patchFiles(pattern, replacement) {
+  const files = [
+    "Dockerfile",
+    ...(await globWalk(".github/workflows", ".yml")),
+  ];
+  let altered = false;
+  for (const f of files) {
+    const txt = await promises_1.default.readFile(f, "utf8");
+    if (pattern.test(txt)) {
+      await promises_1.default.writeFile(f, txt.replace(pattern, replacement));
+      altered = true;
+    }
+  }
+  return altered;
+}
+async function globWalk(dir, ext, out = []) {
+  const entries = await promises_1.default.readdir(dir, {
+    withFileTypes: true,
+  });
+  for (const e of entries) {
+    const p = node_path_1.default.join(dir, e.name);
+    if (e.isDirectory()) await globWalk(p, ext, out);
+    else if (e.name.endsWith(ext)) out.push(p);
+  }
+  return out;
+}
+async function upsertIssue(title, cluster) {
+  const { data: issues } = await octo.rest.issues.listForRepo({
+    owner,
+    repo,
+    state: "open",
+    labels: "ci-watchdog",
+  });
+  const existing = issues.find((i) => i.title === title);
+  const body = `Detected **${cluster.prs.length} PRs** failing with:\n\n\`\`\`\n${cluster.msg}\n\`\`\``;
+  if (existing) {
+    await octo.rest.issues.update({
+      owner,
+      repo,
+      issue_number: existing.number,
+      body,
+    });
+  } else {
+    await octo.rest.issues.create({
+      owner,
+      repo,
+      title,
+      body,
+      labels: ["ci-watchdog"],
+    });
+  }
+}
+async function commentOnPRs(cluster) {
+  for (const pr of new Set(cluster.prs)) {
+    if (pr < 0) continue;
+    await octo.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number: pr,
+      body: `Heads-up 🚦 — CI is currently failing on **all PRs** with:\n\`\`\`\n${cluster.msg}\n\`\`\`\nA fix is being prepared automatically.`,
+    });
+  }
+}
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/ci_watchdog.ts
+++ b/scripts/ci_watchdog.ts
@@ -1,0 +1,143 @@
+import { Octokit } from "@octokit/action";
+import { execSync } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const octo = new Octokit();
+const repoSlug = process.env.GITHUB_REPOSITORY || "";
+const [owner, repo] = repoSlug.split("/");
+
+// --- parameters ---
+const WINDOW_HOURS = 4;
+const MIN_HITS     = 5;
+const MAX_RUNS     = 25;
+
+// helper
+const sinceIso = new Date(Date.now() - WINDOW_HOURS * 3600_000).toISOString();
+
+type Cluster = { msg: string; runs: number[]; prs: number[] };
+
+async function main() {
+  const runs = await octo.paginate(octo.rest.actions.listWorkflowRunsForRepo, {
+    owner, repo, per_page: 100, status: "failure", event: "pull_request", created: `>${sinceIso}`
+  });
+
+  const clusters: Record<string, Cluster> = {};
+
+  for (const r of runs.slice(0, MAX_RUNS)) {
+    const log = await octo.rest.actions.downloadWorkflowRunLogs({
+      owner, repo, run_id: r.id, request: { raw: true }
+    });
+    const firstLine = Buffer.from(log.data as ArrayBuffer)
+      .toString("utf8")
+      .split("\n")
+      .find(Boolean) ?? "unknown error";
+    const key = firstLine.trim().slice(0, 120);
+
+    clusters[key] ??= { msg: key, runs: [], prs: [] };
+    clusters[key].runs.push(r.id);
+    clusters[key].prs.push(r.pull_requests?.[0]?.number ?? -1);
+  }
+
+  const systemic = Object.values(clusters).filter(c => c.prs.length >= MIN_HITS);
+  if (!systemic.length) {
+    console.log("No systemic failure detected");
+    return;
+  }
+
+  for (const cluster of systemic) {
+    const slug = cluster.msg.toLowerCase().replace(/[^a-z0-9]+/g, "-").slice(0, 40);
+    await handleCluster(slug, cluster);
+  }
+}
+
+async function handleCluster(slug: string, cluster: Cluster) {
+  const branch = `ci/auto-fix/${slug}`;
+  const issueTitle = `CI auto-fix: ${cluster.msg}`;
+
+  // --- attempt fix recipes ---
+  let changed = false;
+  if (cluster.msg.includes("npm ci can only install packages")) {
+    console.log("Patching npm ci → npm install");
+    changed ||= await patchFiles(/npm ci --no-audit --no-fund/g,
+                                 "npm install --no-audit --no-fund");
+  }
+  if (cluster.msg.includes("Unauthorized: could not retrieve project")) {
+    console.log("Adding secret guard to Netlify step");
+    changed ||= await patchFiles(/netlify deploy [^\n]+/g,
+`if [[ -n "$NETLIFY_AUTH_TOKEN" && -n "$NETLIFY_SITE_ID" ]]; then
+  netlify deploy --dir=. --site $NETLIFY_SITE_ID --auth $NETLIFY_AUTH_TOKEN --json > deploy.json
+  echo "PREVIEW_URL=$(jq -r '.deploy_url' deploy.json)" >> $GITHUB_ENV
+else
+  echo "ℹ️ Skipping Netlify deploy – secrets missing"
+fi`);
+  }
+
+  if (!changed) {
+    console.log("No recipe matched, just filing issue/comments");
+    await upsertIssue(issueTitle, cluster);
+    await commentOnPRs(cluster);
+    return;
+  }
+
+  // Commit branch & PR
+  execSync(`git checkout -B ${branch}`);
+  execSync('git config user.name "ci-watchdog[bot]"');
+  execSync('git config user.email "ci-watchdog@users.noreply.github.com"');
+  execSync('git commit -am "ci: auto-fix systemic failure"');
+  execSync(`git push -f origin ${branch}`);
+
+  await octo.rest.pulls.create({
+    owner, repo,
+    head: branch, base: "main",
+    title: `ci: auto-fix for "${cluster.msg}"`,
+    body: "This PR was opened automatically by the CI watchdog."
+  });
+}
+
+async function patchFiles(pattern: RegExp, replacement: string) {
+  const files = ["Dockerfile", ...(await globWalk(".github/workflows", ".yml"))];
+  let altered = false;
+  for (const f of files) {
+    const txt = await fs.readFile(f, "utf8");
+    if (pattern.test(txt)) {
+      await fs.writeFile(f, txt.replace(pattern, replacement));
+      altered = true;
+    }
+  }
+  return altered;
+}
+
+async function globWalk(dir: string, ext: string, out: string[] = []): Promise<string[]> {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  for (const e of entries) {
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) await globWalk(p, ext, out);
+    else if (e.name.endsWith(ext)) out.push(p);
+  }
+  return out;
+}
+
+async function upsertIssue(title: string, cluster: Cluster) {
+  const { data: issues } = await octo.rest.issues.listForRepo({ owner, repo, state: "open", labels: "ci-watchdog" });
+  const existing = issues.find(i => i.title === title);
+  const body = `Detected **${cluster.prs.length} PRs** failing with:\n\n\`\`\`\n${cluster.msg}\n\`\`\``;
+
+  if (existing) {
+    await octo.rest.issues.update({ owner, repo, issue_number: existing.number, body });
+  } else {
+    await octo.rest.issues.create({ owner, repo, title, body, labels: ["ci-watchdog"] });
+  }
+}
+
+async function commentOnPRs(cluster: Cluster) {
+  for (const pr of new Set(cluster.prs)) {
+    if (pr < 0) continue;
+    await octo.rest.issues.createComment({
+      owner, repo, issue_number: pr,
+      body: `Heads-up 🚦 — CI is currently failing on **all PRs** with:\n\`\`\`\n${cluster.msg}\n\`\`\`\nA fix is being prepared automatically.`
+    });
+  }
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true
+  },
+  "include": ["ci_watchdog.ts"]
+}

--- a/upload/processThumbnail.js
+++ b/upload/processThumbnail.js
@@ -14,7 +14,7 @@ const sharp = require("sharp");
 /**
  * Process an uploaded thumbnail image according to repository standards.
  * @param {Buffer} fileBuffer Raw image data
- * @returns {Promise<{ok: boolean, buffer?: Buffer, error?: string}>}
+ * @returns {Promise<{ok: boolean, buffer?: Buffer, error?: string}>} Processed thumbnail result
  */
 async function processThumbnail(fileBuffer) {
   try {


### PR DESCRIPTION
## Summary
- implement CI watchdog workflow that scans for systemic CI failures
- add TypeScript watchdog script compiled at `prepare`
- compile script using minimal tsconfig and async fs operations
- ignore watchdog script from ESLint rules
- document return value in `processThumbnail`

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_68580649639c832d98b7305fd3ebbbb7