### PR TITLE
Fix fallback model path in payment script

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -5,7 +5,7 @@ let stripe = null;
 
 // Use a lightweight fallback model and upgrade to the high detail version after load.
 const FALLBACK_GLB_LOW =
-  "https://modelviewer.dev/shared-assets/models/Astronaut.glb";
+  "/models/astronaut_low.glb";
 const FALLBACK_GLB_HIGH = FALLBACK_GLB_LOW;
 const FALLBACK_GLB = FALLBACK_GLB_LOW;
 const PRICES = {


### PR DESCRIPTION
## Summary
- set `FALLBACK_GLB_LOW` in `js/payment.js` to use the local low-poly astronaut model

## Testing
- `npm run setup`
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `npm run ci` *(fails: a11y test interrupted)*
- `npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_6867a3c437d0832db2427c30842dfdb5