### PR TITLE
Add link to payments from addons page

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -98,7 +98,10 @@
         id="locked-msg"
         class="bg-[#2A2A2E] p-4 rounded-xl text-center hidden"
       >
-        Unlock advanced customisation after your first purchase.
+        Unlock advanced customisation after your
+        <a href="payment.html" class="font-bold text-[#30D5C8]"
+          >first purchase</a
+        >.
       </div>
       <section
         id="addons-grid"


### PR DESCRIPTION
## Summary
- add a link from the add-ons page to the payments page

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_685c6cac04a4832dac49703edadeda91