### PR TITLE
Style addon cards

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -107,7 +107,7 @@
       </div>
       <section
         id="addons-grid"
-        class="grid grid-cols-2 gap-4 ml-[36rem] w-[38rem] mt-2"
+        class="grid grid-cols-2 gap-4 ml-[36rem] w-[34rem] mt-2"
       ></section>
       <div
         id="luckybox"

--- a/js/addons.js
+++ b/js/addons.js
@@ -40,8 +40,8 @@ function renderPreview() {
   items.forEach((item) => {
     const div = document.createElement("div");
     div.className =
-      "w-72 bg-[#2A2A2E] border border-white/10 rounded-xl p-3 flex flex-col items-center";
-    div.innerHTML = `<img src="${item.img}" alt="${item.name}" class="h-24 object-contain mb-2" />\n      <span>${item.name}</span>`;
+      "model-card relative h-32 w-64 bg-[#2A2A2E] border border-white/10 rounded-xl hover:bg-[#3A3A3E] transition-shape flex items-center justify-center";
+    div.innerHTML = `<img src="${item.img}" alt="${item.name}" class="w-full h-full object-contain pointer-events-none" />\n      <span class="sr-only">${item.name}</span>`;
     grid.appendChild(div);
   });
   adjustLuckyboxHeight();


### PR DESCRIPTION
## Summary
- resize Add-ons page grid
- match add-on card style to Community page cards

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_685dc0d7f140832dba005611a36514bc