### PR TITLE
Fix luckybox position on addons page

### DIFF
--- a/js/addons.js
+++ b/js/addons.js
@@ -112,6 +112,8 @@ document.addEventListener("DOMContentLoaded", checkAccess);
 window.addEventListener("resize", () => {
   adjustLuckyboxHeight();
   alignGridBottom();
+  setupLuckyboxScroll();
+  updateLuckyboxOnScroll();
 });
 window.addEventListener("load", () => {
   adjustLuckyboxHeight();
@@ -161,6 +163,6 @@ function updateLuckyboxOnScroll() {
     return;
   const lockedBottom = locked.getBoundingClientRect().bottom;
   const clamped = lockedBottom > 0 ? lockedBottom : 0;
-  const newHeight = luckyInitialHeight + (lockedInitialBottom - clamped);
+  const newHeight = luckyInitialHeight + (clamped - lockedInitialBottom);
   lucky.style.height = `${newHeight}px`;
 }


### PR DESCRIPTION
## Summary
- ensure Luckybox adjusts when viewport height changes
- correct scroll calculation so the banner doesn't overlap Luckybox

## Testing
- `npm test --prefix backend`
- `npm run ci`
- `npx playwright install`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68610060bae0832d8ed3a719f0e2fbbd