### PR TITLE
Fix merge markers in addons and payment script

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -110,11 +110,7 @@
       ></section>
       <div
         id="luckybox"
-<<<<<<< codex/resize-luckybox-on-addons-page
-        class="fixed left-4 bottom-4 top-28 w-40 bg-[#2A2A2E] border border-white/10 rounded-xl flex flex-col items-center justify-center space-y-2"
-=======
         class="fixed bottom-4 left-4 w-64 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 flex flex-col items-center space-y-2"
->>>>>>> main
       >
         <span class="font-semibold text-lg">Luckybox</span>
         <p class="text-sm text-center">

--- a/js/payment.js
+++ b/js/payment.js
@@ -638,11 +638,7 @@ async function initPaymentPage() {
     const saved = (discount / 100) * items;
     let lines = [`£${(selectedPrice / 100).toFixed(2)} each`];
     lines.push(
-<<<<<<< codex/update-payments-page-quantity-and-pay-button
       `×${qty * items} prints${qty > 1 ? ` – £${((TWO_PRINT_DISCOUNT * items) / 100).toFixed(0)} bundle discount` : ""}`,
-=======
-      `×${qty} prints${qty > 1 ? ` – £${(TWO_PRINT_DISCOUNT / 100).toFixed(0)} discount` : ""}`,
->>>>>>> main
     );
     lines.push("─────────────");
     let totalLine = `Total: £${total.toFixed(2)}`;
@@ -825,7 +821,8 @@ async function initPaymentPage() {
       const q = JSON.parse(localStorage.getItem("pendingCheckouts") || "[]");
       if (q.length) {
         const next = q.shift();
-        if (q.length) localStorage.setItem("pendingCheckouts", JSON.stringify(q));
+        if (q.length)
+          localStorage.setItem("pendingCheckouts", JSON.stringify(q));
         else localStorage.removeItem("pendingCheckouts");
         setTimeout(() => {
           window.location.href = next;
@@ -1067,7 +1064,8 @@ async function initPaymentPage() {
       const q = JSON.parse(localStorage.getItem("pendingCheckouts") || "[]");
       if (q.length) {
         const next = q.shift();
-        if (q.length) localStorage.setItem("pendingCheckouts", JSON.stringify(q));
+        if (q.length)
+          localStorage.setItem("pendingCheckouts", JSON.stringify(q));
         else localStorage.removeItem("pendingCheckouts");
         setTimeout(() => {
           window.location.href = next;


### PR DESCRIPTION
## Summary
- remove leftover merge conflict markers in `addons.html` and `js/payment.js`

## Validation
- `npm run format` (backend)
- `npm test`
- `npm run ci`
- `npx playwright install`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_685d2330d0b8832d84470581d5dd8e98