### PR TITLE
Add Playwright browser caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,16 @@ jobs:
         env:
           NPM_CONFIG_LEGACY_PEER_DEPS: true
       - run: npm install --no-audit --no-fund
+      - name: Cache Playwright browsers
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
       - name: Install Playwright browsers
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
         run: npx playwright install --with-deps
       - name: Install backend dependencies
         run: npm install --no-audit --no-fund --prefix backend
@@ -46,6 +55,8 @@ jobs:
         run: npm run prepare
 
       - name: Run CI
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
         run: npm run ci
 
       - name: Run coverage
@@ -106,10 +117,13 @@ jobs:
         if: ${{ secrets.PERCY_TOKEN }}
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+          PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
         run: npx percy exec -- npm run e2e
 
       - name: Run smoke tests
         if: ${{ !secrets.PERCY_TOKEN }}
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
         run: npm run e2e
 
       # ← you can add additional steps here, like your tests

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -19,7 +19,16 @@ jobs:
           if [ -f backend/hunyuan_server/package.json ]; then
             npm install --no-audit --no-fund --prefix backend/hunyuan_server
           fi
+      - name: Cache Playwright browsers
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
       - run: npx playwright install --with-deps
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
       - run: npm install -g netlify-cli
       - name: Deploy to Netlify
         if: env.NETLIFY_AUTH_TOKEN != '' && env.NETLIFY_SITE_ID != ''
@@ -32,4 +41,5 @@ jobs:
       - name: Run smoke tests
         env:
           PLAYWRIGHT_BASE_URL: ${{ env.PREVIEW_URL }}
+          PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
         run: npx playwright test e2e/smoke.test.js


### PR DESCRIPTION
## Summary
- cache Playwright browsers in GitHub workflows
- set `PLAYWRIGHT_BROWSERS_PATH` so Playwright tests use the cache

## Testing
- `npm test --prefix backend`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_685bd5e18d7c832d9d24a4057f075511