### PR TITLE
Fix buy button position on Luckybox panel

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -212,7 +212,7 @@
           </p>
           <a
             href="luckybox-payment.html"
-            class="font-bold py-2 px-5 rounded-full shadow-md transition border-2 border-black"
+            class="absolute bottom-4 right-4 font-bold py-2 px-5 rounded-full shadow-md transition border-2 border-black"
             style="background-color: #30d5c8; color: #1a1a1d"
             onmouseover="this.style.opacity='0.85'"
             onmouseout="this.style.opacity='1'"


### PR DESCRIPTION
## Summary
- reposition Luckybox buy arrow to bottom-right of the panel

## Testing
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6863bc78f1a8832d8d62f23e539a5adf