### PR TITLE
Add prefetch messaging for service worker

### DIFF
--- a/index.html
+++ b/index.html
@@ -654,6 +654,9 @@
     <script>
       if ("serviceWorker" in navigator) {
         navigator.serviceWorker.register("service-worker.js");
+        navigator.serviceWorker.ready.then((reg) => {
+          reg.active?.postMessage({ type: "prefetch-models" });
+        });
       }
     </script>
     <script type="module" src="js/printclub.js"></script>

--- a/payment.html
+++ b/payment.html
@@ -777,6 +777,9 @@
     <script>
       if ('serviceWorker' in navigator) {
         navigator.serviceWorker.register('service-worker.js');
+        navigator.serviceWorker.ready.then((reg) => {
+          reg.active?.postMessage({ type: 'prefetch-models' });
+        });
       }
     </script>
     <script>

--- a/service-worker.js
+++ b/service-worker.js
@@ -28,3 +28,19 @@ self.addEventListener("fetch", (event) => {
     );
   }
 });
+
+self.addEventListener("message", (event) => {
+  if (event.data && event.data.type === "prefetch-models") {
+    event.waitUntil(
+      caches
+        .open(CACHE_NAME)
+        .then((cache) =>
+          Promise.all(
+            ASSETS.map((url) =>
+              fetch(url).then((resp) => cache.put(url, resp.clone())),
+            ),
+          ),
+        ),
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- prefetch default model assets from service worker
- trigger the message in `index.html` and `payment.html`

## Testing
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_6867b6f6d8e8832da3df6bc574a69a5e