### PR TITLE
Fix orange colour intensity

### DIFF
--- a/luckybox-payment.html
+++ b/luckybox-payment.html
@@ -353,8 +353,8 @@
                 <button
                   type="button"
                   class="w-8 h-8 rounded-full border border-white/20"
-                  style="background-color: #ff7f00"
-                  data-color="#ff7f00"
+                  style="background-color: #ff5500"
+                  data-color="#ff5500"
                 ></button>
                 <button
                   type="button"

--- a/minis-checkout.html
+++ b/minis-checkout.html
@@ -415,8 +415,8 @@
                   <button
                     type="button"
                     class="w-8 h-8 rounded-full border border-white/20"
-                    style="background-color: #ff6600"
-                    data-color="#ff6600"
+                    style="background-color: #ff5500"
+                    data-color="#ff5500"
                   ></button>
                   <button
                     type="button"

--- a/payment.html
+++ b/payment.html
@@ -388,8 +388,8 @@
                 <button
                   type="button"
                   class="w-8 h-8 rounded-full border border-white/20"
-                  style="background-color: #ff6600"
-                  data-color="#ff6600"
+                  style="background-color: #ff5500"
+                  data-color="#ff5500"
                 ></button>
                 <button
                   type="button"


### PR DESCRIPTION
## Summary
- adjust orange color hex code in payment pages to a deeper shade

## Testing
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68681286b668832dad57393cc484889e