### PR TITLE
Restore Luckybox checkout quote

### DIFF
--- a/luckybox-payment.html
+++ b/luckybox-payment.html
@@ -197,7 +197,7 @@
         <!-- Model Preview -->
         <section
           id="preview-wrapper"
-          class="relative w-full md:w-1/2 max-w-lg h-80 bg-[#2A2A2E] border border-white/10 rounded-3xl overflow-hidden"
+          class="relative w-full md:w-1/2 max-w-lg h-80 bg-[#2A2A2E] border border-white/10 rounded-3xl overflow-visible"
         >
           <img
             id="preview-img"


### PR DESCRIPTION
## Summary
- fix overflow so trust quote appears below the Luckybox preview image

## Testing
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68640907dec8832d9d826501669cb0d6