### PR TITLE
Fix GLB viewer fallback on payment page

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -879,6 +879,14 @@ async function initPaymentPage() {
     if (!checkoutItems.length) return;
     currentIndex = (idx + checkoutItems.length) % checkoutItems.length;
     const item = checkoutItems[currentIndex];
+    if (viewer) {
+      const tag = viewer.tagName.toLowerCase();
+      if (tag === "img") {
+        viewer.src = item.snapshot || item.modelUrl || viewer.src;
+      } else {
+        viewer.src = item.modelUrl || storedModel || FALLBACK_GLB;
+      }
+    }
     if (item.jobId) localStorage.setItem("print3JobId", item.jobId);
     else localStorage.removeItem("print3JobId");
     storedMaterial = item.material || "multi";
@@ -1081,6 +1089,9 @@ async function initPaymentPage() {
   loader.hidden = false;
   // Assign the model source only after the load/error listeners are in place
   const storedModel = localStorage.getItem("print3Model");
+  if (viewer && viewer.tagName.toLowerCase() !== "img") {
+    viewer.src = storedModel || FALLBACK_GLB;
+  }
   // Load saved basket items
   try {
     const arr = JSON.parse(localStorage.getItem("print3CheckoutItems"));


### PR DESCRIPTION
## Summary
- set the payment page model viewer `src` when the page loads
- ensure viewer updates when navigating between basket items

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6863ccc2bb60832db8ba6f97347b79ac