### PR TITLE
Fix recent page grid

### DIFF
--- a/js/community.js
+++ b/js/community.js
@@ -425,6 +425,19 @@ async function loadMore(type, filters = getFilters()) {
   if (btn) {
     if (models.length < limit) {
       btn.classList.add("hidden");
+      if (type === "recent") {
+        const advertOffset = 1;
+        const total = grid.children.length;
+        const remainder = (total - advertOffset) % 3;
+        for (let i = 0; i < remainder; i++) {
+          const last = grid.lastElementChild;
+          if (last) {
+            last.remove();
+            state.models.pop();
+            state.offset -= 1;
+          }
+        }
+      }
     } else {
       btn.classList.remove("hidden");
     }


### PR DESCRIPTION
## Summary
- remove stray panel in Recent grid on 'More' click
- trim leftover items if the last page isn't full

## Testing
- `npm test`
- `npm run ci`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68628f6aefb8832db518d9a9c4c5228f