### PR TITLE
Fix community recent grid alignment

### DIFF
--- a/js/community.js
+++ b/js/community.js
@@ -430,18 +430,18 @@ async function loadMore(type, filters = getFilters()) {
   if (btn) {
     if (models.length < limit) {
       btn.classList.add("hidden");
-      if (type === "recent") {
-        const advertOffset = 1;
-        while ((grid.children.length - advertOffset) % 3 !== 0) {
-          const last = grid.lastElementChild;
-          if (!last) break;
-          last.remove();
-          state.models.pop();
-          state.offset -= 1;
-        }
-      }
     } else {
       btn.classList.remove("hidden");
+    }
+  }
+  if (type === "recent") {
+    const advertOffset = 1;
+    while ((grid.children.length - advertOffset) % 3 !== 0) {
+      const last = grid.lastElementChild;
+      if (!last) break;
+      last.remove();
+      state.models.pop();
+      state.offset -= 1;
     }
   }
   saveState();


### PR DESCRIPTION
## Summary
- trim final card in community recent grid if it leaves a row incomplete

## Testing
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68638baf2ce4832d9e47ea5c89507656