### PR TITLE
Fix setup script to avoid ENOTEMPTY errors

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -2,6 +2,12 @@
 set -e
 unset npm_config_http_proxy npm_config_https_proxy
 
+# Remove any existing node_modules directories to avoid ENOTEMPTY errors
+rm -rf node_modules backend/node_modules
+if [ -d backend/hunyuan_server/node_modules ]; then
+  rm -rf backend/hunyuan_server/node_modules
+fi
+
 # Remove stale apt or dpkg locks that may prevent dependency installation
 if pgrep apt-get >/dev/null 2>&1; then
   sudo pkill apt-get || true


### PR DESCRIPTION
## Summary
- clean existing `node_modules` directories in `setup.sh` to avoid rmdir errors during `npm ci`

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6863baca073c832dabc666de0bf6c09a