### PR TITLE
Add print minis option

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -241,14 +241,27 @@
           <button class="bg-[#30D5C8] text-black px-3 py-1 rounded text-sm">
             Add to Basket
           </button>
-        </div>
-        <section
-          id="addons-grid"
-          class="grid grid-cols-2 gap-6 w-full lg:w-2/5 mt-2 lg:mt-0"
-        ></section>
       </div>
-    </main>
-    <script type="module" src="js/addons.js"></script>
+      <section
+        id="addons-grid"
+        class="grid grid-cols-2 gap-6 w-full lg:w-2/5 mt-2 lg:mt-0"
+      ></section>
+    </div>
+    <div
+      id="print-minis"
+      class="model-card relative w-full min-h-72 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 flex flex-col items-center space-y-2"
+    >
+      <span class="font-semibold text-lg">Print Minis</span>
+      <p class="text-sm text-center">
+        We'll print your design at roughly 75% scale for a pint-sized version.
+      </p>
+      <p class="text-sm text-center font-semibold">£14.99 per mini</p>
+      <button class="bg-[#30D5C8] text-black px-3 py-1 rounded text-sm">
+        Add to Basket
+      </button>
+    </div>
+  </main>
+  <script type="module" src="js/addons.js"></script>
     <script type="module" src="js/rewardBadge.js"></script>
     <script type="module" src="js/trackingPixel.js"></script>
     <script>


### PR DESCRIPTION
## Summary
- add a new 'Print Minis' section on the Add-ons page
- prints are ~75% scale and £14.99 each

## Testing
- `npm run format` (backend)
- `npm test` (backend)
- `npm run ci`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68628c8099f4832d87c37df247dacb41