### PR TITLE
Fix Luckybox checkout layout shift

### DIFF
--- a/luckybox-payment.html
+++ b/luckybox-payment.html
@@ -171,7 +171,7 @@
     </header>
 
     <!-- Main -->
-    <main class="flex-1 flex flex-col items-center justify-center px-4 space-y-8 -mt-40">
+    <main id="page-main" class="flex-1 flex flex-col items-center justify-center px-4 space-y-8 -mt-40" style="visibility: hidden">
       <div id="success" class="hidden text-green-400 text-center space-y-2">
         <p>Payment successful!</p>
         <a href="profile.html" class="underline block">View profile</a>
@@ -615,6 +615,12 @@
           </p>
         </div>
       </div>
+      <script>
+        document.addEventListener('DOMContentLoaded', () => {
+          const main = document.getElementById('page-main');
+          if (main) main.style.visibility = 'visible';
+        });
+      </script>
     </main>
 
     <!-- Exit-intent discount overlay -->


### PR DESCRIPTION
## Summary
- prevent unstyled flash on Luckybox checkout by hiding content until the page is ready

## Testing
- `npm test` in `backend/`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68658cd7fc4c832d8669586349b73945