### PR TITLE
Persist Playwright binaries in repo cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ backend/hunyuan_server/uploads/
 reports/
 backend/coverage/
 coverage/
+.cache/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,11 +5,11 @@ These guidelines apply to all automated agents (e.g. the Codex agent) working on
 ## Mandatory steps
 
 1. **Unset proxy variables** – before running any `npm` commands, execute `unset npm_config_http_proxy npm_config_https_proxy` to silence `http-proxy` warnings.
-2. **Install dependencies** – run `npm run setup` at the repository root. This script unsets proxy variables, runs `npm ci` in the root, `backend/`, and `backend/hunyuan_server/` if present, and installs Playwright browsers.
+2. **Install dependencies** – run `npm run setup` at the repository root. This script unsets proxy variables, runs `npm ci` in the root, `backend/`, and `backend/hunyuan_server/` if present, and installs Playwright browsers to `.cache/ms-playwright`.
 3. **Format code** – run `npm run format` in `backend/` to apply Prettier formatting.
 4. **Run tests** – execute `npm test` in `backend/`. If tests cannot run because of environment limitations, mention this in the PR.
 5. **Run full CI locally** – execute `npm run ci` at the repo root before opening a PR.
-6. **Install Playwright browsers** – the setup script installs these automatically. If browsers are missing, run `CI=1 npx playwright install --with-deps` manually.
+6. **Install Playwright browsers** – the setup script installs these automatically in `.cache/ms-playwright`. If browsers are missing, run `CI=1 PLAYWRIGHT_BROWSERS_PATH=.cache/ms-playwright npx playwright install --with-deps` manually.
 7. **Run smoke tests** – execute `npm run smoke` at the repository root. This script ensures dependencies and Playwright browsers are installed before running the Playwright runner. **Do not run `npx playwright test` directly** – that can trigger `"Playwright Test did not expect test() to be called here"` errors when dependencies are missing.
 8. **Limit scope** – only modify files related to the task. Do not change anything under `img/`, `models/`, or `uploads/` unless explicitly requested. Avoid editing `docs/` unless the task specifically involves documentation.
 9. **Use Conventional Commits** – commit messages must follow the `type: description` format enforced by commitlint. Allowed types are `build`, `ci`, `docs`, `feat`, `fix`, `chore`, `refactor`, `test`, `style`, `perf`, and `revert`. Example: `fix: handle missing avatar images`.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ This repository contains the early MVP code for print2's website and backend.
 
    This script runs `npm ci` in the root, `backend/`, and
    `backend/hunyuan_server/` if present, then downloads the browsers
-   required for the end-to-end tests.
+   required for the end-to-end tests. Browsers are stored under
+   `.cache/ms-playwright` so subsequent runs reuse the same installation.
 
 3. Initialize the database:
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -16,6 +16,7 @@ module.exports = [
       "admin",
       "docs",
       "e2e",
+      ".cache",
       "backend",
       "scripts/ci_watchdog.ts",
       "scripts/ci_watchdog.js",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "bundle:size": "size-limit",
     "setup": "scripts/setup.sh",
     "e2e": "playwright test",
-    "smoke": "npm run setup && npx playwright test e2e/smoke.test.js",
+    "smoke": "npm run setup && PLAYWRIGHT_BROWSERS_PATH=.cache/ms-playwright npx playwright test e2e/smoke.test.js",
     "visual-test": "percy exec -- npm run e2e",
     "test:a11y": "playwright install chromium --with-deps && playwright test e2e/a11y.test.js",
     "netlify:deploy": "scripts/netlify-preflight.sh && netlify deploy"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -17,4 +17,6 @@ fi
 # Ensure dpkg is fully configured before Playwright installs dependencies
 sudo dpkg --configure -a || true
 
-CI=1 npx playwright install --with-deps
+PLAYWRIGHT_BROWSERS_PATH=.cache/ms-playwright
+mkdir -p "$PLAYWRIGHT_BROWSERS_PATH"
+CI=1 PLAYWRIGHT_BROWSERS_PATH="$PLAYWRIGHT_BROWSERS_PATH" npx playwright install --with-deps


### PR DESCRIPTION
## Summary
- cache Playwright browsers under `.cache/ms-playwright`
- update setup and smoke scripts to use the cached path
- ignore cache directory and update ESLint config
- document the browser cache in AGENTS guidelines and README

## Testing
- `npm run setup`
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6863baac23b4832d97dd46bf4ca78c6b