### PR TITLE
Add add-ons page and update tasks

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -1,0 +1,74 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Add-Ons</title>
+    <meta property="og:title" content="Add-Ons – print3" />
+    <meta
+      property="og:description"
+      content="Unlock extra bases, props and accessories for your models."
+    />
+    <meta property="og:image" content="img/boxlogo.png" />
+    <script src="js/applyColorScheme.js"></script>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css"
+    />
+  </head>
+  <body class="bg-[#1A1A1D] text-white font-sans flex flex-col min-h-screen">
+    <header class="relative flex items-center py-4 px-6">
+      <div class="flex items-center flex-1">
+        <a
+          href="index.html"
+          class="inline-flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-3xl px-5 py-2 text-lg font-medium hover:bg-[#3A3A3E] transition-shape"
+        >
+          <svg
+            class="w-4 h-4 mr-2 flex-shrink-0"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M15 19l-7-7 7-7"
+            />
+          </svg>
+          Back
+        </a>
+        <h1 class="flex-1 text-center text-3xl font-semibold">Add-Ons</h1>
+        <a
+          href="earn-rewards.html"
+          id="earn-rewards-badge"
+          class="bg-gradient-to-r from-purple-500 to-pink-500 text-white rounded-3xl px-3 py-2 text-sm transition-shape"
+          >[🎉 NEW] Earn Rewards ⭐</a
+        >
+      </div>
+      <div class="flex items-center space-x-4 ml-4">
+        <a
+          href="printclub.html"
+          id="print-club-badge"
+          class="bg-gradient-to-r from-purple-500 to-pink-500 text-white rounded-3xl px-3 py-2 text-sm transition-shape"
+          >print2 pro £149.99/mo</a
+        >
+      </div>
+    </header>
+    <main class="flex-1 p-6 space-y-8">
+      <div
+        id="locked-msg"
+        class="bg-[#2A2A2E] p-4 rounded-xl text-center hidden"
+      >
+        Unlock advanced customisation after your first purchase.
+      </div>
+      <section
+        id="addons-grid"
+        class="grid grid-cols-2 sm:grid-cols-3 gap-4"
+      ></section>
+    </main>
+    <script type="module" src="js/addons.js"></script>
+    <script type="module" src="js/rewardBadge.js"></script>
+  </body>
+</html>

--- a/docs/task_list.md
+++ b/docs/task_list.md
@@ -302,3 +302,10 @@
 - Track referral clicks and signups through the referral link endpoints.
 - Send competition and reward updates via the mailing list workflow.
 - Expand leaderboards, badges and monthly challenges on community pages.
+## Add-ons Page & Post-Purchase Flow
+- Send follow-up emails after purchase to promote accessories.
+- Automate STL merging for accessories so no manual design work is needed.
+- Provide micro personalisation nudges like small props and texture tweaks.
+- Plan future expansions such as accessory subscriptions and creator uploads.
+- Track add-on performance to refine marketing and bundle offers.
+- Keep fulfilment simple by printing merged models without extra steps.

--- a/index.html
+++ b/index.html
@@ -200,8 +200,12 @@
         <a
           href="CommunityCreations.html"
           class="bg-[#2A2A2E] border border-white/10 rounded-3xl px-4 py-2 text-sm hover:bg-[#3A3A3E] transition-shape"
-          >Community</a
-        >
+          >Community</a>
+        <a
+          href="addons.html"
+          id="addons-link"
+          class="bg-[#2A2A2E] border border-white/10 rounded-3xl px-4 py-2 text-sm hover:bg-[#3A3A3E] transition-shape"
+          >Add-Ons</a>
         <a
           href="profile.html"
           id="profile-link"

--- a/js/addons.js
+++ b/js/addons.js
@@ -1,0 +1,55 @@
+const API_BASE = (window.API_ORIGIN || "") + "/api";
+
+function renderPreview() {
+  const grid = document.getElementById("addons-grid");
+  const items = [
+    {
+      name: "Snow Base",
+      img: "https://images.unsplash.com/photo-1581905764498-f1ec34cc1373?auto=format&fit=crop&w=200&q=60",
+    },
+    {
+      name: "LED Stand",
+      img: "https://images.unsplash.com/photo-1518933165971-611dbc9c412d?auto=format&fit=crop&w=200&q=60",
+    },
+    {
+      name: "Companion Droid",
+      img: "https://images.unsplash.com/photo-1604066867775-4a6c52db06f2?auto=format&fit=crop&w=200&q=60",
+    },
+  ];
+  grid.innerHTML = "";
+  items.forEach((item) => {
+    const div = document.createElement("div");
+    div.className =
+      "bg-[#2A2A2E] border border-white/10 rounded-xl p-3 flex flex-col items-center";
+    div.innerHTML = `<img src="${item.img}" alt="${item.name}" class="h-24 object-contain mb-2" />\n      <span>${item.name}</span>`;
+    grid.appendChild(div);
+  });
+}
+
+async function checkAccess() {
+  const token = localStorage.getItem("token");
+  if (!token) {
+    document.getElementById("locked-msg").classList.remove("hidden");
+    renderPreview();
+    return;
+  }
+  try {
+    const res = await fetch(`${API_BASE}/my/orders`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) throw new Error("fail");
+    const orders = await res.json();
+    if (!orders.length) {
+      document.getElementById("locked-msg").classList.remove("hidden");
+      renderPreview();
+    } else {
+      renderPreview();
+      document.getElementById("locked-msg").classList.add("hidden");
+    }
+  } catch {
+    document.getElementById("locked-msg").classList.remove("hidden");
+    renderPreview();
+  }
+}
+
+document.addEventListener("DOMContentLoaded", checkAccess);


### PR DESCRIPTION
## Summary
- add basic `addons.html` page with soft lock logic
- include new `js/addons.js` for preview rendering and purchase check
- link to Add-Ons from the main page navigation
- update `docs/task_list.md` with remaining add-on tasks

## Testing
- `npm run setup`
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_685bdd42ca24832dbb97cec6c01f382c