### PR TITLE
Fix Luckybox preview image sizing

### DIFF
--- a/luckybox-payment.html
+++ b/luckybox-payment.html
@@ -202,7 +202,7 @@
           <img
             id="preview-img"
             src="https://placehold.co/600x400/2A2A2E/2A2A2E?text="
-            class="object-contain h-full w-full"
+            class="object-cover h-full w-full"
             style="display: none"
             alt="Preview image"
           />
@@ -210,7 +210,7 @@
           id="viewer"
           src="img/ChatGPT Image Jul 1, 2025, 11_35_22 AM.png"
           alt="Luckybox preview"
-          class="object-contain h-full w-full"
+          class="object-cover h-full w-full"
         />
         <p class="absolute top-2 left-2 text-red-300 text-xs">
           Only <span id="slot-count" style="visibility: hidden"></span> print slots remaining


### PR DESCRIPTION
## Summary
- ensure Luckybox preview image covers its panel

## Testing
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6863c8be10c4832da468d7566a6653b3