### PR TITLE
Add placeholder print slide

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -203,7 +203,7 @@
           What people are talking about
         </h2>
         <div id="printing-ticker" class="text-sm mb-2 opacity-0"></div>
-        <div id="printing-carousel" class="relative" data-slides="4">
+        <div id="printing-carousel" class="relative" data-slides="5">
           <div class="overflow-hidden rounded-xl">
             <div class="carousel-track flex transition-transform duration-300">
               <div
@@ -256,6 +256,24 @@
                   class="px-4 py-2 bg-[#30D5C8] text-[#1A1A1D] rounded-lg font-semibold"
                   >Personalise now</a
                 >
+              </div>
+              <div class="carousel-slide flex-none p-4 flex flex-col sm:flex-row items-center justify-center gap-4">
+                <img
+                  src="https://via.placeholder.com/400x300.png?text=Real+Print+Coming+Soon"
+                  alt="Real-life print placeholder"
+                  loading="lazy"
+                  class="w-full sm:w-1/2 h-64 object-cover rounded-xl"
+                />
+                <model-viewer
+                  src="https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoomBox/glTF-Binary/BoomBox.glb"
+                  alt="3D model preview"
+                  environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
+                  camera-controls
+                  auto-rotate
+                  reveal="auto"
+                  loading="lazy"
+                  class="w-full sm:w-1/2 h-64 bg-[#2A2A2E] rounded-xl"
+                ></model-viewer>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- expand printing carousel to 5 slides
- include placeholder panel with real print image spot and 3D model viewer

## Testing
- `npm run format` (backend)
- `npm test` (backend)
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_685bd33f2230832db054eb4d7f0bf846