### PR TITLE
Fix orange color in payment model

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -375,7 +375,7 @@
                   type="button"
                   class="w-8 h-8 rounded-full border border-white/20"
                   style="background-color: #ff7f00"
-                  data-color="#ff6600"
+                  data-color="#ff7f00"
                 ></button>
                 <button
                   type="button"


### PR DESCRIPTION
## Summary
- tweak the orange color hex for single-colour prints

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68605733813c832d9dad7a4ff53a68d5