### PR TITLE
Fix printclub button style

### DIFF
--- a/earn-rewards.html
+++ b/earn-rewards.html
@@ -195,7 +195,8 @@
           <div class="mt-4">
             <a
               href="printclub.html"
-              class="inline-block bg-gradient-to-r from-purple-500 to-pink-500 text-white rounded-3xl px-4 py-2 text-sm"
+              class="block w-full text-center font-bold py-2 px-4 rounded-full shadow-md transition border-2 border-black"
+              style="background-color: #30d5c8; color: #1a1a1d"
               >Join print2 Pro &amp; get 100 bonus points</a
             >
           </div>


### PR DESCRIPTION
## Summary
- match Print Club button style to Print from £29.99
- ensure button spans full width of the Top Referrers section

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68638d0495a0832d9f39f75e99b32225