### PR TITLE
Fix luckybox tier persistence

### DIFF
--- a/js/addons.js
+++ b/js/addons.js
@@ -78,7 +78,15 @@ function initLuckybox() {
     return checked ? checked.value : "basic";
   }
   function update() {
-    desc.textContent = descriptions[selectedTier()] || descriptions.basic;
+    const tier = selectedTier();
+    desc.textContent = descriptions[tier] || descriptions.basic;
+    const material =
+      tier === "multicolour"
+        ? "multi"
+        : tier === "premium"
+          ? "premium"
+          : "single";
+    localStorage.setItem("print3Material", material);
   }
   tierRadios.forEach((r) => r.addEventListener("change", update));
   update();


### PR DESCRIPTION
## Summary
- keep luckybox tier choice in localStorage

## Testing
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6863bd607974832dac475447f391054d