### PR TITLE
Add Playwright browser install step

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,10 +9,12 @@ These guidelines apply to all automated agents (e.g. the Codex agent) working on
 3. **Format code** – run `npm run format` in `backend/` to apply Prettier formatting.
 4. **Run tests** – execute `npm test` in `backend/`. If tests cannot run because of environment limitations, mention this in the PR.
 5. **Run full CI locally** – execute `npm run ci` at the repo root before opening a PR.
-6. **Run smoke tests** – execute `npx playwright test e2e/smoke.test.js` at the repository root. If the tests fail because Playwright isn't set up correctly, mention this in the PR.
-7. **Limit scope** – only modify files related to the task. Do not change anything under `img/`, `models/`, or `uploads/` unless explicitly requested. Avoid editing `docs/` unless the task specifically involves documentation.
-8. **Review your diff** – run `git status --short` and `git diff --stat` to ensure only intended files were modified. Revert any unrelated changes.
-9. **Include logs** – paste the output of `npm test` (or `npm run test-ci`) and `npm run format` in the PR description so maintainers can verify the steps.
+
+6. **Install Playwright browsers** – run `npx playwright install` at the repository root to download browsers for running tests.
+7. **Run smoke tests** – execute `npx playwright test e2e/smoke.test.js` at the repository root. If the tests fail because Playwright isn't set up correctly, mention this in the PR.
+8. **Limit scope** – only modify files related to the task. Do not change anything under `img/`, `models/`, or `uploads/` unless explicitly requested. Avoid editing `docs/` unless the task specifically involves documentation.
+9. **Review your diff** – run `git status --short` and `git diff --stat` to ensure only intended files were modified. Revert any unrelated changes.
+10. **Include logs** – paste the output of `npm test` (or `npm run test-ci`) and `npm run format` in the PR description so maintainers can verify the steps.
 
 ## PR notes
 


### PR DESCRIPTION
## Summary
- document running `npx playwright install` before smoke tests in AGENTS guide

## Testing
- `npm run setup`
- `npm run format`
- `npm test`
- `npm run ci`
- `npx playwright install`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_685c5f13a23c832d8d86f80a1d1b50f3