### PR TITLE
feat: introduce saved creations list

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -54,11 +54,17 @@
             stroke-width="2"
             viewBox="0 0 24 24"
           >
-            <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M15 19l-7-7 7-7"
+            />
           </svg>
           Back
         </a>
-        <h1 class="flex-1 text-center text-3xl font-semibold">Community Creations</h1>
+        <h1 class="flex-1 text-center text-3xl font-semibold">
+          Community Creations
+        </h1>
         <a
           href="earn-rewards.html"
           id="earn-rewards-badge"
@@ -147,7 +153,10 @@
       <!-- Popular Creations -->
       <section class="mb-12">
         <h2 class="text-xl font-semibold mb-4">Bestselling</h2>
-        <div id="popular-grid" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4"></div>
+        <div
+          id="popular-grid"
+          class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4"
+        ></div>
         <div id="popular-sentinel" class="h-8"></div>
         <button
           id="popular-load"
@@ -163,7 +172,10 @@
       <!-- Recent Creations -->
       <section>
         <h2 class="text-xl font-semibold mb-4">Recent</h2>
-        <div id="recent-grid" class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4"></div>
+        <div
+          id="recent-grid"
+          class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4"
+        ></div>
         <div id="recent-sentinel" class="h-8"></div>
         <button
           id="recent-load"
@@ -210,8 +222,6 @@
           id="model-stats"
           class="absolute top-2 left-2 text-xs bg-black/60 text-white px-2 py-1 rounded z-10 pointer-events-none"
         >
-          <span id="likes-count">❤️ 12 likes</span>
-          •
           <span id="print-count">🛒 4 prints sold</span>
         </div>
         <div
@@ -261,12 +271,27 @@
         >
           Add to Basket
         </button>
-        <div id="modal-copy-container" class="absolute bottom-4 left-40 flex items-center gap-2">
-          <button id="modal-copy-link" class="font-bold py-2 px-4 rounded-full shadow-md bg-[#2A2A2E] border border-white/20">Share</button>
-          <span id="modal-copy-msg" class="ml-2 text-sm opacity-0 transition-opacity">Link copied</span>
+        <div
+          id="modal-copy-container"
+          class="absolute bottom-4 left-40 flex items-center gap-2"
+        >
+          <button
+            id="modal-copy-link"
+            class="font-bold py-2 px-4 rounded-full shadow-md bg-[#2A2A2E] border border-white/20"
+          >
+            Share
+          </button>
+          <span
+            id="modal-copy-msg"
+            class="ml-2 text-sm opacity-0 transition-opacity"
+            >Link copied</span
+          >
         </div>
         <div class="bg-[#2A2A2E] p-4 rounded-b-xl">
-          <ul id="comments-list" class="space-y-1 max-h-48 overflow-y-auto text-sm"></ul>
+          <ul
+            id="comments-list"
+            class="space-y-1 max-h-48 overflow-y-auto text-sm"
+          ></ul>
           <div id="comment-form" class="flex gap-2 mt-2">
             <input
               type="text"
@@ -274,56 +299,64 @@
               placeholder="Add a comment..."
               class="flex-1 bg-[#1A1A1D] border border-white/20 rounded px-2 py-1"
             />
-            <button id="comment-submit" class="px-3 py-1 bg-blue-600 rounded">Post</button>
+            <button id="comment-submit" class="px-3 py-1 bg-blue-600 rounded">
+              Post
+            </button>
           </div>
         </div>
       </div>
     </div>
     <script type="module">
-      import { shareOn } from './js/share.js';
-      import { init, closeModel, restoreOpenModel } from './js/community.js';
+      import { shareOn } from "./js/share.js";
+      import { init, closeModel, restoreOpenModel } from "./js/community.js";
       window.shareOn = shareOn;
 
