### PR TITLE
Add promo code toggle

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -433,6 +433,8 @@ async function initPaymentPage() {
   const discountInput = document.getElementById("discount-code");
   const discountMsg = document.getElementById("discount-msg");
   const applyBtn = document.getElementById("apply-discount");
+  const promoToggle = document.querySelector(".promo-toggle");
+  const promoBox = document.querySelector(".promo-input");
   const surpriseToggle = document.getElementById("surprise-toggle");
   const recipientFields = document.getElementById("recipient-fields");
   const qtySelect = document.getElementById("print-qty");
@@ -538,6 +540,9 @@ async function initPaymentPage() {
     colorMenu.classList.add("hidden");
   }
   initPlaceAutocomplete();
+  promoToggle?.addEventListener("click", () => {
+    if (promoBox) promoBox.hidden = !promoBox.hidden;
+  });
   let discountCodes = [];
   let discountValue = 0;
   let percentDiscount = 0;

--- a/luckybox-payment.html
+++ b/luckybox-payment.html
@@ -558,12 +558,15 @@
                 </div>
               </div>
 
-              <div class="flex gap-2">
+              <button type="button" class="promo-toggle text-sm underline">
+                Have a promo code?
+              </button>
+              <div class="promo-input flex gap-2 mt-2" hidden>
                 <input
                   id="discount-code"
                   class="flex-1 p-2 rounded-md bg-[#1A1A1D] border border-white/10"
-                  placeholder="Discount Codes (comma separated)"
-                  aria-label="Discount codes"
+                  placeholder="Promo code"
+                  aria-label="Promo code"
                 />
                 <button
                   id="apply-discount"

--- a/payment.html
+++ b/payment.html
@@ -558,12 +558,15 @@
                 </div>
               </div>
 
-              <div class="flex gap-2">
+              <button type="button" class="promo-toggle text-sm underline">
+                Have a promo code?
+              </button>
+              <div class="promo-input flex gap-2 mt-2" hidden>
                 <input
                   id="discount-code"
                   class="flex-1 p-2 rounded-md bg-[#1A1A1D] border border-white/10"
-                  placeholder="Discount Codes (comma separated)"
-                  aria-label="Discount codes"
+                  placeholder="Promo code"
+                  aria-label="Promo code"
                 />
                 <button
                   id="apply-discount"


### PR DESCRIPTION
## Summary
- hide discount code field behind a small toggle
- add click handler for the new promo code field

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6863900a66f0832d84bfaec4555f6f2f