### PR TITLE
Replace save buttons with add to basket

### DIFF
--- a/competitions.html
+++ b/competitions.html
@@ -167,11 +167,7 @@
           <span class="absolute top-1 left-1 bg-black/60 text-xs px-1 rounded"
             >Ended 05/25</span
           >
-          <button
-            class="save absolute bottom-1 left-1 text-xs bg-blue-600 px-1 rounded"
-          >
-            Save
-          </button>
+          <button class="add-basket absolute bottom-1 left-1 font-bold text-lg py-1.5 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]" style="transform: scale(0.78); transform-origin: left bottom">Add to Basket</button>
           <button
             class="purchase absolute bottom-1 right-2 font-bold text-lg py-1.5 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]"
             style="transform: scale(0.78); transform-origin: right bottom"
@@ -192,11 +188,7 @@
           <span class="absolute top-1 left-1 bg-black/60 text-xs px-1 rounded"
             >Ended 03/25</span
           >
-          <button
-            class="save absolute bottom-1 left-1 text-xs bg-blue-600 px-1 rounded"
-          >
-            Save
-          </button>
+          <button class="add-basket absolute bottom-1 left-1 font-bold text-lg py-1.5 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]" style="transform: scale(0.78); transform-origin: left bottom">Add to Basket</button>
           <button
             class="purchase absolute bottom-1 right-2 font-bold text-lg py-1.5 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]"
             style="transform: scale(0.78); transform-origin: right bottom"
@@ -217,11 +209,7 @@
           <span class="absolute top-1 left-1 bg-black/60 text-xs px-1 rounded"
             >Ended 02/25</span
           >
-          <button
-            class="save absolute bottom-1 left-1 text-xs bg-blue-600 px-1 rounded"
-          >
-            Save
-          </button>
+          <button class="add-basket absolute bottom-1 left-1 font-bold text-lg py-1.5 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]" style="transform: scale(0.78); transform-origin: left bottom">Add to Basket</button>
           <button
             class="purchase absolute bottom-1 right-2 font-bold text-lg py-1.5 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]"
             style="transform: scale(0.78); transform-origin: right bottom"

--- a/js/community.js
+++ b/js/community.js
@@ -6,13 +6,12 @@ const OPEN_KEY = "print3CommunityOpen";
 const FALLBACK_GLB =
   "https://modelviewer.dev/shared-assets/models/Astronaut.glb";
 
