### PR TITLE
Fix price breakdown alignment

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -688,7 +688,9 @@ async function initPaymentPage() {
     if (saved > 0) {
       const percent =
         subtotal > 0 ? Math.round((discount / subtotal) * 100) : 0;
-      text += ` - £${saved.toFixed(2)} = £${total.toFixed(2)} (${percent}% saving)`;
+      text += ` - £${saved.toFixed(2)} = £${total.toFixed(2)}`;
+      const indent = text.lastIndexOf("£");
+      text += `\n${" ".repeat(indent)}(${percent}% saving)`;
     } else {
       text += ` = £${total.toFixed(2)}`;
     }


### PR DESCRIPTION
## Summary
- align the discount text in the price breakdown

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npx playwright install`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_685fc686a1cc832d9f76daba6c60fc40