### PR TITLE
Fix basket removal update on payment page

### DIFF
--- a/js/basket.js
+++ b/js/basket.js
@@ -11,6 +11,9 @@ function saveBasket(items) {
 }
 const RESERVE_MINS = 10;
 let reserveInterval;
+function notifyBasketChange() {
+  window.dispatchEvent(new CustomEvent("basket-change"));
+}
 export function addToBasket(item, opts = {}) {
   const items = getBasket();
   const expire = Date.now() + RESERVE_MINS * 60 * 1000;
@@ -32,6 +35,7 @@ export function addToBasket(item, opts = {}) {
       }
     }
   }
+  notifyBasketChange();
 }
 
 export function addAutoItem(item) {
@@ -44,6 +48,7 @@ export function addAutoItem(item) {
   saveBasket(items);
   updateBadge();
   renderList();
+  notifyBasketChange();
 }
 
 export function manualizeItem(predicate) {
@@ -55,6 +60,7 @@ export function manualizeItem(predicate) {
   }
   updateBadge();
   renderList();
+  notifyBasketChange();
 }
 export function removeFromBasket(index) {
   const items = getBasket();
@@ -69,12 +75,14 @@ export function removeFromBasket(index) {
   } catch {}
   updateBadge();
   renderList();
+  notifyBasketChange();
 }
 export function clearBasket() {
   saveBasket([]);
   localStorage.removeItem("print3CheckoutItems");
   updateBadge();
   renderList();
+  notifyBasketChange();
 }
 function updateBadge() {
   const badge = document.getElementById("basket-count");

--- a/js/payment.js
+++ b/js/payment.js
@@ -744,9 +744,7 @@ async function initPaymentPage() {
     let total = 0;
     const items = checkoutItems.length
       ? checkoutItems
-      : [
-          { qty: Math.max(1, parseInt(qtySelect?.value || "1", 10)) },
-        ];
+      : [{ qty: Math.max(1, parseInt(qtySelect?.value || "1", 10)) }];
     for (const it of items) {
       total += Math.max(1, parseInt(it.qty || 1, 10));
     }
@@ -1456,4 +1454,9 @@ window.addEventListener("storage", (e) => {
   if (e.key === "print3CheckoutItems") {
     window.location.reload();
   }
+});
+
+// Refresh the page if basket changes within this tab
+window.addEventListener("basket-change", () => {
+  window.location.reload();
 });


### PR DESCRIPTION
## Summary
- fire a custom `basket-change` event whenever the basket updates
- reload payment page when the basket-change event fires

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`
- `npx playwright install`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_685fe85c673c832d89b7c5e67d94fc64