### PR TITLE
Update Luckybox panel height

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -118,9 +118,9 @@
       </div>
 
       <!-- ROW: Luckybox (50%) | RIGHT COLUMN (50%) -->
-      <div class="flex gap-6 mt-12 h-full items-stretch">
+      <div class="flex gap-6 mt-12 items-stretch min-h-[calc(100vh-8rem)]">
         <!-- Luckybox (50%) -->
-        <div id="luckybox" class="model-card w-1/2 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 pb-20 flex flex-col space-y-4 relative h-full">
+        <div id="luckybox" class="model-card w-1/2 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 pb-20 flex flex-col space-y-4 relative h-full flex-1">
           <span class="font-semibold text-lg self-center text-center">Luckybox</span>
           <div class="flex justify-between items-start">
             <fieldset id="luckybox-tiers" class="flex gap-4">


### PR DESCRIPTION
## Summary
- adjust layout to let Luckybox panel fill most of the left side

## Testing
- `npm run format`
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6864e26c5100832d921fe6cb3660a275