### PR TITLE
Fix signup error positioning

### DIFF
--- a/signup.html
+++ b/signup.html
@@ -144,12 +144,12 @@
             </div>
           </div>
         </form>
+        <div
+          id="error"
+          class="absolute top-full left-0 ml-4 mt-1 text-red-400 whitespace-nowrap"
+          aria-live="assertive"
+        ></div>
       </div>
-      <div
-        id="error"
-        class="mt-2 text-red-400 text-center"
-        aria-live="assertive"
-      ></div>
     </main>
     <script type="module" src="js/signup.js"></script>
     <script type="module">


### PR DESCRIPTION
## Summary
- stop signup error message from shifting elements
- place the signup error below the button like on the login page

## Testing
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_685acadb9840832dbe522460376977cb