### PR TITLE
Fix trust quote placement on Luckybox checkout

### DIFF
--- a/luckybox-payment.html
+++ b/luckybox-payment.html
@@ -614,13 +614,6 @@
             <span class="text-white">The print2 team: Jia and Matthew</span>
           </p>
         </div>
-        <div class="mt-4 text-center text-sm text-gray-400">
-          <p class="mb-1">Trusted by <span class="text-white">thousands of makers:</span></p>
-          <p>
-            ✅︎ If you don’t love it, we’ll reprint or refund you – no <br />
-            questions asked: <span class="text-white">enquiries@domain.com</span>
-          </p>
-        </div>
       </div>
     </main>
 


### PR DESCRIPTION
## Summary
- remove duplicated trust statement at the bottom of `luckybox-payment.html`
- keep single trust quote beneath the preview image

## Testing
- `npm run setup`
- `npm run format` (backend)
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6863f67399e8832d87158866434d8d10