### PR TITLE
Remove side image on competitions page

### DIFF
--- a/competitions.html
+++ b/competitions.html
@@ -134,12 +134,6 @@
         class="bg-[#2A2A2E] p-4 rounded-xl flex items-center space-x-4 border border-white/10"
       >
 
-        <img
-          src="https://images.unsplash.com/photo-1515378791036-0648a3ef77b2?auto=format&fit=crop&w=200&q=60"
-          alt="Contest winner"
-          class="w-24 h-24 rounded-full object-cover"
-        />
-
         <model-viewer
           src="https://modelviewer.dev/shared-assets/models/Astronaut.glb"
           alt="Contest winner"


### PR DESCRIPTION
## Summary
- remove unsplash image from quote section on `competitions.html`

## Testing
- `npm run setup`
- `npm run format` in `backend`
- `npm test --silent` in `backend`
- `npm run ci`
- `npx playwright install`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_686133acbe54832dae1d9dd7978c4eae