### PR TITLE
Remove print count overlays

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -359,12 +359,6 @@
           class="w-full h-96 bg-[#2A2A2E]"
         ></model-viewer>
         <div
-          id="model-stats"
-          class="absolute top-2 left-2 text-xs bg-black/60 text-white px-2 py-1 rounded z-10 pointer-events-none"
-        >
-          <span id="print-count">🛒 4 prints sold</span>
-        </div>
-        <div
           id="modal-checkout-container"
           class="absolute bottom-4 right-4 flex flex-col items-center"
         >

--- a/competitions.html
+++ b/competitions.html
@@ -296,12 +296,6 @@
           class="w-full h-96 bg-[#2A2A2E] rounded-xl"
         ></model-viewer>
         <div
-          id="model-stats"
-          class="absolute top-2 left-2 text-xs bg-black/60 text-white px-2 py-1 rounded z-10 pointer-events-none"
-        >
-          <span id="print-count">🛒 4 prints sold</span>
-        </div>
-        <div
           id="modal-action-panel"
           class="absolute bottom-4 left-4 right-4 flex justify-between items-end"
         >


### PR DESCRIPTION
## Summary
- delete the stats overlay from community and competitions viewers

## Testing
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6863ac976c30832db0781eaf7a712ab5