### PR TITLE
fix: persist community checkout selection

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -502,6 +502,19 @@
           const job = checkoutBtn.dataset.job;
           if (model) localStorage.setItem("print3Model", model);
           if (job) localStorage.setItem("print3JobId", job);
+          localStorage.removeItem("print3Basket");
+          try {
+            localStorage.setItem(
+              "print3CheckoutItems",
+              JSON.stringify([
+                {
+                  modelUrl: model || "",
+                  jobId: job || "",
+                  snapshot: addBasketBtn?.dataset.snapshot || "",
+                },
+              ]),
+            );
+          } catch {}
         });
 
         addBasketBtn?.addEventListener("click", () => {

--- a/js/community.js
+++ b/js/community.js
@@ -295,6 +295,19 @@ function createCard(model) {
     sessionStorage.setItem("fromCommunity", "1");
     localStorage.setItem("print3Model", model.model_url);
     localStorage.setItem("print3JobId", model.job_id);
+    localStorage.removeItem("print3Basket");
+    try {
+      localStorage.setItem(
+        "print3CheckoutItems",
+        JSON.stringify([
+          {
+            modelUrl: model.model_url,
+            jobId: model.job_id,
+            snapshot: model.snapshot || "",
+          },
+        ]),
+      );
+    } catch {}
     window.location.href = "payment.html";
   });
   const saveBtn = div.querySelector(".save");
@@ -335,6 +348,13 @@ function createViewerCard(modelUrl) {
     sessionStorage.setItem("fromCommunity", "1");
     localStorage.setItem("print3Model", modelUrl);
     localStorage.setItem("print3JobId", "");
+    localStorage.removeItem("print3Basket");
+    try {
+      localStorage.setItem(
+        "print3CheckoutItems",
+        JSON.stringify([{ modelUrl, jobId: "", snapshot: "" }]),
+      );
+    } catch {}
     window.location.href = "payment.html";
   });
   return div;


### PR DESCRIPTION
## Summary
- ensure clicking Buy from community model replaces any previous checkout items
- apply same logic for viewer cards and modal checkout

## Testing
- `npm run format`
- `npm test`
- `npm run ci` *(fails: did not finish due to long output, but tests ran)*
- `npm run smoke` *(failed: apt-get requests blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686552d74bc8832d83388fada902b30f