### PR TITLE
Fix placeholder example in addons

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -145,7 +145,7 @@
             </span>
             <input
               type="text"
-              placeholder="e.g. dragons in space"
+              placeholder="e.g. medieval"
               class="bg-[#1A1A1D] border border-white/10 rounded px-2 py-1 text-sm w-full"
             />
           </label>


### PR DESCRIPTION
## Summary
- update Luckybox B example text in `addons.html`

## Testing
- `npm run format`
- `npm test --silent`
- `npm run ci`
- `npx playwright test e2e/smoke.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68626a24a31c832da4fa7383cc9ca278