### PR TITLE
Fix Luckybox container size

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -110,7 +110,7 @@
       ></section>
       <div
         id="luckybox"
-        class="fixed bottom-4 left-4 w-40 h-40 bg-[#2A2A2E] border border-white/10 rounded-xl flex flex-col items-center justify-center space-y-2"
+        class="fixed left-4 bottom-4 top-28 w-40 bg-[#2A2A2E] border border-white/10 rounded-xl flex flex-col items-center justify-center space-y-2"
       >
         <span class="font-semibold">Luckybox</span>
         <select


### PR DESCRIPTION
## Summary
- resize Luckybox container so it spans vertically from near the grid to above the page bottom

## Testing
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `npm run ci`
- `npx playwright install`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_685d0ee8d4c0832d8a8b96471c0d5ca8