### PR TITLE
Fix Luckybox button spacing

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -153,12 +153,9 @@
           class="model-card relative w-full lg:w-3/5 min-h-96 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 flex flex-col items-center space-y-2"
         >
           <span class="font-semibold text-lg">Luckybox</span>
-          <fieldset
-            id="luckybox-tiers"
-            class="flex w-full justify-between my-2"
-          >
+          <fieldset id="luckybox-tiers" class="flex justify-center gap-4 my-2">
             <label
-              class="cursor-pointer text-center flex flex-col items-center w-1/3"
+              class="cursor-pointer text-center flex flex-col items-center"
             >
               <input
                 type="radio"
@@ -174,7 +171,7 @@
               </span>
             </label>
             <label
-              class="cursor-pointer text-center flex flex-col items-center w-1/3"
+              class="cursor-pointer text-center flex flex-col items-center"
             >
               <input
                 type="radio"
@@ -191,7 +188,7 @@
               </span>
             </label>
             <label
-              class="cursor-pointer text-center flex flex-col items-center w-1/3"
+              class="cursor-pointer text-center flex flex-col items-center"
             >
               <input
                 type="radio"
@@ -265,18 +262,17 @@
         id="print-minis"
         class="model-card relative w-full lg:w-2/5 min-h-72 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 flex flex-col items-center space-y-2 mt-2 lg:mt-0"
       >
-      <span class="font-semibold text-lg">Print Minis</span>
-      <p class="text-sm text-center">
-        We'll print your design at roughly 75% scale for a pint-sized version.
-      </p>
-      <p class="text-sm text-center font-semibold">£14.99 per mini</p>
-      <button class="bg-[#30D5C8] text-black px-3 py-1 rounded text-sm">
-        Add to Basket
-      </button>
-    </div>
-  </div>
-  </main>
-  <script type="module" src="js/addons.js"></script>
+        <span class="font-semibold text-lg">Print Minis</span>
+        <p class="text-sm text-center">
+          We'll print your design at roughly 75% scale for a pint-sized version.
+        </p>
+        <p class="text-sm text-center font-semibold">£14.99 per mini</p>
+        <button class="bg-[#30D5C8] text-black px-3 py-1 rounded text-sm">
+          Add to Basket
+        </button>
+      </div>
+    </main>
+    <script type="module" src="js/addons.js"></script>
 
     <script type="module" src="js/rewardBadge.js"></script>
     <script type="module" src="js/trackingPixel.js"></script>


### PR DESCRIPTION
## Summary
- keep the Luckybox tier buttons close together

## Testing
- `npm run format`
- `npm test`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6862a4fa18e4832da628ae90988fbcb0