### PR TITLE
Clarify smoke test instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ These guidelines apply to all automated agents (e.g. the Codex agent) working on
 5. **Run full CI locally** – execute `npm run ci` at the repo root before opening a PR.
 
 6. **Install Playwright browsers** – the setup script installs these automatically. If browsers are missing, run `CI=1 npx playwright install --with-deps` manually.
-7. **Run smoke tests** – execute `npx playwright test e2e/smoke.test.js` at the repository root. If the tests fail because Playwright isn't set up correctly, mention this in the PR.
+7. **Run smoke tests** – execute `npx playwright test e2e/smoke.test.js` at the repository root. If you see `Playwright Test did not expect test()` or `No tests found`, it usually means `npm run setup` didn't finish properly. Re-run the setup script and try again. Mention any persistent setup problems in the PR.
 8. **Limit scope** – only modify files related to the task. Do not change anything under `img/`, `models/`, or `uploads/` unless explicitly requested. Avoid editing `docs/` unless the task specifically involves documentation.
 9. **Review your diff** – run `git status --short` and `git diff --stat` to ensure only intended files were modified. Revert any unrelated changes.
 10. **Include logs** – paste the output of `npm test` (or `npm run test-ci`) and `npm run format` in the PR description so maintainers can verify the steps.


### PR DESCRIPTION
## Summary
- clarify how to rerun setup when smoke tests error

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6862835fce58832d9d663387f1f5a547