### PR TITLE
Fix basket count visibility on payment page

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -844,6 +844,15 @@ async function initPaymentPage() {
     if (qtySelect) {
       qtySelect.value = String(item.qty || 1);
     }
+    const counter = document.getElementById("model-counter");
+    if (counter) {
+      if (checkoutItems.length > 1) {
+        counter.textContent = `${currentIndex + 1} / ${checkoutItems.length}`;
+        counter.classList.remove("hidden");
+      } else {
+        counter.classList.add("hidden");
+      }
+    }
     updatePayButton();
     updateFlashSaleBanner();
   }

--- a/payment.html
+++ b/payment.html
@@ -241,6 +241,7 @@
         <p class="absolute top-2 left-2 text-red-300 text-xs">
           Only <span id="slot-count" style="visibility: hidden"></span> print slots remaining
         </p>
+        <p id="model-counter" class="absolute top-2 right-2 text-white text-xs hidden"></p>
         <button
           id="prev-model"
           type="button"


### PR DESCRIPTION
## Summary
- show a counter when multiple items are in the basket on the payment page
- update payment script to update the counter while navigating items

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npx playwright install`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_685e90ad9ed8832da4e418e2a8278b36