### PR TITLE
Fix layout shift on checkout panel

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -615,7 +615,12 @@
             >
               Pay £39.99
             </button>
-            <div class="flex justify-between mt-2 mb-2 text-xs min-h-[2.5em]">
+            <!--
+              Use a fixed height so the panel doesn't jump when the price
+              breakdown spans two lines. h-8 corresponds to two lines of the
+              text-xs class.
+            -->
+            <div class="flex justify-between mt-2 mb-2 text-xs h-8">
               <pre id="price-breakdown" class="whitespace-pre-wrap text-right"></pre>
             </div>
             <div id="pay-summary" class="hidden absolute left-1/2 -translate-x-1/2 bottom-[4.5rem] w-64 bg-[#2A2A2E] border border-white/20 rounded-lg p-2 text-sm"></div>


### PR DESCRIPTION
## Summary
- prevent height jump in the payment price breakdown by fixing its height

## Testing
- `npm run format`
- `npm test`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_686146a8a930832dba74fd6ef1a5af40