### PR TITLE
Hide nav arrows when basket has one item

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,11 @@ submits the order immediately and redirects to the Stripe checkout page.
 
 Users can drag and drop image files onto the upload area on `index.html`.
 
+### Payment Page Model Controls
+
+Hide the left and right arrow buttons on `payment.html`'s `.glb` viewer when the
+basket contains only one item.
+
 ## Sharing API
 
 Models can be shared publicly via unique slugs.

--- a/js/payment.js
+++ b/js/payment.js
@@ -847,6 +847,17 @@ async function initPaymentPage() {
   const nextBtn = document.getElementById("next-model");
   const removeBtn = document.getElementById("remove-model");
 
+  function updateNavButtons() {
+    if (!prevBtn || !nextBtn) return;
+    if (checkoutItems.length > 1) {
+      prevBtn.classList.remove("hidden");
+      nextBtn.classList.remove("hidden");
+    } else {
+      prevBtn.classList.add("hidden");
+      nextBtn.classList.add("hidden");
+    }
+  }
+
   function showItem(idx) {
     if (!checkoutItems.length) return;
     currentIndex = (idx + checkoutItems.length) % checkoutItems.length;
@@ -908,6 +919,7 @@ async function initPaymentPage() {
         removeBtn.classList.add("hidden");
       }
     }
+    updateNavButtons();
     applyStoredColorIfNeeded();
     updatePayButton();
     updateFlashSaleBanner();
@@ -1150,6 +1162,7 @@ async function initPaymentPage() {
       );
     }
     viewer.addEventListener("load", applyStoredColorIfNeeded, { once: true });
+    updateNavButtons();
   } else {
     const first = checkoutItems[0];
     viewer.src = first.modelUrl || FALLBACK_GLB;
@@ -1163,6 +1176,7 @@ async function initPaymentPage() {
       if (checkoutItems.length > 1) removeBtn.classList.remove("hidden");
       else removeBtn.classList.add("hidden");
     }
+    updateNavButtons();
   }
 
   if (!checkoutItems.length && qtySelect) {


### PR DESCRIPTION
## Summary
- hide prev/next arrows on payment viewer when only one basket item
- document behavior in README

## Testing
- `npm run format` (backend)
- `npm test` (backend)
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6862a4c52590832db9e6570b8ece604e