### PR TITLE
Update addons page layout

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -158,11 +158,13 @@
       </div>
 
       <!-- ===== FLEX ROW ===== -->
-      <div class="flex flex-col lg:flex-row lg:items-stretch gap-6 mt-12">
+      <div
+        class="flex flex-col gap-6 mt-12 lg:grid lg:grid-cols-2 lg:grid-rows-2 lg:items-stretch"
+      >
         <!-- ---------- LEFT (50 %) : LUCKYBOX ---------- -->
         <div
           id="luckybox"
-          class="model-card relative w-full lg:w-1/2 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 pb-20 flex flex-col space-y-4"
+          class="model-card relative w-full lg:row-span-2 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 pb-20 flex flex-col space-y-4"
         >
           <span class="font-semibold text-lg">Luckybox</span>
           <div class="flex justify-between items-start">
@@ -239,13 +241,12 @@
         </div> <!-- /#luckybox -->
 
 
-        <!-- ---------- RIGHT (50 %) : PRINT MINIS + 2×2 GRID ---------- -->
-        <div class="w-full lg:w-1/2 flex flex-col gap-6">
-          <!-- TOP: Print Minis -->
-          <div
-            id="print-minis"
-            class="model-card relative w-full bg-[#2A2A2E] border border-white/10 rounded-xl p-4 space-y-2"
-          >
+        <!-- ---------- RIGHT (50 %) : PRINT MINIS + REMIX ---------- -->
+        <!-- TOP: Print Minis -->
+        <div
+          id="print-minis"
+          class="model-card relative w-full bg-[#2A2A2E] border border-white/10 rounded-xl p-4 space-y-2 lg:col-start-2 lg:row-start-1"
+        >
             <span class="font-semibold text-lg">Print Minis</span>
             <p class="text-sm text-center">
               We'll print your design at roughly 75% scale for a tiny version.
@@ -256,16 +257,18 @@
             </button>
           </div>
 
-          <!-- BOTTOM: Remix prints preview -->
-          <section id="addons-grid" class="w-full">
-            <div
-              class="model-card p-4 bg-[#2A2A2E] border border-white/10 rounded-xl text-center opacity-50"
-            >
-              <span class="font-semibold">Remix prints</span>
-              <span class="block text-xs mt-1">coming soon</span>
-            </div>
-          </section>
-        </div> <!-- /.right half -->
+        <!-- BOTTOM: Remix prints preview -->
+        <section
+          id="addons-grid"
+          class="w-full lg:col-start-2 lg:row-start-2"
+        >
+          <div
+            class="model-card p-4 bg-[#2A2A2E] border border-white/10 rounded-xl text-center opacity-50"
+          >
+            <span class="font-semibold">Remix prints</span>
+            <span class="block text-xs mt-1">coming soon</span>
+          </div>
+        </section>
       </div> <!-- /.flex row -->
     </main>
 


### PR DESCRIPTION
## Summary
- reorganize Add-Ons page layout so Luckybox fills the left column and Print Minis / Remix panels stack on the right

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6863f6cb6e54832dac973767248ab019