### PR TITLE
Fix public galleries glb viewer

### DIFF
--- a/js/modelViewerTouchFix.js
+++ b/js/modelViewerTouchFix.js
@@ -10,7 +10,9 @@ function applyTouchFix() {
       for (const node of rec.addedNodes) {
         if (node.nodeType !== 1) continue;
         if (node.tagName === "MODEL-VIEWER") setTouchNone(node);
-        node.querySelectorAll?.("model-viewer").forEach(setTouchNone);
+        if (typeof node.querySelectorAll === "function") {
+          node.querySelectorAll("model-viewer").forEach(setTouchNone);
+        }
       }
     }
   });

--- a/js/publicGalleries.js
+++ b/js/publicGalleries.js
@@ -26,7 +26,11 @@ const sampleGalleries = {
 };
 
 function ensureModelViewerLoaded() {
-  if (window.customElements?.get("model-viewer")) {
+  if (
+    window.customElements &&
+    typeof window.customElements.get === "function" &&
+    window.customElements.get("model-viewer")
+  ) {
     return Promise.resolve();
   }
   const cdnUrl =
@@ -48,7 +52,13 @@ function ensureModelViewerLoaded() {
     };
     document.head.appendChild(s);
     setTimeout(() => {
-      if (!window.customElements?.get("model-viewer")) {
+      if (
+        !(
+          window.customElements &&
+          typeof window.customElements.get === "function" &&
+          window.customElements.get("model-viewer")
+        )
+      ) {
         s.onerror();
       }
     }, 3000);
@@ -174,10 +184,12 @@ async function init() {
     }
   }
 
-  loadBtn?.addEventListener("click", () => {
-    offset += 6;
-    renderGallery();
-  });
+  if (loadBtn) {
+    loadBtn.addEventListener("click", () => {
+      offset += 6;
+      renderGallery();
+    });
+  }
 
   async function start() {
     await loadAdvertModels();


### PR DESCRIPTION
## Summary
- patch public gallery slideshow JS to avoid optional chaining
- fix modelViewer touch script to avoid optional chaining

## Testing
- `npm run format`
- `npm test --silent`
- `npm run ci`
- `npm run smoke` *(fails: OutgoingMessage.prototype._headers deprecated)*

------
https://chatgpt.com/codex/tasks/task_e_6868139ddaec832d8736f28de0d74c68