### PR TITLE
Fix uneditable address field

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -529,16 +529,7 @@
               />
             </div>
             <div id="advanced-section" class="space-y-[0.33rem]">
-              <div class="flex flex-col" id="addressStub">
-                <input
-                  id="addressStubInput"
-                  type="text"
-                  placeholder="Tap to add address…"
-                  class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10 text-gray-400 cursor-pointer"
-                  readonly
-                />
-              </div>
-              <div id="addressGroup" class="collapsible collapsed">
+              <div id="addressGroup">
                 <div>
                   <input
                     id="ship-address"

--- a/print2pro-checkout.html
+++ b/print2pro-checkout.html
@@ -79,17 +79,8 @@
               aria-label="Email"
             />
           </div>
-          <div class="flex flex-col" id="addressStub">
+          <div id="addressGroup" class="flex flex-col">
             <label for="ship-address" class="font-medium">Address</label>
-            <input
-              id="addressStubInput"
-              type="text"
-              placeholder="Tap to add address…"
-              class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10 text-gray-400 cursor-pointer"
-              readonly
-            />
-          </div>
-          <div id="addressGroup" class="collapsible collapsed">
             <div>
               <input
                 id="ship-address"


### PR DESCRIPTION
## Summary
- remove the read-only address stub on payment pages
- show the real address inputs so they work like other fields

## Testing
- `npm test`
- `npm run ci`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6862b414090c832da628c3b78d391065