### PR TITLE
Fix typo in addons page

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -100,7 +100,7 @@
       >
         Unlock advanced customisation after
         <a href="login.html" class="font-bold text-[#30D5C8]">Logging In</a>
-        them
+        then
         <a href="payment.html" class="font-bold text-[#30D5C8]"
           >making your first purchase</a
         >.


### PR DESCRIPTION
## Summary
- correct 'them' to 'then' in addons page

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68610072a9a0832d8332b6dcb23e4ca4