### PR TITLE
Implement LHS/RHS split for rewards panel

### DIFF
--- a/earn-rewards.html
+++ b/earn-rewards.html
@@ -89,9 +89,11 @@
     </header>
     <main class="flex-1 flex items-center justify-center p-4">
       <div
-        class="max-w-4xl w-full bg-[#2A2A2E] border border-white/10 p-6 rounded-2xl shadow-lg flex flex-col md:flex-row md:space-x-8 space-y-6 md:space-y-0"
+        class="max-w-4xl w-full flex flex-col md:flex-row md:space-x-8 space-y-6 md:space-y-0"
       >
-        <div class="md:w-1/2 space-y-6 text-center md:text-left">
+        <div
+          class="md:w-1/2 bg-[#2A2A2E] border border-white/10 p-6 rounded-2xl shadow-lg space-y-6 text-center md:text-left"
+        >
           <h2 class="text-2xl font-semibold">Share &amp; earn discounts</h2>
           <p class="text-gray-400">
             You must
@@ -150,7 +152,9 @@
           </div>
           <p id="next-reward-msg" class="text-sm text-gray-300"></p>
         </div>
-        <div class="md:w-1/2 space-y-6 text-left">
+        <div
+          class="md:w-1/2 bg-[#2A2A2E] border border-white/10 p-6 rounded-2xl shadow-lg space-y-6 text-left"
+        >
           <div>
             <h3 class="text-lg font-semibold mt-6 mb-2">Top Referrers</h3>
             <table class="w-full text-sm">
@@ -189,7 +193,9 @@
       id="printclub-modal"
       class="fixed inset-0 bg-black/70 flex items-center justify-center z-50 hidden"
     >
-      <div class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center border border-white/10">
+      <div
+        class="bg-[#2A2A2E] p-6 rounded-xl max-w-sm text-center border border-white/10"
+      >
         <h2 class="text-2xl font-semibold mb-2">print2 Pro</h2>
         <p class="mb-4">
           Get two prints (single or multicolour tiers) every week for


### PR DESCRIPTION
## Summary
- split the central panel on **earn-rewards.html** into left and right panels
- keep the referral/points section in the left half and the leaderboard in the right half

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_686133647960832db3f4aeaa35877cfb