### PR TITLE
Fix node_modules cleanup in setup script

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -9,9 +9,9 @@ if ! npm ping >/dev/null 2>&1; then
 fi
 
 # Remove any existing node_modules directories to avoid ENOTEMPTY errors
-rm -rf node_modules backend/node_modules
+rm -rf node_modules backend/node_modules || sudo rm -rf node_modules backend/node_modules
 if [ -d backend/hunyuan_server/node_modules ]; then
-  rm -rf backend/hunyuan_server/node_modules
+  rm -rf backend/hunyuan_server/node_modules || sudo rm -rf backend/hunyuan_server/node_modules
 fi
 
 # Remove stale apt or dpkg locks that may prevent dependency installation


### PR DESCRIPTION
## Summary
- forcibly remove node_modules directories in `setup.sh` using sudo fallback

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68668ad83b74832d91631fc01b65b2e6