### PR TITLE
fix: update mini print scale

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -162,7 +162,7 @@
           <!-- Print Minis (50% of column) -->
           <div id="print-minis" class="model-card w-full bg-[#2A2A2E] border border-white/10 rounded-xl p-4 flex flex-col justify-center space-y-2 flex-1">
             <span class="font-semibold text-lg self-center text-center">Print Minis</span>
-            <p class="text-sm text-center">We'll print your design at roughly 75% scale for a tiny version.</p>
+            <p class="text-sm text-center">We'll print your design at roughly 25% scale for a tiny version.</p>
             <p class="text-sm text-center font-semibold">£14.99 per mini</p>
             <button class="self-center bg-[#30D5C8] text-black px-3 py-1 rounded text-sm">Add to Basket</button>
           </div>


### PR DESCRIPTION
## Summary
- tweak mini print description to 25% scale

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6864585c94d4832db7cf000e97f396f6