### PR TITLE
Fix slotCount test

### DIFF
--- a/backend/tests/frontend/slotCount.test.js
+++ b/backend/tests/frontend/slotCount.test.js
@@ -7,9 +7,7 @@ let html = fs.readFileSync(path.join(__dirname, '../../../payment.html'), 'utf8'
 html = html
   .replace(/<script[^>]+src="https?:\/\/[^>]+><\/script>/g, '')
   .replace(/<link[^>]+href="https?:\/\/[^>]+>/g, '')
-  .replace(/<script[^>]+src="js\/payment.js"[^>]*><\/script>/, '')
-  .replace(/<script[^>]+src="js\/modelViewerTouchFix.js"[^>]*><\/script>/, '')
-  .replace(/<script[^>]+src="js\/autoFullscreen.js"[^>]*><\/script>/, '');
+  .replace(/<script[^>]+src="js\/[^>]+><\/script>/g, '');
 
 function cycleKey() {
   const tz = 'America/New_York';


### PR DESCRIPTION
## Summary
- avoid executing extraneous scripts when loading payment.html in `slotCount.test.js`

## Testing
- `npm test --prefix backend`
- `npm run ci`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68617dc77484832d8e11d2fe54ae5437