### PR TITLE
Add profile saved items section

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -571,7 +571,9 @@
       id="printclub-modal"
       class="fixed inset-0 bg-black/70 flex items-center justify-center z-50 hidden"
     >
-      <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center border border-white/10">
+      <div
+        class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center border border-white/10"
+      >
         <h2 class="text-2xl font-semibold mb-2">print2 Pro</h2>
         <p class="mb-4">
           Get two prints (single or multicolour tiers) every week for
@@ -589,7 +591,9 @@
     <script type="module" src="js/printclub.js"></script>
     <script type="module" src="js/rewardBadge.js"></script>
     <script type="module" src="js/basket.js"></script>
-
+    <script>
+      window.disableSaveButton = true;
+    </script>
     <script type="module" src="js/saveList.js"></script>
     <script type="module" src="js/printingTicker.js"></script>
     <script type="module" src="js/publicGalleries.js"></script>

--- a/competitions.html
+++ b/competitions.html
@@ -130,7 +130,9 @@
           to submit your best designs.
         </p>
       </section>
-      <section class="bg-[#2A2A2E] p-4 rounded-xl flex items-center space-x-4 border border-white/10">
+      <section
+        class="bg-[#2A2A2E] p-4 rounded-xl flex items-center space-x-4 border border-white/10"
+      >
         <img
           src="https://images.unsplash.com/photo-1515378791036-0648a3ef77b2?auto=format&fit=crop&w=200&q=60"
           alt="Contest winner"
@@ -278,7 +280,10 @@
       id="enter-modal"
       class="fixed inset-0 bg-black/80 flex items-center justify-center hidden z-50"
     >
-      <form id="enter-form" class="bg-[#2A2A2E] p-6 rounded-xl space-y-4 w-80 border border-white/10">
+      <form
+        id="enter-form"
+        class="bg-[#2A2A2E] p-6 rounded-xl space-y-4 w-80 border border-white/10"
+      >
         <input
           id="enter-model-id"
           class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10"
@@ -536,7 +541,9 @@
       id="printclub-modal"
       class="fixed inset-0 bg-black/70 flex items-center justify-center z-50 hidden"
     >
-      <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center border border-white/10">
+      <div
+        class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center border border-white/10"
+      >
         <h2 class="text-2xl font-semibold mb-2">print2 Pro</h2>
         <p class="mb-4">
           Get two prints (single or multicolour tiers) every week for
@@ -562,6 +569,9 @@
     <script type="module" src="js/printclub.js"></script>
     <script type="module" src="js/rewardBadge.js"></script>
     <script type="module" src="js/basket.js"></script>
+    <script>
+      window.disableSaveButton = true;
+    </script>
     <script type="module" src="js/saveList.js"></script>
     <script type="module" src="js/rewardBadge.js"></script>
     <div

--- a/js/profileSaved.js
+++ b/js/profileSaved.js
@@ -1,0 +1,37 @@
+import { getSaved, removeSaved } from "./saveList.js";
+
+function render() {
+  const list = document.getElementById("saved-items-list");
+  if (!list) return;
+  list.innerHTML = "";
+  const items = getSaved();
+  if (!items.length) {
+    list.innerHTML =
+      '<p class="text-white text-center col-span-2">No saved items</p>';
+    return;
+  }
+  items.forEach((it) => {
+    const div = document.createElement("div");
+    div.className = "relative group";
+    const img = document.createElement("img");
+    img.src = it.snapshot || it.modelUrl || "";
+    img.alt = it.title || "Model";
+    img.className =
+      "w-24 h-24 object-cover rounded-lg bg-[#2A2A2E] border border-white/20";
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className =
+      "remove absolute bottom-1 right-1 text-xs px-2 py-1 bg-red-600 rounded opacity-80 group-hover:opacity-100";
+    btn.textContent = "Remove";
+    btn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      removeSaved(it.id);
+      render();
+    });
+    div.appendChild(img);
+    div.appendChild(btn);
+    list.appendChild(div);
+  });
+}
+
+document.addEventListener("DOMContentLoaded", render);

--- a/js/saveList.js
+++ b/js/saveList.js
@@ -134,6 +134,9 @@ export function setupSavedUI() {
   });
   updateBadge();
 }
-window.addEventListener("DOMContentLoaded", setupSavedUI);
+if (!window.disableSaveButton) {
+  window.addEventListener("DOMContentLoaded", setupSavedUI);
+}
 window.addSavedModel = addSaved;
 window.getSavedModels = getSaved;
+window.clearSavedModels = clearSaved;

--- a/my_profile.html
+++ b/my_profile.html
@@ -300,6 +300,13 @@
         <h3 class="text-lg font-semibold mb-2">Achievements</h3>
         <ul id="achievements-list" class="list-disc list-inside text-sm"></ul>
       </div>
+      <div
+        id="saved-items"
+        class="bg-[#2A2A2E] border border-white/10 p-6 rounded-3xl w-full mb-6"
+      >
+        <h2 class="text-lg font-semibold mb-2">Saved Items</h2>
+        <div id="saved-items-list" class="grid grid-cols-2 gap-3"></div>
+      </div>
       <button id="delete-account" class="bg-red-600 px-3 py-1 rounded-xl mb-6">
         Delete Account
       </button>
@@ -345,6 +352,11 @@
     </div>
     <script type="module" src="js/account.js"></script>
     <script type="module" src="js/my_profile.js"></script>
+    <script>
+      window.disableSaveButton = true;
+    </script>
+    <script type="module" src="js/saveList.js"></script>
+    <script type="module" src="js/profileSaved.js"></script>
     <script type="module">
       import { shareOn } from "./js/share.js";
       window.shareOn = shareOn;
@@ -353,7 +365,9 @@
       id="printclub-modal"
       class="fixed inset-0 bg-black/70 flex items-center justify-center z-50 hidden"
     >
-      <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center border border-white/10">
+      <div
+        class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center border border-white/10"
+      >
         <h2 class="text-2xl font-semibold mb-2">print2 Pro</h2>
         <p class="mb-4">
           Get two prints (single or multicolour tiers) every week for

--- a/payment.html
+++ b/payment.html
@@ -793,6 +793,7 @@
       });
     </script>
     <script type="module" src="js/basket.js" defer></script>
+    <script>window.disableSaveButton = true;</script>
     <script type="module" src="js/saveList.js" defer></script>
     <script type="module" src="js/trackingPixel.js"></script>
   </body>


### PR DESCRIPTION
## Summary
- allow disabling the floating save button via `window.disableSaveButton`
- show saved items in profile
- disable floating save button on competitions, community and payment pages

## Testing
- `npm run setup`
- `npm run format` (backend)
- `npm test` (backend)
- `npm run ci`
- `npx playwright install`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6860fc9a7a48832db312f2fe7f54f158