### PR TITLE
Update proxy instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ These guidelines apply to all automated agents (e.g. the Codex agent) working on
 
 ## Mandatory steps
 
-1. **Unset proxy variables** – before running any `npm` commands, execute `unset npm_config_http_proxy npm_config_https_proxy` to silence `http-proxy` warnings.
+1. **Unset proxy variables** – before running any `npm` commands, **and whenever you start a new shell session**, execute `unset npm_config_http_proxy npm_config_https_proxy` to silence `http-proxy` warnings.
 2. **Install dependencies** – run `npm run setup` at the repository root. This script unsets proxy variables, runs `npm ci` in the root, `backend/`, and `backend/hunyuan_server/` if present, and installs Playwright browsers.
 3. **Format code** – run `npm run format` in `backend/` to apply Prettier formatting.
 4. **Run tests** – execute `npm test` in `backend/`. If tests cannot run because of environment limitations, mention this in the PR.


### PR DESCRIPTION
## Summary
- clarify the instruction about unsetting npm proxy env vars

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6863b953b7e8832d8fcb2bfe43eeb632