### PR TITLE
Fix luckybox overlay

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -96,7 +96,7 @@
     <main class="flex-1 p-6 space-y-6">
       <div
         id="locked-msg"
-        class="bg-[#2A2A2E] p-4 rounded-xl text-center hidden border border-white/10"
+        class="relative z-20 bg-[#2A2A2E] p-4 rounded-xl text-center hidden border border-white/10"
       >
         Unlock advanced customisation after
         <a href="login.html" class="font-bold text-[#30D5C8]">Logging In</a>
@@ -111,7 +111,7 @@
       ></section>
       <div
         id="luckybox"
-        class="fixed bottom-6 left-6 w-[32rem] min-h-96 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 flex flex-col items-center space-y-2"
+        class="fixed bottom-6 left-6 w-[32rem] min-h-96 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 flex flex-col items-center space-y-2 z-10"
       >
         <span class="font-semibold text-lg">Luckybox</span>
         <select


### PR DESCRIPTION
## Summary
- ensure Luckybox panel does not cover the locked message

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`
- `npx playwright install`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_686074736140832d81cc2606aa05bbcc