### PR TITLE
Add binary file guidelines and attributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,18 @@
+# Treat common asset types as binary to avoid patching issues
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.webp binary
+*.svg binary
+*.mp3 binary
+*.wav binary
+*.ogg binary
+*.mp4 binary
+*.glb binary
+*.gltf binary
+img/* binary
+sounds/* binary
+models/* binary
+uploads/* binary
+upload/* binary

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ These guidelines apply to all automated agents (e.g. the Codex agent) working on
 10. **Review your diff** – run `git status --short` and `git diff --stat` to ensure only intended files were modified. Revert any unrelated changes.
 11. **Include logs** – paste the output of `npm test` (or `npm run test-ci`) and `npm run format` in the PR description so maintainers can verify the steps.
 12. **Avoid PRs with failing tests** – if `npm run ci` or the smoke tests fail for reasons other than environment limitations, do not open a pull request. Fix the issues or open an issue summarizing the failure instead.
+13. **Avoid committing binary files** – Codex cannot generate patches for binary changes. Do not modify images, audio, or other binary assets. If adding new ones, update `.gitattributes` so they are treated as binary.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- update AGENTS guidelines to warn against committing binary assets
- add `.gitattributes` to treat images and other assets as binary

## Testing
- `npm run setup`
- `npm run format` (backend)
- `npm test` (backend)
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6867abe703a0832db2bdd496f4a132ed