### PR TITLE
Fix popup to show 3D model

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1108,7 +1108,7 @@ async function init() {
     popupEl.innerHTML = "";
     const span = document.createElement("span");
     span.textContent = msg;
-    if (msg.includes("created a model")) {
+    if (msg.includes("created a model") || msg.includes("bought a print")) {
       const viewer = document.createElement("model-viewer");
       viewer.src = "https://modelviewer.dev/shared-assets/models/Astronaut.glb";
       viewer.setAttribute(


### PR DESCRIPTION
## Summary
- update popup logic so "Someone just bought a print" uses the model-viewer

## Testing
- `npm test`
- `npm run ci`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68618b2f4880832d986482d9232c0ee4