### PR TITLE
Move price breakdown below Pay button

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -557,9 +557,6 @@
 
             <p id="cost-estimate" class="text-sm text-center"></p>
             <p id="eta-estimate" class="text-sm text-center"></p>
-            <div class="flex justify-between mt-2 mb-2 text-xs">
-              <pre id="price-breakdown" class="whitespace-pre-wrap text-right"></pre>
-            </div>
             <button
               id="submit-payment"
               type="button"
@@ -567,6 +564,9 @@
             >
               Pay £39.99
             </button>
+            <div class="flex justify-between mt-2 mb-2 text-xs">
+              <pre id="price-breakdown" class="whitespace-pre-wrap text-right"></pre>
+            </div>
             <div id="pay-summary" class="hidden absolute left-1/2 -translate-x-1/2 bottom-[4.5rem] w-64 bg-[#2A2A2E] border border-white/20 rounded-lg p-2 text-sm"></div>
           </form>
 


### PR DESCRIPTION
## Summary
- adjust payment page to show price breakdown under the PAY button

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend --silent`
- `npm run ci`
- `npx playwright install`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_685da293796c832dab08f37a0d839edc