### PR TITLE
Fix print2 pro box styling

### DIFF
--- a/printclub.html
+++ b/printclub.html
@@ -47,7 +47,8 @@
           href="earn-rewards.html"
           id="earn-rewards-badge"
           class="bg-gradient-to-r from-purple-500 to-pink-500 text-white rounded-3xl px-3 py-2 text-sm transition-shape"
-          >[🎉 NEW] Earn Rewards ⭐</a>
+          >[🎉 NEW] Earn Rewards ⭐</a
+        >
         <div class="flex space-x-2">
           <button
             class="w-9 h-9 flex-shrink-0 flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-full hover:bg-[#3A3A3E] transition-shape"
@@ -92,7 +93,7 @@
         class="max-w-4xl w-full flex flex-col md:flex-row items-center justify-between space-y-6 md:space-y-0 md:space-x-8"
       >
         <div
-          class="text-center space-y-4 md:max-w-lg bg-[#2A2A2E] p-6 rounded-2xl shadow-lg"
+          class="text-center space-y-4 md:max-w-lg bg-[#2A2A2E] p-6 rounded-2xl shadow-lg border border-white/20"
         >
           <p class="text-lg">
             Join print2 pro for £149.99 per month to receive 2 prints (single or
@@ -127,7 +128,6 @@
           </div>
         </div>
         <div
-
           class="w-full md:max-w-lg h-96 flex items-center justify-center border border-white/20 rounded-2xl bg-[#2A2A2E] text-sm shadow-lg p-6"
         >
           Real life image here


### PR DESCRIPTION
## Summary
- add missing outline to the print2 pro information box

## Testing
- `npm run format` in `backend`
- `npm test` in `backend`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_685bd62c2e68832d99a426cb7ddf78aa