### PR TITLE
Fix addons page scrolling

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -59,7 +59,7 @@
     </style>
   </head>
 
-  <body class="bg-[#1A1A1D] text-white font-sans flex flex-col h-screen overflow-hidden">
+  <body class="bg-[#1A1A1D] text-white font-sans flex flex-col min-h-screen">
     <!-- HEADER -->
     <header class="flex items-center py-4 px-6">
       <a


### PR DESCRIPTION
## Summary
- remove the `overflow-hidden` class from `addons.html`

## Testing
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `SKIP_PW_DEPS=1 npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6867b0a5f2a4832da81b26fdb2b8db61