### PR TITLE
Fix Luckybox savings display

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -748,8 +748,10 @@ async function initPaymentPage() {
       const percent =
         subtotal > 0 ? Math.round((discount / subtotal) * 100) : 0;
       text += ` - £${saved.toFixed(2)} = £${total.toFixed(2)}`;
-      const indent = text.lastIndexOf("£");
-      text += `\n${" ".repeat(indent)}(${percent}% saving)`;
+      if (!window.location.pathname.endsWith("luckybox-payment.html")) {
+        const indent = text.lastIndexOf("£");
+        text += `\n${" ".repeat(indent)}(${percent}% saving)`;
+      }
     } else {
       text += ` = £${total.toFixed(2)}`;
     }


### PR DESCRIPTION
## Summary
- hide the `(X% saving)` text on Luckybox checkout pages

## Testing
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6863f3834eb0832da62685ae630da411