### PR TITLE
Fix competitions message alignment

### DIFF
--- a/js/competitions.js
+++ b/js/competitions.js
@@ -110,13 +110,13 @@ async function load() {
   if (!res.ok) {
     // When the competitions API fails, show a friendly message
     list.innerHTML =
-      '<p class="text-center text-white/80">No ongoing competitions right now. <a href="signup.html" class="font-bold text-[#30D5C8]">Sign Up</a> to hear when prizes are available.</p>';
+      '<p class="text-left text-white/80">No ongoing competitions right now.</p>';
     return;
   }
   const comps = await res.json();
   if (comps.length === 0) {
     list.innerHTML =
-      '<p class="text-center text-white/80">No ongoing competitions right now. <a href="signup.html" class="font-bold text-[#30D5C8]">Sign Up</a> to hear when prizes are available.</p>';
+      '<p class="text-left text-white/80">No ongoing competitions right now.</p>';
     return;
   }
   const themeEl = document.getElementById("current-theme");
@@ -125,7 +125,8 @@ async function load() {
   }
   comps.forEach((c) => {
     const div = document.createElement("div");
-    div.className = "bg-[#2A2A2E] p-4 rounded-xl space-y-2 border border-white/10";
+    div.className =
+      "bg-[#2A2A2E] p-4 rounded-xl space-y-2 border border-white/10";
     div.innerHTML = `<h2 class="text-xl">${c.name}</h2>
       <p class="text-[#30D5C8]">Theme: ${c.theme || ""}</p>
       <p>${c.prize_description || ""}</p>
@@ -413,7 +414,8 @@ async function loadPast() {
   }
   comps.forEach((c) => {
     const div = document.createElement("div");
-    div.className = "bg-[#2A2A2E] p-4 rounded-xl space-y-2 text-center border border-white/10";
+    div.className =
+      "bg-[#2A2A2E] p-4 rounded-xl space-y-2 text-center border border-white/10";
     div.innerHTML = `<h3 class="text-lg">${c.name}</h3>
       <div class="model-card relative h-32 border border-white/10 rounded-xl flex items-center justify-center cursor-pointer" data-model="${c.model_url}" data-job="${c.winner_model_id}">
         <img src="${c.snapshot || ""}" alt="Winning model" class="w-full h-full object-contain pointer-events-none" />


### PR DESCRIPTION
## Summary
- update message when no competitions are available

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `CI=1 npx playwright install --with-deps`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_686269d6fe0c832db08216b4837d69ac