### PR TITLE
Add add-on upsell email

### DIFF
--- a/backend/email_templates/addon_upsell.txt
+++ b/backend/email_templates/addon_upsell.txt
@@ -1,0 +1,6 @@
+Thanks for your recent order! Want to enhance your print with accessories?
+Use the code below for $5 off any add-on:
+
+{{code}}
+
+Browse our accessories to upgrade your setup!

--- a/backend/server.js
+++ b/backend/server.js
@@ -104,6 +104,17 @@ progressEmitter.on(COMPLETE_EVENT, async ({ jobId }) => {
         "Print Finished",
         `Your print for job ${jobId} has finished. We'll ship it soon!`,
       );
+      try {
+        const code = await createTimedCode(500, 48);
+        await sendTemplate(
+          rows[0].email,
+          "Enhance your print",
+          "addon_upsell.txt",
+          { code },
+        );
+      } catch (err) {
+        logError("Failed to send upsell email", err);
+      }
     }
   } catch (err) {
     logError("Failed to send completion email", err);

--- a/backend/translations.json
+++ b/backend/translations.json
@@ -30,5 +30,7 @@
   "shipping_confirmation.subject": "Your order has shipped",
   "shipping_confirmation.body": "Hi {{username}},\n\nYour order {{order_id}} has shipped! You can track its progress here:\n{{tracking_url}}\n\nThanks for supporting our community!",
   "shipping_update.subject": "Package update: {{status}}",
-  "shipping_update.body": "Hi {{username}},\n\nYour order {{order_id}} status update: {{status}}\n\nWe'll keep you posted until it's delivered."
+  "shipping_update.body": "Hi {{username}},\n\nYour order {{order_id}} status update: {{status}}\n\nWe'll keep you posted until it's delivered.",
+  "addon_upsell.subject": "Enhance your print",
+  "addon_upsell.body": "Thanks for your recent order! Want to enhance your print with accessories? Use code {{code}} for $5 off any add-on."
 }


### PR DESCRIPTION
## Summary
- add new email template to suggest accessories after purchase
- send upsell email with discount code once a print finishes
- localize new email strings

## Testing
- `npm test --prefix backend`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_685c2ec60544832d992e573c7168bd20