### PR TITLE
Add extra spacing around price breakdown

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -536,7 +536,7 @@
 
             <p id="cost-estimate" class="text-sm text-center"></p>
             <p id="eta-estimate" class="text-sm text-center"></p>
-            <div class="flex justify-between mt-1 text-xs">
+            <div class="flex justify-between mt-2 mb-2 text-xs">
               <pre id="price-breakdown" class="whitespace-pre-wrap"></pre>
               <p class="text-red-300 text-right">
                 Only <span id="slot-count" style="visibility: hidden"></span> prints remaining


### PR DESCRIPTION
## Summary
- tweak spacing around price breakdown in checkout page

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npx playwright test e2e/smoke.test.js` *(fails: browsers not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685c5b3d3ddc832daa3bab18f2afcd8c