### PR TITLE
Remove outdated loyalty discount

### DIFF
--- a/printclub.html
+++ b/printclub.html
@@ -122,7 +122,7 @@
               </li>
               <li>
                 12 months – (2 + <span class="text-[#30D5C8]">4 extra</span> =
-                6) prints each week and 25% off
+                6) prints each week
               </li>
             </ul>
           </div>


### PR DESCRIPTION
## Summary
- remove the outdated "25% off" text from 12 month loyalty rewards

## Testing
- `npm run format` in `backend/`
- `npm test --silent` in `backend/`
- `npm run ci`
- `npx playwright install`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_685d6e289de0832dbc6b15d54cf8f04a