### PR TITLE
Fix printclub header alignment

### DIFF
--- a/printclub.html
+++ b/printclub.html
@@ -50,6 +50,7 @@
           >[🎉 NEW] Earn Rewards ⭐</a
         >
       </div>
+      </div>
       <div class="flex items-center space-x-4 ml-4">
         <div class="flex space-x-2">
           <button


### PR DESCRIPTION
## Summary
- close missing div in `printclub.html` to keep share icons on the right

## Testing
- `npm run format`
- `npm test`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_685bb7d846e8832d9899e4c47b3c01a4