### PR TITLE
Update Luckybox basic tier text and price

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -115,13 +115,15 @@
             id="luckybox-tier"
             class="bg-[#1A1A1D] text-sm border border-white/10 rounded px-2 py-1 w-full text-white"
           >
-            <option value="basic" selected>Basic Luckybox £20</option>
+            <option value="basic" selected>
+              Single Colour Luckybox £19.99
+            </option>
             <option value="multicolour">Multicolour Luckybox £29.99</option>
             <option value="premium">Premium Luckybox £59.99</option>
           </select>
           <p id="luckybox-desc" class="text-sm text-center">
             Get a (usually £39.99) single-colour print and 5 print points for
-            just £20.
+            just £19.99.
           </p>
           <label class="flex items-center space-x-2 text-sm">
             <input

--- a/js/addons.js
+++ b/js/addons.js
@@ -80,7 +80,7 @@ function initLuckybox() {
   if (!tier || !desc) return;
   const descriptions = {
     basic:
-      "Get a (usually £39.99) single-colour print and 5 print points for just £20.",
+      "Get a (usually £39.99) single-colour print and 5 print points for just £19.99.",
     multicolour:
       "Get a (usually £39.99) multicolour print and 5 print points for £29.99.",
     premium:


### PR DESCRIPTION
## Summary
- rename 'Basic Luckybox' to 'Single Colour Luckybox'
- update Luckybox description price to £19.99

## Testing
- `npm test`
- `npm run ci`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_686269f4ad78832db2bccc944c986831