### PR TITLE
Add placeholder heading to community page

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -156,7 +156,10 @@
           More
         </button>
       </section>
-
+      <!-- What People Are Printing -->
+      <section class="mb-12">
+        <h2 class="text-xl font-semibold mb-4">What people are printing</h2>
+      </section>
       <!-- Recent Creations -->
       <section>
         <h2 class="text-xl font-semibold mb-4">Recent</h2>


### PR DESCRIPTION
## Summary
- add a "What people are printing" heading placeholder on CommunityCreations page

## Testing
- `npm run format` in `backend`
- `npm test` in `backend`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_685ae9a7f3f0832d83f61558807b9e08