### PR TITLE
Add subscribe button to print2 Pro page

### DIFF
--- a/printclub.html
+++ b/printclub.html
@@ -194,6 +194,13 @@
         }
       });
     </script>
+    <div class="text-center my-8">
+      <a
+        href="print2pro-checkout.html"
+        class="inline-block bg-[#30D5C8] text-[#1A1A1D] px-6 py-3 rounded-xl font-semibold hover:bg-[#28b7a8] transition"
+        >Subscribe Now £149.99/mo</a
+      >
+    </div>
     <div
       id="exit-discount-overlay"
       class="fixed inset-0 bg-black/80 flex items-center justify-center hidden z-50"


### PR DESCRIPTION
## Summary
- add a subscribe button to printclub page so users can join print2 Pro

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6863abe86e88832dbeaeaa7a95719b86