### PR TITLE
Add marketplace description panels

### DIFF
--- a/marketplace.html
+++ b/marketplace.html
@@ -105,6 +105,24 @@
           <a href="payment.html" class="font-bold text-[#30D5C8]">Buy Here</a>.
         </p>
       </section>
+      <section class="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div class="bg-[#2A2A2E] p-4 rounded-xl border border-white/10">
+          <h2 class="text-xl font-semibold mb-2">Your Marketplace</h2>
+          <p>
+            Models you upload appear here. When someone purchases one of your
+            designs, you earn credits towards future prints.
+          </p>
+        </div>
+        <div class="bg-[#2A2A2E] p-4 rounded-xl border border-white/10">
+          <h2 class="text-xl font-semibold mb-2">
+            Other People's Marketplaces
+          </h2>
+          <p>
+            Browse creations from the community. Buying these models rewards the
+            original creator with credits.
+          </p>
+        </div>
+      </section>
       <p class="text-center text-gray-400">Marketplace coming soon...</p>
     </main>
     <script type="module">


### PR DESCRIPTION
## Summary
- expand the Marketplace page
- add two descriptive panels explaining "Your Marketplace" and "Other People's Marketplaces"

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68604803a994832da3588a28feb6e77f