### PR TITLE
Fix Luckybox bulk discount text

### DIFF
--- a/luckybox-payment.html
+++ b/luckybox-payment.html
@@ -757,6 +757,13 @@
         }
       });
     </script>
+    <script>
+      document.addEventListener('DOMContentLoaded', () => {
+        document.querySelectorAll('#bulk-discount-popup li').forEach((li) => {
+          if (li.textContent.includes('£15')) li.remove();
+        });
+      });
+    </script>
     <script type="module" src="js/basket.js" defer></script>
     <script>window.disableSaveButton = true;</script>
     <script type="module" src="js/saveList.js" defer></script>


### PR DESCRIPTION
## Summary
- hide the £15 bulk discount message on Luckybox checkout

## Testing
- `npm run setup`
- `npm run format`
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6863e7340340832d8d79bb67e3596599