### PR TITLE
Add marginal CAC metric

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -1307,6 +1307,16 @@ app.get("/api/metrics/business-intel", async (req, res) => {
   }
 });
 
+app.get("/api/metrics/marginal-cac", async (req, res) => {
+  try {
+    const data = await db.getMarginalCacMetrics();
+    res.json(data);
+  } catch (err) {
+    logError(err);
+    res.status(500).json({ error: "Failed to fetch marginal CAC" });
+  }
+});
+
 app.get("/api/metrics/daily-profit", async (req, res) => {
   try {
     const end = new Date();

--- a/backend/tests/analytics.test.js
+++ b/backend/tests/analytics.test.js
@@ -20,6 +20,7 @@ jest.mock("../db", () => ({
   getDemandForecast: jest.fn(),
   getOrCreateOrderReferralLink: jest.fn(),
   insertReferredOrder: jest.fn(),
+  getMarginalCacMetrics: jest.fn(),
 }));
 const db = require("../db");
 
@@ -134,4 +135,14 @@ test("GET /api/metrics/demand-forecast returns data", async () => {
   expect(res.status).toBe(200);
   expect(res.body[0].demand).toBe(10);
   expect(db.getDemandForecast).toHaveBeenCalled();
+});
+
+test("GET /api/metrics/marginal-cac returns data", async () => {
+  db.getMarginalCacMetrics.mockResolvedValue([
+    { subreddit: "funny", marginalCac: 2 },
+  ]);
+  const res = await request(app).get("/api/metrics/marginal-cac");
+  expect(res.status).toBe(200);
+  expect(res.body[0].marginalCac).toBe(2);
+  expect(db.getMarginalCacMetrics).toHaveBeenCalled();
 });


### PR DESCRIPTION
## Summary
- compute marginal CAC per subreddit in backend
- expose new `/api/metrics/marginal-cac` endpoint
- test new route

## Testing
- `npx prettier --write backend/db.js backend/server.js backend/tests/analytics.test.js`
- `npm test --silent` *(backend)*
- `npx playwright test e2e/smoke.test.js`

------
https://chatgpt.com/codex/tasks/task_e_685edbe36b30832d8973fece67cc1c4b