### PR TITLE
Adjust payment page breakdown

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -676,7 +676,7 @@ async function initPaymentPage() {
     if (saved > 0) {
       const percent =
         subtotal > 0 ? Math.round((discount / subtotal) * 100) : 0;
-      text += ` - £${saved.toFixed(2)} (${percent}% saving) = £${total.toFixed(2)}`;
+      text += ` - £${saved.toFixed(2)} = £${total.toFixed(2)} (${percent}% saving)`;
     } else {
       text += ` = £${total.toFixed(2)}`;
     }

--- a/payment.html
+++ b/payment.html
@@ -558,7 +558,7 @@
             <p id="cost-estimate" class="text-sm text-center"></p>
             <p id="eta-estimate" class="text-sm text-center"></p>
             <div class="flex justify-between mt-2 mb-2 text-xs">
-              <pre id="price-breakdown" class="whitespace-pre-wrap text-right"></pre>
+              <pre id="price-breakdown" class="whitespace-nowrap text-right"></pre>
             </div>
             <button
               id="submit-payment"


### PR DESCRIPTION
## Summary
- move savings text to the end of the equation
- prevent line wrapping on the price breakdown display

## Testing
- `npm test --prefix backend`
- `npm run ci`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_685da1792520832da2e49ade6eedf79f