### PR TITLE
Enhance rewards page with leaderboard

### DIFF
--- a/earn-rewards.html
+++ b/earn-rewards.html
@@ -51,35 +51,35 @@
         <div class="flex space-x-2">
           <button
             class="w-9 h-9 flex-shrink-0 flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-full hover:bg-[#3A3A3E] transition-shape"
-            onclick="shareOn('twitter')"
+            onclick="shareReferral('twitter')"
             aria-label="Share on Twitter"
           >
             <i class="fab fa-twitter"></i>
           </button>
           <button
             class="w-9 h-9 flex-shrink-0 flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-full hover:bg-[#3A3A3E] transition-shape"
-            onclick="shareOn('facebook')"
+            onclick="shareReferral('facebook')"
             aria-label="Share on Facebook"
           >
             <i class="fab fa-facebook-f"></i>
           </button>
           <button
             class="w-9 h-9 flex-shrink-0 flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-full hover:bg-[#3A3A3E] transition-shape"
-            onclick="shareOn('reddit')"
+            onclick="shareReferral('reddit')"
             aria-label="Share on Reddit"
           >
             <i class="fab fa-reddit-alien"></i>
           </button>
           <button
             class="w-9 h-9 flex-shrink-0 flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-full hover:bg-[#3A3A3E] transition-shape"
-            onclick="shareOn('tiktok')"
+            onclick="shareReferral('tiktok')"
             aria-label="Share on TikTok"
           >
             <i class="fab fa-tiktok"></i>
           </button>
           <button
             class="w-9 h-9 flex-shrink-0 flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-full hover:bg-[#3A3A3E] transition-shape"
-            onclick="shareOn('instagram')"
+            onclick="shareReferral('instagram')"
             aria-label="Share on Instagram"
           >
             <i class="fab fa-instagram"></i>
@@ -146,6 +146,30 @@
           >
             Redeem
           </button>
+        </div>
+        <p id="next-reward-msg" class="text-sm text-gray-300"></p>
+        <div class="text-left">
+          <h3 class="text-lg font-semibold mt-6 mb-2">Top Referrers</h3>
+          <table class="w-full text-sm">
+            <thead>
+              <tr>
+                <th class="text-left">User</th>
+                <th class="text-left">Points</th>
+              </tr>
+            </thead>
+            <tbody id="leaderboard-body"></tbody>
+          </table>
+        </div>
+        <div class="text-left">
+          <h3 class="text-lg font-semibold mt-4 mb-2">Your Achievements</h3>
+          <ul id="achievements-list" class="list-disc list-inside text-sm"></ul>
+        </div>
+        <div class="mt-4">
+          <a
+            href="printclub.html"
+            class="inline-block bg-gradient-to-r from-purple-500 to-pink-500 text-white rounded-3xl px-4 py-2 text-sm"
+            >Join print2 pro &amp; get 100 bonus points</a
+          >
         </div>
       </div>
     </main>

--- a/js/share.js
+++ b/js/share.js
@@ -1,90 +1,99 @@
-const API_BASE = (window.API_ORIGIN || '') + '/api';
+const API_BASE = (window.API_ORIGIN || "") + "/api";
 
 async function captureSnapshot(glbUrl) {
   if (!glbUrl) return null;
-  const viewer = document.createElement('model-viewer');
-  viewer.crossOrigin = 'anonymous';
+  const viewer = document.createElement("model-viewer");
+  viewer.crossOrigin = "anonymous";
   viewer.src = glbUrl;
   viewer.setAttribute(
-    'environment-image',
-    'https://modelviewer.dev/shared-assets/environments/neutral.hdr'
+    "environment-image",
+    "https://modelviewer.dev/shared-assets/environments/neutral.hdr",
   );
-  viewer.style.position = 'fixed';
-  viewer.style.left = '-10000px';
-  viewer.style.width = '300px';
-  viewer.style.height = '300px';
+  viewer.style.position = "fixed";
+  viewer.style.left = "-10000px";
+  viewer.style.width = "300px";
+  viewer.style.height = "300px";
   document.body.appendChild(viewer);
   try {
     await viewer.updateComplete;
-    return await viewer.toDataURL('image/png');
+    return await viewer.toDataURL("image/png");
   } catch (err) {
-    console.error('Failed to capture snapshot', err);
+    console.error("Failed to capture snapshot", err);
     return null;
   } finally {
     viewer.remove();
   }
 }
 
-async function shareOn(network) {
-  const shareLink = 'https://print2.io';
+async function shareOn(
+  network,
+  link = "https://print2.io",
+  textMsg = "Check out print3!",
+) {
+  const shareLink = link;
   const url = encodeURIComponent(shareLink);
-  const text = encodeURIComponent('Check out print3!');
-  let shareUrl = '';
+  const text = encodeURIComponent(textMsg);
+  let shareUrl = "";
   switch (network) {
-    case 'facebook':
+    case "facebook":
       shareUrl = `https://www.facebook.com/sharer/sharer.php?u=${url}`;
       break;
-    case 'twitter':
+    case "twitter":
       shareUrl = `https://twitter.com/intent/tweet?url=${url}&text=${text}`;
       break;
-    case 'reddit':
+    case "reddit":
       shareUrl = `https://www.reddit.com/submit?url=${url}&title=${text}`;
       break;
-    case 'linkedin':
+    case "linkedin":
       shareUrl = `https://www.linkedin.com/shareArticle?url=${url}&title=${text}`;
       break;
-    case 'tiktok':
+    case "tiktok":
       shareUrl = `https://www.tiktok.com/upload?url=${url}`;
       break;
-    case 'instagram':
+    case "instagram":
       shareUrl = `https://www.instagram.com/?url=${url}`;
       break;
   }
-  if (typeof fetch === 'function') {
+  if (typeof fetch === "function") {
     try {
       const shareId =
-        typeof localStorage !== 'undefined' ? localStorage.getItem('shareId') : null;
+        typeof localStorage !== "undefined"
+          ? localStorage.getItem("shareId")
+          : null;
       await fetch(`${API_BASE}/track/share`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ shareId, network }),
       });
     } catch (err) {
-      console.error('Failed to track share', err);
+      console.error("Failed to track share", err);
     }
   }
-  const modelUrl = typeof localStorage !== 'undefined' ? localStorage.getItem('print3Model') : null;
+  const modelUrl =
+    typeof localStorage !== "undefined"
+      ? localStorage.getItem("print3Model")
+      : null;
   if (navigator.share && modelUrl) {
     try {
       const dataUrl = await captureSnapshot(modelUrl);
       const response = await fetch(dataUrl);
       const blob = await response.blob();
-      const file = new File([blob], 'model.png', { type: 'image/png' });
+      const file = new File([blob], "model.png", { type: "image/png" });
       await navigator.share({
-        title: 'print3 model',
-        text: 'Check out print3!',
+        title: "print3 model",
+        text: textMsg,
         url: shareLink,
         files: [file],
       });
       return;
     } catch (err) {
-      console.error('Web share failed', err);
+      console.error("Web share failed", err);
     }
   }
-  window.open(shareUrl, '_blank', 'noopener');
+  window.open(shareUrl, "_blank", "noopener");
 }
 
-if (typeof module !== 'undefined') {
+if (typeof module !== "undefined") {
   module.exports = { shareOn };
 }
 export { shareOn };


### PR DESCRIPTION
## Summary
- add referral leaderboard and achievements display
- show progress to next reward and pro subscription upsell
- enable sharing referral link with custom text

## Testing
- `npm run format` (backend)
- `npm test` (backend)
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_685bd5cd6548832d9f612d7f525f75dc