### PR TITLE
Fix progress bar flicker on payment page

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -138,6 +138,11 @@
         animation: shimmer 3s ease-in-out forwards;
         pointer-events: none;
       }
+
+      /* Hide model-viewer's built-in loading bar */
+      model-viewer::part(progress-bar) {
+        display: none;
+      }
     </style>
   </head>
 


### PR DESCRIPTION
## Summary
- hide the built-in model-viewer loading bar so the viewer doesn't flash a thin bar when switching models

## Testing
- `npm run format` (backend)
- `npm test` (backend)
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_685c13d418dc832d9b020258ddbca775