### PR TITLE
Fix Luckybox panel height on addons page

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -122,7 +122,7 @@
         <!-- Luckybox (50%) -->
 
 
-        <div id="luckybox" class="model-card w-1/2 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 pb-20 flex flex-col space-y-2 relative h-full flex-1 min-h-[34rem]">
+        <div id="luckybox" class="model-card w-1/2 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 pb-20 flex flex-col space-y-2 relative h-full flex-1 min-h-[33.5rem]">
           <span class="font-semibold text-lg self-center text-center">Luckybox</span>
           <div class="flex items-start justify-between gap-4">
             <img src="img/luckybox-preview.png" alt="Luckybox preview" class="w-32 h-32 rounded-lg object-cover" />
@@ -160,7 +160,7 @@
         </div>
 
         <!-- RIGHT COLUMN (50%) -->
-        <div class="flex flex-col w-1/2 gap-6 h-full flex-1 min-h-[34rem]">
+        <div class="flex flex-col w-1/2 gap-6 h-full flex-1 min-h-[33.5rem]">
           <!-- Print Minis (50% of column) -->
           <div id="print-minis" class="model-card w-full bg-[#2A2A2E] border border-white/10 rounded-xl p-4 pb-20 flex flex-col justify-center space-y-2 flex-none h-64">
             <span class="font-semibold text-lg self-center text-center">Print Minis</span>


### PR DESCRIPTION
## Summary
- adjust Luckybox panel minimum height to match Remix Prints panel

## Testing
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_686821bf0bf4832dbab249ea65e1aea5