### PR TITLE
Fix Luckybox navigation

### DIFF
--- a/luckybox-payment.html
+++ b/luckybox-payment.html
@@ -224,7 +224,7 @@
         <button
           id="prev-model"
           type="button"
-          class="absolute left-2 top-1/2 -translate-y-1/2 bg-[#2A2A2E] border border-white/20 rounded-full p-2"
+          class="absolute left-2 top-1/2 -translate-y-1/2 bg-[#2A2A2E] border border-white/20 rounded-full p-2 hidden"
         >
           <i class="fas fa-chevron-left"></i>
           <span class="sr-only">Previous model</span>
@@ -232,7 +232,7 @@
         <button
           id="next-model"
           type="button"
-          class="absolute right-2 top-1/2 -translate-y-1/2 bg-[#2A2A2E] border border-white/20 rounded-full p-2"
+          class="absolute right-2 top-1/2 -translate-y-1/2 bg-[#2A2A2E] border border-white/20 rounded-full p-2 hidden"
         >
           <i class="fas fa-chevron-right"></i>
           <span class="sr-only">Next model</span>


### PR DESCRIPTION
## Summary
- hide previous/next buttons on Luckybox checkout on initial load

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_686419d82f7c832db1abb2350b689614