### PR TITLE
Fix price badge movement on hover

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -110,7 +110,8 @@
       #material-options label:hover span.no-transform,
       #material-options input:active + span.no-transform,
       #material-options input:checked + span.no-transform {
-        transform: none;
+        /* Retain the element's translation while preventing scaling */
+        transform: translateX(-4rem);
         box-shadow: none;
       }
 


### PR DESCRIPTION
## Summary
- keep £54.99 price badge from moving when hovering the £39.99 button

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend --silent`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_685b061f6604832db4cf3ea63bd2b976