### PR TITLE
Fix button widths on rewards page

### DIFF
--- a/earn-rewards.html
+++ b/earn-rewards.html
@@ -119,7 +119,7 @@
               />
               <button
                 aria-label="Copy referral link"
-                class="font-bold px-4 rounded-r-xl shadow-md transition border-2 border-black"
+                class="font-bold px-4 w-24 rounded-r-xl shadow-md transition border-2 border-black"
                 style="background-color: #30d5c8; color: #1a1a1d"
                 onmouseover="this.style.opacity='0.85'"
                 onmouseout="this.style.opacity='1'"
@@ -143,7 +143,7 @@
               class="flex-1 bg-[#1A1A1D] border border-white/10 rounded-l-xl px-3 py-2 placeholder-gray-500 appearance-none"
             />
             <button
-              class="font-bold px-4 rounded-r-xl shadow-md transition border-2 border-black"
+              class="font-bold px-4 w-24 rounded-r-xl shadow-md transition border-2 border-black"
               style="background-color: #30d5c8; color: #1a1a1d"
               onmouseover="this.style.opacity='0.85'"
               onmouseout="this.style.opacity='1'"


### PR DESCRIPTION
## Summary
- set a fixed width for the referral copy/redeem buttons so they match in size

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6863b460bac0832db1240dc75649dae8