### PR TITLE
Fix bottom alignment on add-ons page

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -118,7 +118,7 @@
       </div>
 
       <!-- ROW: Luckybox (50%) | RIGHT COLUMN (50%) -->
-      <div class="flex gap-6 mt-12 items-stretch min-h-[calc(100vh-4rem)]">
+      <div class="flex gap-6 mt-12 items-stretch min-h-[calc(100vh-8rem)]">
         <!-- Luckybox (50%) -->
         <div id="luckybox" class="model-card w-1/2 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 pb-20 flex flex-col space-y-4 relative h-full flex-1">
           <span class="font-semibold text-lg self-center text-center">Luckybox</span>
@@ -168,7 +168,7 @@
           </div>
 
           <!-- Remix prints (50% of column) -->
-          <div id="remix-prints" class="model-card w-full bg-[#2A2A2E] border border-white/10 rounded-xl p-4 pb-20 flex items-center justify-center text-center opacity-50 flex-1">
+          <div id="remix-prints" class="model-card w-full bg-[#2A2A2E] border border-white/10 rounded-xl p-4 pb-20 flex items-center justify-center text-center opacity-50 flex-1 h-full">
             <div>
               <span class="font-semibold">Remix prints</span>
               <span class="block text-xs mt-1">coming soon</span>


### PR DESCRIPTION
## Summary
- stretch Luckybox and Remix panels to viewport height
- ensure Remix panel fills column

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6865396f5f3c832d8c4bce61c561141b