### PR TITLE
Update smoke test troubleshooting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ These guidelines apply to all automated agents (e.g. the Codex agent) working on
 4. **Run tests** – execute `npm test` in `backend/`. If tests cannot run because of environment limitations, mention this in the PR.
 5. **Run full CI locally** – execute `npm run ci` at the repo root before opening a PR.
 6. **Install Playwright browsers** – the setup script installs these automatically. If browsers are missing, run `CI=1 npx playwright install --with-deps` manually.
-7. **Run smoke tests** – execute `npx playwright test e2e/smoke.test.js` at the repository root. If the tests fail because Playwright isn't set up correctly or display `Playwright Test did not expect test()` errors, run `npm run setup` and re-run the smoke tests. If problems persist, mention the exact error in the PR.
+7. **Run smoke tests** – execute `npx playwright test e2e/smoke.test.js` at the repository root. If the tests fail with messages like `Executable doesn't exist` or `Playwright Test did not expect test()`, run `npm run setup` (which installs the browsers) and re-run the smoke tests. If problems persist, mention the exact error in the PR.
 8. **Limit scope** – only modify files related to the task. Do not change anything under `img/`, `models/`, or `uploads/` unless explicitly requested. Avoid editing `docs/` unless the task specifically involves documentation.
 9. **Review your diff** – run `git status --short` and `git diff --stat` to ensure only intended files were modified. Revert any unrelated changes.
 10. **Include logs** – paste the output of `npm test` (or `npm run test-ci`) and `npm run format` in the PR description so maintainers can verify the steps.


### PR DESCRIPTION
## Summary
- clarify the troubleshooting step in `AGENTS.md` for missing Playwright browsers

## Testing
- `npm run format --prefix backend`
- `npm run test:ci`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_686298984020832d8f68ece58c639930