### PR TITLE
Add purchase button to community viewer

### DIFF
--- a/js/community.js
+++ b/js/community.js
@@ -295,11 +295,10 @@ function createCard(model) {
 function createViewerCard(modelUrl) {
   const div = document.createElement("div");
   div.className =
-
     "viewer-card model-card relative bg-[#2A2A2E] border border-white/10 rounded-xl flex items-center justify-center cursor-pointer";
 
   div.dataset.model = modelUrl;
-  div.innerHTML = `<model-viewer src="${modelUrl}" alt="3D model preview" environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr" camera-controls auto-rotate loading="lazy" class="w-full h-full bg-[#2A2A2E] rounded-xl"></model-viewer>`;
+  div.innerHTML = `<model-viewer src="${modelUrl}" alt="3D model preview" environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr" camera-controls auto-rotate loading="lazy" class="w-full h-full bg-[#2A2A2E] rounded-xl"></model-viewer>\n    <button class="purchase absolute bottom-1 right-1 font-bold text-lg py-1.5 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]" style="transform: scale(0.78); transform-origin: right bottom;">Buy from £29.99</button>`;
   div.addEventListener("pointerenter", () => prefetchModel(modelUrl));
   div.addEventListener("click", (e) => {
     // Avoid opening the modal when rotating the model preview
@@ -307,6 +306,13 @@ function createViewerCard(modelUrl) {
       e.stopPropagation();
       openModel({ model_url: modelUrl, job_id: "" });
     }
+  });
+  div.querySelector(".purchase")?.addEventListener("click", (e) => {
+    e.stopPropagation();
+    sessionStorage.setItem("fromCommunity", "1");
+    localStorage.setItem("print3Model", modelUrl);
+    localStorage.setItem("print3JobId", "");
+    window.location.href = "payment.html";
   });
   return div;
 }
@@ -322,7 +328,6 @@ function applyPopularViewer() {
   if (cards.length < 2) return;
   const modelUrl = cards[1].dataset.model;
   if (!modelUrl) return;
-
 
   const toRemove = [];
   for (let i = 2; i < Math.min(cards.length, 9); i += 3) {


### PR DESCRIPTION
## Summary
- show "Buy from £29.99" button on the community page viewer

## Testing
- `npm run format`
- `npm test`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6861458b5988832d95293e68dee37312