### PR TITLE
Update Print2 banner link

### DIFF
--- a/competitions.html
+++ b/competitions.html
@@ -142,7 +142,12 @@
         class="bg-[#30D5C8] text-black p-3 rounded-xl text-center hidden"
       >
         Join <strong>print2 Pro</strong> for weekly prints.
-        <a href="#" id="printclub-banner-link" class="underline">Learn more</a>
+        <a
+          href="printclub.html"
+          id="printclub-banner-link"
+          class="bg-gradient-to-r from-purple-500 to-pink-500 text-white rounded-3xl px-3 py-2 text-sm transition-shape ml-2 inline-block"
+          >Learn more</a
+        >
       </div>
       <h2 class="text-2xl">Active Competitions</h2>
       <h3 id="current-theme" class="text-lg text-[#30D5C8] mt-1"></h3>

--- a/js/printclub.js
+++ b/js/printclub.js
@@ -9,8 +9,10 @@ const API_BASE = (window.API_ORIGIN || "") + "/api";
 banner?.classList.remove("hidden");
 
 bannerLink?.addEventListener("click", (e) => {
-  e.preventDefault();
-  modal?.classList.remove("hidden");
+  if (bannerLink.getAttribute("href") === "#") {
+    e.preventDefault();
+    modal?.classList.remove("hidden");
+  }
 });
 closeBtn?.addEventListener("click", () => modal?.classList.add("hidden"));
 modal?.addEventListener("click", (e) => {


### PR DESCRIPTION
## Summary
- make Print2 banner link go directly to membership page
- style the Learn more link to match the header button
- allow popup only when link href is `#`

## Testing
- `npm run format` in `backend`
- `npm test --silent`
- `npm run ci`
- `npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_6863b5d51188832d8667e33574f0d081