-      document.addEventListener('DOMContentLoaded', () => {
-        const modal = document.getElementById('model-modal');
-        const checkoutBtn = document.getElementById('modal-checkout');
-        const addBasketBtn = document.getElementById('modal-add-basket');
-        const closeBtn = document.getElementById('close-modal');
-        const tierToggle = document.getElementById('tier-toggle');
+      document.addEventListener("DOMContentLoaded", () => {
+        const modal = document.getElementById("model-modal");
+        const checkoutBtn = document.getElementById("modal-checkout");
+        const addBasketBtn = document.getElementById("modal-add-basket");
+        const closeBtn = document.getElementById("close-modal");
+        const tierToggle = document.getElementById("tier-toggle");
 
         function setTier(tier) {
-          tierToggle?.querySelectorAll('button[data-tier]').forEach((btn) => {
+          tierToggle?.querySelectorAll("button[data-tier]").forEach((btn) => {
             const active = btn.dataset.tier === tier;
 
-            btn.classList.toggle('ring-2', active);
-            btn.classList.toggle('ring-white', active);
-            btn.classList.toggle('opacity-100', active);
-            btn.classList.toggle('opacity-50', !active);
+            btn.classList.toggle("ring-2", active);
+            btn.classList.toggle("ring-white", active);
+            btn.classList.toggle("opacity-100", active);
+            btn.classList.toggle("opacity-50", !active);
           });
           if (checkoutBtn) {
-            const price = tier === 'bronze' ? 29.99 : tier === 'gold' ? 79.99 : 39.99;
+            const price =
+              tier === "bronze" ? 29.99 : tier === "gold" ? 79.99 : 39.99;
             checkoutBtn.textContent = `Print for £${price.toFixed(2)} →`;
           }
-          const material = tier === 'bronze' ? 'single' : tier === 'gold' ? 'premium' : 'multi';
-          localStorage.setItem('print3Material', material);
+          const material =
+            tier === "bronze"
+              ? "single"
+              : tier === "gold"
+                ? "premium"
+                : "multi";
+          localStorage.setItem("print3Material", material);
         }
 
-        tierToggle?.addEventListener('click', (ev) => {
-          const btn = ev.target.closest('button[data-tier]');
+        tierToggle?.addEventListener("click", (ev) => {
+          const btn = ev.target.closest("button[data-tier]");
           if (btn) setTier(btn.dataset.tier);
         });
 
         const close = closeModel;
 
-        checkoutBtn.addEventListener('click', () => {
-          sessionStorage.setItem('fromCommunity', '1');
+        checkoutBtn.addEventListener("click", () => {
+          sessionStorage.setItem("fromCommunity", "1");
           const model = checkoutBtn.dataset.model;
           const job = checkoutBtn.dataset.job;
-          if (model) localStorage.setItem('print3Model', model);
-          if (job) localStorage.setItem('print3JobId', job);
+          if (model) localStorage.setItem("print3Model", model);
+          if (job) localStorage.setItem("print3JobId", job);
         });
 
-        addBasketBtn?.addEventListener('click', () => {
+        addBasketBtn?.addEventListener("click", () => {
           if (!window.addToBasket) return;
           const model = addBasketBtn.dataset.model;
           const job = addBasketBtn.dataset.job;
@@ -333,49 +366,52 @@
           }
         });
 
-        const copyBtn = document.getElementById('modal-copy-link');
-        const copyMsg = document.getElementById('modal-copy-msg');
-        const help = document.getElementById('modal-copy-help');
-        const tooltip = document.getElementById('modal-copy-tooltip');
-        copyBtn?.addEventListener('click', () => {
+        const copyBtn = document.getElementById("modal-copy-link");
+        const copyMsg = document.getElementById("modal-copy-msg");
+        const help = document.getElementById("modal-copy-help");
+        const tooltip = document.getElementById("modal-copy-tooltip");
+        copyBtn?.addEventListener("click", () => {
           const id = copyBtn.dataset.id;
           if (!id) return;
           const url = `${window.location.origin}/community/model/${id}`;
           navigator.clipboard.writeText(url).then(() => {
             if (copyMsg) {
-              copyMsg.classList.remove('opacity-0');
-              copyMsg.classList.add('opacity-100');
+              copyMsg.classList.remove("opacity-0");
+              copyMsg.classList.add("opacity-100");
               setTimeout(() => {
-                copyMsg.classList.add('opacity-0');
-                copyMsg.classList.remove('opacity-100');
+                copyMsg.classList.add("opacity-0");
+                copyMsg.classList.remove("opacity-100");
               }, 2000);
             }
           });
         });
         if (help && tooltip) {
-          ['mouseenter', 'focus'].forEach((ev) =>
-            help.addEventListener(ev, () => tooltip.classList.remove('hidden'))
+          ["mouseenter", "focus"].forEach((ev) =>
+            help.addEventListener(ev, () => tooltip.classList.remove("hidden")),
           );
-          ['mouseleave', 'blur'].forEach((ev) =>
-            help.addEventListener(ev, () => tooltip.classList.add('hidden'))
+          ["mouseleave", "blur"].forEach((ev) =>
+            help.addEventListener(ev, () => tooltip.classList.add("hidden")),
           );
         }
 
-        closeBtn.addEventListener('click', close);
-        document.addEventListener('keydown', (e) => {
-          if (e.key === 'Escape') close();
+        closeBtn.addEventListener("click", close);
+        document.addEventListener("keydown", (e) => {
+          if (e.key === "Escape") close();
         });
 
-        document.addEventListener('click', (e) => {
-          if (modal.classList.contains('hidden')) return;
-          const container = modal.querySelector('div');
-          const basketBtn = document.getElementById('basket-button');
-          if (!container.contains(e.target) && !(basketBtn && basketBtn.contains(e.target))) {
+        document.addEventListener("click", (e) => {
+          if (modal.classList.contains("hidden")) return;
+          const container = modal.querySelector("div");
+          const basketBtn = document.getElementById("basket-button");
+          if (
+            !container.contains(e.target) &&
+            !(basketBtn && basketBtn.contains(e.target))
+          ) {
             close();
           }
         });
 
-        setTier('silver');
+        setTier("silver");
         init();
         restoreOpenModel();
       });
@@ -387,7 +423,8 @@
       <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center">
         <h2 class="text-2xl font-semibold mb-2">print2 pro</h2>
         <p class="mb-4">
-          Get two prints (single or multicolour tiers) every week for £149.99/month.
+          Get two prints (single or multicolour tiers) every week for
+          £149.99/month.
         </p>
         <button
           id="printclub-close"
@@ -401,6 +438,7 @@
     <script type="module" src="js/printclub.js"></script>
     <script type="module" src="js/rewardBadge.js"></script>
     <script type="module" src="js/basket.js"></script>
+    <script type="module" src="js/saveList.js"></script>
     <script type="module" src="js/rewardBadge.js"></script>
   </body>
 </html>

--- a/js/community.js
+++ b/js/community.js
@@ -4,21 +4,15 @@ const API_BASE = (window.API_ORIGIN || "") + "/api";
 
 const OPEN_KEY = "print3CommunityOpen";
 
-function like(id) {
-  const token = localStorage.getItem("token");
-  if (!token) {
-    alert("Login required");
-    return;
-  }
-  fetch(`${API_BASE}/models/${id}/like`, {
-    method: "POST",
-    headers: { Authorization: `Bearer ${token}` },
-  })
-    .then((r) => r.json())
-    .then((d) => {
-      const span = document.querySelector(`#likes-${id}`);
-      if (span) span.textContent = d.likes;
+function saveModel(model) {
+  if (window.addSavedModel) {
+    window.addSavedModel({
+      id: model.id,
+      modelUrl: model.model_url,
+      snapshot: model.snapshot,
+      title: model.title,
     });
+  }
 }
 
 const SEARCH_DELAY = 300;
@@ -156,7 +150,6 @@ if (!getFallbackModels)
 
     return samples.slice(start, start + count).map((s, i) => ({
       model_url: `${base}/${s.name}/glTF-Binary/${s.name}.glb`,
-      likes: 0,
       id: `fallback-${start + i}`,
       job_id: `fallback-${start + i}`,
       snapshot: `${base}/${s.name}/screenshot/screenshot.${s.ext}`,
@@ -270,7 +263,7 @@ function createCard(model) {
   div.dataset.model = model.model_url;
   div.dataset.job = model.job_id;
 
-  div.innerHTML = `\n      <img src="${model.snapshot || ""}" alt="Model" loading="lazy" fetchpriority="low" class="w-full h-full object-contain pointer-events-none" />\n      <span class="sr-only">${model.title || "Model"}</span>\n      <button class="like absolute bottom-1 right-1 text-xs bg-red-600 px-1 rounded">\u2665</button>\n      <span class="absolute bottom-8 right-1 text-xs bg-black/50 px-1 rounded" id="likes-${model.id}">${model.likes}</span>\n      <button class="share absolute top-1 right-1 w-7 h-7 flex items-center justify-center bg-[#2A2A2E] border border-white/20 rounded-full hover:bg-[#3A3A3E] transition-shape"><i class="fas fa-share text-xs"></i></button>\n      <button class="purchase absolute bottom-1 left-1 font-bold text-lg py-1.5 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]" style="transform: scale(0.6); transform-origin: left bottom;">Buy from £29.99</button>`;
+  div.innerHTML = `\n      <img src="${model.snapshot || ""}" alt="Model" loading="lazy" fetchpriority="low" class="w-full h-full object-contain pointer-events-none" />\n      <span class="sr-only">${model.title || "Model"}</span>\n      <button class="save absolute bottom-1 right-1 text-xs bg-blue-600 px-1 rounded">Save</button>\n      <button class="share absolute top-1 right-1 w-7 h-7 flex items-center justify-center bg-[#2A2A2E] border border-white/20 rounded-full hover:bg-[#3A3A3E] transition-shape"><i class="fas fa-share text-xs"></i></button>\n      <button class="purchase absolute bottom-1 left-1 font-bold text-lg py-1.5 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]" style="transform: scale(0.6); transform-origin: left bottom;">Buy from £29.99</button>`;
 
   div.querySelector(".purchase").addEventListener("click", (e) => {
     e.stopPropagation();
@@ -279,10 +272,10 @@ function createCard(model) {
     localStorage.setItem("print3JobId", model.job_id);
     window.location.href = "payment.html";
   });
-  const likeBtn = div.querySelector(".like");
-  likeBtn?.addEventListener("click", (e) => {
+  const saveBtn = div.querySelector(".save");
+  saveBtn?.addEventListener("click", (e) => {
     e.stopPropagation();
-    like(model.id);
+    saveModel(model);
   });
   const shareBtn = div.querySelector(".share");
   shareBtn?.addEventListener("click", (e) => {
@@ -451,4 +444,4 @@ function init() {
   renderGrid("recent");
 }
 
-export { like, init, closeModel, restoreOpenModel, copyReferral };
+export { saveModel, init, closeModel, restoreOpenModel, copyReferral };

--- a/js/profile.js
+++ b/js/profile.js
@@ -1,24 +1,31 @@
-import { captureSnapshots } from './snapshot.js';
-import { API_BASE, authHeaders } from './api.js';
+import { captureSnapshots } from "./snapshot.js";
+const API_BASE = (window.API_ORIGIN || "") + "/api";
+function authHeaders() {
+  const admin = localStorage.getItem("adminToken");
+  if (admin) return { "x-admin-token": admin };
+  const user = localStorage.getItem("token");
+  if (user) return { Authorization: `Bearer ${user}` };
+  return {};
+}
 
 function isValidEmail(email) {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
 }
 
 function createCard(model) {
-  const div = document.createElement('div');
+  const div = document.createElement("div");
   div.className =
-    'model-card relative h-32 bg-[#2A2A2E] border border-white/10 rounded-xl hover:bg-[#3A3A3E] flex items-center justify-center cursor-pointer';
+    "model-card relative h-32 bg-[#2A2A2E] border border-white/10 rounded-xl hover:bg-[#3A3A3E] flex items-center justify-center cursor-pointer";
   div.dataset.model = model.model_url;
   div.dataset.job = model.job_id;
-  div.innerHTML = `\n    <img src="${model.snapshot || ''}" alt="Model" class="w-full h-full object-contain pointer-events-none" />\n    <span class="sr-only">${model.prompt || 'Model'}</span>\n    <button class="purchase absolute bottom-1 left-1 text-xs bg-blue-600 px-1 rounded">Reorder</button>\n    <button class="add-basket absolute bottom-1 right-1 text-xs bg-green-600 px-1 rounded">Add</button>`;
-  div.querySelector('.purchase').addEventListener('click', (e) => {
+  div.innerHTML = `\n    <img src="${model.snapshot || ""}" alt="Model" class="w-full h-full object-contain pointer-events-none" />\n    <span class="sr-only">${model.prompt || "Model"}</span>\n    <button class="purchase absolute bottom-1 left-1 text-xs bg-blue-600 px-1 rounded">Reorder</button>\n    <button class="add-basket absolute bottom-1 right-1 text-xs bg-green-600 px-1 rounded">Add</button>`;
+  div.querySelector(".purchase").addEventListener("click", (e) => {
     e.stopPropagation();
-    localStorage.setItem('print3Model', model.model_url);
-    localStorage.setItem('print3JobId', model.job_id);
-    window.location.href = 'payment.html';
+    localStorage.setItem("print3Model", model.model_url);
+    localStorage.setItem("print3JobId", model.job_id);
+    window.location.href = "payment.html";
   });
-  div.querySelector('.add-basket').addEventListener('click', (e) => {
+  div.querySelector(".add-basket").addEventListener("click", (e) => {
     e.stopPropagation();
     if (window.addToBasket) {
       window.addToBasket({
@@ -28,74 +35,79 @@ function createCard(model) {
       });
     }
   });
-  div.addEventListener('click', () => {
-    const modal = document.getElementById('model-modal');
-    const viewer = modal.querySelector('model-viewer');
+  div.addEventListener("click", () => {
+    const modal = document.getElementById("model-modal");
+    const viewer = modal.querySelector("model-viewer");
     viewer.src = model.model_url;
-    modal.classList.remove('hidden');
-    document.body.classList.add('overflow-hidden');
+    modal.classList.remove("hidden");
+    document.body.classList.add("overflow-hidden");
   });
   return div;
 }
 
 async function createAccount(e) {
   e.preventDefault();
-  const nameEl = document.getElementById('ca-name');
-  const emailEl = document.getElementById('ca-email');
-  const passEl = document.getElementById('ca-pass');
-  [nameEl, emailEl, passEl].forEach((el) => el.classList.remove('border-red-500'));
+  const nameEl = document.getElementById("ca-name");
+  const emailEl = document.getElementById("ca-email");
+  const passEl = document.getElementById("ca-pass");
+  [nameEl, emailEl, passEl].forEach((el) =>
+    el.classList.remove("border-red-500"),
+  );
   const username = nameEl.value.trim();
   const email = emailEl.value.trim();
   const password = passEl.value.trim();
   if (!username || !email || !password) {
-    document.getElementById('ca-error').textContent = 'All fields required';
-    if (!username) nameEl.classList.add('border-red-500');
-    if (!email) emailEl.classList.add('border-red-500');
-    if (!password) passEl.classList.add('border-red-500');
+    document.getElementById("ca-error").textContent = "All fields required";
+    if (!username) nameEl.classList.add("border-red-500");
+    if (!email) emailEl.classList.add("border-red-500");
+    if (!password) passEl.classList.add("border-red-500");
     return;
   }
   if (!isValidEmail(email)) {
-    document.getElementById('ca-error').textContent = 'Invalid email format';
-    emailEl.classList.add('border-red-500');
+    document.getElementById("ca-error").textContent = "Invalid email format";
+    emailEl.classList.add("border-red-500");
     return;
   }
   const res = await fetch(`${API_BASE}/register`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ username, email, password }),
   });
   const data = await res.json();
   if (data.token) {
-    localStorage.setItem('token', data.token);
-    document.getElementById('create-account-form').classList.add('hidden');
+    localStorage.setItem("token", data.token);
+    document.getElementById("create-account-form").classList.add("hidden");
     load();
   } else {
-    document.getElementById('ca-error').textContent = data.error || 'Signup failed';
-    [nameEl, emailEl, passEl].forEach((el) => el.classList.add('border-red-500'));
+    document.getElementById("ca-error").textContent =
+      data.error || "Signup failed";
+    [nameEl, emailEl, passEl].forEach((el) =>
+      el.classList.add("border-red-500"),
+    );
   }
 }
 
 async function load() {
-  const token = localStorage.getItem('token');
-  const logoutBtn = document.getElementById('logout-btn');
-  const accountLink = document.getElementById('account-link');
+  const token = localStorage.getItem("token");
+  const logoutBtn = document.getElementById("logout-btn");
+  const accountLink = document.getElementById("account-link");
   if (!token) {
-    document.getElementById('auth-options').classList.remove('hidden');
-    logoutBtn?.classList.add('hidden');
-    accountLink?.classList.add('hidden');
+    document.getElementById("auth-options").classList.remove("hidden");
+    logoutBtn?.classList.add("hidden");
+    accountLink?.classList.add("hidden");
     return;
   } else {
-    logoutBtn?.classList.remove('hidden');
-    accountLink?.classList.remove('hidden');
+    logoutBtn?.classList.remove("hidden");
+    accountLink?.classList.remove("hidden");
   }
   const urlParams = new URLSearchParams(window.location.search);
-  const user = urlParams.get('user');
+  const user = urlParams.get("user");
   let endpoint = `${API_BASE}/my/models`;
   if (user) endpoint = `${API_BASE}/users/${encodeURIComponent(user)}/models`;
   const res = await fetch(endpoint, { headers: authHeaders() });
   const models = await res.json();
-  const container = document.getElementById('models');
-  container.innerHTML = '';
+  const container = document.getElementById("models");
+  container.innerHTML = "";
 
   models.forEach((m) => {
     const card = createCard(m);
@@ -105,9 +117,9 @@ async function load() {
 }
 
 async function loadProfileHeader() {
-  const token = localStorage.getItem('token');
+  const token = localStorage.getItem("token");
   const urlParams = new URLSearchParams(window.location.search);
-  const user = urlParams.get('user');
+  const user = urlParams.get("user");
   let endpoint;
   if (user) {
     endpoint = `${API_BASE}/users/${encodeURIComponent(user)}/profile`;
@@ -117,35 +129,36 @@ async function loadProfileHeader() {
   const res = await fetch(endpoint, user ? {} : { headers: authHeaders() });
   if (!res.ok) return;
   const data = await res.json();
-  document.getElementById('profile-name').textContent = data.display_name || 'Profile';
-  const avatar = document.getElementById('profile-avatar');
-  const display = document.getElementById('profile-display');
+  document.getElementById("profile-name").textContent =
+    data.display_name || "Profile";
+  const avatar = document.getElementById("profile-avatar");
+  const display = document.getElementById("profile-display");
   if (avatar && data.avatar_url) avatar.src = data.avatar_url;
-  if (display) display.textContent = data.display_name || '';
+  if (display) display.textContent = data.display_name || "";
 }
 
-document.addEventListener('DOMContentLoaded', () => {
-  const modal = document.getElementById('model-modal');
-  const closeBtn = document.getElementById('close-modal');
+document.addEventListener("DOMContentLoaded", () => {
+  const modal = document.getElementById("model-modal");
+  const closeBtn = document.getElementById("close-modal");
   function close() {
-    modal?.classList.add('hidden');
-    document.body.classList.remove('overflow-hidden');
+    modal?.classList.add("hidden");
+    document.body.classList.remove("overflow-hidden");
   }
-  closeBtn?.addEventListener('click', close);
-  document.addEventListener('keydown', (e) => {
-    if (e.key === 'Escape') close();
+  closeBtn?.addEventListener("click", close);
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape") close();
   });
-  const form = document.getElementById('create-account-form');
-  form?.addEventListener('submit', createAccount);
-  const showCreate = document.getElementById('show-create-btn');
-  showCreate?.addEventListener('click', () => {
-    document.getElementById('auth-options')?.classList.add('hidden');
-    document.getElementById('create-account-form')?.classList.remove('hidden');
+  const form = document.getElementById("create-account-form");
+  form?.addEventListener("submit", createAccount);
+  const showCreate = document.getElementById("show-create-btn");
+  showCreate?.addEventListener("click", () => {
+    document.getElementById("auth-options")?.classList.add("hidden");
+    document.getElementById("create-account-form")?.classList.remove("hidden");
   });
-  const logoutBtn = document.getElementById('logout-btn');
-  logoutBtn?.addEventListener('click', () => {
-    localStorage.removeItem('token');
-    window.location.href = 'index.html';
+  const logoutBtn = document.getElementById("logout-btn");
+  logoutBtn?.addEventListener("click", () => {
+    localStorage.removeItem("token");
+    window.location.href = "index.html";
   });
   loadProfileHeader();
   load();

--- a/js/saveList.js
+++ b/js/saveList.js
@@ -1,0 +1,114 @@
+const KEY = "print3Saved";
+export function getSaved() {
+  try {
+    return JSON.parse(localStorage.getItem(KEY)) || [];
+  } catch {
+    return [];
+  }
+}
+function saveList(items) {
+  localStorage.setItem(KEY, JSON.stringify(items));
+}
+export function addSaved(item) {
+  const items = getSaved();
+  if (!items.find((it) => it.id === item.id)) {
+    items.push(item);
+    saveList(items);
+  }
+  updateBadge();
+  renderList();
+}
+export function removeSaved(id) {
+  const items = getSaved().filter((it) => it.id !== id);
+  saveList(items);
+  updateBadge();
+  renderList();
+}
+export function clearSaved() {
+  saveList([]);
+  updateBadge();
+  renderList();
+}
+function updateBadge() {
+  const badge = document.getElementById("saved-count");
+  if (badge) {
+    const n = getSaved().length;
+    badge.textContent = String(n);
+    badge.hidden = n === 0;
+  }
+}
+function renderList() {
+  const list = document.getElementById("saved-list");
+  if (!list) return;
+  list.innerHTML = "";
+  const items = getSaved();
+  if (!items.length) {
+    list.innerHTML = '<p class="text-white">No saved items</p>';
+    return;
+  }
+  items.forEach((it) => {
+    const div = document.createElement("div");
+    div.className = "relative group";
+    const img = document.createElement("img");
+    img.src = it.snapshot || it.modelUrl || "";
+    img.alt = it.title || "Model";
+    img.className =
+      "w-24 h-24 object-cover rounded-lg bg-[#2A2A2E] border border-white/20";
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className =
+      "remove absolute bottom-1 right-1 text-xs px-2 py-1 bg-red-600 rounded opacity-80 group-hover:opacity-100";
+    btn.textContent = "Remove";
+    btn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      removeSaved(it.id);
+    });
+    div.appendChild(img);
+    div.appendChild(btn);
+    list.appendChild(div);
+  });
+}
+function openSaved() {
+  renderList();
+  document.getElementById("saved-overlay")?.classList.remove("hidden");
+}
+function closeSaved() {
+  document.getElementById("saved-overlay")?.classList.add("hidden");
+}
+export function setupSavedUI() {
+  const btn = document.createElement("button");
+  btn.type = "button";
+  btn.id = "saved-button";
+  btn.className =
+    "fixed bottom-4 left-4 bg-[#2A2A2E] text-white p-3 rounded-full shadow-lg z-50 border border-white/20";
+  btn.innerHTML =
+    '<i class="fas fa-heart"></i> <span id="saved-count" class="ml-1"></span>';
+  btn.addEventListener("click", openSaved);
+  document.body.appendChild(btn);
+
+  const overlay = document.createElement("div");
+  overlay.id = "saved-overlay";
+  overlay.className =
+    "fixed inset-0 bg-black/80 flex items-center justify-center hidden z-50";
+  overlay.innerHTML = `\
+    <div class="relative bg-[#2A2A2E] border border-white/10 rounded-3xl p-6 text-center w-72">
+      <button id="saved-close" type="button" class="absolute -top-1 -right-1 text-white text-4xl w-9 h-9 flex items-center justify-center">
+        <i class="fas fa-times-circle"></i>
+      </button>
+      <h2 class="text-xl font-semibold mb-2 text-white">Saved</h2>
+      <div id="saved-list" class="grid grid-cols-2 gap-3 mb-2"></div>
+    </div>`;
+  document.body.appendChild(overlay);
+  overlay.querySelector("#saved-close")?.addEventListener("click", closeSaved);
+  overlay.addEventListener("click", (e) => {
+    const container = overlay.querySelector("div");
+    const btnEl = document.getElementById("saved-button");
+    if (!container.contains(e.target) && !(btnEl && btnEl.contains(e.target))) {
+      closeSaved();
+    }
+  });
+  updateBadge();
+}
+window.addEventListener("DOMContentLoaded", setupSavedUI);
+window.addSavedModel = addSaved;
+window.getSavedModels = getSaved;

--- a/payment.html
+++ b/payment.html
@@ -509,9 +509,12 @@
               Pay £39.99
             </button>
           </form>
-          <p class="mt-2 text-xs text-red-300 text-center">
-            Only <span id="slot-count" style="visibility: hidden"></span> print slots remaining
-          </p>
+        <p class="mt-2 text-xs text-red-300 text-center">
+          Only <span id="slot-count" style="visibility: hidden"></span> print slots remaining
+        </p>
+        <p id="saved-reminder" class="mt-2 text-sm text-yellow-200 text-center hidden">
+          👋 Don’t forget your saved creations
+        </p>
 
           <div class="flex justify-center gap-4 mt-4 text-2xl text-white">
             <i class="fas fa-lock" aria-label="Secure checkout"></i>
@@ -678,6 +681,15 @@
         }
       });
     </script>
+    <script>
+      document.addEventListener('DOMContentLoaded', () => {
+        const reminder = document.getElementById('saved-reminder');
+        if (reminder && window.getSavedModels && window.getSavedModels().length) {
+          reminder.classList.remove('hidden');
+        }
+      });
+    </script>
     <script type="module" src="js/basket.js" defer></script>
+    <script type="module" src="js/saveList.js" defer></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add new `saveList.js` module for sticky Saved list
- replace heart counter with Save button on the community page
- show reminder about saved creations during checkout
- refactor profile script to avoid import for tests

## Testing
- `npm run format` (backend)
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685af6732a44832daa851edbf8592ec8