### PR TITLE
Update Luckybox layout

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -122,8 +122,11 @@
         <!-- Luckybox (50%) -->
         <div id="luckybox" class="model-card w-1/2 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 pb-20 flex flex-col space-y-4 relative h-full flex-1">
           <span class="font-semibold text-lg self-center text-center">Luckybox</span>
-          <div class="flex justify-between items-start">
-            <fieldset id="luckybox-tiers" class="flex gap-4">
+          <div class="flex items-center justify-between gap-4">
+            <div class="w-32 h-32 rounded-lg border border-white/20 flex items-center justify-center">
+              <span class="text-xs text-center">placeholder</span>
+            </div>
+            <fieldset id="luckybox-tiers" class="flex gap-4 flex-1 justify-center">
               <!-- premium -->
               <label class="cursor-not-allowed flex flex-col items-center text-center opacity-50">
                 <input type="radio" name="luckybox-tier" value="premium" class="sr-only peer" disabled />


### PR DESCRIPTION
## Summary
- center luckybox tier buttons and add a placeholder panel on addons page

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68658d5b6644832dae10c52b2073b268