### PR TITLE
Fix centering for single colour options

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -317,7 +317,7 @@
                     left-1/2
                     -translate-x-1/2
                     -translate-y-[-8%]
-                  grid grid-cols-3 gap-2 p-2
+                  flex flex-wrap justify-center gap-2 p-2
                   bg-[#2A2A2E] border border-white/20
                   rounded-3xl w-28 h-28
                   z-20 hidden


### PR DESCRIPTION
## Summary
- align the single-colour selector by centering the buttons using flexbox

## Testing
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_685b33e54358832dbe015356ca75e5d0