### PR TITLE
Fix slot count messaging

### DIFF
--- a/index.html
+++ b/index.html
@@ -386,7 +386,7 @@
           class="absolute text-right text-sm text-red-400 leading-snug invisible"
         >
           <p class="whitespace-nowrap" style="margin-right: 0.5cm">
-            &lt;<span id="print-run-slots"></span> print slots left for next
+            <span id="print-run-slots"></span> print slots left for next
             <span id="print-run-hours">6</span>
             <span id="print-run-hours-label">hours</span>
           </p>

--- a/js/index.js
+++ b/js/index.js
@@ -323,7 +323,7 @@ async function updatePrintRunInfo() {
   const hours = computePrintRunHours();
   hoursEl.textContent = hours;
   if (hoursLabelEl) hoursLabelEl.textContent = hours === 1 ? "hour" : "hours";
-  if (slotsEl) slotsEl.textContent = `${adjustedSlots(baseSlots) + 1}`;
+  if (slotsEl) slotsEl.textContent = `${adjustedSlots(baseSlots)}`;
 
   if (info) info.classList.remove("invisible");
   if (typeof window.positionQuote === "function") {


### PR DESCRIPTION
## Summary
- remove less-than symbol in slot count text
- keep print-run count consistent across pages

## Testing
- `npm test`
- `npm run ci`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_685eab0d2e90832dbf07361f80cca3e6