### PR TITLE
Fix color order and update orange

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -332,26 +332,26 @@
                 <button
                   type="button"
                   class="w-8 h-8 rounded-full border border-white/20"
-                  style="background-color: #34d399"
-                  data-color="#00ff00"
+                  style="background-color: #ff7f00"
+                  data-color="#ff7f00"
                 ></button>
                 <button
                   type="button"
                   class="w-8 h-8 rounded-full border border-white/20"
-                  style="background-color: #60a5fa"
-                  data-color="#0000ff"
-                ></button>
-                <button
-                  type="button"
-                  class="w-8 h-8 rounded-full border border-white/20 col-start-1"
                   style="background-color: #fbbf24"
                   data-color="#ffff00"
                 ></button>
                 <button
                   type="button"
+                  class="w-8 h-8 rounded-full border border-white/20 col-start-1"
+                  style="background-color: #34d399"
+                  data-color="#00ff00"
+                ></button>
+                <button
+                  type="button"
                   class="w-8 h-8 rounded-full border border-white/20 col-start-2"
-                  style="background-color: #fb923c"
-                  data-color="#fb923c"
+                  style="background-color: #60a5fa"
+                  data-color="#0000ff"
                 ></button>
                 <button
                   type="button"


### PR DESCRIPTION
## Summary
- reorder color swatches in rainbow order
- adjust orange hue to `#ff7f00` for better visibility

## Testing
- `npm run format` in `backend`
- `npm test` in `backend`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_685be8e05f7c832da6e1fdfd9494aaff