### PR TITLE
Remove Luckybox theme dropdown

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -149,16 +149,6 @@
               class="bg-[#1A1A1D] border border-white/10 rounded px-2 py-1 text-sm w-full"
             />
           </label>
-          <select
-            id="luckybox-theme"
-            class="bg-[#1A1A1D] text-sm border border-white/10 rounded px-2 py-1 w-full text-white"
-          >
-            <option value="random" selected>No Theme</option>
-            <option value="halloween">Halloween</option>
-            <option value="christmas">Christmas</option>
-            <option value="scifi">Sci-Fi</option>
-            <option value="fantasy">Fantasy</option>
-          </select>
           <button class="bg-[#30D5C8] text-black px-3 py-1 rounded text-sm">
             Add to Basket
           </button>


### PR DESCRIPTION
## Summary
- remove the unused Luckybox theme selector

## Testing
- `npm test`
- `npm run ci`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68626a986a48832da083063ea02f03c9