### PR TITLE
Fix spacing for discount code section

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,7 @@ node_modules
 uploads
 payment.html
 competitions.html
+addons.html
 
 # Build artifacts
 dist

--- a/payment.html
+++ b/payment.html
@@ -92,6 +92,10 @@
       .collapsible.expanded {
         max-height: 500px; /* big enough for any content */
       }
+      /* Remove extra spacing when address fields are collapsed */
+      #advanced-section > .collapsible.collapsed {
+        margin-top: 0;
+      }
 
       /* Highlight the selected pricing tier */
       #material-options label span {


### PR DESCRIPTION
## Summary
- avoid extra margin when address section is collapsed on the checkout page
- ignore `addons.html` for prettier

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6862a4992f30832db6778fbf990b4db0