### PR TITLE
Fix duplicate BUY button on print2 Pro page

### DIFF
--- a/printclub.html
+++ b/printclub.html
@@ -100,11 +100,6 @@
             multicolour tiers) every week, and unlimited £20 off premium tier
             (£79.99 -> £59.99).
           </p>
-          <a
-            href="print2pro-checkout.html"
-            class="inline-block bg-[#30D5C8] text-[#1A1A1D] px-6 py-3 rounded-xl font-semibold hover:bg-[#28b7a8] transition"
-            >Subscribe Now £149.99/mo</a
-          >
           <div class="text-left text-sm mt-4" id="loyalty-benefits">
             <h3 class="text-lg underline mb-1 text-center">Loyalty Rewards</h3>
             <ul class="list-disc list-inside space-y-1">
@@ -122,6 +117,11 @@
               </li>
             </ul>
           </div>
+          <a
+            href="print2pro-checkout.html"
+            class="inline-block bg-[#30D5C8] text-[#1A1A1D] px-6 py-3 rounded-xl font-semibold hover:bg-[#28b7a8] transition"
+            >Subscribe Now £149.99/mo</a
+          >
         </div>
         <figure
           class="w-full md:max-w-lg h-96 flex flex-col items-center justify-center border border-white/20 rounded-2xl bg-[#2A2A2E] text-sm shadow-lg p-6"
@@ -194,13 +194,6 @@
         }
       });
     </script>
-    <div class="text-center my-8">
-      <a
-        href="print2pro-checkout.html"
-        class="inline-block bg-[#30D5C8] text-[#1A1A1D] px-6 py-3 rounded-xl font-semibold hover:bg-[#28b7a8] transition"
-        >Subscribe Now £149.99/mo</a
-      >
-    </div>
     <div
       id="exit-discount-overlay"
       class="fixed inset-0 bg-black/80 flex items-center justify-center hidden z-50"


### PR DESCRIPTION
## Summary
- remove the extra buy button from `printclub.html`
- move the remaining buy button to the bottom of its panel

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6863b50d96f0832d9be4e022c83218ce