### PR TITLE
Fix smooth carousel prev transition

### DIFF
--- a/js/carousel.js
+++ b/js/carousel.js
@@ -41,14 +41,18 @@ export function initCarousel() {
   }
 
   function prev() {
-    track.style.transition = "none";
-    track.insertBefore(track.lastElementChild, track.firstElementChild);
-    track.style.transform = `translateX(-${slideWidth}%)`;
-    requestAnimationFrame(() => {
-      track.style.transition = transitionStyle;
-      track.style.transform = "translateX(0)";
-    });
-    slides = Array.from(track.children);
+    track.style.transition = transitionStyle;
+    track.style.transform = `translateX(${slideWidth}%)`;
+    track.addEventListener(
+      "transitionend",
+      () => {
+        track.prepend(track.lastElementChild);
+        track.style.transition = "none";
+        track.style.transform = "translateX(0)";
+        slides = Array.from(track.children);
+      },
+      { once: true },
+    );
   }
 
   carousel.querySelector(".carousel-next")?.addEventListener("click", next);


### PR DESCRIPTION
## Summary
- adjust the left arrow behavior so the carousel scrolls smoothly

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_685b2728a974832d8b2a63286e57a458