### PR TITLE
Add login prompt on save

### DIFF
--- a/js/saveList.js
+++ b/js/saveList.js
@@ -9,7 +9,25 @@ export function getSaved() {
 function saveList(items) {
   localStorage.setItem(KEY, JSON.stringify(items));
 }
+
+function showLoginPrompt() {
+  if (document.getElementById("login-save-prompt")) return;
+  const div = document.createElement("div");
+  div.id = "login-save-prompt";
+  div.className =
+    "fixed bottom-20 left-1/2 -translate-x-1/2 bg-[#2A2A2E] border border-white text-white rounded-lg px-4 py-2 z-50";
+  div.innerHTML =
+    'Log in to save models <a href="login.html" class="font-bold text-[#30D5C8] underline">Log In</a>';
+  document.body.appendChild(div);
+  setTimeout(() => div.remove(), 3000);
+}
+
 export function addSaved(item) {
+  const token = localStorage.getItem("token");
+  if (!token) {
+    showLoginPrompt();
+    return;
+  }
   const items = getSaved();
   if (!items.find((it) => it.id === item.id)) {
     items.push(item);


### PR DESCRIPTION
## Summary
- require login to save models
- show temporary login prompt with link when saving without being logged in

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`
- `npx playwright install`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_685c6c77a400832da315daf702ef0e66