### PR TITLE
Fix Luckybox button position

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -120,7 +120,7 @@
       <!-- ROW: Luckybox (50%) | RIGHT COLUMN (50%) -->
       <div class="flex gap-6 mt-12">
         <!-- Luckybox (50%) -->
-        <div id="luckybox" class="model-card w-1/2 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 pb-20 flex flex-col space-y-4">
+        <div id="luckybox" class="model-card w-1/2 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 pb-20 flex flex-col space-y-4 relative">
           <span class="font-semibold text-lg">Luckybox</span>
           <div class="flex justify-between items-start">
             <fieldset id="luckybox-tiers" class="flex gap-4">


### PR DESCRIPTION
## Summary
- keep Luckybox buy button inside panel on Add-Ons page

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68641a084728832dad81e5d7ea7fb5f3