### PR TITLE
Adjust addon panel heights

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -150,7 +150,7 @@
       <div class="flex flex-col lg:flex-row gap-6 mt-12">
         <div
           id="luckybox"
-          class="model-card relative w-full lg:w-3/5 min-h-72 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 flex flex-col items-center space-y-2"
+          class="model-card relative w-full lg:w-3/5 min-h-72 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 pb-20 flex flex-col items-center space-y-2"
         >
           <span class="font-semibold text-lg">Luckybox</span>
           <fieldset id="luckybox-tiers" class="flex justify-center gap-4 my-2">
@@ -249,7 +249,7 @@
         <div class="w-full lg:w-2/5 flex flex-col gap-6">
           <div
             id="print-minis"
-            class="model-card relative w-full min-h-96 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 flex flex-col items-center space-y-2"
+            class="model-card relative w-full min-h-96 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 pb-20 flex flex-col items-center space-y-2"
           >
             <span class="font-semibold text-lg">Print Minis</span>
             <p class="text-sm text-center">


### PR DESCRIPTION
## Summary
- extend bottom padding on Luckybox and Print Minis panels in `addons.html`

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`
- `npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_6863add57320832dbefaa664a5345b46