### PR TITLE
Add missing sale credit API test

### DIFF
--- a/backend/tests/saleCredits.test.js
+++ b/backend/tests/saleCredits.test.js
@@ -108,3 +108,13 @@ test("POST /api/credits/redeem deducts credit", async () => {
   expect(db.adjustSaleCredit).toHaveBeenCalledWith("u1", -500);
   expect(res.body.credit).toBe(100);
 });
+
+test("GET /api/credits returns credit balance", async () => {
+  db.getSaleCredit.mockResolvedValue(800);
+  const token = jwt.sign({ id: "u1" }, "secret");
+  const res = await request(app)
+    .get("/api/credits")
+    .set("authorization", `Bearer ${token}`);
+  expect(res.status).toBe(200);
+  expect(res.body.credit).toBe(800);
+});


### PR DESCRIPTION
## Summary
- add a test for the GET `/api/credits` endpoint

## Validation
- `npm test --prefix backend`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6862f4949a90832dbcfc1b3210e3f550