### PR TITLE
Adjust addons grid layout

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -158,9 +158,9 @@
       </div>
 
 
-      <!-- ===== FLEX ROW ===== -->
+      <!-- ===== GRID LAYOUT ===== -->
       <div
-        class="flex flex-col gap-6 mt-12 lg:grid lg:grid-cols-2 lg:grid-rows-2 lg:items-stretch"
+        class="grid grid-cols-1 gap-6 mt-12 lg:grid-cols-2 lg:grid-rows-2"
       >
         <!-- ---------- LEFT (50 %) : LUCKYBOX ---------- -->
         <div
@@ -246,7 +246,7 @@
         <!-- TOP: Print Minis -->
         <div
           id="print-minis"
-          class="model-card relative w-full bg-[#2A2A2E] border border-white/10 rounded-xl p-4 space-y-2 lg:col-start-2 lg:row-start-1"
+          class="model-card relative w-full h-full bg-[#2A2A2E] border border-white/10 rounded-xl p-4 space-y-2 lg:col-start-2 lg:row-start-1"
         >
             <span class="font-semibold text-lg">Print Minis</span>
             <p class="text-sm text-center">
@@ -262,10 +262,10 @@
 
         <section
           id="addons-grid"
-          class="w-full lg:col-start-2 lg:row-start-2"
+          class="w-full h-full lg:col-start-2 lg:row-start-2"
         >
           <div
-            class="model-card p-4 bg-[#2A2A2E] border border-white/10 rounded-xl text-center opacity-50"
+            class="model-card p-4 bg-[#2A2A2E] border border-white/10 rounded-xl text-center opacity-50 h-full flex flex-col items-center justify-center"
           >
             <span class="font-semibold">Remix prints</span>
             <span class="block text-xs mt-1">coming soon</span>


### PR DESCRIPTION
## Summary
- switch addons page to grid layout
- keep luckybox panel on the left and stack print minis above remix prints on the right

## Testing
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_686409a1a8b8832d8a34b9f79f608388