### PR TITLE
Fix Luckybox panel layout

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -121,14 +121,12 @@
       <div class="flex gap-6 mt-12 items-stretch min-h-[calc(100vh-6rem)]">
         <!-- Luckybox (50%) -->
 
-        <div id="luckybox" class="model-card w-1/2 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 pb-20 flex flex-col space-y-4 relative h-full flex-1 min-h-[36rem] justify-center">
+        <div id="luckybox" class="model-card w-1/2 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 pb-20 flex flex-col space-y-2 relative h-full flex-1 min-h-[36rem]">
 
           <span class="font-semibold text-lg self-center text-center">Luckybox</span>
-          <div class="flex items-center justify-between gap-4 flex-1">
-            <div class="w-32 h-32 rounded-lg border border-white/20 flex items-center justify-center">
-              <span class="text-xs text-center">placeholder</span>
-            </div>
-            <fieldset id="luckybox-tiers" class="flex gap-4 flex-1 justify-between">
+          <div class="flex items-start justify-between gap-4">
+            <img src="img/luckybox-preview.png" alt="Luckybox preview" class="w-32 h-32 rounded-lg object-cover" />
+            <fieldset id="luckybox-tiers" class="flex gap-4 justify-between">
               <!-- premium -->
               <label class="cursor-not-allowed flex flex-col items-center text-center opacity-50">
                 <input type="radio" name="luckybox-tier" value="premium" class="sr-only peer" disabled />
@@ -155,7 +153,6 @@
                 </span>
               </label>
             </fieldset>
-            <img src="img/luckybox-preview.png" alt="Luckybox preview" class="w-32 h-32 rounded-lg object-cover" />
           </div>
           <a href="luckybox-payment.html" class="absolute bottom-4 right-4 font-bold py-2 px-5 rounded-full shadow-md transition border-2 border-black" style="background-color: #30d5c8; color: #1a1a1d" onmouseover="this.style.opacity='0.85'" onmouseout="this.style.opacity='1'">
             Buy →


### PR DESCRIPTION
## Summary
- tweak Luckybox layout in `addons.html`
- remove placeholder, move image left and bring controls closer to title

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6866d91a020c832d9826c18731b278c3