### PR TITLE
Hide remove button when only one item

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -900,7 +900,11 @@ async function initPaymentPage() {
       }
     }
     if (removeBtn) {
-      removeBtn.classList.remove("hidden");
+      if (checkoutItems.length > 1) {
+        removeBtn.classList.remove("hidden");
+      } else {
+        removeBtn.classList.add("hidden");
+      }
     }
     applyStoredColorIfNeeded();
     updatePayButton();
@@ -1147,7 +1151,10 @@ async function initPaymentPage() {
     localStorage.setItem("print3Material", storedMaterial);
     viewer.addEventListener("load", applyStoredColorIfNeeded, { once: true });
     showItem(0);
-    if (removeBtn) removeBtn.classList.remove("hidden");
+    if (removeBtn) {
+      if (checkoutItems.length > 1) removeBtn.classList.remove("hidden");
+      else removeBtn.classList.add("hidden");
+    }
   }
 
   if (!checkoutItems.length && qtySelect) {

--- a/payment.html
+++ b/payment.html
@@ -244,7 +244,7 @@
         <button
           id="remove-model"
           type="button"
-          class="absolute top-2 right-2 w-6 h-6 rounded-full bg-white text-black border border-black flex items-center justify-center z-20"
+          class="absolute top-2 right-2 w-6 h-6 rounded-full bg-white text-black border border-black flex items-center justify-center z-20 hidden"
         >
           <i class="fas fa-times"></i>
           <span class="sr-only">Remove from basket</span>


### PR DESCRIPTION
## Summary
- tweak payment page to hide the remove-model button when only one model is in the basket
- adjust JS logic to toggle the remove button based on basket size

## Testing
- `npm test`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68616fab3fdc832d8dbc17c6ec716e69