### PR TITLE
Fix addons page layout

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -150,7 +150,7 @@
       <div class="flex flex-col lg:flex-row gap-6">
         <div
           id="luckybox"
-          class="model-card relative w-full lg:w-3/5 min-h-96 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 flex flex-col items-center space-y-2"
+          class="model-card relative w-full lg:w-3/5 min-h-72 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 flex flex-col items-center space-y-2"
         >
           <span class="font-semibold text-lg">Luckybox</span>
           <fieldset id="luckybox-tiers" class="flex justify-center gap-4 my-2">
@@ -260,12 +260,13 @@
               Add to Basket
             </button>
           </div>
-          <section
-            id="addons-grid"
-            class="grid grid-cols-2 gap-6 w-full"
-          ></section>
         </div>
       </div>
+
+      <section
+        id="addons-grid"
+        class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 w-full"
+      ></section>
 
       <!-- Additional Print Minis panels removed as requested -->
 


### PR DESCRIPTION
## Summary
- tweak Luckybox height to fit above the fold
- pull addons grid out into a full-width row and show four columns

## Testing
- `npm run setup`
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68638b31a8e8832db737f3c0cfc8d576