### PR TITLE
Fix leftover recent thumbnail

### DIFF
--- a/js/community.js
+++ b/js/community.js
@@ -454,8 +454,9 @@ async function loadMore(type, filters = getFilters()) {
     if (models.length < limit) {
       btn.classList.add("hidden");
       if (type === "recent") {
-        const advertOffset = 1;
-        while ((grid.children.length - advertOffset) % 3 !== 0) {
+        let offset = 1; // account for advert
+        if (grid.querySelector(".viewer-card")) offset += 1;
+        while ((grid.children.length - offset) % 3 !== 0) {
           const last = grid.lastElementChild;
           if (!last) break;
           last.remove();


### PR DESCRIPTION
## Summary
- adjust leftover thumbnail logic for community page
- run formatter
- run backend tests, CI and smoke tests

## Testing
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68640db985c8832d88d52463713793bb