### PR TITLE
Fix exit discount popup outline

### DIFF
--- a/competitions.html
+++ b/competitions.html
@@ -569,7 +569,7 @@
       class="fixed inset-0 bg-black/80 flex items-center justify-center hidden z-50"
     >
       <div
-        class="relative bg-[#2A2A2E] border border-white/10 rounded-3xl p-6 text-center"
+        class="relative bg-[#2A2A2E] border border-white/10 outline outline-white/20 rounded-3xl p-6 text-center"
       >
         <button
           id="exit-discount-close"

--- a/index.html
+++ b/index.html
@@ -495,7 +495,7 @@
       class="fixed inset-0 bg-black/80 flex items-center justify-center hidden z-50"
     >
       <div
-        class="relative bg-[#2A2A2E] border border-white/10 rounded-3xl p-6 text-center"
+        class="relative bg-[#2A2A2E] border border-white/10 outline outline-white/20 rounded-3xl p-6 text-center"
       >
         <button
           id="exit-discount-close"

--- a/payment.html
+++ b/payment.html
@@ -643,7 +643,7 @@
       id="exit-discount-overlay"
       class="fixed inset-0 bg-black/80 flex items-center justify-center hidden z-50"
     >
-      <div class="relative bg-[#2A2A2E] border border-white/10 rounded-3xl p-6 text-center">
+      <div class="relative bg-[#2A2A2E] border border-white/10 outline outline-white/20 rounded-3xl p-6 text-center">
         <button
           id="exit-discount-close"
           class="absolute -top-3 -right-3 w-[3rem] h-[3rem] rounded-full bg-white text-black flex items-center justify-center z-50"

--- a/printclub.html
+++ b/printclub.html
@@ -197,7 +197,7 @@
       class="fixed inset-0 bg-black/80 flex items-center justify-center hidden z-50"
     >
       <div
-        class="relative bg-[#2A2A2E] border border-white/10 rounded-3xl p-6 text-center"
+        class="relative bg-[#2A2A2E] border border-white/10 outline outline-white/20 rounded-3xl p-6 text-center"
       >
         <button
           id="exit-discount-close"


### PR DESCRIPTION
## Summary
- ensure exit discount popup has same faint outline styling as other panels

## Testing
- `npm run format` *(via logs)*
- `npm test` *(via logs)*
- `npm run ci`
- `npx playwright install`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68604fbf45cc832d9e2dbbd402a4b101