### PR TITLE
fix: align and extend add-ons panels

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -118,9 +118,9 @@
       </div>
 
       <!-- ROW: Luckybox (50%) | RIGHT COLUMN (50%) -->
-      <div class="flex gap-6 mt-12 items-stretch min-h-[calc(100vh-8rem)]">
+      <div class="flex gap-6 mt-12 items-stretch min-h-[calc(100vh-6rem)]">
         <!-- Luckybox (50%) -->
-        <div id="luckybox" class="model-card w-1/2 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 pb-20 flex flex-col space-y-4 relative h-full flex-1">
+        <div id="luckybox" class="model-card w-1/2 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 pb-20 flex flex-col space-y-4 relative h-full flex-1 min-h-[36rem]">
           <span class="font-semibold text-lg self-center text-center">Luckybox</span>
           <div class="flex items-center justify-between gap-4">
             <div class="w-32 h-32 rounded-lg border border-white/20 flex items-center justify-center">
@@ -178,7 +178,7 @@
           </div>
 
           <!-- Remix prints (50% of column) -->
-          <div id="remix-prints" class="model-card w-full bg-[#2A2A2E] border border-white/10 rounded-xl p-4 pb-20 flex items-center justify-center text-center opacity-50 flex-1 h-full">
+          <div id="remix-prints" class="model-card w-full bg-[#2A2A2E] border border-white/10 rounded-xl p-4 pb-20 flex items-center justify-center text-center opacity-50 flex-1 h-full min-h-[36rem]">
             <div>
               <span class="font-semibold">Remix prints</span>
               <span class="block text-xs mt-1">coming soon</span>


### PR DESCRIPTION
## Summary
- adjust luckybox and remix panels to have matching bottom edges
- extend the panels downward for more consistent sizing

## Testing
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_686676f6db0c832dab9a7b28eab17b04