### PR TITLE
Fix Docker apt update issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,9 @@ RUN if [ -f backend/hunyuan_server/package-lock.json ]; then \
 
 # -------- copy source and run CI
 COPY . .
-RUN npx playwright install --with-deps
+RUN apt-get update --fix-missing \
+    && npx playwright install --with-deps \
+    && rm -rf /var/lib/apt/lists/*
 RUN if [ "$SKIP_TESTS" = "1" ]; then \
       echo "\u2139\uFE0F  CI tests skipped (SKIP_TESTS=1)"; \
     else \


### PR DESCRIPTION
## Summary
- retry apt update when installing Playwright dependencies

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6862971c5374832daa9455174a3f8880