### PR TITLE
Update addons and mini checkout layouts

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -123,9 +123,9 @@
 
 
         <div id="luckybox" class="model-card w-1/2 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 pb-20 flex flex-col space-y-2 relative h-full flex-1 min-h-[33.5rem]">
-          <span class="font-semibold text-lg self-center text-center">Luckybox</span>
+          <span class="font-semibold text-xl self-center text-center">Luckybox</span>
           <div class="flex items-start justify-between gap-4">
-            <img src="img/luckybox-preview.png" alt="Luckybox preview" class="w-32 h-32 rounded-lg object-cover" />
+            <img src="img/luckybox-preview.png" alt="Luckybox preview" class="w-36 h-36 ml-4 rounded-lg object-cover" />
             <fieldset id="luckybox-tiers" class="flex gap-4 justify-between">
               <!-- premium -->
               <label class="cursor-not-allowed flex flex-col items-center text-center opacity-50">
@@ -139,7 +139,7 @@
               <!-- multicolour -->
               <label class="cursor-pointer flex flex-col items-center text-center">
                 <input type="radio" name="luckybox-tier" value="multicolour" class="sr-only peer" checked />
-                <span id="luckybox-multi" class="w-32 h-32 flex flex-col items-center justify-center rounded-full border-4 border-white/20 shadow-xl peer-checked:border-[#30D5C8]">
+                <span id="luckybox-multi" class="w-36 h-36 flex flex-col items-center justify-center rounded-full border-4 border-white/20 shadow-xl peer-checked:border-[#30D5C8]">
                   <span class="font-semibold">£29.99</span>
                   <span class="text-xs">multicolour</span>
                 </span>
@@ -164,7 +164,7 @@
           <!-- Print Minis (50% of column) -->
           <div id="print-minis" class="model-card w-full bg-[#2A2A2E] border border-white/10 rounded-xl p-4 flex items-center h-64">
             <div class="flex-1 space-y-2">
-              <span class="font-semibold text-lg">Print Minis</span>
+              <span class="font-semibold text-xl">Print Minis</span>
               <p class="text-sm">We'll print your design at roughly 25% scale for a tiny version.</p>
               <p class="text-sm font-semibold">£14.99 per mini</p>
               <div id="minis-basket" class="text-xs overflow-y-auto max-h-20"></div>
@@ -175,7 +175,7 @@
           <!-- Remix prints (50% of column) -->
           <div id="remix-prints" class="model-card w-full bg-[#2A2A2E] border border-white/10 rounded-xl p-4 pb-20 flex items-center justify-center text-center opacity-50 flex-none h-64">
             <div>
-              <span class="font-semibold">Remix prints</span>
+              <span class="font-semibold text-xl">Remix prints</span>
               <span class="block text-xs mt-1">coming soon</span>
             </div>
           </div>

--- a/minis-checkout.html
+++ b/minis-checkout.html
@@ -319,7 +319,7 @@
 
         <!-- Checkout Form -->
         <div
-          class="relative w-full md:w-1/2 max-w-md bg-[#2A2A2E] border border-white/10 rounded-3xl p-6"
+          class="relative w-full md:w-1/2 max-w-md bg-[#2A2A2E] border border-white/10 rounded-3xl p-6 pb-20"
         >
           <h2 class="text-2xl font-semibold mb-4 text-center">
             Minis Checkout
@@ -585,7 +585,10 @@
                 </div>
               </div>
 
-              <button type="button" class="promo-toggle text-sm underline"></button>
+              <button
+                type="button"
+                class="promo-toggle text-sm underline"
+              ></button>
               <div class="promo-input flex gap-2 mt-2" hidden>
                 <input
                   id="discount-code"
@@ -637,7 +640,7 @@
             <button
               id="submit-payment"
               type="button"
-              class="w-full bg-[#30D5C8] text-[#1A1A1D] py-3 rounded-xl font-semibold hover:bg-[#28b7a8] transition"
+              class="absolute bottom-4 right-4 bg-[#30D5C8] text-[#1A1A1D] py-3 px-6 rounded-xl font-semibold hover:bg-[#28b7a8] transition"
             >
               Pay £14.99
             </button>


### PR DESCRIPTION
## Summary
- enlarge feature titles and make Luckybox image and 29.99 selection bigger
- tweak Print Minis checkout so Pay button sits bottom right

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68683aec7dfc832d9a035b14ccd564d0