### PR TITLE
Update gallery init

### DIFF
--- a/js/publicGalleries.js
+++ b/js/publicGalleries.js
@@ -25,7 +25,7 @@ const sampleGalleries = {
   ],
 };
 
-window.addEventListener("DOMContentLoaded", () => {
+async function init() {
   const tagsEl = document.getElementById("subreddit-tags");
   const grid = document.getElementById("gallery-grid");
   const loadBtn = document.getElementById("gallery-load");
@@ -148,11 +148,14 @@ window.addEventListener("DOMContentLoaded", () => {
     renderGallery();
   });
 
-  async function init() {
+  async function start() {
     await loadAdvertModels();
     renderTags();
     renderGallery();
   }
 
-  init();
-});
+  start();
+}
+
+if (document.readyState !== "loading") init();
+else document.addEventListener("DOMContentLoaded", init);


### PR DESCRIPTION
## Summary
- wrap public gallery logic in a new `init()` method
- defer initialization until DOMContentLoaded if needed

## Testing
- `npm run format` in `backend`
- `npm test` in `backend`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6866e11e1528832da652ad01fa2c4737