### PR TITLE
Fix etching warning

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -502,7 +502,7 @@
               >
 
                 <div class="border-t-2 border-[#30D5C8] w-[20ch]"></div>
-                <span class="text-sm text-[#30D5C8] whitespace-nowrap">Colour required</span>
+                <span class="text-sm text-[#30D5C8] whitespace-nowrap">Multi-colour required</span>
 
               </div>
             </div>


### PR DESCRIPTION
## Summary
- clarify that multi-colour material is required before entering an etched name

## Testing
- `npm run setup`
- `npm run format` in `backend`
- `npm test` in `backend`
- `npm run ci`
- `npx playwright install`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68605119aad4832d9fae0a203d0c4940