### PR TITLE
Apply tiered bulk discount

### DIFF
--- a/backend/tests/frontend/bulkDiscount.test.js
+++ b/backend/tests/frontend/bulkDiscount.test.js
@@ -1,0 +1,41 @@
+/** @jest-environment node */
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+function load() {
+  const html = fs
+    .readFileSync(path.join(__dirname, '../../../payment.html'), 'utf8')
+    .replace(/<script[^>]+src="https?:\/\/[^>]+><\/script>/g, '')
+    .replace(/<link[^>]+href="https?:\/\/[^>]+>/g, '')
+    .replace(/<script[^>]+src="js\/payment.js"[^>]*><\/script>/, '');
+  const dom = new JSDOM(html, {
+    runScripts: 'dangerously',
+    resources: 'usable',
+    url: 'http://localhost/',
+  });
+  global.window = dom.window;
+  global.document = dom.window.document;
+  let script = fs.readFileSync(path.join(__dirname, '../../../js/payment.js'), 'utf8');
+  script += '\nwindow._computeBulkDiscount = computeBulkDiscount;';
+  dom.window.eval(script);
+  return dom;
+}
+
+test('bulk discount for 2 prints', () => {
+  const dom = load();
+  const items = [{ qty: 2, material: 'single' }];
+  expect(dom.window._computeBulkDiscount(items)).toBe(700);
+});
+
+test('bulk discount for 3 prints', () => {
+  const dom = load();
+  const items = [{ qty: 3, material: 'single' }];
+  expect(dom.window._computeBulkDiscount(items)).toBe(2200);
+});
+
+test('bulk discount capped after 3 prints', () => {
+  const dom = load();
+  const items = [{ qty: 5, material: 'single' }];
+  expect(dom.window._computeBulkDiscount(items)).toBe(2200);
+});

--- a/js/payment.js
+++ b/js/payment.js
@@ -16,6 +16,7 @@ const PRICES = {
 };
 
 const TWO_PRINT_DISCOUNT = 700;
+const THIRD_PRINT_DISCOUNT = 1500;
 let PRICING_VARIANT = localStorage.getItem("pricingVariant");
 if (!PRICING_VARIANT) {
   PRICING_VARIANT = Math.random() < 0.5 ? "A" : "B";
@@ -59,7 +60,10 @@ function computeBulkDiscount(items) {
   for (const it of items) {
     totalQty += Math.max(1, parseInt(it.qty || 1, 10));
   }
-  return totalQty > 1 ? TWO_PRINT_DISCOUNT : 0;
+  let discount = 0;
+  if (totalQty >= 2) discount += TWO_PRINT_DISCOUNT;
+  if (totalQty >= 3) discount += THIRD_PRINT_DISCOUNT;
+  return discount;
 }
 const NEXT_PROMPTS = [
   "cute robot figurine",
@@ -735,9 +739,24 @@ async function initPaymentPage() {
 
   function updatePopularMessage() {
     if (!bulkMsg) return;
+    let total = 0;
+    const items = checkoutItems.length
+      ? checkoutItems
+      : [
+          { qty: Math.max(1, parseInt(qtySelect?.value || "1", 10)) },
+        ];
+    for (const it of items) {
+      total += Math.max(1, parseInt(it.qty || 1, 10));
+    }
+    const save =
+      total >= 3
+        ? `save £${((TWO_PRINT_DISCOUNT + THIRD_PRINT_DISCOUNT) / 100).toFixed(
+            2,
+          )}`
+        : `save £${(TWO_PRINT_DISCOUNT / 100).toFixed(2)}`;
     bulkMsg.innerHTML =
       '<span class="text-gray-400">Popular: keep one, gift one – </span>' +
-      '<span class="text-white">save £7.00</span>';
+      `<span class="text-white">${save}</span>`;
     bulkMsg.classList.remove("hidden");
   }
 


### PR DESCRIPTION
## Summary
- add `THIRD_PRINT_DISCOUNT` constant and compute additional discount for 3rd print
- update bulk discount logic to cap discount after the third print
- adjust popular message to reflect potential larger savings
- add frontend test covering bulk discount cases

## Validation
- `npm run format`
- `npm test`
- `npm run ci`
- `npx playwright install`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_685fae1d7380832d81313d3a3f2d5026