### PR TITLE
Add Luckybox container

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -107,6 +107,22 @@
         id="addons-grid"
         class="grid grid-cols-2 sm:grid-cols-3 gap-4"
       ></section>
+      <div
+        id="luckybox"
+        class="fixed bottom-4 left-4 w-40 h-40 bg-[#2A2A2E] border border-white/10 rounded-xl flex flex-col items-center justify-center space-y-2"
+      >
+        <span class="font-semibold">Luckybox</span>
+        <select
+          class="bg-[#1A1A1D] border border-white/10 rounded px-2 py-1 text-sm"
+        >
+          <option>Goblin</option>
+          <option>Space</option>
+          <option>Sea life</option>
+        </select>
+        <button class="bg-[#30D5C8] text-black px-3 py-1 rounded text-sm">
+          Add to Basket
+        </button>
+      </div>
     </main>
     <script type="module" src="js/addons.js"></script>
     <script type="module" src="js/rewardBadge.js"></script>


### PR DESCRIPTION
## Summary
- add a simple Luckybox block at the bottom left of `addons.html`

## Testing
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `npm run ci`
- `npx playwright install`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_685cfbbfcb68832d8105dedbdbf00042