### PR TITLE
Update docs and clarify test redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository contains the early MVP code for print2's website and backend.
 - General backend code is in the `backend/` folder.
 - The lightweight Hunyuan3D API server lives in `backend/hunyuan_server/`.
 - The `img/` folder is now reserved strictly for image assets.
+- HTML files in the `uploads/` directory should use the `.links` extension to avoid being served as plain text.
 
 ## Local Setup
 

--- a/_redirects
+++ b/_redirects
@@ -1,3 +1,6 @@
 http://print2.io/* https://print2.io/:splat 301!
 http://www.print2.io/* https://print2.io/:splat 301!
 https://www.print2.io/* https://print2.io/:splat 301!
+
+# Note: The ab-uploads.print2.co.uk redirect used in Playwright tests is
+# not committed to this repo. Add it locally if needed.


### PR DESCRIPTION
## Summary
- document how to store HTML pages under `uploads/`
- note that a special redirect used by Playwright tests is not committed

## Testing
- `npm run format`
- `npm test`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_6867a81cfb50832d8d2372ad10ece1e0