### PR TITLE
Fix addons layout

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -258,7 +258,7 @@
         <div class="w-full lg:w-2/5 flex flex-col gap-6">
           <div
             id="print-minis"
-            class="model-card relative w-full min-h-96 lg:h-full bg-[#2A2A2E] border border-white/10 rounded-xl p-4 pb-20 flex flex-col items-center space-y-2"
+            class="model-card relative w-full min-h-96 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 pb-20 flex flex-col items-center space-y-2"
           >
             <span class="font-semibold text-lg">Print Minis</span>
             <p class="text-sm text-center">
@@ -269,13 +269,13 @@
               Add to Basket
             </button>
           </div>
+          <section
+            id="addons-grid"
+            class="grid grid-cols-2 gap-6 w-full"
+          ></section>
         </div>
       </div>
 
-      <section
-        id="addons-grid"
-        class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 w-full"
-      ></section>
 
       <!-- Additional Print Minis panels removed as requested -->
 


### PR DESCRIPTION
## Summary
- restore grid layout for Add-Ons page

## Testing
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6863df70c364832dad8a9670bbdb88cd