### PR TITLE
Fix leaderboard heading alignment

### DIFF
--- a/earn-rewards.html
+++ b/earn-rewards.html
@@ -149,7 +149,7 @@
           class="md:w-1/2 bg-[#2A2A2E] border border-white/10 p-6 rounded-2xl shadow-lg space-y-6 text-left"
         >
           <div>
-            <h3 class="text-2xl font-semibold mt-6 mb-2">
+            <h3 class="text-2xl font-semibold mb-2">
               What are others earning?
             </h3>
             <table class="w-full text-sm">


### PR DESCRIPTION
## Summary
- align "What are others earning?" heading with the left box on the earn rewards page

## Testing
- `npm test --silent`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6863a1297a88832db1dd8e7b317a2fd2