### PR TITLE
Fix back navigation from payment

### DIFF
--- a/js/basket.js
+++ b/js/basket.js
@@ -329,6 +329,8 @@ export function setupBasketUI() {
     closeBasket();
     if (location.pathname.endsWith("addons.html")) {
       sessionStorage.setItem("fromAddons", "1");
+    } else if (location.pathname.endsWith("marketplace.html")) {
+      sessionStorage.setItem("fromMarketplace", "1");
     }
     window.location.href = "payment.html";
   });

--- a/js/marketplace.js
+++ b/js/marketplace.js
@@ -8,6 +8,7 @@ function createCard(item) {
   div.querySelector(".buy").addEventListener("click", () => {
     localStorage.setItem("print3Model", item.file_path);
     if (item.job_id) localStorage.setItem("print3JobId", item.job_id);
+    sessionStorage.setItem("fromMarketplace", "1");
     window.location.href = "payment.html";
   });
   return div;

--- a/marketplace.html
+++ b/marketplace.html
@@ -152,5 +152,14 @@
     <script type="module" src="js/trackingPixel.js"></script>
     <script type="module" src="js/marketplace.js"></script>
     <script type="module" src="js/basket.js"></script>
+    <script>
+      document.addEventListener("DOMContentLoaded", () => {
+        document.querySelectorAll('a[href="payment.html"]').forEach((link) => {
+          link.addEventListener("click", () => {
+            sessionStorage.setItem("fromMarketplace", "1");
+          });
+        });
+      });
+    </script>
   </body>
 </html>

--- a/payment.html
+++ b/payment.html
@@ -752,6 +752,8 @@
         sessionStorage.removeItem('fromCommunity');
         const fromAddons = sessionStorage.getItem('fromAddons');
         sessionStorage.removeItem('fromAddons');
+        const fromMarketplace = sessionStorage.getItem('fromMarketplace');
+        sessionStorage.removeItem('fromMarketplace');
         try {
           const ref = new URL(document.referrer);
           if (
@@ -761,10 +763,16 @@
             target = 'CommunityCreations.html';
           } else if (fromAddons === '1' || ref.pathname.endsWith('addons.html')) {
             target = 'addons.html';
+          } else if (
+            fromMarketplace === '1' ||
+            ref.pathname.endsWith('marketplace.html')
+          ) {
+            target = 'marketplace.html';
           }
         } catch {
           if (fromCommunity === '1') target = 'CommunityCreations.html';
           else if (fromAddons === '1') target = 'addons.html';
+          else if (fromMarketplace === '1') target = 'marketplace.html';
         }
         link.setAttribute('href', target);
       });


### PR DESCRIPTION
## Summary
- ensure going back from checkout after visiting Marketplace returns to Marketplace
- set a session flag when navigating to payment from Marketplace
- support the new flag in basket checkout

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `CI=1 npx playwright install --with-deps`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6861a6d45eac832da2a4f7497ea8428e