### PR TITLE
Add leaderboard data on marketplace

### DIFF
--- a/js/marketplace.js
+++ b/js/marketplace.js
@@ -4,13 +4,57 @@ function createCard(item) {
   const div = document.createElement("div");
   div.className =
     "model-card relative h-32 bg-[#2A2A2E] border border-white/10 rounded-xl flex items-center justify-center";
-  div.innerHTML = `<model-viewer src="${item.file_path}" alt="Model" environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr" camera-controls auto-rotate loading="lazy" class="w-full h-full bg-[#2A2A2E] rounded-xl"></model-viewer>\n<button class="buy absolute bottom-1 right-1 font-bold text-lg py-1.5 px-4 rounded-full shadow-md transition border-2 border-black" style="background-color:#30D5C8;color:#1A1A1D;transform:scale(0.78);transform-origin:right bottom;">Buy</button>`;
+  div.innerHTML = `<model-viewer src="${item.file_path}" alt="Model" environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr" camera-controls auto-rotate loading="lazy" class="w-full h-full bg-[#2A2A2E] rounded-xl"></model-viewer>\n<progress max="100" value="${item.royalty_percent || 0}" class="absolute left-1 bottom-1 w-16 h-2"></progress>\n<button class="buy absolute bottom-1 right-1 font-bold text-lg py-1.5 px-4 rounded-full shadow-md transition border-2 border-black" style="background-color:#30D5C8;color:#1A1A1D;transform:scale(0.78);transform-origin:right bottom;">Buy</button>`;
   div.querySelector(".buy").addEventListener("click", () => {
     localStorage.setItem("print3Model", item.file_path);
     if (item.job_id) localStorage.setItem("print3JobId", item.job_id);
     window.location.href = "payment.html";
   });
   return div;
+}
+
+async function loadLeaderboard() {
+  try {
+    const res = await fetch(`${API_BASE}/leaderboard?limit=5`);
+    if (!res.ok) return;
+    const data = await res.json();
+    const body = document.getElementById("leaderboard-body");
+    const promo = document.getElementById("designer-month");
+    if (!body) return;
+    body.innerHTML = "";
+    data.forEach((e, idx) => {
+      const tr = document.createElement("tr");
+      tr.innerHTML = `<td class="px-2 py-1">${e.username}</td><td class="px-2 py-1">${e.points}</td>`;
+      body.appendChild(tr);
+      if (idx === 0 && promo) {
+        promo.textContent = `Designer of the Month: ${e.username}`;
+      }
+    });
+  } catch (err) {
+    console.error("Failed to load leaderboard", err);
+  }
+}
+
+async function loadAchievements() {
+  const token = localStorage.getItem("token");
+  if (!token) return;
+  try {
+    const res = await fetch(`${API_BASE}/achievements`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) return;
+    const { achievements } = await res.json();
+    const list = document.getElementById("achievements-list");
+    if (!list) return;
+    list.innerHTML = "";
+    achievements.forEach((a) => {
+      const li = document.createElement("li");
+      li.textContent = a.name;
+      list.appendChild(li);
+    });
+  } catch (err) {
+    console.error("Failed to load achievements", err);
+  }
 }
 
 document.addEventListener("DOMContentLoaded", async () => {
@@ -24,4 +68,6 @@ document.addEventListener("DOMContentLoaded", async () => {
     const items = await res.json();
     items.forEach((it) => grid.appendChild(createCard(it)));
   } catch {}
+  loadLeaderboard();
+  loadAchievements();
 });

--- a/marketplace.html
+++ b/marketplace.html
@@ -136,6 +136,25 @@
           ></div>
         </div>
       </section>
+      <section class="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div class="bg-[#2A2A2E] p-4 rounded-xl border border-white/10">
+          <h2 class="text-xl font-semibold mb-2">Top Sellers</h2>
+          <table class="w-full text-sm">
+            <thead>
+              <tr>
+                <th class="text-left">User</th>
+                <th class="text-left">Points</th>
+              </tr>
+            </thead>
+            <tbody id="leaderboard-body"></tbody>
+          </table>
+          <p id="designer-month" class="mt-4 text-center text-yellow-300 font-semibold"></p>
+        </div>
+        <div class="bg-[#2A2A2E] p-4 rounded-xl border border-white/10">
+          <h2 class="text-xl font-semibold mb-2">Recent Achievements</h2>
+          <ul id="achievements-list" class="list-disc list-inside text-sm"></ul>
+        </div>
+      </section>
     </main>
     <script type="module">
       import { shareOn } from "./js/share.js";


### PR DESCRIPTION
## Summary
- show "Top Sellers" and "Recent Achievements" on the marketplace page
- fetch leaderboard and achievement info in `js/marketplace.js`
- include a progress indicator on each model card

## Testing
- `npm run format`
- `npm run ci`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_686146b348c8832d8483b223e6ddfef6