### PR TITLE
Fix competitions page testimonial model

### DIFF
--- a/competitions.html
+++ b/competitions.html
@@ -133,13 +133,8 @@
       <section
         class="bg-[#2A2A2E] p-4 rounded-xl flex items-center space-x-4 border border-white/10"
       >
-        <img
-          src="https://images.unsplash.com/photo-1515378791036-0648a3ef77b2?auto=format&fit=crop&w=200&q=60"
-          alt="Contest winner"
-
-          class="w-24 h-24 rounded-full object-cover"
-        />
         <model-viewer
+          src="https://modelviewer.dev/shared-assets/models/Astronaut.glb"
           alt="Contest winner"
           environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
           camera-controls


### PR DESCRIPTION
## Summary
- restore single `<model-viewer>` next to Alex's quote on the competitions page

## Testing
- `npm run format` (backend)
- `npm test` (backend)
- `npm run ci`
- `npx playwright install`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68612a4d91dc832d8193f25e65c97c84