### PR TITLE
Improve community carousel performance

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -173,11 +173,11 @@
       <!-- What People Are Printing -->
       <section class="mb-12">
         <h2 class="text-xl font-semibold mb-4">What people are printing</h2>
-        <div id="printing-carousel" class="relative">
+        <div id="printing-carousel" class="relative" data-slides="3">
           <div class="overflow-hidden rounded-xl">
             <div class="carousel-track flex transition-transform duration-300">
               <div
-                class="carousel-slide min-w-full p-4 flex items-center justify-center"
+                class="carousel-slide flex-none p-4 flex items-center justify-center"
               >
                 <model-viewer
                   src="https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoomBox/glTF-Binary/BoomBox.glb"
@@ -185,24 +185,28 @@
                   environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
                   camera-controls
                   auto-rotate
+                  reveal="interaction"
+                  loading="lazy"
                   class="w-full h-64 bg-[#2A2A2E] rounded-xl"
                 ></model-viewer>
               </div>
               <div
-                class="carousel-slide min-w-full p-4 flex items-center justify-center"
+                class="carousel-slide flex-none p-4 flex items-center justify-center"
               >
                 <img
                   src="https://images.unsplash.com/photo-1516117172878-fd2c41f4a759"
                   alt="Real-life print"
+                  loading="lazy"
                   class="w-full h-64 object-cover rounded-xl"
                 />
               </div>
               <div
-                class="carousel-slide min-w-full p-4 flex flex-col items-center justify-center text-center space-y-4"
+                class="carousel-slide flex-none p-4 flex flex-col items-center justify-center text-center space-y-4"
               >
                 <img
                   src="https://images.unsplash.com/photo-1502685104226-ee32379fefbe"
                   alt="User testimonial"
+                  loading="lazy"
                   class="w-20 h-20 rounded-full object-cover"
                 />
                 <p class="max-w-md italic">"I love using print3!"</p>

--- a/js/carousel.js
+++ b/js/carousel.js
@@ -4,16 +4,36 @@ export function initCarousel() {
   const track = carousel.querySelector(".carousel-track");
   const slides = track ? Array.from(track.children) : [];
   if (!track || slides.length === 0) return;
+  function getSlidesPerView() {
+    if (window.matchMedia("(min-width: 1024px)").matches) return 3;
+    if (window.matchMedia("(min-width: 640px)").matches) return 2;
+    return 1;
+  }
+  let slidesPerView = getSlidesPerView();
+  function setWidths() {
+    slidesPerView = getSlidesPerView();
+    slides.forEach((s) => {
+      s.style.flex = `0 0 ${100 / slidesPerView}%`;
+    });
+  }
+  setWidths();
   let index = 0;
   function update() {
-    track.style.transform = `translateX(-${index * 100}%)`;
+    if (index > slides.length - slidesPerView)
+      index = slides.length - slidesPerView;
+    if (index < 0) index = 0;
+    track.style.transform = `translateX(-${index * (100 / slidesPerView)}%)`;
   }
   carousel.querySelector(".carousel-next")?.addEventListener("click", () => {
-    index = (index + 1) % slides.length;
+    index += 1;
     update();
   });
   carousel.querySelector(".carousel-prev")?.addEventListener("click", () => {
-    index = (index - 1 + slides.length) % slides.length;
+    index -= 1;
+    update();
+  });
+  window.addEventListener("resize", () => {
+    setWidths();
     update();
   });
 }

--- a/js/community.js
+++ b/js/community.js
@@ -167,12 +167,12 @@ const prefetchedModels = new Set();
 function prefetchModel(url) {
   if (prefetchedModels.has(url)) return;
   const link = document.createElement("link");
-  // Preload with high priority so the model is ready when clicked
+  // Preload with low priority to reduce initial page load cost
   link.rel = "preload";
   link.href = url;
   link.as = "fetch";
   link.crossOrigin = "anonymous";
-  link.fetchPriority = "high";
+  link.fetchPriority = "low";
   document.head.appendChild(link);
   prefetchedModels.add(url);
 }


### PR DESCRIPTION
## Summary
- show multiple items in the community carousel
- lazily load carousel assets
- reduce prefetch priority for model assets

## Testing
- `npm test` *(fails: SyntaxError in profile.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_685aff150bb8832dbdc7c220481242ce