### PR TITLE
Luckybox panel layout

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -162,14 +162,11 @@
         <!-- ---------- LEFT (50 %) : LUCKYBOX ---------- -->
         <div
           id="luckybox"
-          class="model-card relative w-full lg:w-1/2 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 pb-20 flex flex-col lg:flex-row items-center space-y-2 lg:space-y-0 lg:space-x-4"
+          class="model-card relative w-full lg:w-1/2 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 pb-20 flex flex-col space-y-4"
         >
-          <!-- inner column -->
-          <div class="flex flex-col items-center flex-grow space-y-2">
-            <span class="font-semibold text-lg">Luckybox</span>
-
-            <!-- tiers -->
-            <fieldset id="luckybox-tiers" class="flex justify-center gap-4 my-2">
+          <span class="font-semibold text-lg">Luckybox</span>
+          <div class="flex justify-between items-start">
+            <fieldset id="luckybox-tiers" class="flex justify-start gap-4">
               <!-- premium (disabled) -->
               <label class="cursor-not-allowed text-center flex flex-col items-center opacity-50">
                 <input
@@ -220,13 +217,15 @@
                 </span>
               </label>
             </fieldset>
+            <img
+              src="img/luckybox-preview.png"
+              alt="Luckybox preview"
+              class="w-32 h-32 rounded-lg object-cover"
+            />
+          </div>
 
-            <p id="luckybox-desc" class="text-sm text-center">
-              £19.99 print + 5 print points (usually £29.99)
-            </p>
-
-            <!-- buy button -->
-            <a
+          <!-- buy button -->
+          <a
               href="luckybox-payment.html"
               class="absolute bottom-4 right-4 font-bold py-2 px-5 rounded-full shadow-md transition border-2 border-black"
               style="background-color: #30d5c8; color: #1a1a1d"
@@ -236,46 +235,7 @@
               Buy →
             </a>
 
-            <!-- options -->
-            <div
-              id="luckybox-options"
-              class="flex items-center justify-center gap-4 mt-6 text-lg flex-wrap"
-            >
-              <label class="flex items-center space-x-2 whitespace-nowrap">
-                <input
-                  type="radio"
-                  name="luckybox-option"
-                  value="A"
-                  class="accent-[#30D5C8]"
-                  checked
-                />
-                <span>Luckybox A (truly random print)</span>
-              </label>
-
-              <label class="flex items-center space-x-2 whitespace-nowrap">
-                <input
-                  type="radio"
-                  name="luckybox-option"
-                  value="B"
-                  class="accent-[#30D5C8]"
-                />
-                <span>Luckybox B (choose a theme):</span>
-              </label>
-
-              <input
-                type="text"
-                placeholder="e.g. medieval"
-                class="bg-[#1A1A1D] border border-white/10 rounded px-2 py-1 text-lg w-32"
-              />
-            </div>
-
-            <!-- preview image -->
-            <img
-              src="img/luckybox-preview.png"
-              alt="Luckybox preview"
-              class="w-32 h-32 rounded-lg object-cover lg:ml-auto"
-            />
-          </div> <!-- /.inner column -->
+          </div>
         </div> <!-- /#luckybox -->
 
 


### PR DESCRIPTION
## Summary
- simplify Luckybox panel on the Add‑Ons page
- keep the tier buttons and preview image in a single row
- remove descriptive text and option fields

## Testing
- `npm run format` (backend)
- `npm test` (backend)
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6863ef043c0c832d9f3dfd9f45e4b5a8