### PR TITLE
Add advert placeholder to gallery

### DIFF
--- a/js/publicGalleries.js
+++ b/js/publicGalleries.js
@@ -58,7 +58,15 @@ window.addEventListener("DOMContentLoaded", () => {
     const urls = sampleGalleries[currentTag] || [];
     const visible = urls.slice(0, offset + 6);
     grid.innerHTML = "";
-    visible.forEach((u) => {
+
+    const advert = document.createElement("div");
+    advert.className =
+      "w-full h-32 bg-[#2A2A2E] border border-dashed border-white/40 rounded-xl flex items-center justify-center text-sm";
+    advert.textContent = "Advert Placeholder";
+    grid.appendChild(advert);
+
+    visible.forEach((u, idx) => {
+      if (idx === 0) return;
       const img = document.createElement("img");
       img.src = u;
       img.loading = "lazy";


### PR DESCRIPTION
## Summary
- add placeholder advert to the public galleries grid

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_686187482114832d942a9a438e1ce294