### PR TITLE
Fix checkout button style in basket popup

### DIFF
--- a/js/basket.js
+++ b/js/basket.js
@@ -286,7 +286,7 @@ export function setupBasketUI() {
       <div id="basket-list" class="grid grid-cols-2 gap-3 mb-2"></div>
       <div id="basket-reserve" class="hidden text-sm text-gray-200 mb-2"></div>
       <div id="basket-queue" class="text-sm text-gray-200 mb-2"></div>
-      <button id="basket-checkout" type="button" class="mb-2 px-4 py-2 rounded-md bg-[#30D5C8] text-[#1A1A1D]">Checkout</button>
+      <button id="basket-checkout" type="button" class="mb-2 font-bold py-2 px-4 rounded-full shadow-md bg-[#30D5C8] text-[#1A1A1D] border-2 border-black">Checkout</button>
     </div>`;
   document.body.appendChild(overlay);
   overlay.querySelector("#basket-close").addEventListener("click", closeBasket);


### PR DESCRIPTION
## Summary
- restyle basket popup checkout button to match add-to-basket pill button

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_686677f1f56c832d93ae8dfb98a7012f