### PR TITLE
Fix brief ad flash in community carousel

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -41,14 +41,18 @@
     <style>
       #printing-carousel .carousel-track {
         transform: translateX(0);
-        transition: transform 0.5s ease-in-out;
+        opacity: 0;
+        transition:
+          transform 0.5s ease-in-out,
+          opacity 0.15s ease-in-out;
         will-change: transform;
       }
       @keyframes tickerFade {
         0% {
           opacity: 0;
         }
-        25%, 75% {
+        25%,
+        75% {
           opacity: 1;
         }
         100% {
@@ -241,7 +245,9 @@
                 <i class="fas fa-pen-fancy text-4xl text-[#30D5C8]"></i>
                 <p class="max-w-md">
                   Want personalisation? Have custom text etched on your design
-                  <span class="block text-sm text-gray-400">(colour or premium tier)</span>
+                  <span class="block text-sm text-gray-400"
+                    >(colour or premium tier)</span
+                  >
                 </p>
                 <a
                   href="payment.html?personalise=1"

--- a/js/carousel.js
+++ b/js/carousel.js
@@ -3,7 +3,8 @@ export function initCarousel() {
   if (!carousel) return;
   const track = carousel.querySelector(".carousel-track");
   if (!track) return;
-  const transitionStyle = "transform 0.5s ease-in-out";
+  const transitionStyle =
+    "transform 0.5s ease-in-out, opacity 0.15s ease-in-out";
   track.style.willChange = "transform";
   track.style.transition = transitionStyle;
   let slides = Array.from(track.children);
@@ -24,6 +25,12 @@ export function initCarousel() {
     });
   }
   setWidths();
+
+  // Reveal the carousel after layout calculations to avoid a flash of
+  // misplaced slides when the page first loads.
+  setTimeout(() => {
+    track.style.opacity = "1";
+  }, 50);
 
   function next() {
     track.style.transition = transitionStyle;


### PR DESCRIPTION
## Summary
- hide carousel track initially and show after widths calculated
- update JS carousel init to fade in track

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_685b370722fc832d982f343a4309ac9d