### PR TITLE
Update credit equivalents in leaderboard

### DIFF
--- a/earn-rewards.html
+++ b/earn-rewards.html
@@ -163,7 +163,7 @@
                   <th class="text-left px-2 py-1">User</th>
                   <th class="text-left px-2 py-1 whitespace-nowrap">
                     <span class="inline-block w-16 text-right">Points</span>
-                    <span class="text-[#30D5C8]">(equivalent spend)</span>
+                    <span class="text-[#30D5C8]">(equivalent credit)</span>
                   </th>
                 </tr>
               </thead>
@@ -172,21 +172,21 @@
                   <td class="px-2 py-1">Alex</td>
                   <td class="px-2 py-1 whitespace-nowrap">
                     <span class="inline-block w-16 text-right">150</span>
-                    <span class="text-[#30D5C8]">(£75)</span>
+                    <span class="text-[#30D5C8]">(£30)</span>
                   </td>
                 </tr>
                 <tr>
                   <td class="px-2 py-1">Blake</td>
                   <td class="px-2 py-1 whitespace-nowrap">
                     <span class="inline-block w-16 text-right">120</span>
-                    <span class="text-[#30D5C8]">(£60)</span>
+                    <span class="text-[#30D5C8]">(£24)</span>
                   </td>
                 </tr>
                 <tr>
                   <td class="px-2 py-1">Casey</td>
                   <td class="px-2 py-1 whitespace-nowrap">
                     <span class="inline-block w-16 text-right">100</span>
-                    <span class="text-[#30D5C8]">(£50)</span>
+                    <span class="text-[#30D5C8]">(£20)</span>
                   </td>
                 </tr>
               </tbody>


### PR DESCRIPTION
## Summary
- adjust Top Referrers credit values on the earn rewards page

## Testing
- `npm run setup`
- `npm run format`
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68638c4c81fc832db6744b89b486927a