### PR TITLE
Ensure Jest is installed before running tests

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -32,7 +32,8 @@
     "send-intel-report": "node scripts/send-intel-report.js",
     "notify-clearing": "node scripts/notify-manual-clearing.js",
     "send-ops-report": "node scripts/send-ops-report.js",
-    "flag-overdue-printers": "node scripts/flag-overdue-procurement-orders.js"
+    "flag-overdue-printers": "node scripts/flag-overdue-procurement-orders.js",
+    "pretest": "node scripts/ensure-deps.js"
   },
   "keywords": [],
   "author": "",

--- a/backend/scripts/ensure-deps.js
+++ b/backend/scripts/ensure-deps.js
@@ -1,0 +1,9 @@
+const fs = require("fs");
+const { execSync } = require("child_process");
+
+const jestPath = "node_modules/.bin/jest";
+
+if (!fs.existsSync(jestPath)) {
+  console.log("Jest not found. Installing backend dependencies...");
+  execSync("npm ci", { stdio: "inherit" });
+}


### PR DESCRIPTION
## Summary
- add a pretest script in backend/package.json that checks for Jest
- if Jest is missing, run `npm ci`

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68651518de00832d9adaac9329326814