### PR TITLE
Fix header buttons alignment on print2 pro page

### DIFF
--- a/printclub.html
+++ b/printclub.html
@@ -40,18 +40,21 @@
           </svg>
           Back
         </a>
-      <h1 class="text-3xl font-semibold">print2 pro</h1>
-      <div class="flex items-center space-x-2">
-
+        <h1 class="flex-1 text-center text-3xl font-semibold">print2 pro</h1>
+      </div>
+      <div class="flex items-center space-x-4 ml-4">
         <a
           href="earn-rewards.html"
           id="earn-rewards-badge"
           class="bg-gradient-to-r from-purple-500 to-pink-500 text-white rounded-3xl px-3 py-2 text-sm transition-shape"
           >[🎉 NEW] Earn Rewards ⭐</a
         >
-      </div>
-      </div>
-      <div class="flex items-center space-x-4 ml-4">
+        <a
+          href="printclub.html"
+          id="print-club-badge"
+          class="bg-gradient-to-r from-purple-500 to-pink-500 text-white rounded-3xl px-3 py-2 text-sm transition-shape"
+          >print2 pro £149.99/mo</a
+        >
         <div class="flex space-x-2">
           <button
             class="w-9 h-9 flex-shrink-0 flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-full hover:bg-[#3A3A3E] transition-shape"


### PR DESCRIPTION
## Summary
- realign the Earn Rewards and print2 pro badges on `printclub.html`
- keep them on the top-right before the share buttons

## Testing
- `npm run setup`
- `npm run format` in backend
- `npm test`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_685bbbe6f4d0832d9bf2576bcbd0cf1a