### PR TITLE
Fix colour menu layout

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -317,7 +317,7 @@
                     left-1/2
                     -translate-x-1/2
                     -translate-y-[-8%]
-                  flex flex-wrap justify-center gap-2 p-2
+                  grid grid-cols-3 place-items-center gap-2 p-2
                   bg-[#2A2A2E] border border-white/20
                   rounded-3xl w-28 h-28
                   z-20 hidden
@@ -343,13 +343,13 @@
                 ></button>
                 <button
                   type="button"
-                  class="w-8 h-8 rounded-full border border-white/20"
+                  class="w-8 h-8 rounded-full border border-white/20 col-start-1"
                   style="background-color: #fbbf24"
                   data-color="#ffff00"
                 ></button>
                 <button
                   type="button"
-                  class="w-8 h-8 rounded-full border border-white/20"
+                  class="w-8 h-8 rounded-full border border-white/20 col-start-3"
                   style="background-color: #7c3aed"
                   data-color="#7c3aed"
                 ></button>


### PR DESCRIPTION
## Summary
- adjust single-color menu layout so the 5 colour buttons arrange in two centered rows

## Testing
- `npm run format` (backend)
- `npm test` (backend)


------
https://chatgpt.com/codex/tasks/task_e_685bcef8e414832d82fc7419f731e148