### PR TITLE
Fix apt lock in setup script

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,11 +1,20 @@
 #!/bin/bash
 set -e
 unset npm_config_http_proxy npm_config_https_proxy
+
+# Remove stale apt or dpkg locks that may prevent dependency installation
+if pgrep apt-get >/dev/null 2>&1; then
+  sudo pkill apt-get || true
+fi
+sudo rm -f /var/lib/apt/lists/lock /var/lib/dpkg/lock /var/cache/apt/archives/lock
+
 npm ci
 npm ci --prefix backend
 if [ -f backend/hunyuan_server/package.json ]; then
   npm ci --prefix backend/hunyuan_server
 fi
+
 # Ensure dpkg is fully configured before Playwright installs dependencies
-dpkg --configure -a || true
+sudo dpkg --configure -a || true
+
 CI=1 npx playwright install --with-deps


### PR DESCRIPTION
## Summary
- clear apt-related locks before running setup

## Testing
- `npm run setup`
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6863aa230730832da3dd210dfc17e1a5