### PR TITLE
Fix modal close button placement

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -329,7 +329,7 @@
       class="fixed inset-0 bg-black/80 flex items-center justify-center hidden z-50"
     >
       <div
-        class="relative w-11/12 max-w-3xl bg-[#2A2A2E] border border-white/10 outline outline-white/20 rounded-xl overflow-hidden"
+        class="relative w-11/12 max-w-3xl bg-[#2A2A2E] border border-white/10 outline outline-white/20 rounded-xl"
       >
         <button
           id="close-modal"


### PR DESCRIPTION
## Summary
- prevent the model viewer modal close button from being clipped

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6863a28d9864832d9f5431d0f4ba930b