### PR TITLE
Add addon upsell followup email

### DIFF
--- a/backend/email_templates/addon_upsell.txt
+++ b/backend/email_templates/addon_upsell.txt
@@ -1,6 +1,4 @@
-Thanks for your recent order! Want to enhance your print with accessories?
-Use the code below for $5 off any add-on:
+Thanks for your order! Enhance your print with accessories that pair perfectly with your model.
+Use code {{code}} for $5 off any add-on for the next 48 hours.
 
-{{code}}
-
-Browse our accessories to upgrade your setup!
+Browse accessories and upgrade your setup today!

--- a/backend/server.js
+++ b/backend/server.js
@@ -3019,6 +3019,29 @@ app.post(
               );
             }
           }
+
+          try {
+            const { rows: emailRows } = await db.query(
+              "SELECT email FROM users WHERE id=$1",
+              [userId],
+            );
+            const email = emailRows[0] && emailRows[0].email;
+            if (email) {
+              const base = process.env.SITE_URL || "http://localhost:3000";
+              const { data } = await axios.post(
+                `${base}/api/generate-discount`,
+                {},
+              );
+              await sendTemplate(
+                email,
+                "Enhance your print",
+                "addon_upsell.txt",
+                { code: data.code },
+              );
+            }
+          } catch (err) {
+            logError("Failed to send upsell email after order", err);
+          }
         }
       } catch (err) {
         logError(err);


### PR DESCRIPTION
## Summary
- add addon upsell template
- email addon offer with generated discount after a purchase

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685c35f29c10832d8c1dae59cb1c228b