### PR TITLE
Fix layout on printclub page

### DIFF
--- a/printclub.html
+++ b/printclub.html
@@ -97,11 +97,11 @@
         >
           <p class="text-lg">
             Receive 2 prints (single or multicolour) every week, and unlimited
-            £20 off premium (£79.99 -> £59.99).
+            £20 off premium (<span class="line-through">£79.99</span> £59.99).
           </p>
-          <div class="text-left text-sm my-4 flex-1" id="loyalty-benefits">
+          <div class="text-center text-sm my-4 flex-1" id="loyalty-benefits">
             <h3 class="text-lg underline mb-1 text-center">Loyalty Rewards</h3>
-            <ul class="list-disc list-inside space-y-1">
+            <ul class="list-disc list-inside space-y-1 inline-block text-left">
               <li>
                 3 months – (2 + <span class="text-[#30D5C8]">1 extra</span> = 3)
                 prints each week
@@ -151,7 +151,7 @@
         <h2 class="text-2xl font-semibold mb-2">print2 Pro</h2>
         <p class="mb-4">
           Receive 2 prints (single or multicolour) every week, and unlimited £20
-          off premium (£79.99 -> £59.99).
+          off premium (<span class="line-through">£79.99</span> £59.99).
         </p>
         <button
           id="printclub-close"


### PR DESCRIPTION
## Summary
- center loyalty rewards bullet list
- show strike-through pricing in printclub offer

## Testing
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_686511adf6d0832d8334330f643f6451