### PR TITLE
Fix price badge position

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -265,16 +265,18 @@
                   class="sr-only peer"
                   checked
                 />
-                <span
-                  id="multi-color-button"
-                  class="w-28 h-28 flex flex-col items-center justify-center rounded-full border-4 border-white/20 shadow-xl peer-checked:border-[#30D5C8]"
-                >
+                <span class="relative">
                   <span class="absolute -top-2 -left-2 text-sm line-through whitespace-nowrap">£54.99</span>
-                  <span class="font-semibold leading-none">£39.99</span>
-                  <span class="text-xs leading-tight">multi-colour</span>
-                  <span class="text-[10px] leading-tight text-center mt-2 text-[#30D5C8]"
-                    >+ (optional) name<br />etching</span
+                  <span
+                    id="multi-color-button"
+                    class="w-28 h-28 flex flex-col items-center justify-center rounded-full border-4 border-white/20 shadow-xl peer-checked:border-[#30D5C8]"
                   >
+                    <span class="font-semibold leading-none">£39.99</span>
+                    <span class="text-xs leading-tight">multi-colour</span>
+                    <span class="text-[10px] leading-tight text-center mt-2 text-[#30D5C8]"
+                      >+ (optional) name<br />etching</span
+                    >
+                  </span>
                 </span>
                 <span class="block text-xs mt-1 text-red-300 w-28">
                   Only <span id="color-slot-count" style="visibility: hidden"></span> coloured


### PR DESCRIPTION
## Summary
- position the old price tag outside the multi-colour button so it's visible

## Testing
- `npm run format` *(backend)*
- `npm test` *(backend)*
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_68588748576c832da370c8e2f78ff64f