### PR TITLE
Fix luckybox premium price

### DIFF
--- a/js/basket.js
+++ b/js/basket.js
@@ -389,7 +389,7 @@ export function setupBasketUI() {
       btn.classList.toggle("opacity-50", !active);
     });
     if (viewerCheckoutBtn) {
-      const price = tier === "bronze" ? 29.99 : tier === "gold" ? 79.99 : 39.99;
+      const price = tier === "bronze" ? 29.99 : tier === "gold" ? 59.99 : 39.99;
       viewerCheckoutBtn.textContent = `Print for £${price.toFixed(2)} →`;
     }
     const material =

--- a/js/payment.js
+++ b/js/payment.js
@@ -12,7 +12,7 @@ const FALLBACK_GLB = FALLBACK_GLB_LOW;
 const PRICES = {
   single: 2999,
   multi: 3999,
-  premium: 7999,
+  premium: 5999,
 };
 
 const TWO_PRINT_DISCOUNT = 700;

--- a/luckybox-payment.html
+++ b/luckybox-payment.html
@@ -311,7 +311,7 @@
                 <span
                   class="w-24 h-24 flex flex-col items-center justify-center rounded-full border border-white/20 pt-0"
                 >
-                  <span class="font-semibold">£79.99</span>
+                  <span class="font-semibold">£59.99</span>
                   <span class="text-xs">premium</span>
                 </span>
                 <span class="block text-xs mt-1">coming soon</span>


### PR DESCRIPTION
## Summary
- set Luckybox premium price to £59.99 in the checkout script
- update displayed premium price in Luckybox payment page
- correct basket logic to use £59.99 for premium

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6863bd2763bc832d92da3fe431f2ced2