### PR TITLE
Remove unused progress bar on rewards page

### DIFF
--- a/earn-rewards.html
+++ b/earn-rewards.html
@@ -130,12 +130,6 @@
             <label class="block text-sm"
               >Points: <span id="reward-points">0</span> ⭐</label
             >
-            <progress
-              id="reward-progress"
-              value="0"
-              max="200"
-              class="w-full h-2 rounded"
-            ></progress>
           </div>
           <div class="flex">
             <select


### PR DESCRIPTION
## Summary
- remove progress bar from `earn-rewards.html`

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6863969ff048832d9e485b5dc10cd99c