### PR TITLE
Remove redundant sort filter

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -159,14 +159,6 @@
           <option value="miniatures">Miniatures</option>
           <option value="props">Props</option>
         </select>
-        <select
-          id="sort"
-          aria-label="Sort order"
-          class="bg-[#2A2A2E] border border-white/20 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[#4A4A4E] h-11"
-        >
-          <option value="desc">Newest</option>
-          <option value="asc">Oldest</option>
-        </select>
         <input
           type="text"
           id="search"

--- a/js/community.js
+++ b/js/community.js
@@ -365,7 +365,7 @@ function applyRecentViewer() {
   const viewer = createViewerCard(modelUrl);
 
   // Let the grid determine the final height so alignment matches
-  
+
   viewer.classList.add("row-span-3");
 
   const insertBefore = grid.children[0];
@@ -382,8 +382,7 @@ function addRecentModel(model) {
   const filters = getFilters();
   if (
     !filters.search &&
-    (!filters.category || filters.category === model.category) &&
-    filters.order !== "asc"
+    (!filters.category || filters.category === model.category)
   ) {
     const key = `${filters.category}|${filters.search}|${filters.order}`;
     const cache = window.communityState.recent;
@@ -399,7 +398,7 @@ function addRecentModel(model) {
 function getFilters() {
   const category = document.getElementById("category").value;
   const search = document.getElementById("search")?.value || "";
-  const order = document.getElementById("sort")?.value || "desc";
+  const order = "desc";
   return { category, search, order, key: `${category}|${search}|${order}` };
 }
 
@@ -549,17 +548,6 @@ function init() {
     loadMore("popular");
     loadMore("recent");
   });
-  const sortSelect = document.getElementById("sort");
-  if (sortSelect) {
-    sortSelect.addEventListener("change", () => {
-      document.getElementById("recent-grid").innerHTML = "";
-      document.getElementById("popular-grid").innerHTML = "";
-      window.communityState = { recent: {}, popular: {} };
-      saveState();
-      loadMore("popular");
-      loadMore("recent");
-    });
-  }
   const searchInput = document.getElementById("search");
   if (searchInput) {
     function onSearchInput() {


### PR DESCRIPTION
## Summary
- remove the "Newest/Oldest" dropdown from Community Creations
- default sort to newest in `community.js`

## Testing
- `npm run setup`
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `npm run ci`
- `CI=1 npx playwright install --with-deps`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68618ccb7a04832d8e24d7945026126e