### PR TITLE
Unify competition model viewer UI

### DIFF
--- a/competitions.html
+++ b/competitions.html
@@ -153,21 +153,11 @@
           <span class="absolute top-1 left-1 bg-black/60 text-xs px-1 rounded"
             >Ended 05/25</span
           >
-          <button
-            class="like absolute bottom-1 right-1 text-xs bg-red-600 px-1 rounded"
-          >
-            ♥
-          </button>
-          <span
-            class="absolute bottom-8 right-1 text-xs bg-black/50 px-1 rounded"
-            id="votes-helmet"
-            >0</span
-          >
-          <button
-            class="purchase absolute bottom-1 left-1 font-bold text-lg py-2 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]"
-          >
-            Buy
-          </button>
+          <button class="save absolute bottom-1 left-1 text-xs bg-blue-600 px-1 rounded">Save</button>
+          <button class="share absolute top-1 right-1 w-7 h-7 flex items-center justify-center bg-[#2A2A2E] border border-white/20 rounded-full hover:bg-[#3A3A3E] transition-shape"><i class="fas fa-share text-xs"></i></button>
+          <button class="like absolute bottom-1 right-8 text-xs bg-red-600 px-1 rounded">♥</button>
+          <span class="absolute bottom-8 right-8 text-xs bg-black/50 px-1 rounded" id="votes-helmet">0</span>
+          <button class="purchase absolute bottom-1 right-1 font-bold text-lg py-1.5 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]" style="transform: scale(0.6); transform-origin: right bottom;">Buy from £29.99</button>
         </div>
         <div
           class="model-card relative h-32 bg-[#2A2A2E] border border-white/10 rounded-xl hover:bg-[#3A3A3E] transition-shape flex items-center justify-center cursor-pointer"
@@ -182,21 +172,11 @@
           <span class="absolute top-1 left-1 bg-black/60 text-xs px-1 rounded"
             >Ended 03/24</span
           >
-          <button
-            class="like absolute bottom-1 right-1 text-xs bg-red-600 px-1 rounded"
-          >
-            ♥
-          </button>
-          <span
-            class="absolute bottom-8 right-1 text-xs bg-black/50 px-1 rounded"
-            id="votes-fox"
-            >0</span
-          >
-          <button
-            class="purchase absolute bottom-1 left-1 font-bold text-lg py-2 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]"
-          >
-            Buy
-          </button>
+          <button class="save absolute bottom-1 left-1 text-xs bg-blue-600 px-1 rounded">Save</button>
+          <button class="share absolute top-1 right-1 w-7 h-7 flex items-center justify-center bg-[#2A2A2E] border border-white/20 rounded-full hover:bg-[#3A3A3E] transition-shape"><i class="fas fa-share text-xs"></i></button>
+          <button class="like absolute bottom-1 right-8 text-xs bg-red-600 px-1 rounded">♥</button>
+          <span class="absolute bottom-8 right-8 text-xs bg-black/50 px-1 rounded" id="votes-fox">0</span>
+          <button class="purchase absolute bottom-1 right-1 font-bold text-lg py-1.5 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]" style="transform: scale(0.6); transform-origin: right bottom;">Buy from £29.99</button>
         </div>
         <div
           class="model-card relative h-32 bg-[#2A2A2E] border border-white/10 rounded-xl hover:bg-[#3A3A3E] transition-shape flex items-center justify-center cursor-pointer"
@@ -211,21 +191,11 @@
           <span class="absolute top-1 left-1 bg-black/60 text-xs px-1 rounded"
             >Ended 01/23</span
           >
-          <button
-            class="like absolute bottom-1 right-1 text-xs bg-red-600 px-1 rounded"
-          >
-            ♥
-          </button>
-          <span
-            class="absolute bottom-8 right-1 text-xs bg-black/50 px-1 rounded"
-            id="votes-boombox"
-            >0</span
-          >
-          <button
-            class="purchase absolute bottom-1 left-1 font-bold text-lg py-2 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]"
-          >
-            Buy
-          </button>
+          <button class="save absolute bottom-1 left-1 text-xs bg-blue-600 px-1 rounded">Save</button>
+          <button class="share absolute top-1 right-1 w-7 h-7 flex items-center justify-center bg-[#2A2A2E] border border-white/20 rounded-full hover:bg-[#3A3A3E] transition-shape"><i class="fas fa-share text-xs"></i></button>
+          <button class="like absolute bottom-1 right-8 text-xs bg-red-600 px-1 rounded">♥</button>
+          <span class="absolute bottom-8 right-8 text-xs bg-black/50 px-1 rounded" id="votes-boombox">0</span>
+          <button class="purchase absolute bottom-1 right-1 font-bold text-lg py-1.5 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]" style="transform: scale(0.6); transform-origin: right bottom;">Buy from £29.99</button>
         </div>
       </div>
 
@@ -526,6 +496,7 @@
     <script type="module" src="js/printclub.js"></script>
     <script type="module" src="js/rewardBadge.js"></script>
     <script type="module" src="js/basket.js"></script>
