### PR TITLE
chore: allow skipping playwright deps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ These guidelines apply to all automated agents (e.g. the Codex agent) working on
    - Set `SKIP_PW_DEPS=1` before running the setup script if Playwright dependencies are already installed. This skips the long `apt-get` step and reduces CI time. The `smoke` script automatically exports this variable.
 3. **Format code** – run `npm run format` in `backend/` to apply Prettier formatting.
 4. **Run tests** – execute `npm test` in `backend/`. If tests cannot run because of environment limitations, mention this in the PR.
-5. **Run full CI locally** – execute `npm run ci` at the repo root before opening a PR.
+5. **Run full CI locally** – execute `npm run ci` at the repo root before opening a PR. Set `SKIP_PW_DEPS=1` if Playwright dependencies were installed previously to avoid redundant `apt-get` steps.
 6. **Install Playwright browsers** – the setup script installs these automatically. If browsers are missing, run `CI=1 npx playwright install --with-deps` manually.
 7. **Run smoke tests** – execute `npm run smoke` at the repository root. This script sets `SKIP_PW_DEPS=1` to bypass Playwright's dependency installation when the browsers are already installed. **Do not run `npx playwright test` directly** – that can trigger `"Playwright Test did not expect test() to be called here"` errors when dependencies are missing.
 8. **Limit scope** – only modify files related to the task. Do not change anything under `img/`, `models/`, or `uploads/` unless explicitly requested. Avoid editing `docs/` unless the task specifically involves documentation.

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "e2e": "playwright test",
     "smoke": "SKIP_PW_DEPS=1 npm run setup && npx playwright test e2e/smoke.test.js",
     "visual-test": "percy exec -- npm run e2e",
-    "test:a11y": "playwright install chromium --with-deps && playwright test e2e/a11y.test.js",
+    "test:a11y": "bash scripts/install-playwright.sh chromium && playwright test e2e/a11y.test.js",
     "netlify:deploy": "scripts/netlify-preflight.sh && netlify deploy"
   },
   "keywords": [],

--- a/scripts/install-playwright.sh
+++ b/scripts/install-playwright.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+if [ -z "$SKIP_PW_DEPS" ]; then
+  npx playwright install "$@" --with-deps
+else
+  npx playwright install "$@"
+fi


### PR DESCRIPTION
## Summary
- add helper script for Playwright installs
- respect `SKIP_PW_DEPS` when running a11y tests
- document skipping option in AGENTS guide

## Testing
- `npm test --prefix backend -- -w 1`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_6867abd54998832d91477c4ed21ba104