### PR TITLE
Remove checkout text inputs

### DIFF
--- a/print2pro-checkout.html
+++ b/print2pro-checkout.html
@@ -61,53 +61,6 @@
             before joining print2 Pro.
           </p>
           <form id="checkout-form" class="space-y-4">
-            <div>
-              <input
-                id="ship-name"
-                class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10"
-                placeholder="Full Name"
-                autocomplete="name"
-                aria-label="Full Name"
-              />
-            </div>
-            <div>
-              <input
-                id="checkout-email"
-                type="email"
-                class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10"
-                placeholder="Email"
-                autocomplete="email"
-                aria-label="Email"
-              />
-            </div>
-            <div id="addressGroup" class="flex flex-col space-y-2">
-              <label for="ship-address" class="font-medium">Address</label>
-              <div>
-                <input
-                  id="ship-address"
-                  class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10"
-                  placeholder="Address"
-                  autocomplete="address-line1"
-                  aria-label="Address"
-                />
-              </div>
-              <div class="flex gap-2">
-                <input
-                  id="ship-city"
-                  class="flex-1 p-2 rounded-md bg-[#1A1A1D] border border-white/10"
-                  placeholder="City + Country"
-                  autocomplete="address-level2"
-                  aria-label="City + Country"
-                />
-                <input
-                  id="ship-zip"
-                  class="w-28 p-2 rounded-md bg-[#1A1A1D] border border-white/10"
-                  placeholder="ZIP"
-                  autocomplete="postal-code"
-                  aria-label="ZIP code"
-                />
-              </div>
-            </div>
             <fieldset
               id="subscription-choice"
               class="flex items-center justify-center gap-4 my-4 text-sm"


### PR DESCRIPTION
## Summary
- remove the address fields from the print2 pro checkout page

## Testing
- `npm run setup`
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68681d93930c832d84e4e1348b144ed0