### PR TITLE
Fix rewards label alignment

### DIFF
--- a/earn-rewards.html
+++ b/earn-rewards.html
@@ -147,9 +147,9 @@
               </div>
             </div>
             <div class="space-y-1">
-              <label for="reward-input" class="block text-sm flex justify-between">
-                <span>Points: <span id="reward-points">0</span> ⭐</span>
-                <span class="text-right">(5 points = £1 credit):</span>
+              <label for="reward-input" class="block text-sm">
+                Points: <span id="reward-points">0</span> ⭐ (5 points = £1
+                credit):
               </label>
               <div class="flex">
                 <input


### PR DESCRIPTION
## Summary
- left align rewards helper text on the Earn Rewards page

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68667c9d1490832db55297ff824b4007