### PR TITLE
Add faint borders to promotional panels

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -431,7 +431,7 @@
             >Link copied</span
           >
         </div>
-        <div class="bg-[#2A2A2E] p-4 rounded-b-xl">
+        <div class="bg-[#2A2A2E] p-4 rounded-b-xl border border-white/10">
           <ul
             id="comments-list"
             class="space-y-1 max-h-48 overflow-y-auto text-sm"
@@ -571,7 +571,7 @@
       id="printclub-modal"
       class="fixed inset-0 bg-black/70 flex items-center justify-center z-50 hidden"
     >
-      <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center">
+      <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center border border-white/10">
         <h2 class="text-2xl font-semibold mb-2">print2 Pro</h2>
         <p class="mb-4">
           Get two prints (single or multicolour tiers) every week for

--- a/competitions.html
+++ b/competitions.html
@@ -118,7 +118,7 @@
         Join <strong>print2 Pro</strong> for weekly prints.
         <a href="#" id="printclub-banner-link" class="underline">Learn more</a>
       </div>
-      <section class="bg-[#2A2A2E] p-4 rounded-xl">
+      <section class="bg-[#2A2A2E] p-4 rounded-xl border border-white/10">
         <p class="mb-2">
           Put your modelling skills to the test! Enter our themed contests,
           climb the leaderboard and win free prints.
@@ -130,7 +130,7 @@
           to submit your best designs.
         </p>
       </section>
-      <section class="bg-[#2A2A2E] p-4 rounded-xl flex items-center space-x-4">
+      <section class="bg-[#2A2A2E] p-4 rounded-xl flex items-center space-x-4 border border-white/10">
         <img
           src="https://images.unsplash.com/photo-1515378791036-0648a3ef77b2?auto=format&fit=crop&w=200&q=60"
           alt="Contest winner"
@@ -278,7 +278,7 @@
       id="enter-modal"
       class="fixed inset-0 bg-black/80 flex items-center justify-center hidden z-50"
     >
-      <form id="enter-form" class="bg-[#2A2A2E] p-6 rounded-xl space-y-4 w-80">
+      <form id="enter-form" class="bg-[#2A2A2E] p-6 rounded-xl space-y-4 w-80 border border-white/10">
         <input
           id="enter-model-id"
           class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10"
@@ -536,7 +536,7 @@
       id="printclub-modal"
       class="fixed inset-0 bg-black/70 flex items-center justify-center z-50 hidden"
     >
-      <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center">
+      <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center border border-white/10">
         <h2 class="text-2xl font-semibold mb-2">print2 Pro</h2>
         <p class="mb-4">
           Get two prints (single or multicolour tiers) every week for

--- a/earn-rewards.html
+++ b/earn-rewards.html
@@ -189,7 +189,7 @@
       id="printclub-modal"
       class="fixed inset-0 bg-black/70 flex items-center justify-center z-50 hidden"
     >
-      <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center">
+      <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center border border-white/10">
         <h2 class="text-2xl font-semibold mb-2">print2 Pro</h2>
         <p class="mb-4">
           Get two prints (single or multicolour tiers) every week for

--- a/index.html
+++ b/index.html
@@ -629,7 +629,7 @@
       id="printclub-modal"
       class="fixed inset-0 bg-black/70 flex items-center justify-center z-50 hidden"
     >
-      <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center">
+      <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center border border-white/10">
         <h2 class="text-2xl font-semibold mb-2">print2 Pro</h2>
         <p class="mb-4">
           Get two prints (single or multicolour tiers) every week for

