### PR TITLE
Fix reward label spacing

### DIFF
--- a/earn-rewards.html
+++ b/earn-rewards.html
@@ -108,7 +108,7 @@
           </p>
           <div class="space-y-1">
             <label for="referral-link" class="block text-sm"
-              >Your referral link</label
+              >Your referral link:</label
             >
             <div class="flex">
               <input
@@ -132,10 +132,9 @@
           <div class="space-y-1">
             <label class="block text-sm"
               >Points: <span id="reward-points">0</span> ⭐ (5 points = £1
-              credit)</label
+              credit):</label
             >
-          </div>
-          <div class="flex">
+            <div class="flex">
             <input
               id="reward-input"
               type="number"
@@ -151,6 +150,7 @@
             >
               Redeem
             </button>
+          </div>
           </div>
           <p id="next-reward-msg" class="text-sm text-gray-300"></p>
         </div>


### PR DESCRIPTION
## Summary
- ensure `earn-rewards.html` reward section labels use colons
- align points label spacing with the input

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6863b4d3e0d0832d8f4b3c09985789e9