### PR TITLE
Fix community back navigation

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -382,6 +382,13 @@
         const addBasketBtn = document.getElementById("modal-add-basket");
         const closeBtn = document.getElementById("close-modal");
         const tierToggle = document.getElementById("tier-toggle");
+        document
+          .querySelectorAll('a[href="login.html"], a[href="signup.html"]')
+          .forEach((el) => {
+            el.addEventListener("click", () => {
+              sessionStorage.setItem("fromCommunity", "1");
+            });
+          });
 
         function setTier(tier) {
           tierToggle?.querySelectorAll("button[data-tier]").forEach((btn) => {

--- a/login.html
+++ b/login.html
@@ -21,6 +21,7 @@
     <header class="relative flex items-center py-4 px-6">
       <div class="flex items-center flex-1">
         <a
+          id="back-link"
           href="index.html"
           class="inline-flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-3xl px-5 py-2 text-lg font-medium hover:bg-[#3A3A3E] transition-shape"
         >
@@ -167,5 +168,23 @@
     <script type="module" src="js/rewardBadge.js"></script>
     <script type="module" src="js/basket.js"></script>
     <script type="module" src="js/rewardBadge.js"></script>
+    <script>
+      document.addEventListener('DOMContentLoaded', () => {
+        const link = document.getElementById('back-link');
+        if (!link) return;
+        let target = 'index.html';
+        const from = sessionStorage.getItem('fromCommunity');
+        sessionStorage.removeItem('fromCommunity');
+        try {
+          const ref = new URL(document.referrer);
+          if (from === '1' || ref.pathname.endsWith('CommunityCreations.html')) {
+            target = 'CommunityCreations.html';
+          }
+        } catch {
+          if (from === '1') target = 'CommunityCreations.html';
+        }
+        link.setAttribute('href', target);
+      });
+    </script>
   </body>
 </html>

--- a/signup.html
+++ b/signup.html
@@ -21,6 +21,7 @@
     <header class="relative flex items-center py-4 px-6">
       <div class="flex items-center flex-1">
         <a
+          id="back-link"
           href="login.html"
           class="inline-flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-3xl px-5 py-2 text-lg font-medium hover:bg-[#3A3A3E] transition-shape"
         >
@@ -184,5 +185,23 @@
     <script type="module" src="js/rewardBadge.js"></script>
     <script type="module" src="js/basket.js"></script>
     <script type="module" src="js/rewardBadge.js"></script>
+    <script>
+      document.addEventListener('DOMContentLoaded', () => {
+        const link = document.getElementById('back-link');
+        if (!link) return;
+        let target = 'login.html';
+        const from = sessionStorage.getItem('fromCommunity');
+        sessionStorage.removeItem('fromCommunity');
+        try {
+          const ref = new URL(document.referrer);
+          if (from === '1' || ref.pathname.endsWith('CommunityCreations.html')) {
+            target = 'CommunityCreations.html';
+          }
+        } catch {
+          if (from === '1') target = 'CommunityCreations.html';
+        }
+        link.setAttribute('href', target);
+      });
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- update login and signup pages to detect community referral and adjust Back link
- mark community login/signup links so they store navigation origin

## Testing
- `npm run format` (backend)
- `npm test` (backend)
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_685b0a9a77d8832d99466a63ff08e858