### PR TITLE
Add advert placeholder to Recent grid

### DIFF
--- a/js/community.js
+++ b/js/community.js
@@ -435,6 +435,13 @@ function renderGrid(type, filters = getFilters()) {
   const { key } = filters;
   const grid = document.getElementById(`${type}-grid`);
   grid.innerHTML = "";
+  if (type === "recent") {
+    const advert = document.createElement("div");
+    advert.className =
+      "w-full h-32 bg-[#2A2A2E] border border-dashed border-white/40 rounded-xl flex items-center justify-center text-sm row-start-1 sm:col-start-2 md:col-start-3";
+    advert.textContent = "Advert Placeholder";
+    grid.appendChild(advert);
+  }
   let state = window.communityState[type][key];
   if (state && state.models.length) {
     state.models.forEach((m) => grid.appendChild(createCard(m)));


### PR DESCRIPTION
## Summary
- add an advert placeholder card at the start of the Recent grid
- format backend files and run full test suite

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_686268596584832d92a564f63439f750