### PR TITLE
Optimize Playwright setup for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.38.0-jammy
     services:
       docker:
         image: docker:dind
@@ -32,17 +34,7 @@ jobs:
         env:
           NPM_CONFIG_LEGACY_PEER_DEPS: true
       - run: npm install --no-audit --no-fund
-      - name: Cache Playwright browsers
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-playwright-
-      - name: Install Playwright browsers
-        env:
-          PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
-        run: npx playwright install --with-deps
+      # Playwright dependencies and browsers are preinstalled in the container
       - name: Install backend dependencies
         run: npm install --no-audit --no-fund --prefix backend
 
@@ -55,8 +47,6 @@ jobs:
         run: npm run prepare
 
       - name: Run CI
-        env:
-          PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
         run: npm run ci
 
       - name: Run coverage
@@ -117,13 +107,10 @@ jobs:
         if: ${{ secrets.PERCY_TOKEN }}
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
-          PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
         run: npx percy exec -- npm run e2e
 
       - name: Run smoke tests
         if: ${{ !secrets.PERCY_TOKEN }}
-        env:
-          PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
         run: npm run e2e
 
       # ← you can add additional steps here, like your tests

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.38.0-jammy
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -19,16 +21,7 @@ jobs:
           if [ -f backend/hunyuan_server/package.json ]; then
             npm install --no-audit --no-fund --prefix backend/hunyuan_server
           fi
-      - name: Cache Playwright browsers
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-playwright-
-      - run: npx playwright install --with-deps
-        env:
-          PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
+      # Playwright browsers and dependencies are bundled in the container
       - run: npm install -g netlify-cli
       - name: Deploy to Netlify
         if: env.NETLIFY_AUTH_TOKEN != '' && env.NETLIFY_SITE_ID != ''
@@ -41,5 +34,4 @@ jobs:
       - name: Run smoke tests
         env:
           PLAYWRIGHT_BASE_URL: ${{ env.PREVIEW_URL }}
-          PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
         run: npx playwright test e2e/smoke.test.js


### PR DESCRIPTION
## Summary
- use `mcr.microsoft.com/playwright:v1.38.0-jammy` container in CI jobs
- rely on container's preinstalled browsers and dependencies

## Testing
- `npm test --prefix backend`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_685c44d249a8832da17847c521f1c7e7