### PR TITLE
Fix single-color menu position

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -358,7 +358,7 @@
                     bottom-0
                     left-1/2
                     -translate-x-1/2
-                    -translate-y-[8%]
+                    translate-y-[8%]
                   grid grid-cols-3 place-items-center gap-2 p-2
                   bg-[#2A2A2E] border border-white/20
                   rounded-3xl w-28 h-28


### PR DESCRIPTION
## Summary
- adjust translation of the 6-colour picker so it shows below the £29.99 option

## Testing
- `npm run setup`
- `npm run format` (backend)
- `npm test` (backend)
- `npm run ci`
- `npx playwright install`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_685da4b4d5e4832d8e36f321473bac12