### PR TITLE
Fix addons page panel heights

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -121,7 +121,7 @@
       <div class="flex gap-6 mt-12 items-stretch flex-1">
         <!-- Luckybox (50%) -->
 
-        <div id="luckybox" class="model-card w-1/2 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 pb-20 flex flex-col space-y-2 relative h-full flex-1 min-h-[36rem]">
+        <div id="luckybox" class="model-card w-1/2 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 pb-20 flex flex-col space-y-2 relative h-full flex-1 min-h-[34rem]">
 
           <span class="font-semibold text-lg self-center text-center">Luckybox</span>
           <div class="flex items-start justify-between gap-4">
@@ -160,9 +160,9 @@
         </div>
 
         <!-- RIGHT COLUMN (50%) -->
-        <div class="flex flex-col w-1/2 gap-6 h-full flex-1 min-h-[36rem]">
+        <div class="flex flex-col w-1/2 gap-6 h-full flex-1 min-h-[34rem]">
           <!-- Print Minis (50% of column) -->
-          <div id="print-minis" class="model-card w-full bg-[#2A2A2E] border border-white/10 rounded-xl p-4 pb-20 flex flex-col justify-center space-y-2 flex-1">
+          <div id="print-minis" class="model-card w-full bg-[#2A2A2E] border border-white/10 rounded-xl p-4 pb-20 flex flex-col justify-center space-y-2 flex-none h-64">
             <span class="font-semibold text-lg self-center text-center">Print Minis</span>
             <p class="text-sm text-center">We'll print your design at roughly 25% scale for a tiny version.</p>
             <p class="text-sm text-center font-semibold">£14.99 per mini</p>
@@ -176,7 +176,7 @@
           </div>
 
           <!-- Remix prints (50% of column) -->
-          <div id="remix-prints" class="model-card w-full bg-[#2A2A2E] border border-white/10 rounded-xl p-4 pb-20 flex items-center justify-center text-center opacity-50 flex-1 h-full">
+          <div id="remix-prints" class="model-card w-full bg-[#2A2A2E] border border-white/10 rounded-xl p-4 pb-20 flex items-center justify-center text-center opacity-50 flex-none h-64">
             <div>
               <span class="font-semibold">Remix prints</span>
               <span class="block text-xs mt-1">coming soon</span>


### PR DESCRIPTION
## Summary
- shrink Print Minis panel on addons page
- match Luckybox height with Remix prints panel

## Testing
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68680e3d0280832da392fadc62c40577