### PR TITLE
Fix Playwright server reuse

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,14 +1,15 @@
-const { defineConfig } = require('@playwright/test');
-const baseURL = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3000';
+const { defineConfig } = require("@playwright/test");
+const baseURL = process.env.PLAYWRIGHT_BASE_URL || "http://localhost:3000";
 
 module.exports = defineConfig({
-  testDir: 'e2e',
+  testDir: "e2e",
   use: { baseURL, headless: true },
   webServer: process.env.PLAYWRIGHT_BASE_URL
     ? undefined
     : {
-        command: 'npx http-server -c-1 -p 3000',
+        command: "npx http-server -c-1 -p 3000",
         port: 3000,
         timeout: 120 * 1000,
+        reuseExistingServer: true,
       },
 });


### PR DESCRIPTION
## Summary
- allow Playwright to reuse an existing web server

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68668923eef4832da3f5ae282eec01e7