### PR TITLE
Fix Docker prune sequence

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,11 @@ RUN if [ "$SKIP_TESTS" = "1" ]; then \
     fi
 
 # -------- prune dev dependencies
-RUN pnpm -F . prune --prod && pnpm -F ./backend prune --prod
+RUN pnpm prune --prod \
+    && pnpm prune --prod --dir backend \
+    && if [ -d backend/hunyuan_server ]; then \
+         pnpm prune --prod --dir backend/hunyuan_server; \
+       fi
 
 # -------- runtime stage
 FROM node:20


### PR DESCRIPTION
## Summary
- change Dockerfile prune stage to set directories
- run repository formatting and tests

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `docker build -t mvp-test-image .` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685acff1faa8832daaa185cdb44c6560