### PR TITLE
fix: align points header

### DIFF
--- a/earn-rewards.html
+++ b/earn-rewards.html
@@ -184,7 +184,7 @@
                   <th class="px-2 py-1">User</th>
                   <th class="px-2 py-1 whitespace-nowrap">
                     <span class="inline-block w-16 text-center">Points</span>
-                    <span class="text-[#30D5C8]">(equivalent credit)</span>
+                    <span class="text-[#30D5C8] ml-2">(equivalent credit)</span>
                   </th>
                 </tr>
               </thead>


### PR DESCRIPTION
## Summary
- shift "Points (equivalent credit)" text right so it's centered

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6865848c0cb8832d9a991996acb2e4dc