### PR TITLE
Fix color selection persistence

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -90,8 +90,9 @@ import { shareOn } from "./share.js";
 
 function resetMaterialSelection() {
   try {
-    localStorage.setItem("print3Material", "multi");
-    localStorage.removeItem("print3Color");
+    if (!localStorage.getItem("print3Material")) {
+      localStorage.setItem("print3Material", "multi");
+    }
   } catch {
     /* ignore quota errors */
   }


### PR DESCRIPTION
## Summary
- avoid clearing saved material/color when returning to `index.html`

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npx playwright install`
- `npx playwright test e2e/smoke.test.js`

------
https://chatgpt.com/codex/tasks/task_e_685e4f09305c832dbcf569ae509aecf1