### PR TITLE
Fix Luckybox panel alignment

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -165,7 +165,7 @@
         </div>
         <section
           id="addons-grid"
-          class="grid grid-cols-2 gap-6 mt-2 w-full lg:w-2/5"
+          class="grid grid-cols-2 gap-6 w-full lg:w-2/5 mt-2 lg:mt-0"
         ></section>
       </div>
     </main>


### PR DESCRIPTION
## Summary
- align Luckybox card with right-hand panels on addons page

## Testing
- `npm run format`
- `npm test`
- `npx playwright test e2e/smoke.test.js` *(fails: Playwright Test did not expect test() to be called here)*

------
https://chatgpt.com/codex/tasks/task_e_68619a4b3888832dbdc58c879be3f63c