### PR TITLE
Handle addons back navigation

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -170,5 +170,14 @@
     <script type="module" src="js/addons.js"></script>
     <script type="module" src="js/rewardBadge.js"></script>
     <script type="module" src="js/trackingPixel.js"></script>
+    <script>
+      document.addEventListener("DOMContentLoaded", () => {
+        document.querySelectorAll('a[href="payment.html"]').forEach((link) => {
+          link.addEventListener("click", () => {
+            sessionStorage.setItem("fromAddons", "1");
+          });
+        });
+      });
+    </script>
   </body>
 </html>

--- a/js/basket.js
+++ b/js/basket.js
@@ -240,7 +240,6 @@ export function setupBasketUI() {
     }
     // Save basket contents for payment page navigation
     try {
-
       const existing =
         JSON.parse(localStorage.getItem("print3CheckoutItems")) || [];
       const checkoutItems = items.map((it, idx) => {
@@ -263,6 +262,9 @@ export function setupBasketUI() {
       );
     } catch {}
     closeBasket();
+    if (location.pathname.endsWith("addons.html")) {
+      sessionStorage.setItem("fromAddons", "1");
+    }
     window.location.href = "payment.html";
   });
 

--- a/payment.html
+++ b/payment.html
@@ -701,15 +701,23 @@
         const link = document.getElementById('back-link');
         if (!link) return;
         let target = 'index.html';
-        const from = sessionStorage.getItem('fromCommunity');
+        const fromCommunity = sessionStorage.getItem('fromCommunity');
         sessionStorage.removeItem('fromCommunity');
+        const fromAddons = sessionStorage.getItem('fromAddons');
+        sessionStorage.removeItem('fromAddons');
         try {
           const ref = new URL(document.referrer);
-          if (from === '1' || ref.pathname.endsWith('CommunityCreations.html')) {
+          if (
+            fromCommunity === '1' ||
+            ref.pathname.endsWith('CommunityCreations.html')
+          ) {
             target = 'CommunityCreations.html';
+          } else if (fromAddons === '1' || ref.pathname.endsWith('addons.html')) {
+            target = 'addons.html';
           }
         } catch {
-          if (from === '1') target = 'CommunityCreations.html';
+          if (fromCommunity === '1') target = 'CommunityCreations.html';
+          else if (fromAddons === '1') target = 'addons.html';
         }
         link.setAttribute('href', target);
       });


### PR DESCRIPTION
## Summary
- save `fromAddons` in sessionStorage before navigating to payment
- detect `fromAddons` on payment page to set back-link
- handle basket checkout navigation from addons page

## Testing
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `npm run ci`
- `npx playwright install`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_685f9f33aafc832db8f5a013f5e14daa