### PR TITLE
Fix Print Minis panel alignment

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -249,7 +249,7 @@
         <div class="w-full lg:w-2/5 flex flex-col gap-6">
           <div
             id="print-minis"
-            class="model-card relative w-full min-h-96 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 pb-20 flex flex-col items-center space-y-2"
+            class="model-card relative w-full min-h-96 h-full bg-[#2A2A2E] border border-white/10 rounded-xl p-4 pb-20 flex flex-col items-center space-y-2"
           >
             <span class="font-semibold text-lg">Print Minis</span>
             <p class="text-sm text-center">


### PR DESCRIPTION
## Summary
- tweak Addons page so `Print Minis` panel stretches to match the Luckybox panel height

## Testing
- `npm run setup`
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6863b44b8398832dbc2375f8727ba783