### PR TITLE
Fix placeholder detection for basket snapshots

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -780,7 +780,11 @@ refs.submitBtn.addEventListener("click", async () => {
     showModel();
     if (window.addAutoItem) {
       let snapshot = refs.previewImg?.src;
-      if (!snapshot || snapshot.includes("placehold.co")) {
+      if (
+        !snapshot ||
+        snapshot.includes("placehold.co") ||
+        snapshot.includes("unsplash.com")
+      ) {
         snapshot = await captureModelSnapshot(url);
       }
       lastSnapshot = snapshot;
@@ -975,7 +979,11 @@ async function init() {
   refs.addBasketBtn?.addEventListener("click", async () => {
     if (!window.addToBasket || !refs.viewer?.src) return;
     let snapshot = refs.previewImg?.src;
-    if (!snapshot || snapshot.includes("placehold.co")) {
+    if (
+      !snapshot ||
+      snapshot.includes("placehold.co") ||
+      snapshot.includes("unsplash.com")
+    ) {
       snapshot = await captureModelSnapshot(refs.viewer.src);
     }
     lastSnapshot = snapshot;


### PR DESCRIPTION
## Summary
- ensure snapshot capture runs when the preview uses the new Unsplash placeholder

## Testing
- `npm run format` in `backend`
- `npm test` in `backend`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_68586aa04340832dbfbca2ce23b318cb