### PR TITLE
Add npm registry connectivity check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,8 @@ These guidelines apply to all automated agents (e.g. the Codex agent) working on
 ## Mandatory steps
 
 1. **Unset proxy variables** – before running any `npm` commands, **and whenever you start a new shell session**, execute `unset npm_config_http_proxy npm_config_https_proxy` to silence `http-proxy` warnings.
-2. **Install dependencies** – run `npm run setup` at the repository root. This script unsets proxy variables, runs `npm ci` in the root, `backend/`, and `backend/hunyuan_server/` if present, and installs Playwright browsers.
+   Run `npm ping` to verify that the registry is reachable before proceeding.
+2. **Install dependencies** – run `npm run setup` at the repository root. This script unsets proxy variables, checks registry connectivity, runs `npm ci` in the root, `backend/`, and `backend/hunyuan_server/` if present, and installs Playwright browsers.
    - Set `SKIP_PW_DEPS=1` before running the setup script if Playwright dependencies are already installed. This skips the long `apt-get` step and reduces CI time.
 3. **Format code** – run `npm run format` in `backend/` to apply Prettier formatting.
 4. **Run tests** – execute `npm test` in `backend/`. If tests cannot run because of environment limitations, mention this in the PR.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -2,6 +2,12 @@
 set -e
 unset npm_config_http_proxy npm_config_https_proxy
 
+# Abort early if the npm registry is unreachable
+if ! npm ping >/dev/null 2>&1; then
+  echo "Unable to reach the npm registry. Check network connectivity or proxy settings." >&2
+  exit 1
+fi
+
 # Remove any existing node_modules directories to avoid ENOTEMPTY errors
 rm -rf node_modules backend/node_modules
 if [ -d backend/hunyuan_server/node_modules ]; then


### PR DESCRIPTION
## Summary
- check npm registry reachability in the setup script
- document connectivity check in AGENTS guidelines

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend --silent`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6865155df618832d91f2561cda1ce475