### PR TITLE
Center text on rewards page

### DIFF
--- a/earn-rewards.html
+++ b/earn-rewards.html
@@ -109,14 +109,14 @@
             <h2 class="text-2xl font-semibold text-center">
               Share &amp; earn discounts
             </h2>
-            <p class="text-gray-400">
+            <p class="text-gray-400 text-center">
               You must
               <a href="login.html" class="font-bold text-[#30D5C8]">Log In</a>
               or
               <a href="signup.html" class="font-bold text-[#30D5C8]">Sign Up</a>
               to get rewards.
             </p>
-            <p class="text-lg">
+            <p class="text-lg text-center">
               Invite other using the link below. Earn
               <span class="text-[#30D5C8]">£ credits</span> if they buy.
             </p>
@@ -178,12 +178,12 @@
             <h3 class="text-2xl font-semibold mb-2 text-center">
               What are others earning?
             </h3>
-            <table class="w-full text-sm">
+            <table class="w-full text-sm text-center">
               <thead>
                 <tr>
-                  <th class="text-left px-2 py-1">User</th>
-                  <th class="text-left px-2 py-1 whitespace-nowrap">
-                    <span class="inline-block w-16 text-right">Points</span>
+                  <th class="px-2 py-1">User</th>
+                  <th class="px-2 py-1 whitespace-nowrap">
+                    <span class="inline-block w-16 text-center">Points</span>
                     <span class="text-[#30D5C8]">(equivalent credit)</span>
                   </th>
                 </tr>
@@ -192,21 +192,21 @@
                 <tr>
                   <td class="px-2 py-1">Alex</td>
                   <td class="px-2 py-1 whitespace-nowrap">
-                    <span class="inline-block w-16 text-right">150</span>
+                    <span class="inline-block w-16 text-center">150</span>
                     <span class="text-[#30D5C8]">(£30)</span>
                   </td>
                 </tr>
                 <tr>
                   <td class="px-2 py-1">Blake</td>
                   <td class="px-2 py-1 whitespace-nowrap">
-                    <span class="inline-block w-16 text-right">120</span>
+                    <span class="inline-block w-16 text-center">120</span>
                     <span class="text-[#30D5C8]">(£24)</span>
                   </td>
                 </tr>
                 <tr>
                   <td class="px-2 py-1">Casey</td>
                   <td class="px-2 py-1 whitespace-nowrap">
-                    <span class="inline-block w-16 text-right">100</span>
+                    <span class="inline-block w-16 text-center">100</span>
                     <span class="text-[#30D5C8]">(£20)</span>
                   </td>
                 </tr>


### PR DESCRIPTION
## Summary
- center the login/signup instructions on rewards page
- center the rewards leaderboard text

## Testing
- `npm test --prefix backend`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68651145c07c832d93cc9db934426196