### PR TITLE
Remove duplicate Print Minis panels

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -258,35 +258,9 @@
         </div>
       </div>
 
-      <div
-        id="print-minis"
-        class="model-card relative w-full min-h-72 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 flex flex-col items-center space-y-2"
-      >
-        <span class="font-semibold text-lg">Print Minis</span>
-        <p class="text-sm text-center">
-          We'll print your design at roughly 75% scale for a tiny version.
-        </p>
-        <p class="text-sm text-center font-semibold">£14.99 per mini</p>
-        <button class="bg-[#30D5C8] text-black px-3 py-1 rounded text-sm">
-          Add to Basket
-        </button>
-      </div>
+      <!-- Additional Print Minis panels removed as requested -->
 
 
-      <div
-        id="print-minis"
-        class="model-card relative w-full lg:w-2/5 min-h-72 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 flex flex-col items-center space-y-2 mt-2 lg:mt-0"
-      >
-
-      <span class="font-semibold text-lg">Print Minis</span>
-      <p class="text-sm text-center">
-        We'll print your design at roughly 75% scale for a pint-sized version.
-      </p>
-      <p class="text-sm text-center font-semibold">£14.99 per mini</p>
-      <button class="bg-[#30D5C8] text-black px-3 py-1 rounded text-sm">
-        Add to Basket
-      </button>
-    </div>
   </main>
   <script type="module" src="js/addons.js"></script>
 


### PR DESCRIPTION
## Summary
- clean up `addons.html` by deleting two extra "Print Minis" sections

## Testing
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6862ddf1d124832d9ac347e4d5ce3289