### PR TITLE
Enable navigation for multiple basket items at checkout

### DIFF
--- a/js/basket.js
+++ b/js/basket.js
@@ -230,6 +230,18 @@ export function setupBasketUI() {
         localStorage.removeItem("print3JobId");
       }
     }
+    // Save basket contents for payment page navigation
+    try {
+      const checkoutItems = items.map((it) => ({
+        modelUrl: it.modelUrl,
+        jobId: it.jobId,
+        material: localStorage.getItem("print3Material") || "multi",
+      }));
+      localStorage.setItem(
+        "print3CheckoutItems",
+        JSON.stringify(checkoutItems),
+      );
+    } catch {}
     closeBasket();
     window.location.href = "payment.html";
   });

--- a/js/payment.js
+++ b/js/payment.js
@@ -34,6 +34,8 @@ const API_BASE = (window.API_ORIGIN || "") + "/api";
 const TZ = "America/New_York";
 let flashTimerId = null;
 let flashSale = null;
+let checkoutItems = [];
+let currentIndex = 0;
 const NEXT_PROMPTS = [
   "cute robot figurine",
   "ornate chess piece",
@@ -681,6 +683,32 @@ async function initPaymentPage() {
   }
   updatePayButton();
   updatePopularMessage();
+  const prevBtn = document.getElementById("prev-model");
+  const nextBtn = document.getElementById("next-model");
+
+  function showItem(idx) {
+    if (!checkoutItems.length) return;
+    currentIndex = (idx + checkoutItems.length) % checkoutItems.length;
+    const item = checkoutItems[currentIndex];
+    viewer.src = item.modelUrl || FALLBACK_GLB;
+    if (item.jobId) localStorage.setItem("print3JobId", item.jobId);
+    else localStorage.removeItem("print3JobId");
+    storedMaterial = item.material || "multi";
+    localStorage.setItem("print3Material", storedMaterial);
+    const radio = document.querySelector(
+      `#material-options input[value="${storedMaterial}"]`,
+    );
+    if (radio) {
+      radio.checked = true;
+      radio.dispatchEvent(new Event("change"));
+    }
+    updatePayButton();
+    updateFlashSaleBanner();
+  }
+
+  prevBtn?.addEventListener("click", () => showItem(currentIndex - 1));
+  nextBtn?.addEventListener("click", () => showItem(currentIndex + 1));
+  if (checkoutItems.length) showItem(0);
   const sessionId = qs("session_id");
   if (sessionId) {
     recordPurchase();
@@ -787,25 +815,40 @@ async function initPaymentPage() {
   loader.hidden = false;
   // Assign the model source only after the load/error listeners are in place
   const storedModel = localStorage.getItem("print3Model");
-  viewer.src = storedModel || FALLBACK_GLB;
-  if (!storedModel) {
-    viewer.addEventListener(
-      "load",
-      () => {
-        const temp = document.createElement("model-viewer");
-        temp.style.display = "none";
-        temp.crossOrigin = "anonymous";
-        temp.src = FALLBACK_GLB_HIGH;
-        temp.addEventListener("load", () => {
-          if (viewer.src === FALLBACK_GLB_LOW) {
-            viewer.src = FALLBACK_GLB_HIGH;
-          }
-          temp.remove();
-        });
-        document.body.appendChild(temp);
-      },
-      { once: true },
-    );
+  // Load saved basket items
+  try {
+    const arr = JSON.parse(localStorage.getItem("print3CheckoutItems"));
+    if (Array.isArray(arr) && arr.length) checkoutItems = arr;
+  } catch {}
+
+  if (!checkoutItems.length) {
+    viewer.src = storedModel || FALLBACK_GLB;
+    if (!storedModel) {
+      viewer.addEventListener(
+        "load",
+        () => {
+          const temp = document.createElement("model-viewer");
+          temp.style.display = "none";
+          temp.crossOrigin = "anonymous";
+          temp.src = FALLBACK_GLB_HIGH;
+          temp.addEventListener("load", () => {
+            if (viewer.src === FALLBACK_GLB_LOW) {
+              viewer.src = FALLBACK_GLB_HIGH;
+            }
+            temp.remove();
+          });
+          document.body.appendChild(temp);
+        },
+        { once: true },
+      );
+    }
+  } else {
+    const first = checkoutItems[0];
+    viewer.src = first.modelUrl || FALLBACK_GLB;
+    if (first.jobId) localStorage.setItem("print3JobId", first.jobId);
+    else localStorage.removeItem("print3JobId");
+    storedMaterial = first.material || storedMaterial;
+    localStorage.setItem("print3Material", storedMaterial);
   }
 
   // Hide the overlay if nothing happens after a short delay

--- a/payment.html
+++ b/payment.html
@@ -207,14 +207,30 @@
             style="display: none"
             alt="Preview image"
           />
-          <model-viewer
-            id="viewer"
-            alt="3D astronaut"
-            environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
-            camera-controls
-            auto-rotate
-            style="width: 100%; height: 100%; display: block"
-          ></model-viewer>
+        <model-viewer
+          id="viewer"
+          alt="3D astronaut"
+          environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
+          camera-controls
+          auto-rotate
+          style="width: 100%; height: 100%; display: block"
+        ></model-viewer>
+        <button
+          id="prev-model"
+          type="button"
+          class="absolute left-2 top-1/2 -translate-y-1/2 bg-[#2A2A2E] border border-white/20 rounded-full p-2"
+        >
+          <i class="fas fa-chevron-left"></i>
+          <span class="sr-only">Previous model</span>
+        </button>
+        <button
+          id="next-model"
+          type="button"
+          class="absolute right-2 top-1/2 -translate-y-1/2 bg-[#2A2A2E] border border-white/20 rounded-full p-2"
+        >
+          <i class="fas fa-chevron-right"></i>
+          <span class="sr-only">Next model</span>
+        </button>
           <div
             id="loader"
             class="absolute inset-0 flex items-center justify-center bg-[#2A2A2E]/80"


### PR DESCRIPTION
## Summary
- allow payment page to cycle through basket items
- persist basket items for checkout navigation
- add navigation controls around the model viewer

## Testing
- `npm run format` in `backend/`
- `npm test`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_685c092541b0832d8be2efe740c0178c