### PR TITLE
fix: replace 3D viewer with static image

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -577,7 +577,8 @@ async function initPaymentPage() {
       });
     };
     if (viewer.model) apply();
-    else viewer.addEventListener("load", apply, { once: true });
+    else if (viewer && viewer.tagName.toLowerCase() !== "img")
+      viewer.addEventListener("load", apply, { once: true });
   }
 
   function captureOriginal() {
@@ -600,8 +601,10 @@ async function initPaymentPage() {
 
   // Capture the original colours every time a new model loads so that
   // switching between items restores the correct textures.
-  viewer.addEventListener("load", captureOriginal);
-  if (viewer.model) captureOriginal();
+  if (viewer && viewer.tagName.toLowerCase() !== "img") {
+    viewer.addEventListener("load", captureOriginal);
+    if (viewer.model) captureOriginal();
+  }
 
   function updateEtchVisibility(val) {
     if (!etchInput || !etchContainer) return;
@@ -869,7 +872,6 @@ async function initPaymentPage() {
     if (!checkoutItems.length) return;
     currentIndex = (idx + checkoutItems.length) % checkoutItems.length;
     const item = checkoutItems[currentIndex];
-    viewer.src = item.modelUrl || FALLBACK_GLB;
     if (item.jobId) localStorage.setItem("print3JobId", item.jobId);
     else localStorage.removeItem("print3JobId");
     storedMaterial = item.material || "multi";
@@ -1051,11 +1053,12 @@ async function initPaymentPage() {
   // <model-viewer> element upgrades while this script is still loading. If the
   // library fails to load, the "error" handler falls back to the astronaut
   // model and hides the loader overlay.
-  viewer.addEventListener("load", hideLoader);
-  viewer.addEventListener("error", () => {
-    viewer.src = FALLBACK_GLB;
-    hideLoader();
-  });
+  if (viewer && viewer.tagName.toLowerCase() !== "img") {
+    viewer.addEventListener("load", hideLoader);
+    viewer.addEventListener("error", () => {
+      hideLoader();
+    });
+  }
 
   // Wait for the <model-viewer> definition before assigning the model source.
   // Some browsers won't process the "src" attribute on a custom element until
@@ -1152,36 +1155,16 @@ async function initPaymentPage() {
 
   if (!checkoutItems.length) {
     if (removeBtn) removeBtn.classList.add("hidden");
-    viewer.src = storedModel || FALLBACK_GLB;
-    if (!storedModel) {
-      viewer.addEventListener(
-        "load",
-        () => {
-          const temp = document.createElement("model-viewer");
-          temp.style.display = "none";
-          temp.crossOrigin = "anonymous";
-          temp.src = FALLBACK_GLB_HIGH;
-          temp.addEventListener("load", () => {
-            if (viewer.src === FALLBACK_GLB_LOW) {
-              viewer.src = FALLBACK_GLB_HIGH;
-            }
-            temp.remove();
-          });
-          document.body.appendChild(temp);
-        },
-        { once: true },
-      );
+    if (viewer && viewer.tagName.toLowerCase() !== "img") {
+      viewer.addEventListener("load", applyStoredColorIfNeeded, { once: true });
     }
-    viewer.addEventListener("load", applyStoredColorIfNeeded, { once: true });
     updateNavButtons();
   } else {
     const first = checkoutItems[0];
-    viewer.src = first.modelUrl || FALLBACK_GLB;
     if (first.jobId) localStorage.setItem("print3JobId", first.jobId);
     else localStorage.removeItem("print3JobId");
     storedMaterial = first.material || storedMaterial;
     localStorage.setItem("print3Material", storedMaterial);
-    viewer.addEventListener("load", applyStoredColorIfNeeded, { once: true });
     showItem(0);
     if (removeBtn) {
       if (checkoutItems.length > 1) removeBtn.classList.remove("hidden");

--- a/luckybox-payment.html
+++ b/luckybox-payment.html
@@ -10,21 +10,7 @@
     <link rel="preconnect" href="https://js.stripe.com" crossorigin />
     <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin />
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
-    <link rel="preconnect" href="https://modelviewer.dev" crossorigin />
-
-    <!-- Preload 3D assets -->
-    <link
-      rel="preload"
-      href="https://modelviewer.dev/shared-assets/models/Astronaut.glb"
-      as="fetch"
-      crossorigin
-    />
-    <link
-      rel="preload"
-      href="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
-      as="fetch"
-      crossorigin
-    />
+    <!-- Preload 3D assets removed -->
 
     <!-- Tailwind CSS -->
     <script src="https://cdn.tailwindcss.com"></script>
@@ -35,16 +21,6 @@
     <!-- Font Awesome (back-arrow icon) -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" referrerpolicy="no-referrer">
 
-    <!-- model-viewer -->
-    <script
-      type="module"
-      src="https://cdn.jsdelivr.net/npm/@google/model-viewer@1.12.0/dist/model-viewer.min.js"
-    ></script>
-    <script
-      nomodule
-      src="https://cdn.jsdelivr.net/npm/@google/model-viewer@1.12.0/dist/model-viewer-legacy.js"
-      defer
-    ></script>
     <style>
       /* Add rainbow shimmer effect used on the index submit arrow */
       #multi-color-button {
@@ -161,10 +137,6 @@
         display: block;
       }
 
-      /* Hide model-viewer's built-in loading bar */
-      model-viewer::part(progress-bar) {
-        display: none;
-      }
     </style>
   </head>
 
@@ -234,14 +206,12 @@
             style="display: none"
             alt="Preview image"
           />
-        <model-viewer
+        <img
           id="viewer"
-          alt="3D astronaut"
-          environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
-          camera-controls
-          auto-rotate
-          style="width: 100%; height: 100%; display: block"
-        ></model-viewer>
+          src="img/ChatGPT Image Jul 1, 2025, 11_35_22 AM.png"
+          alt="Luckybox preview"
+          class="object-contain h-full w-full"
+        />
         <p class="absolute top-2 left-2 text-red-300 text-xs">
           Only <span id="slot-count" style="visibility: hidden"></span> print slots remaining
         </p>


### PR DESCRIPTION
## Summary
- remove model viewer assets from Luckybox checkout page
- show static image in Luckybox checkout
- guard viewer code against missing model viewer element

## Testing
- `npm test --prefix backend`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6863bcf7a36c832d83c3c651e74468a0