### PR TITLE
Fix overflow for luckybox preview

### DIFF
--- a/luckybox-payment.html
+++ b/luckybox-payment.html
@@ -197,7 +197,7 @@
         <!-- Model Preview -->
         <section
           id="preview-wrapper"
-          class="relative w-full md:w-1/2 max-w-lg h-80 bg-[#2A2A2E] border border-white/10 rounded-3xl overflow-visible"
+          class="relative w-full md:w-1/2 max-w-lg h-80 bg-[#2A2A2E] border border-white/10 rounded-3xl overflow-hidden"
         >
           <img
             id="preview-img"


### PR DESCRIPTION
## Summary
- contain the mystery box preview inside its panel

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6863e03dd2a8832dac7d906c867e9ed1