### PR TITLE
Refactor auth headers

### DIFF
--- a/js/adminAds.js
+++ b/js/adminAds.js
@@ -1,12 +1,4 @@
-const API_BASE = (window.API_ORIGIN || '') + '/api';
-
-function authHeaders() {
-  const admin = localStorage.getItem('adminToken');
-  if (admin) return { 'x-admin-token': admin };
-  const user = localStorage.getItem('token');
-  if (user) return { Authorization: `Bearer ${user}` };
-  return {};
-}
+import { API_BASE, authHeaders } from './api.js';
 
 async function load() {
   const app = document.getElementById('app');

--- a/js/adminCompetitions.js
+++ b/js/adminCompetitions.js
@@ -6,15 +6,7 @@ function setToken(token) {
   localStorage.setItem('adminToken', token);
 }
 
-function authHeaders() {
-  const admin = localStorage.getItem('adminToken');
-  if (admin) return { 'x-admin-token': admin };
-  const user = localStorage.getItem('token');
-  if (user) return { Authorization: `Bearer ${user}` };
-  return {};
-}
-
-const API_BASE = (window.API_ORIGIN || '') + '/api';
+import { API_BASE, authHeaders } from './api.js';
 
 async function load() {
   const list = document.getElementById('list');

--- a/js/adminFlashSale.js
+++ b/js/adminFlashSale.js
@@ -6,15 +6,7 @@ function setToken(token) {
   localStorage.setItem('adminToken', token);
 }
 
-function authHeaders() {
-  const admin = localStorage.getItem('adminToken');
-  if (admin) return { 'x-admin-token': admin };
-  const user = localStorage.getItem('token');
-  if (user) return { Authorization: `Bearer ${user}` };
-  return {};
-}
-
-const API_BASE = (window.API_ORIGIN || '') + '/api';
+import { API_BASE, authHeaders } from './api.js';
 
 async function load() {
   const container = document.getElementById('sale');

--- a/js/adminHubs.js
+++ b/js/adminHubs.js
@@ -1,12 +1,4 @@
-const API_BASE = (window.API_ORIGIN || "") + "/api";
-
-function authHeaders() {
-  const admin = localStorage.getItem("adminToken");
-  if (admin) return { "x-admin-token": admin };
-  const user = localStorage.getItem("token");
-  if (user) return { Authorization: `Bearer ${user}` };
-  return {};
-}
+import { API_BASE, authHeaders } from './api.js';
 
 async function load() {
   const app = document.getElementById("app");

--- a/js/adminOperations.js
+++ b/js/adminOperations.js
@@ -1,12 +1,4 @@
-const API_BASE = (window.API_ORIGIN || "") + "/api";
-
-function authHeaders() {
-  const admin = localStorage.getItem("adminToken");
-  if (admin) return { "x-admin-token": admin };
-  const user = localStorage.getItem("token");
-  if (user) return { Authorization: `Bearer ${user}` };
-  return {};
-}
+import { API_BASE, authHeaders } from './api.js';
 
 async function load() {
   const app = document.getElementById("app");

--- a/js/api.js
+++ b/js/api.js
@@ -1,0 +1,9 @@
+export const API_BASE = (window.API_ORIGIN || '') + '/api';
+
+export function authHeaders() {
+  const admin = localStorage.getItem('adminToken');
+  if (admin) return { 'x-admin-token': admin };
+  const user = localStorage.getItem('token');
+  if (user) return { Authorization: `Bearer ${user}` };
+  return {};
+}

--- a/js/profile.js
+++ b/js/profile.js
@@ -1,6 +1,5 @@
 import { captureSnapshots } from './snapshot.js';
-
-const API_BASE = (window.API_ORIGIN || '') + '/api';
+import { API_BASE, authHeaders } from './api.js';
 
 function isValidEmail(email) {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
@@ -93,9 +92,7 @@ async function load() {
   const user = urlParams.get('user');
   let endpoint = `${API_BASE}/my/models`;
   if (user) endpoint = `${API_BASE}/users/${encodeURIComponent(user)}/models`;
-  const res = await fetch(endpoint, {
-    headers: { Authorization: `Bearer ${token}` },
-  });
+  const res = await fetch(endpoint, { headers: authHeaders() });
   const models = await res.json();
   const container = document.getElementById('models');
   container.innerHTML = '';
@@ -117,7 +114,7 @@ async function loadProfileHeader() {
   } else {
     endpoint = `${API_BASE}/profile`;
   }
-  const res = await fetch(endpoint, user ? {} : { headers: { Authorization: `Bearer ${token}` } });
+  const res = await fetch(endpoint, user ? {} : { headers: authHeaders() });
   if (!res.ok) return;
   const data = await res.json();
   document.getElementById('profile-name').textContent = data.display_name || 'Profile';


### PR DESCRIPTION
## Summary
- centralize `API_BASE` and authentication headers in `js/api.js`
- reuse the new helper in admin scripts and profile page

## Testing
- `npm run setup`
- `npm run format` in `backend/`
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_685adaf1cc88832d9e1743104dd48570