### PR TITLE
Align addon panels

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -118,7 +118,7 @@
       </div>
 
       <!-- ROW: Luckybox (50%) | RIGHT COLUMN (50%) -->
-      <div class="flex gap-6 mt-12 items-stretch min-h-[calc(100vh-8rem)]">
+      <div class="flex gap-6 mt-12 items-stretch min-h-[calc(100vh-4rem)]">
         <!-- Luckybox (50%) -->
         <div id="luckybox" class="model-card w-1/2 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 pb-20 flex flex-col space-y-4 relative h-full flex-1">
           <span class="font-semibold text-lg self-center text-center">Luckybox</span>
@@ -168,7 +168,7 @@
           </div>
 
           <!-- Remix prints (50% of column) -->
-          <div id="remix-prints" class="model-card w-full bg-[#2A2A2E] border border-white/10 rounded-xl p-4 flex items-center justify-center text-center opacity-50 flex-1">
+          <div id="remix-prints" class="model-card w-full bg-[#2A2A2E] border border-white/10 rounded-xl p-4 pb-20 flex items-center justify-center text-center opacity-50 flex-1">
             <div>
               <span class="font-semibold">Remix prints</span>
               <span class="block text-xs mt-1">coming soon</span>


### PR DESCRIPTION
## Summary
- align Luckybox and Remix panels
- extend the row height so both panels sit near the fold

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68650fd29d24832db89b24b11e07b2c0