### PR TITLE
Fix print run slots display

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -324,8 +324,9 @@ async function updatePrintRunInfo() {
     /* ignore */
   }
   hoursEl.textContent = computePrintRunHours();
-  if (slotsEl)
-    slotsEl.textContent = `<${adjustedSlots(baseSlots) + 1} slots remain`;
+  if (slotsEl) {
+    slotsEl.textContent = String(adjustedSlots(baseSlots) + 1);
+  }
   if (info) info.classList.remove("invisible");
   if (typeof window.positionQuote === "function") {
     requestAnimationFrame(() => window.positionQuote());


### PR DESCRIPTION
## Summary
- adjust index page slot display so the <X slots remain text shows the number only

## Testing
- `npm run format` in `backend`
- `npm test` in `backend`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_68566c850b94832dadfe3878d1ea81f8