### PR TITLE
Fix Earn £5 text color on auth pages

### DIFF
--- a/login.html
+++ b/login.html
@@ -97,7 +97,7 @@
     <main class="flex-1 flex items-center justify-center">
       <div class="relative w-96">
         <p class="text-center mb-4 text-gray-400">
-          <span class="text-[#30D5C8]">Earn £5</span>
+          <span class="text-white">Earn £5</span>
           credit when someone buys your print
         </p>
         <form

--- a/signup.html
+++ b/signup.html
@@ -97,7 +97,7 @@
     <main class="flex-1 flex items-center justify-center">
       <div class="relative w-96">
         <p class="text-center mb-4 text-gray-400">
-          <span class="text-[#30D5C8]">Earn £5</span>
+          <span class="text-white">Earn £5</span>
           credit when someone buys your print
         </p>
         <form


### PR DESCRIPTION
## Summary
- make the Earn £5 text white on login and signup pages

## Testing
- `npm test` in `backend/`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68682d9c98ec832daee778b98bc8d124