### PR TITLE
Fix Luckybox checkout rounded image

### DIFF
--- a/luckybox-payment.html
+++ b/luckybox-payment.html
@@ -197,12 +197,12 @@
         <!-- Model Preview -->
         <section
           id="preview-wrapper"
-          class="relative w-full md:w-1/2 max-w-lg h-80 bg-[#2A2A2E] border border-white/10 rounded-3xl overflow-visible"
+          class="relative w-full md:w-1/2 max-w-lg h-80 bg-[#2A2A2E] border border-white/10 rounded-3xl overflow-hidden"
         >
           <img
             id="preview-img"
             src="https://placehold.co/600x400/2A2A2E/2A2A2E?text="
-            class="object-cover h-full w-full"
+            class="object-cover h-full w-full rounded-3xl"
             style="display: none"
             alt="Preview image"
           />
@@ -210,7 +210,7 @@
           id="viewer"
           src="img/luckybox-preview.png"
           alt="Luckybox preview"
-          class="object-cover h-full w-full"
+          class="object-cover h-full w-full rounded-3xl"
         />
         <button
           id="remove-model"


### PR DESCRIPTION
## Summary
- ensure Luckybox checkout preview image is rounded like its container

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npm run smoke`

`scripts/update_locks.py` could not run because `GITHUB_TOKEN` and `GITHUB_REPOSITORY` were not set.

------
https://chatgpt.com/codex/tasks/task_e_686402fb88f4832dad2bea1a8fe95671