### PR TITLE
Add faint border to marketplace and similar panels

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -237,7 +237,7 @@
                   auto-rotate
                   reveal="auto"
                   loading="lazy"
-                  class="w-full h-64 bg-[#2A2A2E] rounded-xl"
+                  class="w-full h-64 bg-[#2A2A2E] border border-white/10 rounded-xl"
                 ></model-viewer>
               </div>
               <div
@@ -294,7 +294,7 @@
                   auto-rotate
                   reveal="auto"
                   loading="lazy"
-                  class="w-full sm:w-1/2 h-64 bg-[#2A2A2E] rounded-xl"
+                  class="w-full sm:w-1/2 h-64 bg-[#2A2A2E] border border-white/10 rounded-xl"
                 ></model-viewer>
               </div>
             </div>
@@ -360,7 +360,7 @@
           environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
           camera-controls
           auto-rotate
-          class="w-full h-96 bg-[#2A2A2E] rounded-t-xl"
+          class="w-full h-96 bg-[#2A2A2E] border border-white/10 rounded-t-xl"
         ></model-viewer>
         <div
           id="model-stats"
@@ -431,7 +431,7 @@
             >Link copied</span
           >
         </div>
-        <div class="bg-[#2A2A2E] p-4 rounded-b-xl">
+        <div class="bg-[#2A2A2E] border border-white/10 p-4 rounded-b-xl">
           <ul
             id="comments-list"
             class="space-y-1 max-h-48 overflow-y-auto text-sm"
@@ -571,7 +571,9 @@
       id="printclub-modal"
       class="fixed inset-0 bg-black/70 flex items-center justify-center z-50 hidden"
     >
-      <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center">
+      <div
+        class="bg-[#2A2A2E] border border-white/10 p-6 rounded-xl max-w-sm text-center"
+      >
         <h2 class="text-2xl font-semibold mb-2">print2 pro</h2>
         <p class="mb-4">
           Get two prints (single or multicolour tiers) every week for

--- a/competitions.html
+++ b/competitions.html
@@ -118,7 +118,7 @@
         Join <strong>print2 pro</strong> for weekly prints.
         <a href="#" id="printclub-banner-link" class="underline">Learn more</a>
       </div>
-      <section class="bg-[#2A2A2E] p-4 rounded-xl">
+      <section class="bg-[#2A2A2E] border border-white/10 p-4 rounded-xl">
         <p class="mb-2">
           Put your modelling skills to the test! Enter our themed contests,
           climb the leaderboard and win free prints.
@@ -130,7 +130,9 @@
           to submit your best designs.
         </p>
       </section>
-      <section class="bg-[#2A2A2E] p-4 rounded-xl flex items-center space-x-4">
+      <section
+        class="bg-[#2A2A2E] border border-white/10 p-4 rounded-xl flex items-center space-x-4"
+      >
         <img
           src="https://images.unsplash.com/photo-1515378791036-0648a3ef77b2?auto=format&fit=crop&w=200&q=60"
           alt="Contest winner"
@@ -278,7 +280,10 @@
       id="enter-modal"
       class="fixed inset-0 bg-black/80 flex items-center justify-center hidden z-50"
     >
-      <form id="enter-form" class="bg-[#2A2A2E] p-6 rounded-xl space-y-4 w-80">
+      <form
+        id="enter-form"
+        class="bg-[#2A2A2E] border border-white/10 p-6 rounded-xl space-y-4 w-80"
+      >
         <input
           id="enter-model-id"
           class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10"
@@ -333,7 +338,7 @@
           environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
           camera-controls
           auto-rotate
-          class="w-full h-96 bg-[#2A2A2E] rounded-xl"
+          class="w-full h-96 bg-[#2A2A2E] border border-white/10 rounded-xl"
         ></model-viewer>
         <div
           id="model-stats"
@@ -536,7 +541,9 @@
       id="printclub-modal"
       class="fixed inset-0 bg-black/70 flex items-center justify-center z-50 hidden"
     >
