### PR TITLE
Avoid apt downloads during smoke tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,12 +7,12 @@ These guidelines apply to all automated agents (e.g. the Codex agent) working on
 1. **Unset proxy variables** – before running any `npm` commands, **and whenever you start a new shell session**, execute `unset npm_config_http_proxy npm_config_https_proxy` to silence `http-proxy` warnings.
    Run `npm ping` to verify that the registry is reachable before proceeding.
 2. **Install dependencies** – run `npm run setup` at the repository root. This script unsets proxy variables, checks registry connectivity, runs `npm ci` in the root, `backend/`, and `backend/hunyuan_server/` if present, and installs Playwright browsers.
-   - Set `SKIP_PW_DEPS=1` before running the setup script if Playwright dependencies are already installed. This skips the long `apt-get` step and reduces CI time.
+   - Set `SKIP_PW_DEPS=1` before running the setup script if Playwright dependencies are already installed. This skips the long `apt-get` step and reduces CI time. The `smoke` script automatically exports this variable.
 3. **Format code** – run `npm run format` in `backend/` to apply Prettier formatting.
 4. **Run tests** – execute `npm test` in `backend/`. If tests cannot run because of environment limitations, mention this in the PR.
 5. **Run full CI locally** – execute `npm run ci` at the repo root before opening a PR.
 6. **Install Playwright browsers** – the setup script installs these automatically. If browsers are missing, run `CI=1 npx playwright install --with-deps` manually.
-7. **Run smoke tests** – execute `npm run smoke` at the repository root. This script ensures dependencies and Playwright browsers are installed before running the Playwright runner. **Do not run `npx playwright test` directly** – that can trigger `"Playwright Test did not expect test() to be called here"` errors when dependencies are missing.
+7. **Run smoke tests** – execute `npm run smoke` at the repository root. This script sets `SKIP_PW_DEPS=1` to bypass Playwright's dependency installation when the browsers are already installed. **Do not run `npx playwright test` directly** – that can trigger `"Playwright Test did not expect test() to be called here"` errors when dependencies are missing.
 8. **Limit scope** – only modify files related to the task. Do not change anything under `img/`, `models/`, or `uploads/` unless explicitly requested. Avoid editing `docs/` unless the task specifically involves documentation.
 9. **Use Conventional Commits** – commit messages must follow the `type: description` format enforced by commitlint. Allowed types are `build`, `ci`, `docs`, `feat`, `fix`, `chore`, `refactor`, `test`, `style`, `perf`, and `revert`. Example: `fix: handle missing avatar images`.
 10. **Review your diff** – run `git status --short` and `git diff --stat` to ensure only intended files were modified. Revert any unrelated changes.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ This repository contains the early MVP code for print2's website and backend.
 
    This script runs `npm ci` in the root, `backend/`, and
    `backend/hunyuan_server/` if present, then downloads the browsers
-   required for the end-to-end tests.
+   required for the end-to-end tests. Set `SKIP_PW_DEPS=1` to skip the
+   Playwright dependency installation when the browsers are already available.
 
 3. Initialize the database:
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "bundle:size": "size-limit",
     "setup": "scripts/setup.sh",
     "e2e": "playwright test",
-    "smoke": "npm run setup && npx playwright test e2e/smoke.test.js",
+    "smoke": "SKIP_PW_DEPS=1 npm run setup && npx playwright test e2e/smoke.test.js",
     "visual-test": "percy exec -- npm run e2e",
     "test:a11y": "playwright install chromium --with-deps && playwright test e2e/a11y.test.js",
     "netlify:deploy": "scripts/netlify-preflight.sh && netlify deploy"


### PR DESCRIPTION
## Summary
- skip Playwright dependency installation when running `npm run smoke`
- document SKIP_PW_DEPS usage in setup instructions
- clarify the behavior in the agent guidelines

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68655bfea2b8832d88a2dda286e3ac7c