### PR TITLE
Add hover zoom and 1:1 thumbnail cropping

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,6 +140,15 @@
       .purchase-fade {
         animation: purchaseFade 8s forwards;
       }
+      .thumbnail-wrapper img {
+        transition:
+          transform 0.2s ease,
+          filter 0.2s ease;
+      }
+      .thumbnail-wrapper:hover img {
+        transform: scale(1.1);
+        filter: url(#thumb-sharp);
+      }
     </style>
   </head>
 
@@ -619,6 +628,15 @@
       id="purchase-popups"
       class="fixed bottom-28 left-4 bg-black/80 text-white px-3 py-1 rounded hidden opacity-0 text-sm flex items-center space-x-2"
     ></div>
+    <svg xmlns="http://www.w3.org/2000/svg" class="hidden">
+      <filter id="thumb-sharp">
+        <feConvolveMatrix
+          order="3"
+          kernelMatrix="0 -1 0 -1 5 -1 0 -1 0"
+          divisor="1"
+        />
+      </filter>
+    </svg>
     <img src="/pixel" alt="" width="1" height="1" style="display: none" />
   </body>
 </html>

--- a/js/index.js
+++ b/js/index.js
@@ -641,12 +641,10 @@ function renderThumbnails(arr) {
     // Make the wrapper fill the preview container so images and
     // buttons are sized relative to it rather than their natural
     // dimensions. This avoids oversized previews in Safari on iPad.
-    wrap.className = "relative w-full h-full";
+    wrap.className = "thumbnail-wrapper relative w-full h-full overflow-hidden";
     const img = document.createElement("img");
     img.src = url;
-    // Use object-contain so tall images fit within the square thumbnail
-    // without overflowing in Safari on iPad.
-    img.className = "object-contain w-full h-full rounded-md shadow-md";
+    img.className = "w-full h-full rounded-md shadow-md";
     wrap.appendChild(img);
 
     const btn = document.createElement("button");
@@ -681,16 +679,27 @@ function getThumbnail(file) {
     R.onload = () => {
       const im = new Image();
       im.onload = () => {
-        let [w, h] = [im.width, im.height],
-          max = 200,
-          r = Math.min(max / w, max / h, 1);
-        w *= r;
-        h *= r;
+        const size = 200;
         const c = document.createElement("canvas");
-        c.width = w;
-        c.height = h;
-        c.getContext("2d").drawImage(im, 0, 0, w, h);
-        res(c.toDataURL("image/png", 0.7));
+        c.width = size;
+        c.height = size;
+        const ctx = c.getContext("2d");
+        ctx.fillStyle = "#1e1e1e";
+        ctx.fillRect(0, 0, size, size);
+        let sx = 0,
+          sy = 0,
+          sw = im.width,
+          sh = im.height;
+        if (im.width > im.height) {
+          sx = (im.width - im.height) / 2;
+          sw = im.height;
+        } else if (im.height > im.width) {
+          sy = (im.height - im.width) / 2;
+          sh = im.width;
+        }
+        ctx.imageSmoothingQuality = "high";
+        ctx.drawImage(im, sx, sy, sw, sh, 0, 0, size, size);
+        res(c.toDataURL("image/jpeg", 0.7));
       };
       im.src = R.result;
     };

--- a/upload/processThumbnail.js
+++ b/upload/processThumbnail.js
@@ -36,6 +36,8 @@ async function processThumbnail(fileBuffer) {
         right: 400 - width,
         background: { r: 0, g: 0, b: 0, alpha: 0 },
       })
+      // Keep thumbnails crisp
+      .sharpen()
       .flatten({ background: "#1e1e1e" })
       .jpeg({ quality: 80 });
 


### PR DESCRIPTION
## Summary
- crop uploaded thumbnails to 1:1 square with neutral background
- add hover zoom effect with sharpening on thumbnails
- keep thumbnails crisp during processing

## Testing
- `npm run format` in backend
- `npm test` in backend
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_685ac84ba970832d907910b69e84c30d