### PR TITLE
Fix price layout on payment page

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -269,16 +269,16 @@
                   id="multi-color-button"
                   class="relative w-28 h-28 flex flex-col items-center justify-center rounded-full border-4 border-white/20 shadow-xl peer-checked:border-[#30D5C8]"
                 >
-                  <span class="absolute -top-2 -left-2 text-sm line-through whitespace-nowrap">£54.99</span>
                   <span class="font-semibold leading-none">£39.99</span>
                   <span class="text-xs leading-tight">multi-colour</span>
                   <span class="text-[10px] leading-tight text-center mt-2 text-[#30D5C8]"
                     >+ (optional) name<br />etching</span
                   >
-                </span>
-                <span class="block text-xs mt-1 text-red-300 w-28">
-                  Only <span id="color-slot-count" style="visibility: hidden"></span> coloured
-                  prints left
+                  </span>
+                  <span class="absolute -top-2 left-1/2 -translate-x-16 text-sm line-through whitespace-nowrap pointer-events-none z-10">£54.99</span>
+                  <span class="block text-xs mt-1 text-red-300 w-28">
+                    Only <span id="color-slot-count" style="visibility: hidden"></span> coloured
+                    prints left
                 </span>
                 <span class="block text-xs mt-1 text-white w-28">(most popular)</span>
               </label>


### PR DESCRIPTION
## Summary
- move crossed-out price label above the color button without clipping

## Testing
- `npm run format` in `backend`
- `npm test` in `backend`
- `npm run ci` *(fails: [error] CommunityCreations.html SyntaxError)*

------
https://chatgpt.com/codex/tasks/task_e_685ad9c4a108832dbffdad3dc9d54ddf