### PR TITLE
Fix price hover movement

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -240,11 +240,7 @@
               <path d="M9 6l6 6-6 6" />
             </svg>
           </button>
-              camera-controls
-              class="w-40 h-40 bg-[#2A2A2E] rounded-xl"
-              crossOrigin="anonymous"
-            ></model-viewer>
-          </div>
+        </div>
           <div class="flex gap-2 items-start min-w-[24rem]">
             <model-viewer
               src="https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/AntiqueCamera/glTF-Binary/AntiqueCamera.glb"
@@ -268,8 +264,6 @@
             />
           </div>
         </div>
-
-      </section>
 
       <!-- What others are printing carousel -->
       <section class="mb-12">

--- a/payment.html
+++ b/payment.html
@@ -106,6 +106,16 @@
         box-shadow: 0 0 10px rgba(48, 213, 200, 0.6),
           0 6px 10px rgba(0, 0, 0, 0.6);
       }
+      /* Prevent price strike-through text from scaling */
+      #material-options label span.no-scale {
+        transform: translateX(-4rem);
+      }
+      #material-options label:hover span.no-scale,
+      #material-options input:active + span.no-scale,
+      #material-options input:checked + span.no-scale {
+        transform: translateX(-4rem);
+        box-shadow: none;
+      }
 
 
       /* Add glow and single-pass shimmer to the Pay button */
@@ -275,7 +285,7 @@
                     >+ (optional) name<br />etching</span
                   >
                   </span>
-                  <span class="absolute -top-2 left-1/2 -translate-x-16 text-sm line-through whitespace-nowrap pointer-events-none z-10">£54.99</span>
+                  <span class="no-scale text-base absolute -top-2 left-1/2 -translate-x-16 font-semibold leading-none line-through whitespace-nowrap pointer-events-none z-10">£54.99</span>
                   <span class="block text-xs mt-1 text-red-300 w-28">
                     Only <span id="color-slot-count" style="visibility: hidden"></span> coloured
                     prints left


### PR DESCRIPTION
## Summary
- keep crossed-out £54.99 text from moving when hovering the option
- clean up a stray closing tag in CommunityCreations carousel

## Testing
- `npm run format`
- `npm test`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_685ae336df14832d8ac97eb675f985e7