### PR TITLE
Fix Luckybox preselection

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -138,7 +138,7 @@
               </label>
               <!-- multicolour -->
               <label class="cursor-pointer flex flex-col items-center text-center">
-                <input type="radio" name="luckybox-tier" value="multicolour" class="sr-only peer" />
+                <input type="radio" name="luckybox-tier" value="multicolour" class="sr-only peer" checked />
                 <span id="luckybox-multi" class="w-28 h-28 flex flex-col items-center justify-center rounded-full border-4 border-white/20 shadow-xl peer-checked:border-[#30D5C8]">
                   <span class="font-semibold">£29.99</span>
                   <span class="text-xs">multicolour</span>
@@ -146,7 +146,7 @@
               </label>
               <!-- single colour -->
               <label class="cursor-pointer flex flex-col items-center text-center">
-                <input type="radio" name="luckybox-tier" value="basic" class="sr-only peer" checked />
+                <input type="radio" name="luckybox-tier" value="basic" class="sr-only peer" />
                 <span class="w-24 h-24 flex flex-col items-center justify-center rounded-full border border-white/20 peer-checked:border-2 peer-checked:border-[#30D5C8]">
                   <span class="font-semibold">£19.99</span>
                   <span class="text-xs">single colour</span>

--- a/js/addons.js
+++ b/js/addons.js
@@ -45,25 +45,17 @@ function initLuckybox() {
     '#luckybox-tiers input[name="luckybox-tier"]',
   );
   const desc = document.getElementById("luckybox-desc");
-  if (!tierRadios.length || !desc) return;
+  if (!tierRadios.length) return;
   const descriptions = {
     basic: "£19.99 print + 5 print points (usually £29.99)",
     multicolour: "£29.99 print + 5 print points (usually £39.99)",
     premium: "£59.99 print + 10 print points (usually £79.99)",
   };
-  const stored = localStorage.getItem("print3Material");
-  if (stored) {
-    const val =
-      stored === "multi"
-        ? "multicolour"
-        : stored === "premium"
-          ? "premium"
-          : "basic";
-    const radio = document.querySelector(
-      `#luckybox-tiers input[value="${val}"]`,
-    );
-    if (radio) radio.checked = true;
-  }
+  const defaultRadio = document.querySelector(
+    '#luckybox-tiers input[value="multicolour"]',
+  );
+  if (defaultRadio) defaultRadio.checked = true;
+  localStorage.setItem("print3Material", "multi");
   function selectedTier() {
     const checked = document.querySelector(
       '#luckybox-tiers input[name="luckybox-tier"]:checked',
@@ -72,7 +64,7 @@ function initLuckybox() {
   }
   function update() {
     const tier = selectedTier();
-    desc.textContent = descriptions[tier] || descriptions.basic;
+    if (desc) desc.textContent = descriptions[tier] || descriptions.basic;
     const material =
       tier === "multicolour"
         ? "multi"


### PR DESCRIPTION
## Summary
- default to multicolour luckybox when loading Add-ons page

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6865aadfa7b4832d8a1d14f21f56b3ae