### PR TITLE
Fix referral input interactivity

### DIFF
--- a/js/community.js
+++ b/js/community.js
@@ -522,16 +522,20 @@ function renderGrid(type, filters = getFilters()) {
     if (type === "popular") {
       advert.classList.add("flex-col");
       const loggedIn = !!localStorage.getItem("token");
+      const inputClass =
+        "flex-1 bg-[#1A1A1D] border border-white/10 rounded-l-xl px-3 py-2 text-white placeholder-gray-500" +
+        (loggedIn ? "" : " cursor-default pointer-events-none");
       const btnClass =
         "bg-[#30D5C8] text-[#1A1A1D] px-4 rounded-r-xl" +
-        (loggedIn ? "" : " opacity-50");
+        (loggedIn ? "" : " opacity-50 cursor-default pointer-events-none");
+      const btnHandler = loggedIn ? ' onclick="copyReferralLink()"' : "";
       advert.innerHTML =
         '<p class="mb-2 text-center text-white">Earn <span class="text-[#30D5C8]">£5 credit</span> when someone buys with your link.</p>' +
         '<div class="space-y-1 w-full max-w-xs">' +
         '<label for="referral-link" class="block text-sm">Your referral link:</label>' +
         '<div class="flex">' +
-        '<input id="referral-link" aria-label="Referral link" class="flex-1 bg-[#1A1A1D] border border-white/10 rounded-l-xl px-3 py-2 text-white placeholder-gray-500" placeholder="Log in to get your link" readonly />' +
-        `<button aria-label="Copy referral link" class="${btnClass}" onclick="copyReferralLink()">Copy</button>` +
+        `<input id="referral-link" aria-label="Referral link" class="${inputClass}" placeholder="Log in to get your link" readonly />` +
+        `<button aria-label="Copy referral link" class="${btnClass}"${btnHandler}>Copy</button>` +
         "</div></div>";
     } else {
       advert.classList.add("flex-col", "text-center", "space-y-2", "relative");


### PR DESCRIPTION
## Summary
- disable referral link input and copy button when user isn't logged in

## Testing
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6868133ea010832d8d249e1ae4e04aea