### PR TITLE
Ensure quantity defaults to 2 when single item

### DIFF
--- a/backend/tests/frontend/quantityDefault.test.js
+++ b/backend/tests/frontend/quantityDefault.test.js
@@ -1,0 +1,30 @@
+/** @jest-environment node */
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+function loadDom() {
+  const html = fs
+    .readFileSync(path.join(__dirname, '../../../payment.html'), 'utf8')
+    .replace(/<script[^>]+src="https?:\/\/[^>]+><\/script>/g, '')
+    .replace(/<link[^>]+href="https?:\/\/[^>]+>/g, '')
+    .replace(/<script[^>]+src="js\/modelViewerTouchFix.js"[^>]*><\/script>/, '');
+  const dom = new JSDOM(html, {
+    runScripts: 'dangerously',
+    resources: 'usable',
+    url: 'http://localhost/payment.html',
+  });
+  global.window = dom.window;
+  global.document = dom.window.document;
+  const script = fs.readFileSync(path.join(__dirname, '../../../js/payment.js'), 'utf8');
+  dom.window.eval(script);
+  return dom;
+}
+
+test('single item defaults quantity to 2', async () => {
+  const dom = loadDom();
+  dom.window.localStorage.setItem('print3Basket', JSON.stringify([{ modelUrl: 'm', jobId: 'j' }]));
+  dom.window.document.dispatchEvent(new dom.window.Event('DOMContentLoaded'));
+  await new Promise((r) => setTimeout(r, 0));
+  expect(dom.window.document.getElementById('print-qty').value).toBe('2');
+});

--- a/js/payment.js
+++ b/js/payment.js
@@ -1083,7 +1083,10 @@ async function initPaymentPage() {
   try {
     const arr = JSON.parse(localStorage.getItem("print3CheckoutItems"));
     if (Array.isArray(arr) && arr.length) {
-      if (arr.length === 1 && arr[0].qty == null) {
+      if (
+        arr.length === 1 &&
+        (arr[0].qty == null || parseInt(arr[0].qty, 10) === 1)
+      ) {
         arr[0].qty = 2;
       }
       checkoutItems = arr.map((it) => ({
@@ -1118,13 +1121,14 @@ async function initPaymentPage() {
           color: prev.color || null,
           etchName:
             prev.etchName || localStorage.getItem("print3EtchName") || "",
-          qty: Math.max(
-            1,
-            parseInt(
-              prev.qty ?? it.quantity ?? (basket.length === 1 ? "2" : "1"),
-              10,
-            ),
-          ),
+          qty: (() => {
+            let q = prev.qty ?? it.quantity;
+            if (basket.length === 1 && (q == null || parseInt(q, 10) === 1)) {
+              q = "2";
+            }
+            if (q == null) q = "1";
+            return Math.max(1, parseInt(q, 10));
+          })(),
         };
       });
       localStorage.setItem(


### PR DESCRIPTION
## Summary
- default quantity to 2 any time there is a single checkout item
- keep that quantity when navigating away and back
- test the quantity default logic

## Testing
- `npm run format` (backend)
- `npm test --color=false`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6862e9732824832d8d98613873aa34b2