### PR TITLE
Add Luckybox option row

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -210,32 +210,6 @@
           <p id="luckybox-desc" class="text-sm text-center">
             £19.99 print + 5 print points (usually £29.99)
           </p>
-          <label class="flex items-center space-x-2 text-sm">
-            <input
-              type="radio"
-              name="luckybox-option"
-              value="A"
-              class="accent-[#30D5C8]"
-              checked
-            />
-            <span>Luckybox A: get a truly random print</span>
-          </label>
-          <label class="flex flex-col items-center w-full text-sm space-y-2">
-            <span class="flex items-center space-x-2">
-              <input
-                type="radio"
-                name="luckybox-option"
-                value="B"
-                class="accent-[#30D5C8]"
-              />
-              <span>Luckybox B: describe a genre</span>
-            </span>
-            <input
-              type="text"
-              placeholder="e.g. medieval"
-              class="bg-[#1A1A1D] border border-white/10 rounded px-2 py-1 text-sm w-full"
-            />
-          </label>
           <a
             href="luckybox-payment.html"
             class="font-bold py-2 px-5 rounded-full shadow-md transition border-2 border-black"
@@ -245,6 +219,35 @@
           >
             Buy →
           </a>
+          <div
+            id="luckybox-options"
+            class="flex items-center justify-center gap-4 mt-6 text-lg flex-wrap"
+          >
+            <label class="flex items-center space-x-2 whitespace-nowrap">
+              <input
+                type="radio"
+                name="luckybox-option"
+                value="A"
+                class="accent-[#30D5C8]"
+                checked
+              />
+              <span>Luckybox A (truly random print)</span>
+            </label>
+            <label class="flex items-center space-x-2 whitespace-nowrap">
+              <input
+                type="radio"
+                name="luckybox-option"
+                value="B"
+                class="accent-[#30D5C8]"
+              />
+              <span>Luckybox B (choose a theme):</span>
+            </label>
+            <input
+              type="text"
+              placeholder="e.g. medieval"
+              class="bg-[#1A1A1D] border border-white/10 rounded px-2 py-1 text-lg w-32"
+            />
+          </div>
         </div>
         <div class="w-full lg:w-2/5 flex flex-col gap-6">
           <div


### PR DESCRIPTION
## Summary
- update Luckybox section layout so the A/B selection and theme field appear in one line

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6863b70f8574832d942f673f4419a2d8