### PR TITLE
Add referral share link and signup reward

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,9 @@ Models can be shared publicly via unique slugs.
   redirect to `share.html` for viewing.
 - Item cards in **Community Creations** now include a share icon that copies a
   referral link like `https://prints3.com/item/<ID>?ref=<CODE>` to the clipboard.
-  Signups via this link grant both parties a £3 discount code.
+  Signups via this link grant both parties a £3 discount code. The referrer's
+  code is stored in their incentives list while the new user's code is returned
+  from `/api/referral-signup` for display after signup.
 
 ## Model Lists
 

--- a/backend/tests/rewards.test.js
+++ b/backend/tests/rewards.test.js
@@ -99,6 +99,8 @@ test("POST /api/referral-signup grants codes", async () => {
   expect(incentive[1][1]).toMatch(/^referral_/);
   expect(res.body.code).toBe("DISC123");
   expect(createTimedCode).toHaveBeenCalledTimes(2);
+  expect(createTimedCode).toHaveBeenNthCalledWith(1, 300, 168);
+  expect(createTimedCode).toHaveBeenNthCalledWith(2, 300, 168);
 });
 
 test("GET /api/orders/:id/referral-link returns code", async () => {

--- a/js/community.js
+++ b/js/community.js
@@ -259,7 +259,7 @@ async function copyReferral(id) {
       console.error("Failed to fetch referral", err);
     }
   }
-  const url = `${window.location.origin}/item/${id}${ref}`;
+  const url = `https://prints3.com/item/${id}${ref}`;
   await navigator.clipboard.writeText(url);
 }
 

--- a/js/signup.js
+++ b/js/signup.js
@@ -38,6 +38,8 @@ async function signup(e) {
   if (data.token) {
     localStorage.setItem("token", data.token);
     const ref = localStorage.getItem("referrerId");
+    const codeEl = document.getElementById("referral-code");
+    if (codeEl) codeEl.textContent = "";
     if (ref) {
       try {
         const r = await fetch(`${API_BASE}/referral-signup`, {
@@ -47,14 +49,14 @@ async function signup(e) {
         });
         if (r.ok) {
           const d = await r.json();
-          if (d.code) {
-            alert(`Your £3 discount code: ${d.code}`);
+          if (d.code && codeEl) {
+            codeEl.textContent = `Your £3 discount code: ${d.code}`;
           }
-        } else {
-          alert("Failed to apply referral");
+        } else if (codeEl) {
+          codeEl.textContent = "Failed to apply referral";
         }
       } catch (err) {
-        alert("Failed to apply referral");
+        if (codeEl) codeEl.textContent = "Failed to apply referral";
       }
     }
     if (optIn) {

--- a/signup.html
+++ b/signup.html
@@ -150,6 +150,11 @@
         class="mt-2 text-red-400 text-center"
         aria-live="assertive"
       ></div>
+      <div
+        id="referral-code"
+        class="mt-2 text-green-400 text-center"
+        aria-live="polite"
+      ></div>
     </main>
     <script type="module" src="js/signup.js"></script>
     <script type="module">


### PR DESCRIPTION
## Summary
- copy a referral link via share icon in Community Creations
- show discount code after signing up via referral
- return referrer reward code via API and verify in tests
- document referral share flow

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ad4890b50832d8f5047b599d40763