### PR TITLE
Remove Trending Prints section

### DIFF
--- a/competitions.html
+++ b/competitions.html
@@ -261,12 +261,6 @@
           </button>
         </div>
       </div>
-
-      <h2 class="text-2xl mt-8">Trending Prints</h2>
-      <div
-        id="trending-prints"
-        class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 mt-4"
-      ></div>
     </main>
     <div
       id="enter-modal"

--- a/js/competitions.js
+++ b/js/competitions.js
@@ -498,7 +498,6 @@ document.addEventListener("DOMContentLoaded", () => {
   });
   load();
   loadPast();
-  loadTrending();
   const subForm = document.getElementById("comp-subscribe");
   const emailInput = document.getElementById("comp-email");
   const msgEl = document.getElementById("comp-subscribe-msg");


### PR DESCRIPTION
## Summary
- remove `Trending Prints` section from competitions page
- drop unused `loadTrending()` call

## Testing
- `npm test --silent`
- `npm run ci --silent`

------
https://chatgpt.com/codex/tasks/task_e_685bc33e62c0832d92117775bb567118