### PR TITLE
Fix auto rebase workflow for Codex branches

### DIFF
--- a/.github/workflows/auto_rebase_merge_queue.yml
+++ b/.github/workflows/auto_rebase_merge_queue.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Rebase
+        if: ${{ !startsWith(github.head_ref, 'codex/') }}
         id: rebase
         uses: peter-evans/rebase@v2
         with:


### PR DESCRIPTION
## Summary
- update auto_rebase_merge_queue workflow to skip Codex PR branches

## Testing
- `npm run format` in `backend`
- `npm test` in `backend`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_685bcb04a710832db7b7e5c6dd1b7292