### PR TITLE
Remove unused marketplace panels

### DIFF
--- a/js/marketplace.js
+++ b/js/marketplace.js
@@ -68,6 +68,4 @@ document.addEventListener("DOMContentLoaded", async () => {
     const items = await res.json();
     items.forEach((it) => grid.appendChild(createCard(it)));
   } catch {}
-  loadLeaderboard();
-  loadAchievements();
 });

--- a/marketplace.html
+++ b/marketplace.html
@@ -136,25 +136,6 @@
           ></div>
         </div>
       </section>
-      <section class="grid grid-cols-1 md:grid-cols-2 gap-6">
-        <div class="bg-[#2A2A2E] p-4 rounded-xl border border-white/10">
-          <h2 class="text-xl font-semibold mb-2">Top Sellers</h2>
-          <table class="w-full text-sm">
-            <thead>
-              <tr>
-                <th class="text-left">User</th>
-                <th class="text-left">Points</th>
-              </tr>
-            </thead>
-            <tbody id="leaderboard-body"></tbody>
-          </table>
-          <p id="designer-month" class="mt-4 text-center text-yellow-300 font-semibold"></p>
-        </div>
-        <div class="bg-[#2A2A2E] p-4 rounded-xl border border-white/10">
-          <h2 class="text-xl font-semibold mb-2">Recent Achievements</h2>
-          <ul id="achievements-list" class="list-disc list-inside text-sm"></ul>
-        </div>
-      </section>
     </main>
     <script type="module">
       import { shareOn } from "./js/share.js";


### PR DESCRIPTION
## Summary
- remove Top Sellers and Recent Achievements panels from marketplace
- stop fetching leaderboard and achievements data

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`
- `npx playwright install`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68615db9c724832da97785ad97531e57