### PR TITLE
Change reward selector to input

### DIFF
--- a/earn-rewards.html
+++ b/earn-rewards.html
@@ -132,10 +132,12 @@
             >
           </div>
           <div class="flex">
-            <select
-              id="reward-select"
-              class="flex-1 bg-[#1A1A1D] border border-white/10 rounded-l-xl px-3 py-2"
-            ></select>
+            <input
+              id="reward-input"
+              type="number"
+              placeholder="£1 credit per 5 points. Type what you want to redeem"
+              class="flex-1 bg-[#1A1A1D] border border-white/10 rounded-l-xl px-3 py-2 placeholder-gray-500"
+            />
             <button
               class="bg-green-600 px-4 rounded-r-xl"
               onclick="redeemReward()"

--- a/js/rewards.js
+++ b/js/rewards.js
@@ -9,18 +9,6 @@ async function loadRewardOptions() {
     if (res.ok) {
       const { options } = await res.json();
       rewardOptions = options;
-      const sel = document.getElementById("reward-select");
-      if (sel) {
-        sel.innerHTML = "";
-        options.forEach((o) => {
-          const opt = document.createElement("option");
-          opt.value = o.points;
-          opt.textContent = `${o.points} pts - £${(
-            o.amount_cents / 100
-          ).toFixed(2)} off`;
-          sel.appendChild(opt);
-        });
-      }
     }
   } catch (err) {
     console.error("Failed to load reward options", err);
@@ -137,9 +125,9 @@ async function shareReferral(network) {
 }
 
 async function redeemReward() {
-  const sel = document.getElementById("reward-select");
-  if (!sel) return;
-  const points = parseInt(sel.value, 10);
+  const input = document.getElementById("reward-input");
+  if (!input) return;
+  const points = parseInt(input.value, 10);
   const token = localStorage.getItem("token");
   if (!token || !points) return;
   try {


### PR DESCRIPTION
## Summary
- swap reward select menu for an input box on earn-rewards page
- adjust rewards.js to read value from the new text input

## Testing
- `npm test --prefix backend`
- `npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_6863a1091490832dad7da373ffca69b3