### PR TITLE
fix: adjust bulk discount tagline

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -775,7 +775,7 @@ async function initPaymentPage() {
           )}`
         : `save £${(TWO_PRINT_DISCOUNT / 100).toFixed(2)}`;
     bulkMsg.innerHTML =
-      '<span class="text-gray-400">Popular: keep one, gift two – </span>' +
+      '<span class="text-gray-400">Popular: keep one, gift one – </span>' +
       `<span class="text-white">${save}</span>`;
     bulkMsg.classList.remove("hidden");
   }


### PR DESCRIPTION
## Summary
- change the bulk discount tagline from "gift two" to "gift one"

## Testing
- `npm run format`
- `npm test` (backend)
- `npm run ci`
- `npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6862bf3951d8832db3ca431e04a7ad60