### PR TITLE
Fix print2 Pro banner style

### DIFF
--- a/competitions.html
+++ b/competitions.html
@@ -113,7 +113,7 @@
     <main class="flex-1 p-4 space-y-6">
       <div
         id="printclub-banner"
-        class="bg-blue-600 text-white p-3 rounded-xl text-center hidden"
+        class="bg-[#30D5C8] text-black p-3 rounded-xl text-center hidden"
       >
         Join <strong>print2 Pro</strong> for weekly prints.
         <a href="#" id="printclub-banner-link" class="underline">Learn more</a>


### PR DESCRIPTION
## Summary
- update competitions page banner to use light blue background and black text

## Testing
- `npm run format` in backend
- `npm test` in backend
- `npm run ci`
- `npx playwright install`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_686133d768c0832da536810a6fe38bcd