### PR TITLE
Fix setup script for interrupted dpkg

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -6,4 +6,6 @@ npm ci --prefix backend
 if [ -f backend/hunyuan_server/package.json ]; then
   npm ci --prefix backend/hunyuan_server
 fi
+# Ensure dpkg is fully configured before Playwright installs dependencies
+dpkg --configure -a || true
 CI=1 npx playwright install --with-deps


### PR DESCRIPTION
## Summary
- ensure `dpkg` is configured before Playwright dependencies install

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_686398c2c780832d8e027e915656f963