### PR TITLE
Fix apt update in setup script

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -8,6 +8,16 @@ if pgrep apt-get >/dev/null 2>&1; then
 fi
 sudo rm -f /var/lib/apt/lists/lock /var/lib/dpkg/lock /var/cache/apt/archives/lock
 
+# Retry apt-get update to ensure the proxy is respected and networking is ready
+for i in {1..3}; do
+  if sudo -E apt-get update; then
+    break
+  else
+    echo "apt-get update failed, retrying ($i/3)..." >&2
+    sleep 5
+  fi
+done
+
 npm ci
 npm ci --prefix backend
 if [ -f backend/hunyuan_server/package.json ]; then


### PR DESCRIPTION
## Summary
- retry `apt-get update` during setup to avoid intermittent network failures

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_6863beec57ec832d873b5a255eaccc81