### PR TITLE
fix: restore community page thumbnails

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -441,14 +441,14 @@
       </div>
     </div>
     <script type="module">
-      import { shareOn } from "/js/share.js";
+      import { shareOn } from "./js/share.js";
       import {
         init,
         closeModel,
         restoreOpenModel,
         loadReferralLink,
         copyReferralLink,
-      } from "/js/community.js";
+      } from "./js/community.js";
       window.shareOn = shareOn;
       window.copyReferralLink = copyReferralLink;
 


### PR DESCRIPTION
## Summary
- load community scripts using relative paths so the grids work when served from a subdirectory

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6863e66024d8832d860fa7f799291296