### PR TITLE
Update Add-Ons layout

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -125,7 +125,7 @@
         <div id="luckybox" class="model-card w-1/2 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 pb-20 flex flex-col space-y-2 relative h-full flex-1 min-h-[33.5rem]">
           <span class="font-semibold text-xl self-center text-center">Luckybox</span>
           <div class="flex items-start justify-between gap-4">
-            <img src="img/luckybox-preview.png" alt="Luckybox preview" class="w-36 h-36 ml-4 rounded-lg object-cover" />
+            <img src="img/luckybox-preview.png" alt="Luckybox preview" class="w-44 h-44 ml-10 rounded-lg object-cover" />
             <fieldset id="luckybox-tiers" class="flex gap-4 justify-between">
               <!-- premium -->
               <label class="cursor-not-allowed flex flex-col items-center text-center opacity-50">
@@ -162,14 +162,14 @@
         <!-- RIGHT COLUMN (50%) -->
         <div class="flex flex-col w-1/2 gap-6 h-full flex-1 min-h-[33.5rem]">
           <!-- Print Minis (50% of column) -->
-          <div id="print-minis" class="model-card w-full bg-[#2A2A2E] border border-white/10 rounded-xl p-4 flex items-center h-64">
-            <div class="flex-1 space-y-2">
-              <span class="font-semibold text-xl">Print Minis</span>
+          <div id="print-minis" class="model-card w-full bg-[#2A2A2E] border border-white/10 rounded-xl p-4 flex flex-col h-64 relative">
+            <span class="font-semibold text-xl text-center">Print Minis</span>
+            <div class="flex-1 flex flex-col items-center justify-center space-y-2 text-center">
               <p class="text-sm">We'll print your design at roughly 25% scale for a tiny version.</p>
               <p class="text-sm font-semibold">£14.99 per mini</p>
               <div id="minis-basket" class="text-xs overflow-y-auto max-h-20"></div>
             </div>
-            <a href="minis-checkout.html" class="ml-4 font-bold py-2 px-5 rounded-full shadow-md transition border-2 border-black text-sm self-center" style="background-color: #30d5c8; color: #1a1a1d" onmouseover="this.style.opacity='0.85'" onmouseout="this.style.opacity='1'">Print my basket in mini size →</a>
+            <a href="minis-checkout.html" class="absolute bottom-4 right-4 font-bold py-2 px-5 rounded-full shadow-md transition border-2 border-black text-sm" style="background-color: #30d5c8; color: #1a1a1d" onmouseover="this.style.opacity='0.85'" onmouseout="this.style.opacity='1'">Print my basket in mini size →</a>
           </div>
 
           <!-- Remix prints (50% of column) -->
@@ -222,7 +222,7 @@
     </script>
     <div
       id="addons-banner"
-      class="fixed bottom-0 left-0 right-0 text-center py-8 bg-[#1A1A1D] text-white font-semibold z-40"
+      class="fixed bottom-0 left-0 right-0 text-center py-8 bg-[#1A1A1D] text-white font-semibold z-40 border border-white/20"
     >
       Discover more add-ons in the marketplace!
     </div>


### PR DESCRIPTION
## Summary
- tweak layout of Luckybox preview image
- reposition and style Print Minis panel
- give bottom banner a subtle outline

## Testing
- `npm run format` (backend)
- `npm test` (backend)
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_686858a30bf4832da83c0d6d581f83a3