### PR TITLE
Fix Luckybox panel height

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -150,7 +150,7 @@
       <div class="flex flex-col lg:flex-row gap-6">
         <div
           id="luckybox"
-          class="model-card relative w-full lg:w-3/5 min-h-96 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 flex flex-col items-center space-y-2"
+          class="model-card relative w-full lg:w-3/5 min-h-80 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 flex flex-col items-center space-y-2"
         >
           <span class="font-semibold text-lg">Luckybox</span>
           <fieldset
@@ -274,7 +274,6 @@
         Add to Basket
       </button>
     </div>
-  </div>
   </main>
   <script type="module" src="js/addons.js"></script>
 


### PR DESCRIPTION
## Summary
- shrink Luckybox panel height so it fits above the fold
- remove stray closing tag in `addons.html`

## Testing
- `npm run format` (backend)
- `npm test` (backend)
- `npm run ci`
- `CI=1 npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6862a2d20184832d93fa19ba0f94ba04