### PR TITLE
Fix smoke test execution error

### DIFF
--- a/e2e/smoke.test.js
+++ b/e2e/smoke.test.js
@@ -1,3 +1,10 @@
+if (require.main === module) {
+  console.error(
+    'This file is a Playwright test. Run it with "npx playwright test e2e/smoke.test.js".'
+  );
+  process.exit(1);
+}
+
 const { test, expect } = require('@playwright/test');
 const { percySnapshot } = require('@percy/playwright');
 


### PR DESCRIPTION
## Summary
- add guard to `e2e/smoke.test.js` to show helpful message when run directly

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`
- `CI=1 npx playwright install --with-deps`
- `npx playwright test e2e/smoke.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68619ddb41e8832da338a89c20654b51