### PR TITLE
Fix model colour reset when switching tiers

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -534,7 +534,9 @@ async function initPaymentPage() {
     }
   }
 
-  viewer.addEventListener("load", captureOriginal, { once: true });
+  // Capture the original colours every time a new model loads so that
+  // switching between items restores the correct textures.
+  viewer.addEventListener("load", captureOriginal);
   if (viewer.model) captureOriginal();
 
   function updateEtchVisibility(val) {


### PR DESCRIPTION
## Summary
- handle model load events each time to store original colours

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685c15578274832db6e288ece9a2ee01