### PR TITLE
Add arrow on basket checkout button

### DIFF
--- a/js/basket.js
+++ b/js/basket.js
@@ -286,7 +286,7 @@ export function setupBasketUI() {
       <div id="basket-list" class="grid grid-cols-2 gap-3 mb-2"></div>
       <div id="basket-reserve" class="hidden text-sm text-[#30D5C8] mb-2"></div>
       <div id="basket-queue" class="text-sm text-gray-200 mb-2"></div>
-      <button id="basket-checkout" type="button" class="mb-2 font-bold py-2 px-4 rounded-full shadow-md bg-[#30D5C8] text-[#1A1A1D] border-2 border-black">Checkout</button>
+      <button id="basket-checkout" type="button" class="mb-2 font-bold py-2 px-4 rounded-full shadow-md bg-[#30D5C8] text-[#1A1A1D] border-2 border-black">Checkout →</button>
     </div>`;
   document.body.appendChild(overlay);
   overlay.querySelector("#basket-close").addEventListener("click", closeBasket);


### PR DESCRIPTION
## Summary
- add a right arrow to the basket checkout button

## Testing
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_686687ca7338832da4ccecc4ac6478a3