### PR TITLE
Add addon upsell email

### DIFF
--- a/backend/email_templates/addon_upsell.txt
+++ b/backend/email_templates/addon_upsell.txt
@@ -1,0 +1,7 @@
+Hi {{username}},
+
+Thanks for your recent order! Enhance your prints with our accessory add-ons:
+
+{{addons_url}}
+
+Use code {{code}} for a discount on your next purchase.

--- a/backend/server.js
+++ b/backend/server.js
@@ -3008,6 +3008,25 @@ app.post(
               );
             }
           }
+
+          const { rows: userRows } = await db.query(
+            "SELECT email, username FROM users WHERE id=$1",
+            [userId],
+          );
+          if (userRows.length) {
+            const code = await createTimedCode(500, 48);
+            const addonsUrl = `$\{process.env.SITE_URL || "http://localhost:3000"}/addons.html`;
+            await sendTemplate(
+              userRows[0].email,
+              "Check out add-ons",
+              "addon_upsell.txt",
+              {
+                username: userRows[0].username,
+                addons_url: addonsUrl,
+                code,
+              },
+            );
+          }
         }
       } catch (err) {
         logError(err);

--- a/backend/translations.json
+++ b/backend/translations.json
@@ -30,5 +30,7 @@
   "shipping_confirmation.subject": "Your order has shipped",
   "shipping_confirmation.body": "Hi {{username}},\n\nYour order {{order_id}} has shipped! You can track its progress here:\n{{tracking_url}}\n\nThanks for supporting our community!",
   "shipping_update.subject": "Package update: {{status}}",
-  "shipping_update.body": "Hi {{username}},\n\nYour order {{order_id}} status update: {{status}}\n\nWe'll keep you posted until it's delivered."
+  "shipping_update.body": "Hi {{username}},\n\nYour order {{order_id}} status update: {{status}}\n\nWe'll keep you posted until it's delivered.",
+  "addon_upsell.subject": "Enhance your setup",
+  "addon_upsell.body": "Hi {{username}},\n\nLooking to customize your print even more? Check out our add-ons:\n{{addons_url}}\n\nUse code {{code}} to save on your next order."
 }


### PR DESCRIPTION
## Summary
- add addon upsell email template
- email users a discount code for add-ons after order completion
- provide translations for the new template

## Testing
- `npm test`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_685c2ebb58f0832d9cf592b787f3a61f