### PR TITLE
Initialize public galleries earlier

### DIFF
--- a/js/publicGalleries.js
+++ b/js/publicGalleries.js
@@ -25,7 +25,7 @@ const sampleGalleries = {
   ],
 };
 
-window.addEventListener("DOMContentLoaded", () => {
+async function init() {
   const tagsEl = document.getElementById("subreddit-tags");
   const grid = document.getElementById("gallery-grid");
   const loadBtn = document.getElementById("gallery-load");
@@ -148,11 +148,13 @@ window.addEventListener("DOMContentLoaded", () => {
     renderGallery();
   });
 
-  async function init() {
-    await loadAdvertModels();
-    renderTags();
-    renderGallery();
-  }
+  await loadAdvertModels();
+  renderTags();
+  renderGallery();
+}
 
+if (document.readyState !== "loading") {
   init();
-});
+} else {
+  window.addEventListener("DOMContentLoaded", init);
+}


### PR DESCRIPTION
## Summary
- load public galleries script sooner by creating an `init()` function
- call `init()` immediately when the DOM is ready
- ensure fallback `.glb` models appear if API models fail to load

## Testing
- `npm test --silent`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6866eb6384a8832db329033c28afa3e0