### PR TITLE
Fix login/signup back navigation

### DIFF
--- a/login.html
+++ b/login.html
@@ -173,8 +173,15 @@
         const link = document.getElementById('back-link');
         if (!link) return;
         let target = 'index.html';
-        const from = sessionStorage.getItem('fromCommunity');
-        sessionStorage.removeItem('fromCommunity');
+        const params = new URLSearchParams(location.search);
+        let from = params.get('from') || sessionStorage.getItem('fromCommunity');
+
+        if (from === '1') {
+          sessionStorage.setItem('fromCommunity', '1');
+        } else {
+          sessionStorage.removeItem('fromCommunity');
+        }
+
         try {
           const ref = new URL(document.referrer);
           if (from === '1' || ref.pathname.endsWith('CommunityCreations.html')) {
@@ -183,7 +190,13 @@
         } catch {
           if (from === '1') target = 'CommunityCreations.html';
         }
+
         link.setAttribute('href', target);
+
+        const signup = document.querySelector('a[href="signup.html"]');
+        if (signup && target === 'CommunityCreations.html') {
+          signup.setAttribute('href', 'signup.html?from=community');
+        }
       });
     </script>
   </body>

--- a/signup.html
+++ b/signup.html
@@ -190,8 +190,15 @@
         const link = document.getElementById('back-link');
         if (!link) return;
         let target = 'login.html';
-        const from = sessionStorage.getItem('fromCommunity');
-        sessionStorage.removeItem('fromCommunity');
+        const params = new URLSearchParams(location.search);
+        let from = params.get('from') || sessionStorage.getItem('fromCommunity');
+
+        if (from === '1') {
+          sessionStorage.setItem('fromCommunity', '1');
+        } else {
+          sessionStorage.removeItem('fromCommunity');
+        }
+
         try {
           const ref = new URL(document.referrer);
           if (from === '1' || ref.pathname.endsWith('CommunityCreations.html')) {
@@ -200,7 +207,13 @@
         } catch {
           if (from === '1') target = 'CommunityCreations.html';
         }
+
         link.setAttribute('href', target);
+
+        const login = document.querySelector('a[href="login.html"]');
+        if (login && target === 'CommunityCreations.html') {
+          login.setAttribute('href', 'login.html?from=community');
+        }
       });
     </script>
   </body>


### PR DESCRIPTION
## Summary
- ensure login and signup pages remember when a user came from the community page
- update back links so returning from login or signup goes to CommunityCreations.html

## Testing
- `npm run format`
- `npm test`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_685bc0370998832dbbe6768447026c89