### PR TITLE
fix: use relative path for LuckyBox preview

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -150,7 +150,7 @@
                 </span>
               </label>
             </fieldset>
-            <img src="/img/luckybox-preview.png" alt="Luckybox preview" class="w-32 h-32 rounded-lg object-cover" />
+            <img src="img/luckybox-preview.png" alt="Luckybox preview" class="w-32 h-32 rounded-lg object-cover" />
           </div>
           <a href="luckybox-payment.html" class="absolute bottom-4 right-4 font-bold py-2 px-5 rounded-full shadow-md transition border-2 border-black" style="background-color: #30d5c8; color: #1a1a1d" onmouseover="this.style.opacity='0.85'" onmouseout="this.style.opacity='1'">
             Buy →

--- a/luckybox-payment.html
+++ b/luckybox-payment.html
@@ -208,7 +208,7 @@
           />
         <img
           id="viewer"
-          src="/img/luckybox-preview.png"
+          src="img/luckybox-preview.png"
           alt="Luckybox preview"
           class="object-cover h-full w-full rounded-3xl"
         />


### PR DESCRIPTION
## Summary
- use relative image paths for LuckyBox preview

## Testing
- `npm test` in `backend`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6865664ca65c832dae8ea2e5fdfd2290