### PR TITLE
Add advert slot to recent creations

### DIFF
--- a/js/community.js
+++ b/js/community.js
@@ -348,17 +348,23 @@ function applyRecentViewer() {
   const grid = document.getElementById("recent-grid");
   if (!grid) return;
 
-  const existing = grid.querySelector(".viewer-card");
-  if (existing) existing.remove();
+  const existingViewer = grid.querySelector(".viewer-card");
+  if (existingViewer) existingViewer.remove();
+
+  const existingAd = grid.querySelector(".recent-ad");
+  if (existingAd) existingAd.remove();
 
   const cards = Array.from(grid.children);
   if (cards.length < 2) return;
-  const modelUrl = cards[1].dataset.model;
+
+  const nonAds = cards.filter((c) => !c.classList.contains("recent-ad"));
+  if (nonAds.length < 2) return;
+  const modelUrl = nonAds[1].dataset.model;
   if (!modelUrl) return;
 
   const toRemove = [];
-  for (let i = 0; i < Math.min(cards.length, 9); i += 3) {
-    if (cards[i]) toRemove.push(cards[i]);
+  for (let i = 0; i < Math.min(nonAds.length, 9); i += 3) {
+    if (nonAds[i]) toRemove.push(nonAds[i]);
   }
   toRemove.forEach((el) => el.remove());
 
@@ -371,6 +377,13 @@ function applyRecentViewer() {
   const insertBefore = grid.children[0];
   if (insertBefore) grid.insertBefore(viewer, insertBefore);
   else grid.appendChild(viewer);
+
+  const advert = document.createElement("div");
+  advert.className =
+    "recent-ad w-full h-32 bg-[#2A2A2E] border border-dashed border-white/40 rounded-xl flex items-center justify-center text-sm";
+  advert.textContent = "Advert Placeholder";
+  if (grid.children[2]) grid.insertBefore(advert, grid.children[2]);
+  else grid.appendChild(advert);
 }
 
 function addRecentModel(model) {


### PR DESCRIPTION
## Summary
- show an advert placeholder in the Recent section of Community Creations
- keep only real model cards when inserting the viewer and ad

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6861b0ccdc84832d8b1ca90152fbdb9d