-      <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center">
+      <div
+        class="bg-[#2A2A2E] border border-white/10 p-6 rounded-xl max-w-sm text-center"
+      >
         <h2 class="text-2xl font-semibold mb-2">print2 pro</h2>
         <p class="mb-4">
           Get two prints (single or multicolour tiers) every week for

--- a/earn-rewards.html
+++ b/earn-rewards.html
@@ -92,63 +92,63 @@
         class="max-w-4xl w-full bg-[#2A2A2E] border border-white/10 p-6 rounded-2xl shadow-lg flex flex-col md:flex-row md:space-x-8 space-y-6 md:space-y-0"
       >
         <div class="md:w-1/2 space-y-6 text-center md:text-left">
-        <h2 class="text-2xl font-semibold">Share &amp; earn discounts</h2>
-        <p class="text-gray-400">
-          You must
-          <a href="login.html" class="font-bold text-[#30D5C8]">Log In</a>
-          or
-          <a href="signup.html" class="font-bold text-[#30D5C8]">Sign Up</a>
-          to get rewards.
-        </p>
-        <p class="text-lg">
-          Invite friends to try print2 using your personal link below. When they
-          place orders you'll earn points that can be redeemed for discounts on
-          future prints.
-        </p>
-        <div class="space-y-1">
-          <label for="referral-link" class="block text-sm"
-            >Your referral link</label
-          >
-          <div class="flex">
-            <input
-              id="referral-link"
-              aria-label="Referral link"
-              class="flex-1 bg-[#1A1A1D] border border-white/10 rounded-l-xl px-3 py-2"
-              readonly
-            />
-            <button
-              aria-label="Copy referral link"
-              class="bg-blue-600 px-4 rounded-r-xl"
-              onclick="copyReferral()"
+          <h2 class="text-2xl font-semibold">Share &amp; earn discounts</h2>
+          <p class="text-gray-400">
+            You must
+            <a href="login.html" class="font-bold text-[#30D5C8]">Log In</a>
+            or
+            <a href="signup.html" class="font-bold text-[#30D5C8]">Sign Up</a>
+            to get rewards.
+          </p>
+          <p class="text-lg">
+            Invite friends to try print2 using your personal link below. When
+            they place orders you'll earn points that can be redeemed for
+            discounts on future prints.
+          </p>
+          <div class="space-y-1">
+            <label for="referral-link" class="block text-sm"
+              >Your referral link</label
             >
-              Copy
+            <div class="flex">
+              <input
+                id="referral-link"
+                aria-label="Referral link"
+                class="flex-1 bg-[#1A1A1D] border border-white/10 rounded-l-xl px-3 py-2"
+                readonly
+              />
+              <button
+                aria-label="Copy referral link"
+                class="bg-blue-600 px-4 rounded-r-xl"
+                onclick="copyReferral()"
+              >
+                Copy
+              </button>
+            </div>
+          </div>
+          <div class="space-y-1">
+            <label class="block text-sm"
+              >Points: <span id="reward-points">0</span> ⭐</label
+            >
+            <progress
+              id="reward-progress"
+              value="0"
+              max="200"
+              class="w-full h-2 rounded"
+            ></progress>
+          </div>
+          <div class="flex">
+            <select
+              id="reward-select"
+              class="flex-1 bg-[#1A1A1D] border border-white/10 rounded-l-xl px-3 py-2"
+            ></select>
+            <button
+              class="bg-green-600 px-4 rounded-r-xl"
+              onclick="redeemReward()"
+            >
+              Redeem
             </button>
           </div>
-        </div>
-        <div class="space-y-1">
-          <label class="block text-sm"
-            >Points: <span id="reward-points">0</span> ⭐</label
-          >
-          <progress
-            id="reward-progress"
-            value="0"
-            max="200"
-            class="w-full h-2 rounded"
-          ></progress>
-        </div>
-        <div class="flex">
-          <select
-            id="reward-select"
-            class="flex-1 bg-[#1A1A1D] border border-white/10 rounded-l-xl px-3 py-2"
-          ></select>
-          <button
-            class="bg-green-600 px-4 rounded-r-xl"
-            onclick="redeemReward()"
-          >
-            Redeem
-          </button>
-        </div>
-        <p id="next-reward-msg" class="text-sm text-gray-300"></p>
+          <p id="next-reward-msg" class="text-sm text-gray-300"></p>
         </div>
         <div class="md:w-1/2 space-y-6 text-left">
           <div>
