### PR TITLE
Fix email validity highlight on payment page

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -403,7 +403,12 @@ async function initPaymentPage() {
   ];
   const highlightValid = (el) => {
     if (!el) return;
-    const valid = !el.disabled && el.value.trim() !== "" && el.checkValidity();
+    const value = el.value.trim();
+    let valid = !el.disabled && value !== "" && el.checkValidity();
+    if (el.id === "checkout-email") {
+      const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+      valid = valid && emailRegex.test(value);
+    }
     if (valid) {
       el.classList.add("ring-2", "ring-green-500");
     } else {


### PR DESCRIPTION
## Summary
- validate email format before highlighting the email field

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_685bd0ec5080832d9b321a035dbc5b2e