### PR TITLE
Fix basket button on addons page

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -266,6 +266,7 @@
 
   </main>
   <script type="module" src="js/addons.js"></script>
+  <script type="module" src="js/basket.js"></script>
 
     <script type="module" src="js/rewardBadge.js"></script>
     <script type="module" src="js/trackingPixel.js"></script>


### PR DESCRIPTION
## Summary
- include basket.js script on addons page so the floating basket button renders

## Testing
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6862ebcc5dc4832dada050c844c17419