### PR TITLE
Fix payment page spacing

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -292,7 +292,7 @@
           <h2 class="text-2xl font-semibold mb-4 text-center">Checkout</h2>
           <form id="checkout-form" class="space-y-[0.33rem]">
             <!-- Material/Size Options -->
-            <fieldset id="material-options" class="flex w-full justify-between my-4">
+            <fieldset id="material-options" class="flex w-full justify-between">
               <label
                 class="cursor-not-allowed text-center flex flex-col items-center w-1/3 opacity-50"
               >
@@ -526,7 +526,6 @@
             </div>
             <div id="advanced-section" class="space-y-[0.33rem]">
               <div class="flex flex-col" id="addressStub">
-                <label for="ship-address" class="font-medium">Address</label>
                 <input
                   id="addressStubInput"
                   type="text"
@@ -581,13 +580,13 @@
               </div>
               <p id="discount-msg" class="text-xs text-center"></p>
 
-              <div id="credit-option" class="my-2 text-sm hidden">
+              <div id="credit-option" class="text-sm hidden">
                 <label class="flex items-center gap-1">
                   <input type="checkbox" id="use-credit" class="accent-[#30D5C8]" />
                   Use print2 Pro credit (<span id="credits-remaining">0</span> left this week)
                 </label>
               </div>
-              <div id="sale-credit-option" class="my-2 text-sm hidden">
+              <div id="sale-credit-option" class="text-sm hidden">
                 <label class="flex items-center gap-1">
                   <input type="checkbox" id="use-sale-credit" class="accent-[#30D5C8]" />
                   Use account credit (£<span id="sale-credit-balance">0.00</span> available)


### PR DESCRIPTION
## Summary
- remove address label from checkout form
- keep consistent spacing between inputs

## Testing
- `npm test`
- `npm run ci`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68629ad003b0832d99ba04232d6b31ea