### PR TITLE
Fix community viewer layout and interaction

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -189,6 +189,7 @@
         <div
           id="popular-grid"
           class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4"
+          style="grid-auto-rows: 8rem"
         ></div>
         <div id="popular-sentinel" class="h-8"></div>
         <button

--- a/js/community.js
+++ b/js/community.js
@@ -302,8 +302,11 @@ function createViewerCard(modelUrl) {
   div.innerHTML = `<model-viewer src="${modelUrl}" alt="3D model preview" environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr" camera-controls auto-rotate loading="lazy" class="w-full h-full bg-[#2A2A2E] rounded-xl"></model-viewer>`;
   div.addEventListener("pointerenter", () => prefetchModel(modelUrl));
   div.addEventListener("click", (e) => {
-    e.stopPropagation();
-    openModel({ model_url: modelUrl, job_id: "" });
+    // Avoid opening the modal when rotating the model preview
+    if (!e.target.closest("model-viewer")) {
+      e.stopPropagation();
+      openModel({ model_url: modelUrl, job_id: "" });
+    }
   });
   return div;
 }
@@ -328,7 +331,8 @@ function applyPopularViewer() {
   toRemove.forEach((el) => el.remove());
 
   const viewer = createViewerCard(modelUrl);
-  viewer.classList.add("row-span-3", "h-[24rem]");
+  // Let the grid determine the final height so alignment matches
+  viewer.classList.add("row-span-3");
 
   const insertBefore = grid.children[2];
   if (insertBefore) grid.insertBefore(viewer, insertBefore);


### PR DESCRIPTION
## Summary
- prevent accidental modal pop-up when rotating preview
- allow grid to control viewer height
- set auto rows for popular grid so viewer aligns

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6861345715ac832db8838923f7ac961e