### PR TITLE
Fix Luckybox third item discount

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -69,7 +69,12 @@ function computeBulkDiscount(items) {
   }
   let discount = 0;
   if (totalQty >= 2) discount += TWO_PRINT_DISCOUNT;
-  if (totalQty >= 3) discount += THIRD_PRINT_DISCOUNT;
+  if (
+    totalQty >= 3 &&
+    !window.location.pathname.endsWith("luckybox-payment.html")
+  ) {
+    discount += THIRD_PRINT_DISCOUNT;
+  }
   return discount;
 }
 const NEXT_PROMPTS = [


### PR DESCRIPTION
## Summary
- skip the third item discount when checking out via `luckybox-payment.html`

## Testing
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6863e7340340832d8d79bb67e3596599