### PR TITLE
Add personalisation option panel

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -182,7 +182,7 @@
       <!-- What People Are Printing -->
       <section class="mb-12">
         <h2 class="text-xl font-semibold mb-4">What people are printing</h2>
-        <div id="printing-carousel" class="relative" data-slides="3">
+        <div id="printing-carousel" class="relative" data-slides="4">
           <div class="overflow-hidden rounded-xl">
             <div class="carousel-track flex transition-transform duration-300">
               <div
@@ -219,6 +219,20 @@
                   class="w-20 h-20 rounded-full object-cover"
                 />
                 <p class="max-w-md italic">"I love using print2!" – Anna J.</p>
+              </div>
+              <div
+                class="carousel-slide flex-none p-4 flex flex-col items-center justify-center text-center space-y-4"
+              >
+                <i class="fas fa-pen-fancy text-4xl text-[#30D5C8]"></i>
+                <p class="max-w-md">
+                  Want personalisation? Have custom text etched on your design
+                  <span class="block text-sm text-gray-400">(colour or premium tier)</span>
+                </p>
+                <a
+                  href="payment.html?personalise=1"
+                  class="px-4 py-2 bg-[#30D5C8] text-[#1A1A1D] rounded-lg font-semibold"
+                  >Personalise now</a
+                >
               </div>
             </div>
           </div>

--- a/js/payment.js
+++ b/js/payment.js
@@ -62,8 +62,13 @@ async function fetchPaymentInit() {
 }
 
 // Restore previously selected material option and colour
-const storedMaterial = localStorage.getItem("print3Material");
+let storedMaterial = localStorage.getItem("print3Material");
 const storedColor = localStorage.getItem("print3Color");
+const personalise = qs("personalise");
+if (personalise !== null) {
+  storedMaterial = "multi";
+  localStorage.setItem("print3Material", storedMaterial);
+}
 if (storedMaterial && PRICES[storedMaterial]) {
   selectedPrice = PRICES[storedMaterial];
 }
@@ -452,6 +457,12 @@ async function initPaymentPage() {
   );
   if (storedRadio) storedRadio.checked = true;
   updateEtchVisibility(storedMaterial);
+  if (personalise !== null && etchInput) {
+    requestAnimationFrame(() => {
+      etchInput.focus();
+      etchInput.scrollIntoView({ behavior: "smooth", block: "center" });
+    });
+  }
   if (storedMaterial === "single") {
     if (singleButton && storedColor) {
       singleButton.style.backgroundColor = storedColor;


### PR DESCRIPTION
## Summary
- expand carousel to 4 slides
- add new personalisation slide linking to payment page
- support `personalise` query param on payment page
- auto-focus etching field when personalisation is requested

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_685b28cfa918832d9bd1dac90507044c