### PR TITLE
Combine competition intro panels

### DIFF
--- a/competitions.html
+++ b/competitions.html
@@ -111,22 +111,9 @@
       </div>
     </header>
     <main class="flex-1 p-4 space-y-6">
-      <section class="bg-[#2A2A2E] p-4 rounded-xl border border-white/10">
-        <p class="mb-2">
-          Put your modelling skills to the test! Enter our themed contests,
-          climb the leaderboard and win free prints.
-        </p>
-        <p>
-          <a href="signup.html" class="font-bold text-[#30D5C8]">Sign Up</a>
-          or
-          <a href="login.html" class="font-bold text-[#30D5C8]">Log In</a>
-          to submit your best designs.
-        </p>
-      </section>
       <section
         class="bg-[#2A2A2E] p-4 rounded-xl flex items-center space-x-4 border border-white/10"
       >
-
         <model-viewer
           src="https://modelviewer.dev/shared-assets/models/Astronaut.glb"
           alt="Contest winner"
@@ -135,13 +122,25 @@
           auto-rotate
           class="w-24 h-24 rounded-full"
         ></model-viewer>
-        <p class="text-sm italic">
-          "Entering competitions pushed my skills and the free prints are
-          awesome!" –
-          <span class="font-semibold"
-            >Alex, who entered a dragon and won £20 credit</span
-          >
-        </p>
+        <div>
+          <p class="mb-2">
+            Put your modelling skills to the test! Enter our themed contests,
+            climb the leaderboard and win free prints.
+          </p>
+          <p>
+            <a href="signup.html" class="font-bold text-[#30D5C8]">Sign Up</a>
+            or
+            <a href="login.html" class="font-bold text-[#30D5C8]">Log In</a>
+            to submit your best designs.
+          </p>
+          <p class="text-sm italic mt-2">
+            "Entering competitions pushed my skills and the free prints are
+            awesome!" –
+            <span class="font-semibold"
+              >Alex, who entered a dragon and won £20 credit</span
+            >
+          </p>
+        </div>
       </section>
       <h2 class="text-2xl">Active Competitions</h2>
       <h3 id="current-theme" class="text-lg text-[#30D5C8] mt-1"></h3>


### PR DESCRIPTION
## Summary
- merge the signup panel and testimonial panel into a single section on `competitions.html`
- ran formatting and tests

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68617e9e8398832daa115806e42ee2b9