### PR TITLE
Skip rebase step for Codex PRs

### DIFF
--- a/.github/workflows/auto_rebase_merge_queue.yml
+++ b/.github/workflows/auto_rebase_merge_queue.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   rebase:
+    if: ${{ !startsWith(github.event.pull_request.head.ref, 'codex/') }}
     runs-on: ubuntu-latest
     steps:
       - name: Rebase
@@ -36,7 +37,7 @@ jobs:
             })
   merge-queue:
     needs: rebase
-    if: needs.rebase.result == 'success'
+    if: ${{ needs.rebase.result == 'success' || needs.rebase.result == 'skipped' }}
     runs-on: ubuntu-latest
     steps:
       - name: Queue for merge


### PR DESCRIPTION
## Summary
- skip auto-rebase for branches starting with `codex/`
- allow merge queue when rebase job is skipped

## Testing
- `npm run setup`
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_685bcb04a710832db7b7e5c6dd1b7292