### PR TITLE
Update smoke test process

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ These guidelines apply to all automated agents (e.g. the Codex agent) working on
 4. **Run tests** – execute `npm test` in `backend/`. If tests cannot run because of environment limitations, mention this in the PR.
 5. **Run full CI locally** – execute `npm run ci` at the repo root before opening a PR.
 6. **Install Playwright browsers** – the setup script installs these automatically. If browsers are missing, run `CI=1 npx playwright install --with-deps` manually.
-7. **Run smoke tests** – execute `npx playwright test e2e/smoke.test.js` at the repository root. If the tests fail with messages like `Executable doesn't exist` or `Playwright Test did not expect test()`, run `npm run setup` (which installs the browsers) and re-run the smoke tests. If problems persist, mention the exact error in the PR.
+7. **Run smoke tests** – execute `npm run smoke` at the repository root. This script ensures dependencies and Playwright browsers are installed before running `npx playwright test e2e/smoke.test.js`. If problems persist, mention the exact error in the PR.
 8. **Limit scope** – only modify files related to the task. Do not change anything under `img/`, `models/`, or `uploads/` unless explicitly requested. Avoid editing `docs/` unless the task specifically involves documentation.
 9. **Review your diff** – run `git status --short` and `git diff --stat` to ensure only intended files were modified. Revert any unrelated changes.
 10. **Include logs** – paste the output of `npm test` (or `npm run test-ci`) and `npm run format` in the PR description so maintainers can verify the steps.

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "bundle:size": "size-limit",
     "setup": "scripts/setup.sh",
     "e2e": "playwright test",
+    "smoke": "npm run setup && npx playwright test e2e/smoke.test.js",
     "visual-test": "percy exec -- npm run e2e",
     "test:a11y": "playwright install chromium --with-deps && playwright test e2e/a11y.test.js",
     "netlify:deploy": "scripts/netlify-preflight.sh && netlify deploy"


### PR DESCRIPTION
## Summary
- add `smoke` script for running setup and smoke tests
- update agent guidelines to use the new script

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6862baf9629c832da453486725c74258