### PR TITLE
Fix rewards box outline

### DIFF
--- a/earn-rewards.html
+++ b/earn-rewards.html
@@ -89,7 +89,7 @@
     </header>
     <main class="flex-1 flex items-center justify-center p-4">
       <div
-        class="max-w-md w-full space-y-6 bg-[#2A2A2E] p-6 rounded-2xl text-center shadow-lg"
+        class="max-w-md w-full space-y-6 bg-[#2A2A2E] border border-white/10 p-6 rounded-2xl text-center shadow-lg"
       >
         <h2 class="text-2xl font-semibold">Share &amp; earn discounts</h2>
         <p>


### PR DESCRIPTION
## Summary
- add the missing subtle outline on `earn-rewards.html`

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_685bd6684528832da7ecad6c519bc36b