### PR TITLE
Remove promo code text

### DIFF
--- a/luckybox-payment.html
+++ b/luckybox-payment.html
@@ -525,9 +525,7 @@
                 </div>
               </div>
 
-              <button type="button" class="promo-toggle text-sm underline">
-                Have a promo code?
-              </button>
+              <button type="button" class="promo-toggle text-sm underline"></button>
               <div class="promo-input flex gap-2 mt-2" hidden>
                 <input
                   id="discount-code"

--- a/minis-checkout.html
+++ b/minis-checkout.html
@@ -585,9 +585,7 @@
                 </div>
               </div>
 
-              <button type="button" class="promo-toggle text-sm underline">
-                Have a promo code?
-              </button>
+              <button type="button" class="promo-toggle text-sm underline"></button>
               <div class="promo-input flex gap-2 mt-2" hidden>
                 <input
                   id="discount-code"

--- a/payment.html
+++ b/payment.html
@@ -558,9 +558,7 @@
                 </div>
               </div>
 
-              <button type="button" class="promo-toggle text-sm underline">
-                Have a promo code?
-              </button>
+              <button type="button" class="promo-toggle text-sm underline"></button>
               <div class="promo-input flex gap-2 mt-2" hidden>
                 <input
                   id="discount-code"


### PR DESCRIPTION
## Summary
- drop the "Have a promo code?" line from checkout pages

## Testing
- `npm test`
- `npm run ci`
- `npm run smoke`
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_6867d0eea308832d999269453cd09cf2