### PR TITLE
fix: hide model nav buttons initially

### DIFF
--- a/minis-checkout.html
+++ b/minis-checkout.html
@@ -283,7 +283,7 @@
           <button
             id="prev-model"
             type="button"
-            class="absolute left-2 top-1/2 -translate-y-1/2 bg-[#2A2A2E] border border-white/20 rounded-full p-2"
+            class="absolute left-2 top-1/2 -translate-y-1/2 bg-[#2A2A2E] border border-white/20 rounded-full p-2 hidden"
           >
             <i class="fas fa-chevron-left"></i>
             <span class="sr-only">Previous model</span>
@@ -291,7 +291,7 @@
           <button
             id="next-model"
             type="button"
-            class="absolute right-2 top-1/2 -translate-y-1/2 bg-[#2A2A2E] border border-white/20 rounded-full p-2"
+            class="absolute right-2 top-1/2 -translate-y-1/2 bg-[#2A2A2E] border border-white/20 rounded-full p-2 hidden"
           >
             <i class="fas fa-chevron-right"></i>
             <span class="sr-only">Next model</span>

--- a/payment.html
+++ b/payment.html
@@ -259,7 +259,7 @@
         <button
           id="prev-model"
           type="button"
-          class="absolute left-2 top-1/2 -translate-y-1/2 bg-[#2A2A2E] border border-white/20 rounded-full p-2"
+          class="absolute left-2 top-1/2 -translate-y-1/2 bg-[#2A2A2E] border border-white/20 rounded-full p-2 hidden"
         >
           <i class="fas fa-chevron-left"></i>
           <span class="sr-only">Previous model</span>
@@ -267,7 +267,7 @@
         <button
           id="next-model"
           type="button"
-          class="absolute right-2 top-1/2 -translate-y-1/2 bg-[#2A2A2E] border border-white/20 rounded-full p-2"
+          class="absolute right-2 top-1/2 -translate-y-1/2 bg-[#2A2A2E] border border-white/20 rounded-full p-2 hidden"
         >
           <i class="fas fa-chevron-right"></i>
           <span class="sr-only">Next model</span>


### PR DESCRIPTION
## Summary
- hide prev/next buttons in payment and minis-checkout until JS shows them

## Testing
- `npm run format` (backend)
- `npm test` (backend)
- `SKIP_PW_DEPS=1 npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_686811841e28832d97e95f552f84a216