-function saveModel(model) {
-  if (window.addSavedModel) {
-    window.addSavedModel({
-      id: model.id,
+function addBasketModel(model) {
+  if (window.addToBasket) {
+    window.addToBasket({
+      jobId: model.job_id,
       modelUrl: model.model_url,
-      snapshot: model.snapshot,
-      title: model.title,
+      snapshot: model.snapshot || "",
     });
   }
 }
@@ -300,7 +299,7 @@ function createCard(model) {
   div.dataset.model = model.model_url;
   div.dataset.job = model.job_id;
 
-  div.innerHTML = `\n      <img src="${model.snapshot || ""}" alt="Model" loading="lazy" fetchpriority="low" class="w-full h-full object-contain pointer-events-none" />\n      <span class="sr-only">${model.title || "Model"}</span>\n      <button class="save absolute bottom-1 left-1 text-xs bg-blue-600 px-1 rounded">Save</button>\n      <button class="share absolute top-1 right-1 w-7 h-7 flex items-center justify-center bg-[#2A2A2E] border border-white/20 rounded-full hover:bg-[#3A3A3E] transition-shape"><i class="fas fa-share text-xs"></i></button>\n      <button class="purchase absolute bottom-1 right-1 font-bold text-lg py-1.5 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]" style="transform: scale(0.78); transform-origin: right bottom;">Buy from £29.99</button>`;
+  div.innerHTML = `\n      <img src="${model.snapshot || ""}" alt="Model" loading="lazy" fetchpriority="low" class="w-full h-full object-contain pointer-events-none" />\n      <span class="sr-only">${model.title || "Model"}</span>\n      <button class="add-basket absolute bottom-1 left-1 font-bold text-lg py-1.5 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]" style="transform: scale(0.78); transform-origin: left bottom;">Add to Basket</button>\n      <button class="share absolute top-1 right-1 w-7 h-7 flex items-center justify-center bg-[#2A2A2E] border border-white/20 rounded-full hover:bg-[#3A3A3E] transition-shape"><i class="fas fa-share text-xs"></i></button>\n      <button class="purchase absolute bottom-1 right-1 font-bold text-lg py-1.5 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]" style="transform: scale(0.78); transform-origin: right bottom;">Buy from £29.99</button>`;
 
   div.querySelector(".purchase").addEventListener("click", (e) => {
     e.stopPropagation();
@@ -322,10 +321,10 @@ function createCard(model) {
     } catch {}
     window.location.href = "payment.html";
   });
-  const saveBtn = div.querySelector(".save");
-  saveBtn?.addEventListener("click", (e) => {
+  const basketBtn = div.querySelector(".add-basket");
+  basketBtn?.addEventListener("click", (e) => {
     e.stopPropagation();
-    saveModel(model);
+    addBasketModel(model);
   });
   const shareBtn = div.querySelector(".share");
   shareBtn?.addEventListener("click", (e) => {
@@ -676,7 +675,7 @@ function init() {
 }
 
 export {
-  saveModel,
+  addBasketModel,
   init,
   closeModel,
   restoreOpenModel,

--- a/js/competitions.js
+++ b/js/competitions.js
@@ -15,9 +15,9 @@ function prefetchModel(url) {
   prefetchedModels.add(url);
 }
 
-function saveModel(item) {
-  if (window.addSavedModel) {
-    window.addSavedModel(item);
+function addBasketItem(item) {
+  if (window.addToBasket) {
+    window.addToBasket(item);
   }
 }
 
@@ -206,17 +206,17 @@ function renderEntriesPage(grid, pager, page) {
     card.dataset.model = r.model_url;
     card.dataset.job = r.model_id;
     card.dataset.id = r.model_id;
-    card.innerHTML = `<img src="" alt="Model" class="w-full h-full object-contain pointer-events-none" />\n      <button class="save absolute bottom-1 left-1 text-xs bg-blue-600 px-1 rounded">Save</button>\n      <button class="purchase absolute bottom-1 right-2 font-bold text-lg py-1.5 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]" style="transform: scale(0.78); transform-origin: right bottom;">Buy from £29.99</button>`;
+    card.innerHTML = `<img src="" alt="Model" class="w-full h-full object-contain pointer-events-none" />\n      <button class="add-basket absolute bottom-1 left-1 font-bold text-lg py-1.5 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]" style="transform: scale(0.78); transform-origin: left bottom;">Add to Basket</button>\n      <button class="purchase absolute bottom-1 right-2 font-bold text-lg py-1.5 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]" style="transform: scale(0.78); transform-origin: right bottom;">Buy from £29.99</button>`;
     const buyBtn = card.querySelector(".purchase");
     buyBtn.addEventListener("click", (e) => {
       e.stopPropagation();
       purchase(r.model_url, r.model_id);
     });
-    const saveBtn = card.querySelector(".save");
-    saveBtn?.addEventListener("click", (e) => {
+    const basketBtn = card.querySelector(".add-basket");
+    basketBtn?.addEventListener("click", (e) => {
       e.stopPropagation();
       const img = card.querySelector("img");
-      saveModel({
+      addBasketItem({
         id: r.model_id,
         modelUrl: r.model_url,
         snapshot: img ? img.src : "",
@@ -439,18 +439,18 @@ document.addEventListener("DOMContentLoaded", () => {
   });
   document.querySelectorAll("#winners-grid .model-card").forEach((card) => {
     const buyBtn = card.querySelector(".purchase");
-    const saveBtn = card.querySelector(".save");
+    const basketBtn = card.querySelector(".add-basket");
     if (buyBtn) {
       buyBtn.addEventListener("click", (e) => {
         e.stopPropagation();
         purchase(card.dataset.model, card.dataset.job);
       });
     }
-    if (saveBtn) {
-      saveBtn.addEventListener("click", (e) => {
+    if (basketBtn) {
+      basketBtn.addEventListener("click", (e) => {
         e.stopPropagation();
         const img = card.querySelector("img");
-        saveModel({
+        addBasketItem({
           id: card.dataset.job,
           modelUrl: card.dataset.model,
           snapshot: img ? img.src : "",


### PR DESCRIPTION
## Summary
- switch Save buttons to "Add to Basket" on competitions and community pages
- wire up new buttons to add items to the basket

## Testing
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_686857afd00c832daf2614f7c396ab03