@@ -165,7 +165,10 @@
           </div>
           <div>
             <h3 class="text-lg font-semibold mt-4 mb-2">Your Achievements</h3>
-            <ul id="achievements-list" class="list-disc list-inside text-sm"></ul>
+            <ul
+              id="achievements-list"
+              class="list-disc list-inside text-sm"
+            ></ul>
           </div>
           <div class="mt-4">
             <a
@@ -186,7 +189,9 @@
       id="printclub-modal"
       class="fixed inset-0 bg-black/70 flex items-center justify-center z-50 hidden"
     >
-      <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center">
+      <div
+        class="bg-[#2A2A2E] border border-white/10 p-6 rounded-xl max-w-sm text-center"
+      >
         <h2 class="text-2xl font-semibold mb-2">print2 pro</h2>
         <p class="mb-4">
           Get two prints (single or multicolour tiers) every week for

--- a/index.html
+++ b/index.html
@@ -629,7 +629,9 @@
       id="printclub-modal"
       class="fixed inset-0 bg-black/70 flex items-center justify-center z-50 hidden"
     >
-      <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center">
+      <div
+        class="bg-[#2A2A2E] border border-white/10 p-6 rounded-xl max-w-sm text-center"
+      >
         <h2 class="text-2xl font-semibold mb-2">print2 pro</h2>
         <p class="mb-4">
           Get two prints (single or multicolour tiers) every week for

--- a/library.html
+++ b/library.html
@@ -137,7 +137,7 @@
           environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
           camera-controls
           auto-rotate
-          class="w-full h-96 bg-[#2A2A2E] rounded-xl"
+          class="w-full h-96 bg-[#2A2A2E] border border-white/10 rounded-xl"
         ></model-viewer>
       </div>
     </div>

--- a/login.html
+++ b/login.html
@@ -149,7 +149,9 @@
       id="printclub-modal"
       class="fixed inset-0 bg-black/70 flex items-center justify-center z-50 hidden"
     >
-      <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center">
+      <div
+        class="bg-[#2A2A2E] border border-white/10 p-6 rounded-xl max-w-sm text-center"
+      >
         <h2 class="text-2xl font-semibold mb-2">print2 pro</h2>
         <p class="mb-4">
           Get two prints (single or multicolour tiers) every week for

--- a/marketplace.html
+++ b/marketplace.html
@@ -88,7 +88,7 @@
       </div>
     </header>
     <main class="flex-1 p-4 space-y-6">
-      <section class="bg-[#2A2A2E] p-4 rounded-xl">
+      <section class="bg-[#2A2A2E] border border-white/10 p-4 rounded-xl">
         <p>
           Purchase items here to get
           <span class="text-[#30D5C8]">£7 off</span>

--- a/my_creations.html
+++ b/my_creations.html
@@ -91,7 +91,7 @@
           environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
           camera-controls
           auto-rotate
-          class="w-full h-96 bg-[#2A2A2E] rounded-xl"
+          class="w-full h-96 bg-[#2A2A2E] border border-white/10 rounded-xl"
         ></model-viewer>
         <div class="absolute bottom-4 left-4 flex items-center gap-2">
           <button

--- a/my_profile.html
+++ b/my_profile.html
@@ -339,7 +339,7 @@
           environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
           camera-controls
           auto-rotate
-          class="w-full h-96 bg-[#2A2A2E] rounded-xl"
+          class="w-full h-96 bg-[#2A2A2E] border border-white/10 rounded-xl"
         ></model-viewer>
       </div>
     </div>
@@ -353,7 +353,9 @@
       id="printclub-modal"
       class="fixed inset-0 bg-black/70 flex items-center justify-center z-50 hidden"
     >
