### PR TITLE
Update gitattributes for more binary types

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,6 +11,17 @@
 *.mp4 binary
 *.glb binary
 *.gltf binary
+*.ico binary
+*.pdf binary
+*.zip binary
+*.tar binary
+*.gz binary
+*.bz2 binary
+*.7z binary
+*.ttf binary
+*.otf binary
+*.woff binary
+*.woff2 binary
 img/* binary
 sounds/* binary
 models/* binary

--- a/README.md
+++ b/README.md
@@ -278,6 +278,9 @@ pull request:
 4. Check your diff with `git status --short` to verify no unrelated files were
    modified.
 5. Add the format and test logs to the PR so reviewers can confirm.
+6. If you add new binary asset types (like fonts or archives), update
+   `.gitattributes` so Git treats them as binary. This prevents Codex from
+   failing to create a patch.
 
 ## Printer Service
 


### PR DESCRIPTION
## Summary
- allow additional binary file types in `.gitattributes`
- mention updating `.gitattributes` when adding new binary assets in `README`

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68680b845da4832da4eb18a712198f72