### PR TITLE
Fix payment page address field spacing

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -529,7 +529,7 @@
               />
             </div>
             <div id="advanced-section" class="space-y-[0.33rem]">
-              <div id="addressGroup">
+              <div id="addressGroup" class="space-y-[0.33rem]">
                 <div>
                   <input
                     id="ship-address"


### PR DESCRIPTION
## Summary
- make checkout address fields use consistent spacing

## Testing
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6862c09e7034832db2de07c6863e15eb