### PR TITLE
fix: remove outdated marketplace blurb

### DIFF
--- a/marketplace.html
+++ b/marketplace.html
@@ -117,9 +117,7 @@
         <div class="bg-[#2A2A2E] p-4 rounded-xl border border-white/10">
           <h2 class="text-xl font-semibold mb-2">Your Marketplace</h2>
           <p>
-            Models you upload appear here. When someone purchases one of your
-            designs, you earn credits towards future prints. Either create a
-            model using this website, or
+            Either create a model using this website, or
             <a
               href="#"
               class="font-bold text-[#30D5C8]"


### PR DESCRIPTION
## Summary
- remove the credit-earning blurb from the Marketplace page

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `CI=1 npx playwright install --with-deps`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6861908a2f10832d9427a8739cf959f0