### PR TITLE
Add previous price marker on payment page

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -269,6 +269,7 @@
                   id="multi-color-button"
                   class="w-28 h-28 flex flex-col items-center justify-center rounded-full border-4 border-white/20 shadow-xl peer-checked:border-[#30D5C8]"
                 >
+                  <span class="absolute -top-3 -left-1 text-sm text-gray-300 line-through">£54.99</span>
                   <span class="font-semibold leading-none">£39.99</span>
                   <span class="text-xs leading-tight">multi-colour</span>
                   <span class="text-[10px] leading-tight text-center mt-2 text-[#30D5C8]"


### PR DESCRIPTION
## Summary
- show discounted original price above the £39.99 option on payment page

## Testing
- `npm run format` in `backend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_685866b9af94832da0b46929fc50e0be