### PR TITLE
Fix color persistence for single-color tier

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -98,7 +98,6 @@ function resetMaterialSelection() {
 }
 
 resetMaterialSelection();
-window.addEventListener("pageshow", resetMaterialSelection);
 
 /**
  * Load the <model-viewer> library if it hasn't already been loaded.


### PR DESCRIPTION
## Summary
- stop clearing saved material settings on index page so single-colour choices persist

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`
- `npx playwright install`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_685db3f8d728832d83d4baf9464e42fc