### PR TITLE
Add eslint setup hint

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,3 +361,8 @@ sudo dpkg --configure -a
 ```
 
 This resolves any partially configured packages left over from an interrupted `apt` operation.
+
+### "Cannot find module '@eslint/js'"
+
+If `eslint` fails with this error, it usually means dependencies aren't installed.
+Run `npm run setup` in the repository root to install them.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,3 +1,11 @@
+// Display a helpful message if dependencies have not been installed.
+try {
+  require.resolve("@eslint/js");
+} catch {
+  console.error("Dependencies not installed. Run 'npm run setup' at the repository root.");
+  process.exit(1);
+}
+
 const js = require("@eslint/js");
 const prettier = require("eslint-config-prettier");
 const globals = require("globals");


### PR DESCRIPTION
## Summary
- add troubleshooting note for missing `@eslint/js`
- exit early from ESLint config when dependencies aren't installed

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68651518f650832db19340038c5ea917