### PR TITLE
Persist checkout settings across navigation

### DIFF
--- a/js/basket.js
+++ b/js/basket.js
@@ -60,11 +60,19 @@ export function removeFromBasket(index) {
   const items = getBasket();
   items.splice(index, 1);
   saveBasket(items);
+  try {
+    const arr = JSON.parse(localStorage.getItem("print3CheckoutItems"));
+    if (Array.isArray(arr) && index >= 0 && index < arr.length) {
+      arr.splice(index, 1);
+      localStorage.setItem("print3CheckoutItems", JSON.stringify(arr));
+    }
+  } catch {}
   updateBadge();
   renderList();
 }
 export function clearBasket() {
   saveBasket([]);
+  localStorage.removeItem("print3CheckoutItems");
   updateBadge();
   renderList();
 }


### PR DESCRIPTION
## Summary
- persist basket item selections in local storage so removing an item clears just that entry
- remember entered shipping details and etch name on the payment page

## Testing
- `npm test`
- `npm run ci`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_685c70be979c832dbda300202c616ad8