### PR TITLE
Fix reward input spinners

### DIFF
--- a/earn-rewards.html
+++ b/earn-rewards.html
@@ -16,6 +16,17 @@
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css"
     />
+    <style>
+      /* Hide number input spinners for the reward input */
+      #reward-input::-webkit-inner-spin-button,
+      #reward-input::-webkit-outer-spin-button {
+        -webkit-appearance: none;
+        margin: 0;
+      }
+      #reward-input {
+        -moz-appearance: textfield;
+      }
+    </style>
   </head>
   <body class="bg-[#1A1A1D] text-white font-sans flex flex-col min-h-screen">
     <header class="relative flex items-center py-4 px-6">


### PR DESCRIPTION
## Summary
- hide number input spinner in the rewards page

## Testing
- `npm run setup`
- `npm run format` in backend
- `npm test` in backend
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6863b4918c2c832db95affb90a6f380a