### PR TITLE
Fix GLB advert size on community page

### DIFF
--- a/js/publicGalleries.js
+++ b/js/publicGalleries.js
@@ -54,9 +54,9 @@ window.addEventListener("DOMContentLoaded", () => {
   }
 
   const advertModels = [
-    "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/DamagedHelmet/glTF-Binary/DamagedHelmet.glb",
+    "models/bag.glb",
     "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/Avocado/glTF-Binary/Avocado.glb",
-    "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoomBox/glTF-Binary/BoomBox.glb",
+    "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/DamagedHelmet/glTF-Binary/DamagedHelmet.glb",
   ];
   let advertIdx = 0;
   let advertInterval;
@@ -71,7 +71,7 @@ window.addEventListener("DOMContentLoaded", () => {
   function createAdvert() {
     const advert = document.createElement("div");
     advert.className =
-      "relative w-full h-64 bg-[#2A2A2E] border border-dashed border-white/40 rounded-xl flex items-center justify-center";
+      "relative w-full h-32 bg-[#2A2A2E] border border-dashed border-white/40 rounded-xl flex items-center justify-center";
     advert.innerHTML = `
       <model-viewer id="advert-viewer" src="${advertModels[0]}" camera-controls auto-rotate environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr" class="w-full h-full rounded-xl"></model-viewer>
       <button id="advert-prev" class="absolute top-1/2 left-2 -translate-y-1/2 bg-black/50 p-2 rounded-full text-white"><i class="fas fa-chevron-left"></i><span class="sr-only">Previous</span></button>


### PR DESCRIPTION
## Summary
- scale the Public Galleries advert panel
- add real GLB files to the rotating viewer

## Testing
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68669530656c832db6d3f44a327fbdc8