### PR TITLE
Fix addon grid alignment

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -107,7 +107,7 @@
       </div>
       <section
         id="addons-grid"
-        class="grid grid-cols-2 gap-4 ml-auto mt-2"
+        class="grid grid-cols-2 gap-4 ml-[36rem] w-[32rem] mt-2"
       ></section>
       <div
         id="luckybox"

--- a/js/addons.js
+++ b/js/addons.js
@@ -40,7 +40,7 @@ function renderPreview() {
   items.forEach((item) => {
     const div = document.createElement("div");
     div.className =
-      "bg-[#2A2A2E] border border-white/10 rounded-xl p-3 flex flex-col items-center";
+      "w-64 bg-[#2A2A2E] border border-white/10 rounded-xl p-3 flex flex-col items-center";
     div.innerHTML = `<img src="${item.img}" alt="${item.name}" class="h-24 object-contain mb-2" />\n      <span>${item.name}</span>`;
     grid.appendChild(div);
   });


### PR DESCRIPTION
## Summary
- ensure Luckybox occupies left side
- shrink and offset addon grid to the right of Luckybox

## Testing
- `npm test --prefix backend`
- `npm run ci`
- `npx playwright install`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_685da692d6c8832d92ea24afb316109b