### PR TITLE
Add striked-out old price on checkout

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -269,6 +269,7 @@
                   id="multi-color-button"
                   class="w-28 h-28 flex flex-col items-center justify-center rounded-full border-4 border-white/20 shadow-xl peer-checked:border-[#30D5C8]"
                 >
+                  <span class="absolute -top-2 -left-2 text-sm line-through whitespace-nowrap">£54.99</span>
                   <span class="font-semibold leading-none">£39.99</span>
                   <span class="text-xs leading-tight">multi-colour</span>
                   <span class="text-[10px] leading-tight text-center mt-2 text-[#30D5C8]"


### PR DESCRIPTION
## Summary
- show a striked-out `£54.99` above the `£39.99` multi-colour option on `payment.html`

## Testing
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_685882c32c14832db281b58f05be44f3