### PR TITLE
Move print2 Pro banner

### DIFF
--- a/competitions.html
+++ b/competitions.html
@@ -138,11 +138,6 @@
           </p>
         </div>
       </section>
-      <h2 class="text-2xl">Active Competitions</h2>
-      <h3 id="current-theme" class="text-lg text-[#30D5C8] mt-1"></h3>
-      <div id="list" class="space-y-4"></div>
-      <div id="comp-subscribe-msg" class="text-sm"></div>
-      <div id="entry-success" class="hidden text-green-400 mt-2"></div>
       <div
         id="printclub-banner"
         class="bg-[#30D5C8] text-black p-3 rounded-xl text-center hidden"
@@ -150,6 +145,11 @@
         Join <strong>print2 Pro</strong> for weekly prints.
         <a href="#" id="printclub-banner-link" class="underline">Learn more</a>
       </div>
+      <h2 class="text-2xl">Active Competitions</h2>
+      <h3 id="current-theme" class="text-lg text-[#30D5C8] mt-1"></h3>
+      <div id="list" class="space-y-4"></div>
+      <div id="comp-subscribe-msg" class="text-sm"></div>
+      <div id="entry-success" class="hidden text-green-400 mt-2"></div>
       <h2 class="text-2xl mt-8">Past Winners</h2>
       <div
         id="winners-grid"


### PR DESCRIPTION
## Summary
- show the print2 Pro banner above the "Active Competitions" heading

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68627685d6ec832daf004bbcb7740e6b