### PR TITLE
Fix centered addon headings

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -121,7 +121,7 @@
       <div class="flex gap-6 mt-12">
         <!-- Luckybox (50%) -->
         <div id="luckybox" class="model-card w-1/2 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 pb-20 flex flex-col space-y-4 relative">
-          <span class="font-semibold text-lg">Luckybox</span>
+          <span class="font-semibold text-lg self-center text-center">Luckybox</span>
           <div class="flex justify-between items-start">
             <fieldset id="luckybox-tiers" class="flex gap-4">
               <!-- premium -->
@@ -161,7 +161,7 @@
         <div class="flex flex-col w-1/2 gap-6">
           <!-- Print Minis (50% of column) -->
           <div id="print-minis" class="model-card w-full bg-[#2A2A2E] border border-white/10 rounded-xl p-4 flex flex-col justify-center space-y-2">
-            <span class="font-semibold text-lg">Print Minis</span>
+            <span class="font-semibold text-lg self-center text-center">Print Minis</span>
             <p class="text-sm text-center">We'll print your design at roughly 75% scale for a tiny version.</p>
             <p class="text-sm text-center font-semibold">£14.99 per mini</p>
             <button class="self-center bg-[#30D5C8] text-black px-3 py-1 rounded text-sm">Add to Basket</button>


### PR DESCRIPTION
## Summary
- center Luckybox and Print Minis titles in `addons.html`

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68641ff38b54832d9ef2bfbc7efcbae3