### PR TITLE
chore: ignore binary files & update README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,15 @@ backend/hunyuan_server/uploads/
 reports/
 backend/coverage/
 coverage/
+# ignore compiled and binary files
+*.exe
+*.dll
+*.so
+*.bin
+*.o
+*.pyc
+/build/
+/dist/
+*.jpg
+*.png
+*.pdf

--- a/README.md
+++ b/README.md
@@ -368,3 +368,9 @@ This resolves any partially configured packages left over from an interrupted `a
 
 If `eslint` fails with this error, it usually means dependencies aren't installed.
 Run `npm run setup` in the repository root to install them.
+
+## Contributing
+
+⚠️ **Note:** this project uses OpenAI Codex to generate PRs;
+binary files (images, compiled objects, etc.) will cause errors.
+Please remove or exclude any binary assets before opening a PR.


### PR DESCRIPTION
## Summary
- add patterns for binary files to `.gitignore`
- document Codex binary file restriction in `README`

## Testing
- `npm run format`
- `npm test --silent --runInBand`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68680d135ed0832d9935122f39e362d6