### PR TITLE
Fix payment page not refreshing basket items

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -1403,3 +1403,11 @@ if (document.readyState === "loading") {
 } else {
   initPaymentPage();
 }
+
+// Reload the page when returning via back/forward cache so newly added basket
+// items are displayed correctly.
+window.addEventListener("pageshow", (e) => {
+  if (e.persisted) {
+    window.location.reload();
+  }
+});


### PR DESCRIPTION
## Summary
- reload the payment page when restored from browser cache so newly added items appear

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`
- `npx playwright install`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_685e74d7a7c8832da42008dc0c2991a3