### PR TITLE
Add Luckybox preview image

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -150,8 +150,9 @@
       <div class="flex flex-col lg:flex-row gap-6 mt-12">
         <div
           id="luckybox"
-          class="model-card relative w-full lg:w-3/5 min-h-72 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 pb-20 flex flex-col items-center space-y-2"
+          class="model-card relative w-full lg:w-3/5 min-h-72 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 pb-20 flex flex-col lg:flex-row items-center space-y-2 lg:space-y-0 lg:space-x-4"
         >
+          <div class="flex flex-col items-center flex-grow space-y-2">
           <span class="font-semibold text-lg">Luckybox</span>
           <fieldset id="luckybox-tiers" class="flex justify-center gap-4 my-2">
             <label
@@ -245,6 +246,12 @@
           >
             Buy →
           </a>
+          </div>
+          <img
+            src="img/ChatGPT%20Image%20Jul%201,%202025,%2011_35_22%20AM.png"
+            alt="Luckybox preview"
+            class="w-32 h-32 rounded-lg object-cover lg:ml-auto"
+          />
         </div>
         <div class="w-full lg:w-2/5 flex flex-col gap-6">
           <div


### PR DESCRIPTION
## Summary
- add `ChatGPT Image Jul 1, 2025, 11_35_22 AM.png` on Luckybox panel
- keep formatting and tests passing

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6863ba87d330832d875e4f138280f5bd