### PR TITLE
Fix color menu closing

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -662,7 +662,6 @@ async function initPaymentPage() {
       localStorage.setItem("print3Material", "single");
       colorMenu.classList.add("hidden");
     };
-    colorMenu.addEventListener("pointerdown", handleColorSelect);
     colorMenu.addEventListener("click", handleColorSelect);
   }
   updatePayButton();


### PR DESCRIPTION
## Summary
- ensure single color menu closes on color selection

## Testing
- `npm run format`
- `npm test`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_685ac95e9f9c832d91cb5369288738be