### PR TITLE
Animate index prompt placeholder

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,6 +111,12 @@
         line-height: 1.75rem;
         max-height: calc(1.75rem * 4);
       }
+      .placeholder-transition {
+        transition: opacity 1s;
+      }
+      .placeholder-fade {
+        opacity: 0;
+      }
       /*
         Remove the pseudo-element and animation that created the
         multicolored shimmer on the submit button. Keeping the
@@ -401,7 +407,7 @@
                 rows="1"
                 placeholder="Text, image, or both — we’ll 3D print it…"
                 aria-label="Prompt"
-                class="prompt-textarea w-full bg-transparent resize-none text-lg placeholder-gray-500 focus:outline-none"
+                class="prompt-textarea placeholder-transition w-full bg-transparent resize-none text-lg placeholder-gray-500 focus:outline-none"
               ></textarea>
             </div>
             <button

--- a/js/index.js
+++ b/js/index.js
@@ -153,6 +153,10 @@ const EXAMPLES = [
   "ornate chess piece",
   "geometric flower vase",
 ];
+const PLACEHOLDERS = [
+  "Text, image, or both \u2014 we\u2019ll 3D print it\u2026",
+  "a custom battle robot mini for D&D",
+];
 const TRENDING = ["dragon statue", "space rover", "anime character"];
 const THEME_CAMPAIGNS = [
   { name: "Sci-fi Month", tagline: "Explore out-of-this-world designs!" },
@@ -237,6 +241,25 @@ let usingViewerProgress = false;
 let lastSnapshot = null;
 let errorFadeTimeout = null;
 let errorClearTimeout = null;
+
+function cyclePlaceholders(input) {
+  let idx = 0;
+  const FADE_CLASS = "placeholder-fade";
+  function step() {
+    if (input.value) {
+      setTimeout(step, 5000);
+      return;
+    }
+    input.classList.add(FADE_CLASS);
+    setTimeout(() => {
+      idx = (idx + 1) % PLACEHOLDERS.length;
+      input.placeholder = PLACEHOLDERS[idx];
+      input.classList.remove(FADE_CLASS);
+      setTimeout(step, 5000);
+    }, 1000);
+  }
+  setTimeout(step, 5000);
+}
 
 function getCycleKey() {
   const now = new Date();
@@ -933,9 +956,8 @@ async function init() {
     }
   }
   if (usePlaceholder) {
-    // Keep placeholder text consistent with index.html
-    refs.promptInput.placeholder =
-      "Text, image, or both — we\u2019ll 3D print it\u2026";
+    refs.promptInput.placeholder = PLACEHOLDERS[0];
+    cyclePlaceholders(refs.promptInput);
   }
   if (refs.examples) {
     refs.examples.textContent = `Try: ${EXAMPLES.join(" · ")}`;


### PR DESCRIPTION
## Summary
- add CSS classes for placeholder fade animation
- cycle placeholder text between default and example text

## Testing
- `npm run format` in backend
- `npm test` in backend
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_68587099db50832dac1d345701f18ec2