### PR TITLE
feat: align addon panels

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -118,9 +118,9 @@
       </div>
 
       <!-- ROW: Luckybox (50%) | RIGHT COLUMN (50%) -->
-      <div class="flex gap-6 mt-12">
+      <div class="flex gap-6 mt-12 h-full items-stretch">
         <!-- Luckybox (50%) -->
-        <div id="luckybox" class="model-card w-1/2 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 pb-20 flex flex-col space-y-4 relative">
+        <div id="luckybox" class="model-card w-1/2 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 pb-20 flex flex-col space-y-4 relative h-full">
           <span class="font-semibold text-lg self-center text-center">Luckybox</span>
           <div class="flex justify-between items-start">
             <fieldset id="luckybox-tiers" class="flex gap-4">
@@ -158,9 +158,9 @@
         </div>
 
         <!-- RIGHT COLUMN (50%) -->
-        <div class="flex flex-col w-1/2 gap-6">
+        <div class="flex flex-col w-1/2 gap-6 h-full">
           <!-- Print Minis (50% of column) -->
-          <div id="print-minis" class="model-card w-full bg-[#2A2A2E] border border-white/10 rounded-xl p-4 flex flex-col justify-center space-y-2">
+          <div id="print-minis" class="model-card w-full bg-[#2A2A2E] border border-white/10 rounded-xl p-4 flex flex-col justify-center space-y-2 flex-1">
             <span class="font-semibold text-lg self-center text-center">Print Minis</span>
             <p class="text-sm text-center">We'll print your design at roughly 75% scale for a tiny version.</p>
             <p class="text-sm text-center font-semibold">£14.99 per mini</p>
@@ -168,7 +168,7 @@
           </div>
 
           <!-- Remix prints (50% of column) -->
-          <div id="remix-prints" class="model-card w-full bg-[#2A2A2E] border border-white/10 rounded-xl p-4 flex items-center justify-center text-center opacity-50">
+          <div id="remix-prints" class="model-card w-full bg-[#2A2A2E] border border-white/10 rounded-xl p-4 flex items-center justify-center text-center opacity-50 flex-1">
             <div>
               <span class="font-semibold">Remix prints</span>
               <span class="block text-xs mt-1">coming soon</span>


### PR DESCRIPTION
## Summary
- align luckybox and remix prints panels on addons page
- ensure print minis and remix prints are equal height

## Testing
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68643876a248832d9e5f2c1098d18c3f