### PR TITLE
Update setup script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,12 +5,12 @@ These guidelines apply to all automated agents (e.g. the Codex agent) working on
 ## Mandatory steps
 
 1. **Unset proxy variables** – before running any `npm` commands, execute `unset npm_config_http_proxy npm_config_https_proxy` to silence `http-proxy` warnings.
-2. **Install dependencies** – run `npm run setup` at the repository root. This script unsets proxy variables and runs `npm ci` in the root, `backend/`, and `backend/hunyuan_server/` if present.
+2. **Install dependencies** – run `npm run setup` at the repository root. This script unsets proxy variables, runs `npm ci` in the root, `backend/`, and `backend/hunyuan_server/` if present, and installs Playwright browsers.
 3. **Format code** – run `npm run format` in `backend/` to apply Prettier formatting.
 4. **Run tests** – execute `npm test` in `backend/`. If tests cannot run because of environment limitations, mention this in the PR.
 5. **Run full CI locally** – execute `npm run ci` at the repo root before opening a PR.
 
-6. **Install Playwright browsers** – run `CI=1 npx playwright install --with-deps` at the repository root to download browsers for running tests without interactive prompts.
+6. **Install Playwright browsers** – the setup script installs these automatically. If browsers are missing, run `CI=1 npx playwright install --with-deps` manually.
 7. **Run smoke tests** – execute `npx playwright test e2e/smoke.test.js` at the repository root. If the tests fail because Playwright isn't set up correctly, mention this in the PR.
 8. **Limit scope** – only modify files related to the task. Do not change anything under `img/`, `models/`, or `uploads/` unless explicitly requested. Avoid editing `docs/` unless the task specifically involves documentation.
 9. **Review your diff** – run `git status --short` and `git diff --stat` to ensure only intended files were modified. Revert any unrelated changes.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -6,3 +6,4 @@ npm ci --prefix backend
 if [ -f backend/hunyuan_server/package.json ]; then
   npm ci --prefix backend/hunyuan_server
 fi
+CI=1 npx playwright install --with-deps


### PR DESCRIPTION
## Summary
- install Playwright browsers as part of `npm run setup`
- mention automatic Playwright install in AGENTS guidelines

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `CI=1 npx playwright install --with-deps`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68626cf1da58832da17ed9b8a98c3b3e