### PR TITLE
Add phone field to signup page

### DIFF
--- a/signup.html
+++ b/signup.html
@@ -115,6 +115,13 @@
             />
           </div>
           <input
+            id="su-phone"
+            type="tel"
+            class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10 text-gray-200"
+            placeholder="Phone number (optional)"
+            aria-label="Phone number"
+          />
+          <input
             id="su-name"
             class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10 text-gray-200"
             placeholder="Username"


### PR DESCRIPTION
## Summary
- add an optional phone number field below the email field on the signup page

## Testing
- `npm run format` (in backend)
- `npm test`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_685bd02477a8832d801ece52de0a72d3