### PR TITLE
Implement dynamic viewer in bestselling grid

### DIFF
--- a/js/community.js
+++ b/js/community.js
@@ -292,6 +292,36 @@ function createCard(model) {
   return div;
 }
 
+function createViewerCard(modelUrl) {
+  const div = document.createElement("div");
+  div.className =
+    "model-card relative h-32 bg-[#2A2A2E] border border-white/10 rounded-xl flex items-center justify-center cursor-pointer";
+  div.dataset.model = modelUrl;
+  div.innerHTML = `<model-viewer src="${modelUrl}" alt="3D model preview" environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr" camera-controls auto-rotate loading="lazy" class="w-full h-full bg-[#2A2A2E] rounded-xl"></model-viewer>`;
+  div.addEventListener("pointerenter", () => prefetchModel(modelUrl));
+  div.addEventListener("click", (e) => {
+    e.stopPropagation();
+    openModel({ model_url: modelUrl, job_id: "" });
+  });
+  return div;
+}
+
+function applyPopularViewer() {
+  const grid = document.getElementById("popular-grid");
+  if (!grid) return;
+  const cards = Array.from(grid.children);
+  if (cards.length < 2) return;
+  const modelUrl = cards[1].dataset.model;
+  if (!modelUrl) return;
+  for (let i = 2; i < cards.length; i += 3) {
+    const card = cards[i];
+    if (!card) continue;
+    const viewer = createViewerCard(modelUrl);
+    card.replaceWith(viewer);
+    cards[i] = viewer;
+  }
+}
+
 function addRecentModel(model) {
   if (!model || model.model_url === FALLBACK_GLB) return;
   const grid = document.getElementById("recent-grid");
@@ -342,6 +372,7 @@ async function loadMore(type, filters = getFilters()) {
   const grid = document.getElementById(`${type}-grid`);
   models.forEach((m) => grid.appendChild(createCard(m)));
   await captureSnapshots(grid);
+  if (type === "popular") applyPopularViewer();
   const btn = document.getElementById(`${type}-load`);
   if (btn) {
     if (models.length < 9) {
@@ -361,6 +392,7 @@ function renderGrid(type, filters = getFilters()) {
   if (state && state.models.length) {
     state.models.forEach((m) => grid.appendChild(createCard(m)));
     captureSnapshots(grid);
+    if (type === "popular") applyPopularViewer();
     const btn = document.getElementById(`${type}-load`);
     if (btn) {
       if (state.models.length < 9) btn.classList.add("hidden");


### PR DESCRIPTION
## Summary
- show a model viewer in the third item of each bestselling row
- reuse the second model from the grid for the viewer

## Testing
- `npm run format`
- `npm test`
- `npx playwright test e2e/smoke.test.js`
- `npm run ci` *(fails: Opening tag "img" not terminated in competitions.html)*

------
https://chatgpt.com/codex/tasks/task_e_686113de921c832dbae415ff1fb362b3