### PR TITLE
Add share buttons to Add-Ons page

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -54,6 +54,43 @@
           class="bg-gradient-to-r from-purple-500 to-pink-500 text-white rounded-3xl px-3 py-2 text-sm transition-shape"
           >print2 pro £149.99/mo</a
         >
+        <div class="flex space-x-2">
+          <button
+            class="w-9 h-9 flex-shrink-0 flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-full hover:bg-[#3A3A3E] transition-shape"
+            onclick="shareOn('twitter')"
+            aria-label="Share on Twitter"
+          >
+            <i class="fab fa-twitter"></i>
+          </button>
+          <button
+            class="w-9 h-9 flex-shrink-0 flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-full hover:bg-[#3A3A3E] transition-shape"
+            onclick="shareOn('facebook')"
+            aria-label="Share on Facebook"
+          >
+            <i class="fab fa-facebook-f"></i>
+          </button>
+          <button
+            class="w-9 h-9 flex-shrink-0 flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-full hover:bg-[#3A3A3E] transition-shape"
+            onclick="shareOn('reddit')"
+            aria-label="Share on Reddit"
+          >
+            <i class="fab fa-reddit-alien"></i>
+          </button>
+          <button
+            class="w-9 h-9 flex-shrink-0 flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-full hover:bg-[#3A3A3E] transition-shape"
+            onclick="shareOn('tiktok')"
+            aria-label="Share on TikTok"
+          >
+            <i class="fab fa-tiktok"></i>
+          </button>
+          <button
+            class="w-9 h-9 flex-shrink-0 flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-full hover:bg-[#3A3A3E] transition-shape"
+            onclick="shareOn('instagram')"
+            aria-label="Share on Instagram"
+          >
+            <i class="fab fa-instagram"></i>
+          </button>
+        </div>
       </div>
     </header>
     <main class="flex-1 p-6 space-y-8">


### PR DESCRIPTION
## Summary
- add share buttons to the Add-Ons header

## Testing
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_685c167b0d08832daa03865da7d533d0