### PR TITLE
Fix Luckybox preview and pricing

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -67,14 +67,15 @@ function computeBulkDiscount(items) {
   for (const it of items) {
     totalQty += Math.max(1, parseInt(it.qty || 1, 10));
   }
+  if (window.location.pathname.endsWith("luckybox-payment.html")) {
+    if (totalQty >= 3) return THIRD_PRINT_DISCOUNT;
+    if (totalQty >= 2) return TWO_PRINT_DISCOUNT;
+    return 0;
+  }
+
   let discount = 0;
   if (totalQty >= 2) discount += TWO_PRINT_DISCOUNT;
-  if (
-    totalQty >= 3 &&
-    !window.location.pathname.endsWith("luckybox-payment.html")
-  ) {
-    discount += THIRD_PRINT_DISCOUNT;
-  }
+  if (totalQty >= 3) discount += THIRD_PRINT_DISCOUNT;
   return discount;
 }
 const NEXT_PROMPTS = [

--- a/luckybox-payment.html
+++ b/luckybox-payment.html
@@ -774,5 +774,11 @@
     <script>window.disableSaveButton = true;</script>
     <script type="module" src="js/saveList.js" defer></script>
     <script type="module" src="js/trackingPixel.js"></script>
+    <script>
+      document.addEventListener('DOMContentLoaded', () => {
+        const img = document.getElementById('viewer');
+        if (img) img.src = 'img/luckybox-preview.png';
+      });
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- keep luckybox preview image instead of last viewed model
- apply luckybox-specific bulk discounts

## Testing
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68664f985860832da88b23880e4b071b