### PR TITLE
Remove Luckybox third purchase discount

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -68,7 +68,6 @@ function computeBulkDiscount(items) {
     totalQty += Math.max(1, parseInt(it.qty || 1, 10));
   }
   if (window.location.pathname.endsWith("luckybox-payment.html")) {
-    if (totalQty >= 3) return THIRD_PRINT_DISCOUNT;
     if (totalQty >= 2) return TWO_PRINT_DISCOUNT;
     return 0;
   }


### PR DESCRIPTION
## Summary
- remove £15 discount logic from Luckybox checkout

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6866763d954c832dbc6b90daf19bea31