### PR TITLE
Fix center alignment on rewards headings

### DIFF
--- a/earn-rewards.html
+++ b/earn-rewards.html
@@ -106,7 +106,9 @@
           class="md:w-1/2 bg-[#2A2A2E] border border-white/10 p-6 rounded-2xl shadow-lg flex flex-col h-full min-h-[32rem] text-center md:text-left"
         >
           <div class="space-y-6 flex-1">
-            <h2 class="text-2xl font-semibold">Share &amp; earn discounts</h2>
+            <h2 class="text-2xl font-semibold text-center">
+              Share &amp; earn discounts
+            </h2>
             <p class="text-gray-400">
               You must
               <a href="login.html" class="font-bold text-[#30D5C8]">Log In</a>
@@ -173,7 +175,7 @@
           class="md:w-1/2 bg-[#2A2A2E] border border-white/10 p-6 rounded-2xl shadow-lg space-y-6 min-h-[32rem] flex flex-col text-left"
         >
           <div>
-            <h3 class="text-2xl font-semibold mb-2">
+            <h3 class="text-2xl font-semibold mb-2 text-center">
               What are others earning?
             </h3>
             <table class="w-full text-sm">


### PR DESCRIPTION
## Summary
- center text for rewards panels on the Earn Rewards page

## Testing
- `npm run format` in `backend`
- `npm test --silent` in `backend`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6864120b7368832dba10ac9f30b75162