### PR TITLE
Add printing ticker

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -44,6 +44,20 @@
         transition: transform 0.5s ease-in-out;
         will-change: transform;
       }
+      @keyframes tickerFade {
+        0% {
+          opacity: 0;
+        }
+        25%, 75% {
+          opacity: 1;
+        }
+        100% {
+          opacity: 0;
+        }
+      }
+      .ticker-fade {
+        animation: tickerFade 8s forwards;
+      }
     </style>
   </head>
   <body class="bg-[#1A1A1D] text-white font-sans flex flex-col min-h-screen">
@@ -182,6 +196,7 @@
       <!-- What People Are Printing -->
       <section class="mb-12">
         <h2 class="text-xl font-semibold mb-4">What people are printing</h2>
+        <div id="printing-ticker" class="text-sm mb-2 opacity-0"></div>
         <div id="printing-carousel" class="relative" data-slides="3">
           <div class="overflow-hidden rounded-xl">
             <div class="carousel-track flex transition-transform duration-300">
@@ -514,6 +529,7 @@
     <script type="module" src="js/basket.js"></script>
 
     <script type="module" src="js/saveList.js"></script>
+    <script type="module" src="js/printingTicker.js"></script>
     <script type="module" src="js/carousel.js"></script>
     <script type="module" src="js/rewardBadge.js"></script>
   </body>

--- a/js/printingTicker.js
+++ b/js/printingTicker.js
@@ -1,0 +1,52 @@
+import { createClient } from "https://cdn.jsdelivr.net/npm/@supabase/supabase-js/+esm";
+
+const supabaseUrl = window.SUPABASE_URL;
+const supabaseKey = window.SUPABASE_ANON_KEY;
+const ticker = document.getElementById("printing-ticker");
+if (ticker && supabaseUrl && supabaseKey) {
+  const supabase = createClient(supabaseUrl, supabaseKey);
+  let queue = [];
+  let idx = 0;
+
+  async function loadInitial() {
+    const { data } = await supabase
+      .from("orders")
+      .select("customer_name,country,model_name")
+      .order("created_at", { ascending: false })
+      .limit(20);
+    if (data) {
+      queue = data.map(
+        (o) => `\uD83D\uDDA8\uFE0F ${o.customer_name} (${o.country}) just printed the ${o.model_name}!`,
+      );
+    }
+  }
+
+  function showNext() {
+    if (!queue.length) return;
+    ticker.classList.remove("ticker-fade");
+    ticker.textContent = queue[idx];
+    void ticker.offsetWidth;
+    ticker.classList.add("ticker-fade");
+    idx = (idx + 1) % queue.length;
+  }
+
+  supabase
+    .channel("orders")
+    .on(
+      "postgres_changes",
+      { event: "INSERT", schema: "public", table: "orders" },
+      (payload) => {
+        const { customer_name, country, model_name } = payload.new;
+        queue.unshift(
+          `\uD83D\uDDA8\uFE0F ${customer_name} (${country}) just printed the ${model_name}!`,
+        );
+        queue = queue.slice(0, 20);
+      },
+    )
+    .subscribe();
+
+  loadInitial().then(() => {
+    if (queue.length) showNext();
+    setInterval(showNext, 8000);
+  });
+}


### PR DESCRIPTION
## Summary
- show a real-time "printing now" ticker on the Community Creations page
- stream order events via Supabase in new `printingTicker.js`

## Testing
- `npm run format`
- `npm test`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_685b2955f49c832da1e85155d5bf8f19