### PR TITLE
Add circular buttons for Luckybox tiers

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -16,6 +16,23 @@
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css"
     />
+    <style>
+      #luckybox-tiers label span {
+        transition:
+          transform 0.2s ease,
+          box-shadow 0.2s ease;
+      }
+      #luckybox-tiers label:hover span,
+      #luckybox-tiers input:active + span {
+        transform: scale(1.04);
+      }
+      #luckybox-tiers input:checked + span {
+        transform: scale(1.04);
+        box-shadow:
+          0 0 10px rgba(48, 213, 200, 0.6),
+          0 6px 10px rgba(0, 0, 0, 0.6);
+      }
+    </style>
   </head>
   <body class="bg-[#1A1A1D] text-white font-sans flex flex-col min-h-screen">
     <header class="relative flex items-center py-4 px-6">
@@ -111,16 +128,60 @@
           class="model-card relative w-full lg:w-3/5 min-h-96 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 flex flex-col items-center space-y-2"
         >
           <span class="font-semibold text-lg">Luckybox</span>
-          <select
-            id="luckybox-tier"
-            class="bg-[#1A1A1D] text-sm border border-white/10 rounded px-2 py-1 w-full text-white"
+          <fieldset
+            id="luckybox-tiers"
+            class="flex w-full justify-between my-2"
           >
-            <option value="basic" selected>
-              Single Colour Luckybox £19.99
-            </option>
-            <option value="multicolour">Multicolour Luckybox £29.99</option>
-            <option value="premium">Premium Luckybox £59.99</option>
-          </select>
+            <label
+              class="cursor-pointer text-center flex flex-col items-center w-1/3"
+            >
+              <input
+                type="radio"
+                name="luckybox-tier"
+                value="basic"
+                class="sr-only peer"
+                checked
+              />
+              <span
+                class="w-24 h-24 flex flex-col items-center justify-center rounded-full border border-white/20 peer-checked:border-2 peer-checked:border-[#30D5C8]"
+              >
+                <span class="font-semibold">£19.99</span>
+                <span class="text-xs">single colour</span>
+              </span>
+            </label>
+            <label
+              class="cursor-pointer text-center flex flex-col items-center w-1/3"
+            >
+              <input
+                type="radio"
+                name="luckybox-tier"
+                value="multicolour"
+                class="sr-only peer"
+              />
+              <span
+                class="w-24 h-24 flex flex-col items-center justify-center rounded-full border border-white/20 peer-checked:border-2 peer-checked:border-[#30D5C8]"
+              >
+                <span class="font-semibold">£29.99</span>
+                <span class="text-xs">multicolour</span>
+              </span>
+            </label>
+            <label
+              class="cursor-pointer text-center flex flex-col items-center w-1/3"
+            >
+              <input
+                type="radio"
+                name="luckybox-tier"
+                value="premium"
+                class="sr-only peer"
+              />
+              <span
+                class="w-24 h-24 flex flex-col items-center justify-center rounded-full border border-white/20 peer-checked:border-2 peer-checked:border-[#30D5C8]"
+              >
+                <span class="font-semibold">£59.99</span>
+                <span class="text-xs">premium</span>
+              </span>
+            </label>
+          </fieldset>
           <p id="luckybox-desc" class="text-sm text-center">
             Get a (usually £39.99) single-colour print and 5 print points for
             just £19.99.

--- a/js/addons.js
+++ b/js/addons.js
@@ -75,9 +75,11 @@ async function checkAccess() {
 document.addEventListener("DOMContentLoaded", checkAccess);
 
 function initLuckybox() {
-  const tier = document.getElementById("luckybox-tier");
+  const tierRadios = document.querySelectorAll(
+    '#luckybox-tiers input[name="luckybox-tier"]',
+  );
   const desc = document.getElementById("luckybox-desc");
-  if (!tier || !desc) return;
+  if (!tierRadios.length || !desc) return;
   const descriptions = {
     basic:
       "Get a (usually £39.99) single-colour print and 5 print points for just £19.99.",
@@ -86,10 +88,16 @@ function initLuckybox() {
     premium:
       "Get a (usually £79.99) premium print and 10 print points for £59.99.",
   };
-  function update() {
-    desc.textContent = descriptions[tier.value] || descriptions.basic;
+  function selectedTier() {
+    const checked = document.querySelector(
+      '#luckybox-tiers input[name="luckybox-tier"]:checked',
+    );
+    return checked ? checked.value : "basic";
   }
-  tier.addEventListener("change", update);
+  function update() {
+    desc.textContent = descriptions[selectedTier()] || descriptions.basic;
+  }
+  tierRadios.forEach((r) => r.addEventListener("change", update));
   update();
 }
 


### PR DESCRIPTION
## Summary
- replace Luckybox tier dropdown in `addons.html` with circular radio buttons
- update `js/addons.js` to handle new tier radio buttons
- style Luckybox tier buttons like on the payment page

## Testing
- `npm run format` (backend)
- `npm test`
- `npm run ci`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6862747c351c832d95d146300a66b150