### PR TITLE
Fix checkout panel height

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -609,7 +609,7 @@
             >
               Pay £39.99
             </button>
-            <div class="flex justify-between mt-2 mb-2 text-xs">
+            <div class="flex justify-between mt-2 mb-2 text-xs min-h-[2.5em]">
               <pre id="price-breakdown" class="whitespace-pre-wrap text-right"></pre>
             </div>
             <div id="pay-summary" class="hidden absolute left-1/2 -translate-x-1/2 bottom-[4.5rem] w-64 bg-[#2A2A2E] border border-white/20 rounded-lg p-2 text-sm"></div>


### PR DESCRIPTION
## Summary
- avoid panel height change when price breakdown wraps

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6860fb53d2f0832d8fc7cfb99807b894