### PR TITLE
Fix alignment of 'Points' in rewards table

### DIFF
--- a/earn-rewards.html
+++ b/earn-rewards.html
@@ -184,7 +184,9 @@
                 <tr>
                   <th class="px-2 py-1">User</th>
                   <th class="px-2 py-1 whitespace-nowrap text-right">
-                    <span class="inline-block w-16 text-center">Points</span>
+                    <span class="inline-block w-16 text-center mr-1"
+                      >Points</span
+                    >
                     <span class="text-[#30D5C8] ml-2">(equivalent credit)</span>
                   </th>
                 </tr>


### PR DESCRIPTION
## Summary
- tiny tweak to align "Points" header with leaderboard numbers

## Testing
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6866da5e46d8832d8f1486c87f1487d6