+    <script type="module" src="js/saveList.js"></script>
     <script type="module" src="js/rewardBadge.js"></script>
   </body>
 </html>

--- a/js/competitions.js
+++ b/js/competitions.js
@@ -2,6 +2,12 @@ import { captureSnapshots } from "./snapshot.js";
 
 const API_BASE = (window.API_ORIGIN || "") + "/api";
 
+function saveModel(data) {
+  if (window.addSavedModel) {
+    window.addSavedModel(data);
+  }
+}
+
 const prefetchedModels = new Set();
 function prefetchModel(url) {
   if (prefetchedModels.has(url)) return;
@@ -177,7 +183,7 @@ function renderEntriesPage(grid, pager, page) {
       "entry-card relative h-32 bg-[#2A2A2E] border border-white/10 rounded-xl flex items-center justify-center cursor-pointer";
     card.dataset.model = r.model_url;
     card.dataset.job = r.model_id;
-    card.innerHTML = `<img src="" alt="Model" class="w-full h-full object-contain pointer-events-none" />\n      <button class="like absolute bottom-1 right-1 text-xs bg-red-600 px-1 rounded">\u2665</button>\n      <span class="absolute bottom-8 right-1 text-xs bg-black/50 px-1 rounded" id="votes-${r.model_id}">${r.votes}</span>\n      <button class="purchase absolute bottom-1 left-1 font-bold text-lg py-2 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]">Buy</button>`;
+    card.innerHTML = `<img src="" alt="Model" class="w-full h-full object-contain pointer-events-none" />\n      <button class="save absolute bottom-1 left-1 text-xs bg-blue-600 px-1 rounded">Save</button>\n      <button class="share absolute top-1 right-1 w-7 h-7 flex items-center justify-center bg-[#2A2A2E] border border-white/20 rounded-full hover:bg-[#3A3A3E] transition-shape"><i class=\"fas fa-share text-xs\"></i></button>\n      <button class="like absolute bottom-1 right-8 text-xs bg-red-600 px-1 rounded">\u2665</button>\n      <span class="absolute bottom-8 right-8 text-xs bg-black/50 px-1 rounded" id="votes-${r.model_id}">${r.votes}</span>\n      <button class="purchase absolute bottom-1 right-1 font-bold text-lg py-1.5 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]" style="transform: scale(0.6); transform-origin: right bottom;">Buy from £29.99</button>`;
     card.querySelector(".like").addEventListener("click", (e) => {
       e.stopPropagation();
       vote(r.model_id);
@@ -186,6 +192,24 @@ function renderEntriesPage(grid, pager, page) {
     buyBtn.addEventListener("click", (e) => {
       e.stopPropagation();
       purchase(r.model_url, r.model_id);
+    });
+    const saveBtn = card.querySelector(".save");
+    saveBtn?.addEventListener("click", (e) => {
+      e.stopPropagation();
+      const img = card.querySelector("img");
+      saveModel({
+        id: r.model_id,
+        modelUrl: r.model_url,
+        snapshot: img ? img.src : "",
+        title: "",
+      });
+    });
+    const shareBtn = card.querySelector(".share");
+    shareBtn?.addEventListener("click", async (e) => {
+      e.stopPropagation();
+      if (typeof copyReferral === "function") {
+        await copyReferral(r.model_id);
+      }
     });
     card.addEventListener("click", (e) => {
       e.stopPropagation();
@@ -403,6 +427,8 @@ document.addEventListener("DOMContentLoaded", () => {
   document.querySelectorAll("#winners-grid .model-card").forEach((card) => {
     const likeBtn = card.querySelector(".like");
     const buyBtn = card.querySelector(".purchase");
+    const saveBtn = card.querySelector(".save");
+    const shareBtn = card.querySelector(".share");
     if (likeBtn) {
       likeBtn.addEventListener("click", (e) => {
         e.stopPropagation();
@@ -415,6 +441,22 @@ document.addEventListener("DOMContentLoaded", () => {
         purchase(card.dataset.model, card.dataset.job);
       });
     }
+    saveBtn?.addEventListener("click", (e) => {
+      e.stopPropagation();
+      const img = card.querySelector("img");
+      saveModel({
+        id: card.dataset.job,
+        modelUrl: card.dataset.model,
+        snapshot: img ? img.src : "",
+        title: "",
+      });
+    });
+    shareBtn?.addEventListener("click", async (e) => {
+      e.stopPropagation();
+      if (typeof copyReferral === "function") {
+        await copyReferral(card.dataset.job);
+      }
+    });
     card.addEventListener("click", (e) => {
       e.stopPropagation();
       const img = card.querySelector("img");


### PR DESCRIPTION
## Summary
- add saveModel helper to competitions.js
- include save & share buttons plus consistent pricing in competition cards
- update winners-grid event handlers
- include saveList script on competitions page

## Testing
- `npm run format`
- `npm test`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_685b1120a9cc832da093e70057e06355