### PR TITLE
Update preview background color

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -684,7 +684,7 @@ function getThumbnail(file) {
         c.width = size;
         c.height = size;
         const ctx = c.getContext("2d");
-        ctx.fillStyle = "#1e1e1e";
+        ctx.fillStyle = "#2A2A2E";
         ctx.fillRect(0, 0, size, size);
         let sx = 0,
           sy = 0,

--- a/upload/processThumbnail.js
+++ b/upload/processThumbnail.js
@@ -38,7 +38,7 @@ async function processThumbnail(fileBuffer) {
       })
       // Keep thumbnails crisp
       .sharpen()
-      .flatten({ background: "#1e1e1e" })
+      .flatten({ background: "#2A2A2E" })
       .jpeg({ quality: 80 });
 
     const buffer = await square.toBuffer();


### PR DESCRIPTION
## Summary
- update snapshot viewer background color
- use the same shade in thumbnail generator and processing script

## Testing
- `npm test --prefix backend --silent`
- `npx playwright test e2e/smoke.test.js`

------
https://chatgpt.com/codex/tasks/task_e_685ec2ee6df4832d8a3730ccdf875c54