### PR TITLE
Add GLB preview in recent model popup

### DIFF
--- a/competitions.html
+++ b/competitions.html
@@ -135,9 +135,10 @@
       >
         <img
           src="https://images.unsplash.com/photo-1515378791036-0648a3ef77b2?auto=format&fit=crop&w=200&q=60"
-
+          alt="Contest winner"
+          class="w-24 h-24 rounded-full"
+        />
         <model-viewer
-
           alt="Contest winner"
           environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
           camera-controls

--- a/js/index.js
+++ b/js/index.js
@@ -1109,7 +1109,19 @@ async function init() {
     const span = document.createElement("span");
     span.textContent = msg;
     popupEl.appendChild(span);
-    if (popupIdx % popupMsgs.length === 0 && lastSnapshot) {
+    if (msg.includes("created a model")) {
+      const viewer = document.createElement("model-viewer");
+      viewer.src = "https://modelviewer.dev/shared-assets/models/Astronaut.glb";
+      viewer.setAttribute(
+        "environment-image",
+        "https://modelviewer.dev/shared-assets/environments/neutral.hdr",
+      );
+      viewer.setAttribute("camera-controls", "");
+      viewer.setAttribute("auto-rotate", "");
+      viewer.setAttribute("crossOrigin", "anonymous");
+      viewer.className = "w-10 h-10 ml-2";
+      popupEl.appendChild(viewer);
+    } else if (popupIdx % popupMsgs.length === 0 && lastSnapshot) {
       const img = document.createElement("img");
       img.src = lastSnapshot;
       img.className = "w-10 h-10 ml-2 rounded";


### PR DESCRIPTION
## Summary
- show a rotating 3D model for "recently created" popup
- fix broken img tag in competitions page

## Testing
- `npm test`
- `npm run ci`
- `npx playwright test e2e/smoke.test.js`

------
https://chatgpt.com/codex/tasks/task_e_686119b6267c832da110a2981ea164ef