### PR TITLE
Adjust layout of add-ons page

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -157,12 +157,12 @@
         >.
       </div>
 
-      <!-- ===== FLEX ROW ===== -->
-      <div class="flex flex-col lg:flex-row lg:items-stretch gap-6 mt-12">
+      <!-- ===== GRID LAYOUT ===== -->
+      <div class="grid gap-6 mt-12 lg:grid-cols-2 lg:grid-rows-2">
         <!-- ---------- LEFT (50 %) : LUCKYBOX ---------- -->
         <div
           id="luckybox"
-          class="model-card relative w-full lg:w-1/2 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 pb-20 flex flex-col space-y-4"
+          class="model-card relative w-full lg:row-span-2 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 pb-20 flex flex-col space-y-4"
         >
           <span class="font-semibold text-lg">Luckybox</span>
           <div class="flex justify-between items-start">
@@ -239,13 +239,12 @@
         </div> <!-- /#luckybox -->
 
 
-        <!-- ---------- RIGHT (50 %) : PRINT MINIS + 2×2 GRID ---------- -->
-        <div class="w-full lg:w-1/2 flex flex-col gap-6">
-          <!-- TOP: Print Minis -->
-          <div
-            id="print-minis"
-            class="model-card relative w-full bg-[#2A2A2E] border border-white/10 rounded-xl p-4 space-y-2"
-          >
+        <!-- ---------- RIGHT (50 %) : PRINT MINIS + REMIX ---------- -->
+        <!-- TOP: Print Minis -->
+        <div
+          id="print-minis"
+          class="model-card relative w-full lg:col-start-2 lg:row-start-1 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 space-y-2"
+        >
             <span class="font-semibold text-lg">Print Minis</span>
             <p class="text-sm text-center">
               We'll print your design at roughly 75% scale for a tiny version.
@@ -254,19 +253,18 @@
             <button class="bg-[#30D5C8] text-black px-3 py-1 rounded text-sm">
               Add to Basket
             </button>
-          </div>
+        </div>
 
-          <!-- BOTTOM: Remix prints preview -->
-          <section id="addons-grid" class="w-full">
-            <div
-              class="model-card p-4 bg-[#2A2A2E] border border-white/10 rounded-xl text-center opacity-50"
-            >
-              <span class="font-semibold">Remix prints</span>
-              <span class="block text-xs mt-1">coming soon</span>
-            </div>
-          </section>
-        </div> <!-- /.right half -->
-      </div> <!-- /.flex row -->
+        <!-- BOTTOM: Remix prints preview -->
+        <section id="addons-grid" class="w-full lg:col-start-2 lg:row-start-2">
+          <div
+            class="model-card p-4 bg-[#2A2A2E] border border-white/10 rounded-xl text-center opacity-50"
+          >
+            <span class="font-semibold">Remix prints</span>
+            <span class="block text-xs mt-1">coming soon</span>
+          </div>
+        </section>
+      </div> <!-- /.grid layout -->
     </main>
 
     <!-- ---------- SCRIPTS ---------- -->


### PR DESCRIPTION
## Summary
- restructure add-ons main content using a responsive grid
- position luckybox panel on the left and print minis/remix panels on the right

## Testing
- `npm run setup`
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6863f6cb6e54832dac973767248ab019