### PR TITLE
Reposition addons grid under Print Minis

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -238,22 +238,24 @@
             Add to Basket
           </button>
         </div>
-        <section
-          id="addons-grid"
-          class="grid grid-cols-2 gap-6 w-full lg:w-2/5 mt-2 lg:mt-0"
-        ></section>
-        <div
-          id="print-minis"
-          class="model-card relative w-full min-h-72 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 flex flex-col items-center space-y-2"
-        >
-          <span class="font-semibold text-lg">Print Minis</span>
-          <p class="text-sm text-center">
-            We'll print your design at roughly 75% scale for a tiny version.
-          </p>
-          <p class="text-sm text-center font-semibold">£14.99 per mini</p>
-          <button class="bg-[#30D5C8] text-black px-3 py-1 rounded text-sm">
-            Add to Basket
-          </button>
+        <div class="w-full lg:w-2/5 flex flex-col gap-6">
+          <div
+            id="print-minis"
+            class="model-card relative w-full min-h-72 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 flex flex-col items-center space-y-2"
+          >
+            <span class="font-semibold text-lg">Print Minis</span>
+            <p class="text-sm text-center">
+              We'll print your design at roughly 75% scale for a tiny version.
+            </p>
+            <p class="text-sm text-center font-semibold">£14.99 per mini</p>
+            <button class="bg-[#30D5C8] text-black px-3 py-1 rounded text-sm">
+              Add to Basket
+            </button>
+          </div>
+          <section
+            id="addons-grid"
+            class="grid grid-cols-2 gap-6 w-full"
+          ></section>
         </div>
       </div>
 

--- a/js/addons.js
+++ b/js/addons.js
@@ -20,13 +20,13 @@ function renderPreview() {
   grid.innerHTML = "";
   const advert = document.createElement("div");
   advert.className =
-    "w-full h-32 bg-[#2A2A2E] border border-dashed border-white/40 rounded-xl flex items-center justify-center text-sm row-start-1 col-start-2";
+    "w-full h-48 bg-[#2A2A2E] border border-dashed border-white/40 rounded-xl flex items-center justify-center text-sm row-start-1 col-start-2";
   advert.textContent = "Advert Placeholder";
   grid.appendChild(advert);
   items.forEach((item) => {
     const div = document.createElement("div");
     div.className =
-      "model-card relative h-32 w-full bg-[#2A2A2E] border border-white/10 rounded-xl hover:bg-[#3A3A3E] transition-shape flex items-center justify-center";
+      "model-card relative h-48 w-full bg-[#2A2A2E] border border-white/10 rounded-xl hover:bg-[#3A3A3E] transition-shape flex items-center justify-center";
     div.innerHTML = `<img src="${item.img}" alt="${item.name}" class="w-full h-full object-contain pointer-events-none" />\n      <span class="sr-only">${item.name}</span>`;
     grid.appendChild(div);
   });


### PR DESCRIPTION
## Summary
- move central addon panels below the Print Minis section
- enlarge addon panel placeholders

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6862e57f0308832dae047bde961662ca