### PR TITLE
Fix luckybox pricing text

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -183,7 +183,7 @@
             </label>
           </fieldset>
           <p id="luckybox-desc" class="text-sm text-center">
-            Get a (usually £39.99) single-colour print and 5 print points for
+            Get a (usually £29.99) single-colour print and 5 print points for
             just £19.99.
           </p>
           <label class="flex items-center space-x-2 text-sm">

--- a/js/addons.js
+++ b/js/addons.js
@@ -82,7 +82,7 @@ function initLuckybox() {
   if (!tierRadios.length || !desc) return;
   const descriptions = {
     basic:
-      "Get a (usually £39.99) single-colour print and 5 print points for just £19.99.",
+      "Get a (usually £29.99) single-colour print and 5 print points for just £19.99.",
     multicolour:
       "Get a (usually £39.99) multicolour print and 5 print points for £29.99.",
     premium:


### PR DESCRIPTION
## Summary
- correct single-colour luckybox pricing from £39.99 to £29.99

## Testing
- `npm run format`
- `npm test`
- `npm run ci` *(fails: send-intel-report.js lines over 1600 bytes)*
- `npx playwright test e2e/smoke.test.js` *(failed: Playwright Test did not expect test() to be called here)*

------
https://chatgpt.com/codex/tasks/task_e_68627bb24be0832d8328df931c49799e