### PR TITLE
Fix Playwright install instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ These guidelines apply to all automated agents (e.g. the Codex agent) working on
 ## Mandatory steps
 
 1. **Unset proxy variables** – before running any `npm` commands, execute `unset npm_config_http_proxy npm_config_https_proxy` to silence `http-proxy` warnings.
-2. **Install dependencies** – run `npm ci` inside `backend/`. If `backend/hunyuan_server/` contains a `package.json`, run `npm ci` there as well.
+2. **Install dependencies** – first run `npm ci` at the repository root so tools like Playwright are available. Then run `npm ci` inside `backend/`. If `backend/hunyuan_server/` contains a `package.json`, run `npm ci` there as well.
 3. **Format code** – run `npm run format` in `backend/` to apply Prettier formatting.
 4. **Run tests** – execute `npm test` in `backend/`. If tests cannot run because of environment limitations, mention this in the PR.
 5. **Run full CI locally** – execute `npm run ci` at the repo root before opening a PR.


### PR DESCRIPTION
## Summary
- clarify running `npm ci` at repo root before `backend`

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_6859255e689c832d88e42b1c0ca2b012