### PR TITLE
Add community carousel

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -400,6 +400,67 @@
           </div>
         </div>
       </section>
+      <!-- What others are printing -->
+      <section class="mb-12">
+        <h2 class="text-xl font-semibold mb-4 text-center">
+          What others are printing
+        </h2>
+        <div
+          id="prints-carousel"
+          class="flex overflow-x-auto gap-4 pb-2 snap-x justify-center"
+        >
+          <div class="flex-shrink-0 flex gap-2 w-80 snap-start">
+            <model-viewer
+              src="https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Fox/glTF-Binary/Fox.glb"
+              alt="Fox model"
+              environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
+              camera-controls
+              auto-rotate
+              class="w-1/2 h-40"
+            ></model-viewer>
+            <img
+              src="https://images.unsplash.com/photo-1585124701440-7718ee1af7aa?auto=format&fit=crop&w=240&q=60"
+              alt="Printed fox"
+              loading="lazy"
+              class="w-1/2 h-40 object-cover rounded"
+            />
+          </div>
+          <div class="flex-shrink-0 w-48 snap-start">
+            <model-viewer
+              src="https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/WaterBottle/glTF-Binary/WaterBottle.glb"
+              alt="Water bottle model"
+              environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
+              camera-controls
+              auto-rotate
+              class="w-full h-40"
+            ></model-viewer>
+          </div>
+          <div class="flex-shrink-0 flex gap-2 w-80 snap-start">
+            <model-viewer
+              src="https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AntiqueCamera/glTF-Binary/AntiqueCamera.glb"
+              alt="Camera model"
+              environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
+              camera-controls
+              auto-rotate
+              class="w-1/2 h-40"
+            ></model-viewer>
+            <img
+              src="https://images.unsplash.com/photo-1519183071298-a2962be566f2?auto=format&fit=crop&w=240&q=60"
+              alt="Printed camera"
+              loading="lazy"
+              class="w-1/2 h-40 object-cover rounded"
+            />
+          </div>
+          <div class="flex-shrink-0 w-48 snap-start">
+            <img
+              src="https://images.unsplash.com/photo-1555617117-08ce2a69e83d?auto=format&fit=crop&w=240&q=60"
+              alt="Printed vase"
+              loading="lazy"
+              class="w-full h-40 object-cover rounded"
+            />
+          </div>
+        </div>
+      </section>
 
       <!-- Recent Creations -->
       <section>


### PR DESCRIPTION
## Summary
- revert previous commit
- add center-aligned "What others are printing" carousel between Bestselling and Recent sections on Community Creations

## Testing
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_685ac845ff00832da4022c0c66840d96