### PR TITLE
Fix etched name persistence

### DIFF
--- a/js/basket.js
+++ b/js/basket.js
@@ -244,6 +244,8 @@ export function setupBasketUI() {
         modelUrl: it.modelUrl,
         jobId: it.jobId,
         material: localStorage.getItem("print3Material") || "multi",
+        // Preserve personalised etch text per model for the payment page.
+        etchName: localStorage.getItem("print3EtchName") || "",
       }));
       localStorage.setItem(
         "print3CheckoutItems",


### PR DESCRIPTION
## Summary
- preserve personalized etch text when switching basket items on payment page

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npx playwright install`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_685cf8b9cdb4832dbe4381734dd3261f