### PR TITLE
Fix payment page basket sync

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -1420,3 +1420,10 @@ window.addEventListener("pageshow", (e) => {
     window.location.reload();
   }
 });
+
+// Refresh the page if basket contents change in another tab
+window.addEventListener("storage", (e) => {
+  if (e.key === "print3CheckoutItems") {
+    window.location.reload();
+  }
+});


### PR DESCRIPTION
## Summary
- reload payment page when basket contents change in another tab

## Validation
- `npm run format` (backend)
- `npm test` (backend)
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_685fa1d25adc832d81fdf417b6353b45