### PR TITLE
Improve model viewer performance

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,12 +74,14 @@
       href="https://modelviewer.dev/shared-assets/models/Astronaut.glb"
       as="fetch"
       type="model/gltf-binary"
+      fetchpriority="high"
       crossorigin
     />
     <link
       rel="preload"
       href="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
       as="fetch"
+      fetchpriority="high"
       crossorigin
     />
 
@@ -163,6 +165,14 @@
         animation: basketBob 0.6s ease;
       }
     </style>
+    <script>
+      if ("serviceWorker" in navigator) {
+        navigator.serviceWorker.register("service-worker.js");
+        navigator.serviceWorker.ready.then((reg) => {
+          reg.active?.postMessage({ type: "prefetch-models" });
+        });
+      }
+    </script>
   </head>
 
   <body class="bg-[#1A1A1D] text-white font-sans flex flex-col">
@@ -312,6 +322,7 @@
             camera-controls
             auto-rotate
             crossOrigin="anonymous"
+            fetchpriority="high"
             style="width: 100%; height: 100%; display: block"
           ></model-viewer>
 

--- a/service-worker.js
+++ b/service-worker.js
@@ -8,6 +8,11 @@ self.addEventListener("install", (event) => {
   event.waitUntil(
     caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS)),
   );
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(self.clients.claim());
 });
 
 self.addEventListener("fetch", (event) => {


### PR DESCRIPTION
## Summary
- preload model assets with fetchpriority
- register service worker earlier and claim clients

## Testing
- `npm run format`
- `npm test --prefix backend`
- `npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6867d291b8d8832db01c2bccc46cb459