### PR TITLE
Fix Luckybox height on scroll

### DIFF
--- a/js/addons.js
+++ b/js/addons.js
@@ -164,5 +164,5 @@ function updateLuckyboxOnScroll() {
   const lockedBottom = locked.getBoundingClientRect().bottom;
   const clamped = lockedBottom > 0 ? lockedBottom : 0;
   const newHeight = luckyInitialHeight + (clamped - lockedInitialBottom);
-  lucky.style.height = `${newHeight}px`;
+  lucky.style.height = `${Math.max(luckyInitialHeight, newHeight)}px`;
 }


### PR DESCRIPTION
## Summary
- maintain Luckybox panel size while scrolling

## Testing
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `npm run ci`
- `npx playwright install`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6861325378ac832dae5c0e262aa6c803