### PR TITLE
Fix price breakdown alignment

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -558,7 +558,7 @@
             <p id="cost-estimate" class="text-sm text-center"></p>
             <p id="eta-estimate" class="text-sm text-center"></p>
             <div class="flex justify-between mt-2 mb-2 text-xs">
-              <pre id="price-breakdown" class="whitespace-pre-wrap"></pre>
+              <pre id="price-breakdown" class="whitespace-pre-wrap text-right"></pre>
             </div>
             <button
               id="submit-payment"


### PR DESCRIPTION
## Summary
- right-align the price breakdown on the payment page

## Testing
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `npm run ci`
- `npx playwright install`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_685c7dbb2ff0832d9809c7cbb182e657