### PR TITLE
Fix purchase popup

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1125,12 +1125,6 @@ async function init() {
     viewer.setAttribute("crossOrigin", "anonymous");
     viewer.className = "w-[13rem] h-[13rem] mb-2";
     popupEl.appendChild(viewer);
-    if (popupIdx % popupMsgs.length === 0 && lastSnapshot) {
-      const img = document.createElement("img");
-      img.src = lastSnapshot;
-      img.className = "w-10 h-10 rounded";
-      popupEl.appendChild(img);
-    }
     popupEl.appendChild(span);
     popupEl.classList.remove("hidden");
     popupEl.classList.remove("purchase-fade");


### PR DESCRIPTION
## Summary
- remove static snapshot image from purchase popup so only the GLB viewer shows

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6863a0988248832d94e3c54c9daede10