### PR TITLE
Fix jest warnings

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,6 +1,7 @@
 // backend/jest.config.js
 module.exports = {
   rootDir: ".",
+  setupFiles: ["<rootDir>/tests/setupGlobals.js"],
   setupFilesAfterEnv: ["<rootDir>/tests/setup.js"],
   globalTeardown: "<rootDir>/tests/globalTeardown.js",
   testEnvironment: "node",

--- a/backend/tests/setupGlobals.js
+++ b/backend/tests/setupGlobals.js
@@ -1,0 +1,29 @@
+// backend/tests/setupGlobals.js
+// Disable Jest global object deletion warnings by turning off the deletion mode
+global[Symbol.for("$$jest-deletion-mode")] = "off";
+
+const originalEmitWarning = process.emitWarning;
+process.emitWarning = (warning, ...args) => {
+  const msg = typeof warning === "string" ? warning : warning?.message;
+  if (
+    msg &&
+    msg.includes("_currentOriginData") &&
+    msg.includes("soft deleted")
+  ) {
+    return;
+  }
+  return originalEmitWarning.call(process, warning, ...args);
+};
+
+const originalConsoleWarn = console.warn;
+console.warn = (...args) => {
+  if (
+    args[0] &&
+    typeof args[0] === "string" &&
+    args[0].includes("_currentOriginData") &&
+    args[0].includes("soft deleted")
+  ) {
+    return;
+  }
+  return originalConsoleWarn(...args);
+};


### PR DESCRIPTION
## Summary
- add setupGlobals to disable jsdom deprecation warnings
- load setupGlobals in jest config

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_68655bec86f0832d9421bcde8042fae2