### PR TITLE
Fix printclub modal link font size

### DIFF
--- a/competitions.html
+++ b/competitions.html
@@ -556,7 +556,7 @@
           <a
             href="printclub.html"
             id="printclub-learn"
-            class="col-span-3 flex items-center justify-center bg-gradient-to-r from-purple-500 to-pink-500 text-white rounded-3xl px-3 py-2 text-sm transition-shape"
+            class="col-span-3 flex items-center justify-center bg-gradient-to-r from-purple-500 to-pink-500 text-white rounded-3xl px-3 py-2 text-lg font-medium transition-shape"
             >Learn More</a
           >
           <button


### PR DESCRIPTION
## Summary
- enlarge the `Learn More` link text in the competitions printclub modal

## Testing
- `npm run format` in backend
- `npm test`
- `npm run ci`
- `CI=1 npx playwright install --with-deps`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68617e7d7fd0832d9ca0e035a600b951