### PR TITLE
Fix referral text layout

### DIFF
--- a/earn-rewards.html
+++ b/earn-rewards.html
@@ -105,21 +105,23 @@
         <div
           class="md:w-1/2 bg-[#2A2A2E] border border-white/10 p-6 rounded-2xl shadow-lg flex flex-col h-full min-h-[32rem] text-center md:text-left"
         >
-          <div class="space-y-6 flex-1">
+          <div class="space-y-6 flex-1 flex flex-col">
             <h2 class="text-2xl font-semibold text-center">
               Share &amp; earn discounts
             </h2>
-            <p class="text-gray-400 text-center">
+            <p id="login-reminder" class="text-gray-400 text-center">
               You must
               <a href="login.html" class="font-bold text-[#30D5C8]">Log In</a>
               or
               <a href="signup.html" class="font-bold text-[#30D5C8]">Sign Up</a>
               to get rewards.
             </p>
-            <p class="text-lg text-center">
-              Invite other using the link below. Earn
-              <span class="text-[#30D5C8]">£ credits</span> if they buy.
-            </p>
+            <div class="flex-1 flex items-center">
+              <p class="text-lg text-center w-full">
+                Invite other using the link below. Earn
+                <span class="text-[#30D5C8]">£ credits</span> if they buy.
+              </p>
+            </div>
           </div>
           <div class="mt-auto space-y-4">
             <div class="space-y-1">
@@ -217,7 +219,9 @@
             </table>
           </div>
           <div class="flex-1 flex items-center justify-center">
-            <div class="w-full border border-dashed border-white/20 rounded-xl py-8 text-center text-sm text-gray-400">
+            <div
+              class="w-full border border-dashed border-white/20 rounded-xl py-8 text-center text-sm text-gray-400"
+            >
               real world social proof image here
             </div>
           </div>

--- a/js/rewards.js
+++ b/js/rewards.js
@@ -154,6 +154,10 @@ window.redeemReward = redeemReward;
 window.shareReferral = shareReferral;
 export { shareReferral };
 window.addEventListener("DOMContentLoaded", () => {
+  const reminder = document.getElementById("login-reminder");
+  if (localStorage.getItem("token") && reminder) {
+    reminder.classList.add("hidden");
+  }
   loadRewardOptions().then(() => {
     loadRewards();
     loadLeaderboard();


### PR DESCRIPTION
## Summary
- show login reminder only when user is logged out
- vertically center invitation paragraph on Earn Rewards page

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68682548f988832dbf9f09b2f47f317a