### PR TITLE
Implement basic cart backend/frontend

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -885,6 +885,56 @@ async function getLowInventory() {
   return rows;
 }
 
+async function insertCartItem(userId, jobId, quantity = 1) {
+  const { rows } = await query(
+    `INSERT INTO cart_items(user_id, job_id, quantity)
+     VALUES($1,$2,$3) RETURNING *`,
+    [userId, jobId, quantity],
+  );
+  return rows[0];
+}
+
+async function updateCartItem(id, quantity) {
+  const { rows } = await query(
+    `UPDATE cart_items SET quantity=$2 WHERE id=$1 RETURNING *`,
+    [id, quantity],
+  );
+  return rows[0];
+}
+
+async function deleteCartItem(id) {
+  await query("DELETE FROM cart_items WHERE id=$1", [id]);
+}
+
+async function getCartItems(userId) {
+  const { rows } = await query(
+    `SELECT id, job_id, quantity FROM cart_items WHERE user_id=$1 ORDER BY id`,
+    [userId],
+  );
+  return rows;
+}
+
+async function clearCart(userId) {
+  await query("DELETE FROM cart_items WHERE user_id=$1", [userId]);
+}
+
+async function insertOrderItems(orderId, items) {
+  for (const item of items) {
+    await query(
+      "INSERT INTO order_items(order_id, job_id, quantity) VALUES($1,$2,$3)",
+      [orderId, item.jobId, item.quantity || 1],
+    );
+  }
+}
+
+async function getOrderItems(orderId) {
+  const { rows } = await query(
+    "SELECT id, job_id, quantity FROM order_items WHERE order_id=$1 ORDER BY id",
+    [orderId],
+  );
+  return rows;
+}
+
 async function upsertHubSaturationSummary(date, hubId, saturation) {
   const { rows } = await query(
     `INSERT INTO hub_saturation_summary(summary_date, hub_id, avg_queue_saturation)
@@ -1070,4 +1120,11 @@ module.exports = {
   getMarginalCacMetrics,
   adjustInventory,
   getLowInventory,
+  insertCartItem,
+  updateCartItem,
+  deleteCartItem,
+  getCartItems,
+  clearCart,
+  insertOrderItems,
+  getOrderItems,
 };

--- a/backend/migrations/057_create_cart_tables.sql
+++ b/backend/migrations/057_create_cart_tables.sql
@@ -1,0 +1,17 @@
+CREATE TABLE cart_items (
+  id SERIAL PRIMARY KEY,
+  user_id TEXT REFERENCES users(id) ON DELETE CASCADE,
+  job_id UUID REFERENCES print_jobs(job_id) ON DELETE CASCADE,
+  quantity INTEGER NOT NULL DEFAULT 1,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+CREATE TRIGGER cart_items_set_updated BEFORE UPDATE ON cart_items
+  FOR EACH ROW EXECUTE PROCEDURE set_updated_at();
+
+CREATE TABLE order_items (
+  id SERIAL PRIMARY KEY,
+  order_id TEXT REFERENCES orders(session_id) ON DELETE CASCADE,
+  job_id UUID REFERENCES print_jobs(job_id) ON DELETE SET NULL,
+  quantity INTEGER NOT NULL DEFAULT 1
+);

--- a/backend/tests/cart.test.js
+++ b/backend/tests/cart.test.js
@@ -1,0 +1,81 @@
+process.env.STRIPE_SECRET_KEY = "test";
+process.env.STRIPE_WEBHOOK_SECRET = "whsec";
+process.env.DB_URL = "postgres://user:pass@localhost/db";
+process.env.HUNYUAN_API_KEY = "test";
+process.env.HUNYUAN_SERVER_URL = "http://localhost:4000";
+
+jest.mock("../db", () => ({
+  insertCartItem: jest.fn(),
+  updateCartItem: jest.fn(),
+  deleteCartItem: jest.fn(),
+  getCartItems: jest.fn().mockResolvedValue([]),
+  clearCart: jest.fn(),
+  insertOrderItems: jest.fn(),
+  query: jest.fn(),
+}));
+const db = require("../db");
+
+jest.mock("stripe");
+const Stripe = require("stripe");
+const stripeMock = {
+  checkout: {
+    sessions: { create: jest.fn().mockResolvedValue({ id: "cs", url: "u" }) },
+  },
+};
+Stripe.mockImplementation(() => stripeMock);
+
+const request = require("supertest");
+const app = require("../server");
+const jwt = require("jsonwebtoken");
+
+test("POST /api/cart/items adds item", async () => {
+  const token = jwt.sign({ id: "u1" }, "secret");
+  db.insertCartItem.mockResolvedValueOnce({ id: 1 });
+  const res = await request(app)
+    .post("/api/cart/items")
+    .set("authorization", `Bearer ${token}`)
+    .send({ jobId: "j1", quantity: 2 });
+  expect(res.status).toBe(200);
+  expect(db.insertCartItem).toHaveBeenCalledWith("u1", "j1", 2);
+});
+
+test("PATCH /api/cart/items/:id updates item", async () => {
+  const token = jwt.sign({ id: "u1" }, "secret");
+  db.updateCartItem.mockResolvedValueOnce({ id: 1, quantity: 3 });
+  const res = await request(app)
+    .patch("/api/cart/items/1")
+    .set("authorization", `Bearer ${token}`)
+    .send({ quantity: 3 });
+  expect(res.status).toBe(200);
+  expect(db.updateCartItem).toHaveBeenCalledWith("1", 3);
+});
+
+test("DELETE /api/cart/items/:id removes item", async () => {
+  const token = jwt.sign({ id: "u1" }, "secret");
+  const res = await request(app)
+    .delete("/api/cart/items/1")
+    .set("authorization", `Bearer ${token}`);
+  expect(res.status).toBe(204);
+  expect(db.deleteCartItem).toHaveBeenCalledWith("1");
+});
+
+test("GET /api/cart returns items", async () => {
+  const token = jwt.sign({ id: "u1" }, "secret");
+  db.getCartItems.mockResolvedValueOnce([{ id: 1 }]);
+  const res = await request(app)
+    .get("/api/cart")
+    .set("authorization", `Bearer ${token}`);
+  expect(res.status).toBe(200);
+  expect(Array.isArray(res.body.items)).toBe(true);
+});
+
+test("POST /api/cart/checkout creates session", async () => {
+  const token = jwt.sign({ id: "u1" }, "secret");
+  db.getCartItems.mockResolvedValueOnce([{ id: 1, job_id: "j1", quantity: 1 }]);
+  const res = await request(app)
+    .post("/api/cart/checkout")
+    .set("authorization", `Bearer ${token}`);
+  expect(res.status).toBe(200);
+  expect(stripeMock.checkout.sessions.create).toHaveBeenCalled();
+  expect(db.clearCart).toHaveBeenCalled();
+});

--- a/cart.html
+++ b/cart.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Cart</title>
+    <script src="js/applyColorScheme.js"></script>
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body class="bg-[#1A1A1D] text-white">
+    <main class="p-4 max-w-lg mx-auto">
+      <h1 class="text-2xl mb-4">Your Cart</h1>
+      <div id="cart-items" class="space-y-4"></div>
+      <button
+        id="checkout-all"
+        class="mt-4 px-4 py-2 rounded bg-[#30D5C8] text-[#1A1A1D]"
+      >
+        Checkout
+      </button>
+    </main>
+    <script type="module" src="js/cart.js"></script>
+  </body>
+</html>

--- a/js/cart.js
+++ b/js/cart.js
@@ -1,0 +1,65 @@
+const API_BASE = (window.API_ORIGIN || "") + "/api";
+import { getBasket, removeFromBasket } from "./basket.js";
+
+function render() {
+  const list = document.getElementById("cart-items");
+  list.innerHTML = "";
+  const items = getBasket();
+  if (!items.length) {
+    list.textContent = "Cart empty";
+    return;
+  }
+  items.forEach((it, idx) => {
+    const div = document.createElement("div");
+    div.className = "flex items-center gap-2";
+    const img = document.createElement("img");
+    img.src = it.snapshot || it.modelUrl || "";
+    img.className = "w-16 h-16 object-cover rounded";
+    div.appendChild(img);
+    const input = document.createElement("input");
+    input.type = "number";
+    input.value = it.quantity || 1;
+    input.min = "1";
+    input.className = "w-16 text-black px-1";
+    input.addEventListener("change", () => {
+      const q = parseInt(input.value, 10) || 1;
+      const items = getBasket();
+      items[idx].quantity = q;
+      localStorage.setItem("print3Basket", JSON.stringify(items));
+      if (it.serverId) {
+        const token = localStorage.getItem("token");
+        if (token)
+          fetch(`${API_BASE}/cart/items/${it.serverId}`, {
+            method: "PATCH",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${token}`,
+            },
+            body: JSON.stringify({ quantity: q }),
+          }).catch(() => {});
+      }
+    });
+    div.appendChild(input);
+    const btn = document.createElement("button");
+    btn.textContent = "Remove";
+    btn.className = "text-red-500";
+    btn.addEventListener("click", () => removeFromBasket(idx));
+    div.appendChild(btn);
+    list.appendChild(div);
+  });
+}
+
+async function checkout() {
+  const token = localStorage.getItem("token");
+  if (!token) return;
+  const res = await fetch(`${API_BASE}/cart/checkout`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  const data = await res.json();
+  if (data.checkoutUrl) window.location.href = data.checkoutUrl;
+}
+
+document.getElementById("checkout-all").addEventListener("click", checkout);
+window.addEventListener("basket-change", render);
+render();

--- a/js/login.js
+++ b/js/login.js
@@ -23,6 +23,7 @@ async function login(e) {
   if (data.token) {
     localStorage.setItem("token", data.token);
     if (data.isAdmin) localStorage.setItem("isAdmin", "true");
+    if (window.syncServerCart) window.syncServerCart();
     window.location.href = "my_profile.html";
   } else {
     document.getElementById("error").textContent = data.error || "Login failed";


### PR DESCRIPTION
## Summary
- add cart_items and order_items tables
- expose server-side cart API
- update basket for server cart sync
- create cart page with checkout
- sync cart on login

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`
- `npx playwright install`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68612ec49b64832db8026988bc404a09