-      <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center">
+      <div
+        class="bg-[#2A2A2E] border border-white/10 p-6 rounded-xl max-w-sm text-center"
+      >
         <h2 class="text-2xl font-semibold mb-2">print2 pro</h2>
         <p class="mb-4">
           Get two prints (single or multicolour tiers) every week for

--- a/payment.html
+++ b/payment.html
@@ -205,7 +205,7 @@
             <input
               id="referral-link" aria-label="Referral link"
               readonly
-              class="bg-[#2A2A2E] px-2 py-1 rounded text-white w-64"
+              class="bg-[#2A2A2E] border border-white/10 px-2 py-1 rounded text-white w-64"
             />
             <button aria-label="Copy referral link" id="copy-referral" class="px-2 py-1 bg-[#30D5C8] text-[#1A1A1D] rounded">
               Copy

--- a/printclub.html
+++ b/printclub.html
@@ -146,7 +146,9 @@
       id="printclub-modal"
       class="fixed inset-0 bg-black/70 flex items-center justify-center z-50 hidden"
     >
-      <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center">
+      <div
+        class="bg-[#2A2A2E] border border-white/10 p-6 rounded-xl max-w-sm text-center"
+      >
         <h2 class="text-2xl font-semibold mb-2">print2 pro</h2>
         <p class="mb-4">
           Get two prints (single or multicolour tiers) every week for

--- a/profile.html
+++ b/profile.html
@@ -212,7 +212,7 @@
           environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
           camera-controls
           auto-rotate
-          class="w-full h-96 bg-[#2A2A2E] rounded-xl"
+          class="w-full h-96 bg-[#2A2A2E] border border-white/10 rounded-xl"
         ></model-viewer>
       </div>
     </div>
@@ -225,7 +225,9 @@
       id="printclub-modal"
       class="fixed inset-0 bg-black/70 flex items-center justify-center z-50 hidden"
     >
-      <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center">
+      <div
+        class="bg-[#2A2A2E] border border-white/10 p-6 rounded-xl max-w-sm text-center"
+      >
         <h2 class="text-2xl font-semibold mb-2">print2 pro</h2>
         <p class="mb-4">
           Get two prints (single or multicolour tiers) every week for

--- a/request-reset.html
+++ b/request-reset.html
@@ -123,7 +123,9 @@
       id="printclub-modal"
       class="fixed inset-0 bg-black/70 flex items-center justify-center z-50 hidden"
     >
-      <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center">
+      <div
+        class="bg-[#2A2A2E] border border-white/10 p-6 rounded-xl max-w-sm text-center"
+      >
         <h2 class="text-2xl font-semibold mb-2">print2 pro</h2>
         <p class="mb-4">
           Get two prints (single or multicolour tiers) every week for

--- a/reset-password.html
+++ b/reset-password.html
@@ -123,7 +123,9 @@
       id="printclub-modal"
       class="fixed inset-0 bg-black/70 flex items-center justify-center z-50 hidden"
     >
-      <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center">
+      <div
+        class="bg-[#2A2A2E] border border-white/10 p-6 rounded-xl max-w-sm text-center"
+      >
         <h2 class="text-2xl font-semibold mb-2">print2 pro</h2>
         <p class="mb-4">
           Get two prints (single or multicolour tiers) every week for

--- a/signup.html
+++ b/signup.html
@@ -172,7 +172,9 @@
       id="printclub-modal"
       class="fixed inset-0 bg-black/70 flex items-center justify-center z-50 hidden"
     >
-      <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center">
+      <div
+        class="bg-[#2A2A2E] border border-white/10 p-6 rounded-xl max-w-sm text-center"
+      >
         <h2 class="text-2xl font-semibold mb-2">print2 pro</h2>
         <p class="mb-4">
           Get two prints (single or multicolour tiers) every week for


### PR DESCRIPTION
## Summary
- ensure marketplace promo box has faint white outline
- add same border style to various panels across site

## Testing
- `npm run format`
- `cd backend && npm test`
- `npm run ci`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_686041b3fd3c832da75972756c8c91ab