### PR TITLE
Move printclub banner below competitions message

### DIFF
--- a/competitions.html
+++ b/competitions.html
@@ -111,13 +111,6 @@
       </div>
     </header>
     <main class="flex-1 p-4 space-y-6">
-      <div
-        id="printclub-banner"
-        class="bg-[#30D5C8] text-black p-3 rounded-xl text-center hidden"
-      >
-        Join <strong>print2 Pro</strong> for weekly prints.
-        <a href="#" id="printclub-banner-link" class="underline">Learn more</a>
-      </div>
       <section class="bg-[#2A2A2E] p-4 rounded-xl border border-white/10">
         <p class="mb-2">
           Put your modelling skills to the test! Enter our themed contests,
@@ -155,6 +148,13 @@
       <div id="list" class="space-y-4"></div>
       <div id="comp-subscribe-msg" class="text-sm"></div>
       <div id="entry-success" class="hidden text-green-400 mt-2"></div>
+      <div
+        id="printclub-banner"
+        class="bg-[#30D5C8] text-black p-3 rounded-xl text-center hidden"
+      >
+        Join <strong>print2 Pro</strong> for weekly prints.
+        <a href="#" id="printclub-banner-link" class="underline">Learn more</a>
+      </div>
       <h2 class="text-2xl mt-8">Past Winners</h2>
       <div
         id="winners-grid"


### PR DESCRIPTION
## Summary
- reposition the printclub banner so it's displayed after the active competitions section

## Testing
- `npm run setup`
- `npm run format` in backend
- `npm test` in backend
- `npm run ci`
- `CI=1 npx playwright install --with-deps`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68616fe58b64832dae59fa58daae2ab5