### PR TITLE
Allow custom genre input for Luckybox B

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -134,15 +134,13 @@
               value="B"
               class="accent-[#30D5C8]"
             />
-            <span>Luckybox B: choose a genre</span>
+            <span>Luckybox B: describe a genre</span>
           </span>
-          <select
+          <input
+            type="text"
+            placeholder="e.g. dragons in space"
             class="bg-[#1A1A1D] border border-white/10 rounded px-2 py-1 text-sm w-full"
-          >
-            <option>Goblin</option>
-            <option>Space</option>
-            <option>Sea life</option>
-          </select>
+          />
         </label>
         <button class="bg-[#30D5C8] text-black px-3 py-1 rounded text-sm">
           Add to Basket


### PR DESCRIPTION
## Summary
- change Luckybox B on addons page to take text instead of a dropdown

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npx playwright test e2e/smoke.test.js`

------
https://chatgpt.com/codex/tasks/task_e_685d77b70638832d95a48b298a88b842