### PR TITLE
Update leaderboard header alignment

### DIFF
--- a/earn-rewards.html
+++ b/earn-rewards.html
@@ -147,7 +147,10 @@
               </div>
             </div>
             <div class="space-y-1">
-              <label for="reward-input" class="block text-sm flex justify-between">
+              <label
+                for="reward-input"
+                class="block text-sm flex justify-between"
+              >
                 <span>Points: <span id="reward-points">0</span> ⭐</span>
                 <span class="text-right">(5 points = £1 credit):</span>
               </label>
@@ -183,7 +186,7 @@
               <thead>
                 <tr>
                   <th class="px-2 py-1">User</th>
-                  <th class="px-2 py-1 whitespace-nowrap">
+                  <th class="px-2 py-1 whitespace-nowrap text-right">
                     <span class="inline-block w-16 text-center">Points</span>
                     <span class="text-[#30D5C8] ml-2">(equivalent credit)</span>
                   </th>


### PR DESCRIPTION
## Summary
- align 'Points (equivalent credit)' header with the table data in `earn-rewards.html`

## Testing
- `npx prettier --write earn-rewards.html`
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68667cb881c8832db89ae2cd2d5298f2