### PR TITLE
Add avatar glb support

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,7 @@
 node_modules
 uploads
 payment.html
+competitions.html
 
 # Build artifacts
 dist

--- a/backend/migrations/056_add_avatar_glb.sql
+++ b/backend/migrations/056_add_avatar_glb.sql
@@ -1,0 +1,1 @@
+ALTER TABLE user_profiles ADD COLUMN IF NOT EXISTS avatar_glb TEXT;

--- a/backend/server.js
+++ b/backend/server.js
@@ -352,7 +352,7 @@ app.get("/api/me", authRequired, async (req, res) => {
     if (!rows.length) return res.status(404).json({ error: "User not found" });
     const user = rows[0];
     const profile = await db.query(
-      "SELECT display_name, avatar_url, shipping_info, payment_info, competition_notify FROM user_profiles WHERE user_id=$1",
+      "SELECT display_name, avatar_url, avatar_glb, shipping_info, payment_info, competition_notify FROM user_profiles WHERE user_id=$1",
       [req.user.id],
     );
     res.json({
@@ -361,6 +361,7 @@ app.get("/api/me", authRequired, async (req, res) => {
       email: user.email,
       displayName: profile.rows[0]?.display_name || null,
       avatarUrl: profile.rows[0]?.avatar_url || null,
+      avatarGlb: profile.rows[0]?.avatar_glb || null,
       profile: profile.rows[0] || {},
     });
   } catch (err) {
@@ -684,18 +685,19 @@ app.get("/api/profile", authRequired, async (req, res) => {
 });
 
 app.post("/api/profile", authRequired, async (req, res) => {
-  const { shippingInfo, paymentInfo, competitionNotify } = req.body;
+  const { shippingInfo, paymentInfo, competitionNotify, avatarGlb } = req.body;
   try {
     await db.query(
-      `INSERT INTO user_profiles(user_id, shipping_info, payment_info, competition_notify)
-       VALUES($1,$2,$3,$4)
+      `INSERT INTO user_profiles(user_id, shipping_info, payment_info, competition_notify, avatar_glb)
+       VALUES($1,$2,$3,$4,$5)
        ON CONFLICT (user_id)
-       DO UPDATE SET shipping_info=$2, payment_info=$3, competition_notify=$4`,
+       DO UPDATE SET shipping_info=$2, payment_info=$3, competition_notify=$4, avatar_glb=COALESCE($5, user_profiles.avatar_glb)`,
       [
         req.user.id,
         shippingInfo || {},
         paymentInfo || {},
         competitionNotify !== false,
+        avatarGlb || null,
       ],
     );
     res.sendStatus(204);
@@ -889,7 +891,7 @@ app.get("/api/dashboard", authRequired, async (req, res) => {
           req.user.id,
         ]),
         db.query(
-          "SELECT display_name, avatar_url, shipping_info, payment_info, competition_notify FROM user_profiles WHERE user_id=$1",
+          "SELECT display_name, avatar_url, avatar_glb, shipping_info, payment_info, competition_notify FROM user_profiles WHERE user_id=$1",
           [req.user.id],
         ),
         db.query(
@@ -1388,7 +1390,7 @@ app.get("/api/users/:username/models", async (req, res) => {
 app.get("/api/users/:username/profile", async (req, res) => {
   try {
     const { rows } = await db.query(
-      `SELECT p.display_name, p.avatar_url
+      `SELECT p.display_name, p.avatar_url, p.avatar_glb
        FROM users u
        JOIN user_profiles p ON u.id=p.user_id
        WHERE u.username=$1`,

--- a/backend/tests/api.test.js
+++ b/backend/tests/api.test.js
@@ -649,12 +649,15 @@ test("/api/status/:id returns 404 when missing", async () => {
 
 test("GET /api/users/:username/profile returns profile", async () => {
   db.query.mockResolvedValueOnce({
-    rows: [{ display_name: "Alice", avatar_url: "a.png" }],
+    rows: [
+      { display_name: "Alice", avatar_url: "a.png", avatar_glb: "model.glb" },
+    ],
   });
   const res = await request(app).get("/api/users/alice/profile");
   expect(res.status).toBe(200);
   expect(res.body.display_name).toBe("Alice");
   expect(res.body.avatar_url).toBe("a.png");
+  expect(res.body.avatar_glb).toBe("model.glb");
 });
 
 test("GET /api/users/:username/profile 404 when missing", async () => {
@@ -666,13 +669,21 @@ test("GET /api/users/:username/profile 404 when missing", async () => {
 test("GET /api/profile returns profile", async () => {
   const token = jwt.sign({ id: "u1" }, "secret");
   db.query.mockResolvedValueOnce({
-    rows: [{ user_id: "u1", shipping_info: {}, payment_info: {} }],
+    rows: [
+      {
+        user_id: "u1",
+        shipping_info: {},
+        payment_info: {},
+        avatar_glb: "model.glb",
+      },
+    ],
   });
   const res = await request(app)
     .get("/api/profile")
     .set("authorization", `Bearer ${token}`);
   expect(res.status).toBe(200);
   expect(res.body.user_id).toBe("u1");
+  expect(res.body.avatar_glb).toBe("model.glb");
 });
 
 test("POST /api/profile saves details", async () => {
@@ -681,7 +692,11 @@ test("POST /api/profile saves details", async () => {
   const res = await request(app)
     .post("/api/profile")
     .set("authorization", `Bearer ${token}`)
-    .send({ shippingInfo: { a: 1 }, paymentInfo: { b: 2 } });
+    .send({
+      shippingInfo: { a: 1 },
+      paymentInfo: { b: 2 },
+      avatarGlb: "model.glb",
+    });
   expect(res.status).toBe(204);
   const call = db.query.mock.calls.find((c) =>
     c[0].includes("INSERT INTO user_profiles"),

--- a/js/my_profile.js
+++ b/js/my_profile.js
@@ -168,6 +168,16 @@ async function loadDashboard() {
       if (data.profile.avatar_url) {
         document.getElementById("avatar-preview").src = data.profile.avatar_url;
       }
+      if (data.profile.avatar_glb) {
+        const mv = document.getElementById("avatar-model-preview");
+        if (mv) {
+          mv.src = data.profile.avatar_glb;
+          mv.classList.remove("hidden");
+          document.getElementById("avatar-preview")?.classList.add("hidden");
+        }
+        document.getElementById("avatar-glb-input").value =
+          data.profile.avatar_glb;
+      }
     }
     if (data.orders) {
       const body = document.getElementById("orders-body");
@@ -238,6 +248,8 @@ async function uploadAvatar(e) {
   if (res.ok) {
     const data = await res.json();
     document.getElementById("avatar-preview").src = data.url;
+    document.getElementById("avatar-preview").classList.remove("hidden");
+    document.getElementById("avatar-model-preview")?.classList.add("hidden");
   }
 }
 
@@ -247,6 +259,7 @@ async function saveProfile(e) {
   if (!token) return;
   const shipping = document.getElementById("shipping-input").value.trim();
   const payment = document.getElementById("payment-input").value.trim();
+  const avatarGlb = document.getElementById("avatar-glb-input").value.trim();
   const notify = document.getElementById("competition-toggle").checked;
   await fetch(`${API_BASE}/profile`, {
     method: "POST",
@@ -258,8 +271,17 @@ async function saveProfile(e) {
       shippingInfo: { address: shipping },
       paymentInfo: { details: payment },
       competitionNotify: notify,
+      avatarGlb: avatarGlb || null,
     }),
   });
+  if (avatarGlb) {
+    const mv = document.getElementById("avatar-model-preview");
+    if (mv) {
+      mv.src = avatarGlb;
+      mv.classList.remove("hidden");
+    }
+    document.getElementById("avatar-preview")?.classList.add("hidden");
+  }
 }
 
 async function loadOrders() {

--- a/js/profile.js
+++ b/js/profile.js
@@ -132,8 +132,17 @@ async function loadProfileHeader() {
   document.getElementById("profile-name").textContent =
     data.display_name || "Profile";
   const avatar = document.getElementById("profile-avatar");
+  const model = document.getElementById("profile-avatar-model");
   const display = document.getElementById("profile-display");
-  if (avatar && data.avatar_url) avatar.src = data.avatar_url;
+  if (data.avatar_glb && model) {
+    model.src = data.avatar_glb;
+    model.classList.remove("hidden");
+    avatar?.classList.add("hidden");
+  } else if (avatar && data.avatar_url) {
+    avatar.src = data.avatar_url;
+    avatar.classList.remove("hidden");
+    model?.classList.add("hidden");
+  }
   if (display) display.textContent = data.display_name || "";
 }
 

--- a/my_profile.html
+++ b/my_profile.html
@@ -134,6 +134,15 @@
           class="w-24 h-24 rounded-full object-cover"
           alt="Avatar preview"
         />
+        <model-viewer
+          id="avatar-model-preview"
+          src=""
+          alt="3D avatar preview"
+          environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
+          camera-controls
+          auto-rotate
+          class="w-24 h-24 mx-auto mb-2 hidden"
+        ></model-viewer>
         <input
           id="avatar-input"
           type="file"
@@ -165,6 +174,12 @@
           class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10"
           placeholder="Payment Info"
           aria-label="Payment info"
+        />
+        <input
+          id="avatar-glb-input"
+          class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10"
+          placeholder="Avatar GLB URL"
+          aria-label="Avatar GLB URL"
         />
         <label class="inline-flex items-center">
           <input type="checkbox" id="competition-toggle" class="mr-2" />

--- a/profile.html
+++ b/profile.html
@@ -128,6 +128,15 @@
           class="w-24 h-24 rounded-full mx-auto mb-2"
           alt="Profile avatar"
         />
+        <model-viewer
+          id="profile-avatar-model"
+          src=""
+          alt="Profile 3D avatar"
+          environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
+          camera-controls
+          auto-rotate
+          class="w-24 h-24 mx-auto mb-2 hidden"
+        ></model-viewer>
         <h2 id="profile-display" class="text-xl font-semibold"></h2>
       </div>
       <div
@@ -225,7 +234,9 @@
       id="printclub-modal"
       class="fixed inset-0 bg-black/70 flex items-center justify-center z-50 hidden"
     >
-      <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center border border-white/10">
+      <div
+        class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center border border-white/10"
+      >
         <h2 class="text-2xl font-semibold mb-2">print2 Pro</h2>
         <p class="mb-4">
           Get two prints (single or multicolour tiers) every week for


### PR DESCRIPTION
## Summary
- allow prettier to ignore competitions.html
- add avatar_glb column via migration
- store and return avatar_glb in profile API
- surface avatar glb on profile pages
- allow editing avatar glb in profile settings

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_686114b9842c832dbc22595ee9f02641