### PR TITLE
Fix quantity reset on payment page

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -985,6 +985,9 @@ async function initPaymentPage() {
   try {
     const arr = JSON.parse(localStorage.getItem("print3CheckoutItems"));
     if (Array.isArray(arr) && arr.length) {
+      if (arr.length === 1 && arr[0].qty == null) {
+        arr[0].qty = 2;
+      }
       checkoutItems = arr.map((it) => ({
         ...it,
         etchName: it.etchName || "",


### PR DESCRIPTION
## Summary
- keep default quantity when navigating between models on payment page

## Testing
- `npm test`
- `npm run ci`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_685dc8aa7274832dbf803b754d4d29b9