--- a/js/adminAds.js
+++ b/js/adminAds.js
@@ -12,7 +12,7 @@ async function load() {
   app.innerHTML = '';
   ads.forEach((ad) => {
     const div = document.createElement('div');
-    div.className = 'bg-[#2A2A2E] p-4 rounded space-y-2';
+    div.className = 'bg-[#2A2A2E] p-4 rounded space-y-2 border border-white/10';
     div.innerHTML = `
       <p class="text-sm">Subreddit: r/${ad.subreddit}</p>
       <textarea class="copy w-full bg-[#1A1A1D] border border-white/10 rounded p-1">${ad.copy}</textarea>

--- a/js/adminCompetitions.js
+++ b/js/adminCompetitions.js
@@ -22,7 +22,7 @@ async function load() {
   list.innerHTML = '';
   comps.forEach((c) => {
     const div = document.createElement('div');
-    div.className = 'bg-[#2A2A2E] p-4 rounded space-y-2';
+    div.className = 'bg-[#2A2A2E] p-4 rounded space-y-2 border border-white/10';
     div.innerHTML = `
       <h2 class="text-lg font-semibold">${c.name}</h2>
       <label class="block text-sm">Prize Description

--- a/js/adminHubs.js
+++ b/js/adminHubs.js
@@ -16,7 +16,7 @@ async function load() {
     });
     const shipments = shipRes.ok ? await shipRes.json() : [];
     const div = document.createElement("div");
-    div.className = "bg-[#2A2A2E] p-4 rounded space-y-2";
+    div.className = "bg-[#2A2A2E] p-4 rounded space-y-2 border border-white/10";
     div.innerHTML = `
       <h2 class="text-lg font-semibold">${hub.name}</h2>
       <div class="space-y-1">

--- a/js/adminOperations.js
+++ b/js/adminOperations.js
@@ -23,7 +23,7 @@ async function load() {
 
   data.hubs.forEach((hub) => {
     const div = document.createElement("div");
-    div.className = "bg-[#2A2A2E] p-4 rounded space-y-2";
+    div.className = "bg-[#2A2A2E] p-4 rounded space-y-2 border border-white/10";
     const errors = hub.errors
       .map((e) => `<div class="text-red-500 text-sm">${e.error}</div>`)
       .join("");
@@ -38,7 +38,7 @@ async function load() {
 
   if (forecast.length) {
     const div = document.createElement("div");
-    div.className = "bg-[#2A2A2E] p-4 rounded space-y-2";
+    div.className = "bg-[#2A2A2E] p-4 rounded space-y-2 border border-white/10";
     div.innerHTML =
       '<h2 class="text-lg font-semibold">Fulfillment Forecast</h2>' +
       '<canvas id="forecastChart" class="w-full"></canvas>';
@@ -70,7 +70,7 @@ async function load() {
 
   if (events.length) {
     const div = document.createElement("div");
-    div.className = "bg-[#2A2A2E] p-4 rounded space-y-2";
+    div.className = "bg-[#2A2A2E] p-4 rounded space-y-2 border border-white/10";
     div.innerHTML =
       '<h2 class="text-lg font-semibold">Recent Scaling Events</h2>' +
       events

--- a/js/competitions.js
+++ b/js/competitions.js
@@ -125,7 +125,7 @@ async function load() {
   }
   comps.forEach((c) => {
     const div = document.createElement("div");
-    div.className = "bg-[#2A2A2E] p-4 rounded-xl space-y-2";
+    div.className = "bg-[#2A2A2E] p-4 rounded-xl space-y-2 border border-white/10";
     div.innerHTML = `<h2 class="text-xl">${c.name}</h2>
       <p class="text-[#30D5C8]">Theme: ${c.theme || ""}</p>
       <p>${c.prize_description || ""}</p>
@@ -413,7 +413,7 @@ async function loadPast() {
   }
   comps.forEach((c) => {
     const div = document.createElement("div");
-    div.className = "bg-[#2A2A2E] p-4 rounded-xl space-y-2 text-center";
+    div.className = "bg-[#2A2A2E] p-4 rounded-xl space-y-2 text-center border border-white/10";
     div.innerHTML = `<h3 class="text-lg">${c.name}</h3>
       <div class="model-card relative h-32 border border-white/10 rounded-xl flex items-center justify-center cursor-pointer" data-model="${c.model_url}" data-job="${c.winner_model_id}">
         <img src="${c.snapshot || ""}" alt="Winning model" class="w-full h-full object-contain pointer-events-none" />

--- a/login.html
+++ b/login.html
@@ -149,7 +149,7 @@
       id="printclub-modal"
       class="fixed inset-0 bg-black/70 flex items-center justify-center z-50 hidden"
     >
-      <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center">
+      <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center border border-white/10">
         <h2 class="text-2xl font-semibold mb-2">print2 Pro</h2>
         <p class="mb-4">
           Get two prints (single or multicolour tiers) every week for

--- a/marketplace.html
+++ b/marketplace.html
@@ -88,7 +88,7 @@
       </div>
     </header>
     <main class="flex-1 p-4 space-y-6">
-      <section class="bg-[#2A2A2E] p-4 rounded-xl">
+      <section class="bg-[#2A2A2E] p-4 rounded-xl border border-white/10">
         <p>
           Purchase items here to get
           <span class="text-[#30D5C8]">£7 off</span>

--- a/my_profile.html
+++ b/my_profile.html
@@ -353,7 +353,7 @@
       id="printclub-modal"
       class="fixed inset-0 bg-black/70 flex items-center justify-center z-50 hidden"
     >
-      <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center">
+      <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center border border-white/10">
         <h2 class="text-2xl font-semibold mb-2">print2 Pro</h2>
         <p class="mb-4">
           Get two prints (single or multicolour tiers) every week for

--- a/printclub.html
+++ b/printclub.html
@@ -146,7 +146,7 @@
       id="printclub-modal"
       class="fixed inset-0 bg-black/70 flex items-center justify-center z-50 hidden"
     >
-      <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center">
+      <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center border border-white/10">
         <h2 class="text-2xl font-semibold mb-2">print2 Pro</h2>
         <p class="mb-4">
           Get two prints (single or multicolour tiers) every week for

--- a/profile.html
+++ b/profile.html
@@ -225,7 +225,7 @@
       id="printclub-modal"
       class="fixed inset-0 bg-black/70 flex items-center justify-center z-50 hidden"
     >
-      <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center">
+      <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center border border-white/10">
         <h2 class="text-2xl font-semibold mb-2">print2 Pro</h2>
         <p class="mb-4">
           Get two prints (single or multicolour tiers) every week for

--- a/request-reset.html
+++ b/request-reset.html
@@ -123,7 +123,7 @@
       id="printclub-modal"
       class="fixed inset-0 bg-black/70 flex items-center justify-center z-50 hidden"
     >
-      <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center">
+      <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center border border-white/10">
         <h2 class="text-2xl font-semibold mb-2">print2 Pro</h2>
         <p class="mb-4">
           Get two prints (single or multicolour tiers) every week for

--- a/reset-password.html
+++ b/reset-password.html
@@ -123,7 +123,7 @@
       id="printclub-modal"
       class="fixed inset-0 bg-black/70 flex items-center justify-center z-50 hidden"
     >
-      <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center">
+      <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center border border-white/10">
         <h2 class="text-2xl font-semibold mb-2">print2 Pro</h2>
         <p class="mb-4">
           Get two prints (single or multicolour tiers) every week for

--- a/signup.html
+++ b/signup.html
@@ -172,7 +172,7 @@
       id="printclub-modal"
       class="fixed inset-0 bg-black/70 flex items-center justify-center z-50 hidden"
     >
-      <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center">
+      <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center border border-white/10">
         <h2 class="text-2xl font-semibold mb-2">print2 Pro</h2>
         <p class="mb-4">
           Get two prints (single or multicolour tiers) every week for


### PR DESCRIPTION
## Summary
- add faint white border to marketplace banner
- ensure competitions panels and modals use same border style
- update printclub modals across site for consistent outline
- add borders when dynamic panels are created in admin scripts

## Testing
- `npm run setup`
- `npm run format` in backend
- `npm test` in backend
- `npm run ci`
- `npx playwright install`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68604784437c832d933bf8b845a28c21