### PR TITLE
Fix addon columns gap

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -107,7 +107,7 @@
       </div>
       <section
         id="addons-grid"
-        class="grid grid-cols-2 gap-4 w-3/5 ml-auto mt-2"
+        class="grid grid-cols-2 gap-6 w-3/5 ml-auto mt-2"
       ></section>
       <div
         id="luckybox"


### PR DESCRIPTION
## Summary
- increase horizontal spacing between the two addon columns on the Add-Ons page

## Testing
- `npm run setup`
- `npx playwright install`
- `npx playwright test e2e/smoke.test.js`
- `npm run format`
- `npm test --silent`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_6860fa9c5170832daef291ec743aaca6