### PR TITLE
docs: add setup step for Playwright

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,15 @@ This repository contains the early MVP code for print2's website and backend.
 - Optional: `HUNYUAN_SERVER_URL` if your Hunyuan API runs on a custom URL.
 - Optional: `DALLE_SERVER_URL` if the DALL-E server runs on a custom URL.
 
-2. Install dependencies for the servers:
+2. Install all dependencies and the Playwright browsers:
 
    ```bash
-   cd backend && npm install
-   cd hunyuan_server && npm install
-   cd ../dalle_server && npm install
+   npm run setup
    ```
+
+   This script runs `npm ci` in the root, `backend/`, and
+   `backend/hunyuan_server/` if present, then downloads the browsers
+   required for the end-to-end tests.
 
 3. Initialize the database:
 


### PR DESCRIPTION
## Summary
- describe running `npm run setup` in README

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_686295230bb4832db9a93dbfe22cc2e1