### PR TITLE
Fix Playwright browser path in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Install Playwright browsers
         env:
           PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '0'
         run: npx playwright install --with-deps
       - name: Install backend dependencies
         run: npm install --no-audit --no-fund --prefix backend
@@ -57,6 +58,7 @@ jobs:
       - name: Run CI
         env:
           PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '0'
         run: npm run ci
 
       - name: Run coverage
@@ -118,12 +120,14 @@ jobs:
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
           PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '0'
         run: npx percy exec -- npm run e2e
 
       - name: Run smoke tests
         if: ${{ !secrets.PERCY_TOKEN }}
         env:
           PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '0'
         run: npm run e2e
 
       # ← you can add additional steps here, like your tests

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -29,6 +29,7 @@ jobs:
       - run: npx playwright install --with-deps
         env:
           PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '0'
       - run: npm install -g netlify-cli
       - name: Deploy to Netlify
         if: env.NETLIFY_AUTH_TOKEN != '' && env.NETLIFY_SITE_ID != ''
@@ -42,4 +43,5 @@ jobs:
         env:
           PLAYWRIGHT_BASE_URL: ${{ env.PREVIEW_URL }}
           PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '0'
         run: npx playwright test e2e/smoke.test.js


### PR DESCRIPTION
## Summary
- allow Playwright to download browsers in CI workflows

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_685c4b2c3f40832d925c7b44378e3037