### PR TITLE
Restore credit banner on Community page

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -155,6 +155,13 @@
           class="bg-[#2A2A2E] border border-white/20 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#4A4A4E] flex-1 min-w-[10rem] h-11"
         />
       </div>
+      <p class="text-center mb-6">
+        £8 942 credit earned by creators so far.
+        <a href="login.html" class="font-bold text-[#30D5C8]">Log In</a>
+        or
+        <a href="signup.html" class="font-bold text-[#30D5C8]">Sign Up</a>
+        to do the same.
+      </p>
       <!-- Popular Creations -->
       <section class="mb-12">
         <h2 class="text-xl font-semibold mb-4">Bestselling</h2>


### PR DESCRIPTION
## Summary
- display community credit stats above the "Bestselling" section

## Testing
- `npm run format`
- `npm test`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_685b07a72b90832d83efd8ea86a7e944