### PR TITLE
Fix vertical rotation in model viewers

### DIFF
--- a/js/modelViewerTouchFix.js
+++ b/js/modelViewerTouchFix.js
@@ -1,11 +1,27 @@
 function applyTouchFix() {
-  document.querySelectorAll('model-viewer').forEach((el) => (el.style.touchAction = 'none'));
+  function setTouchNone(el) {
+    el.style.touchAction = "none";
+  }
+
+  document.querySelectorAll("model-viewer").forEach(setTouchNone);
+
+  const observer = new MutationObserver((records) => {
+    for (const rec of records) {
+      for (const node of rec.addedNodes) {
+        if (node.nodeType !== 1) continue;
+        if (node.tagName === "MODEL-VIEWER") setTouchNone(node);
+        node.querySelectorAll?.("model-viewer").forEach(setTouchNone);
+      }
+    }
+  });
+  observer.observe(document.body, { childList: true, subtree: true });
 
   let active = false;
 
   function start(e) {
-    if (e.touches.length === 1 && e.target.closest('model-viewer')) {
+    if (e.touches.length === 1 && e.target.closest("model-viewer")) {
       active = true;
+      e.preventDefault();
     }
   }
 
@@ -19,14 +35,14 @@ function applyTouchFix() {
     active = false;
   }
 
-  document.addEventListener('touchstart', start, { passive: true });
-  document.addEventListener('touchmove', move, { passive: false });
-  document.addEventListener('touchend', end, { passive: true });
-  document.addEventListener('touchcancel', end, { passive: true });
+  document.addEventListener("touchstart", start, { passive: false });
+  document.addEventListener("touchmove", move, { passive: false });
+  document.addEventListener("touchend", end, { passive: true });
+  document.addEventListener("touchcancel", end, { passive: true });
 }
 
-if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', applyTouchFix);
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", applyTouchFix);
 } else {
   applyTouchFix();
 }


### PR DESCRIPTION
## Summary
- ensure touch interaction starts on vertical movements by preventing default on touchstart
- observe DOM for dynamically added model-viewer elements so touch behavior applies consistently

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68664f9ffcc8832d8d94c160a4f73054