### PR TITLE
fix: unify outline style on community carousel

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -220,7 +220,7 @@
           <div class="overflow-hidden rounded-xl">
             <div class="carousel-track flex transition-transform duration-300">
               <div
-                class="carousel-slide flex-none p-4 flex items-center justify-center"
+                class="carousel-slide flex-none p-4 flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-xl"
               >
                 <model-viewer
                   src="https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoomBox/glTF-Binary/BoomBox.glb"
@@ -234,7 +234,7 @@
                 ></model-viewer>
               </div>
               <div
-                class="carousel-slide flex-none p-4 flex items-center justify-center"
+                class="carousel-slide flex-none p-4 flex items-center justify-center bg-[#2A2A2E] border border-white/10 rounded-xl"
               >
                 <img
                   src="https://images.unsplash.com/photo-1516117172878-fd2c41f4a759"
@@ -244,7 +244,7 @@
                 />
               </div>
               <div
-                class="carousel-slide flex-none p-4 flex flex-col items-center justify-center text-center space-y-4"
+                class="carousel-slide flex-none p-4 flex flex-col items-center justify-center text-center space-y-4 bg-[#2A2A2E] border border-white/10 rounded-xl"
               >
                 <img
                   src="https://images.unsplash.com/photo-1502685104226-ee32379fefbe"
@@ -266,7 +266,7 @@
                 >
               </div>
               <div
-                class="carousel-slide flex-none p-4 flex flex-col sm:flex-row items-center justify-center gap-4"
+                class="carousel-slide flex-none p-4 flex flex-col sm:flex-row items-center justify-center gap-4 bg-[#2A2A2E] border border-white/10 rounded-xl"
               >
                 <img
                   src="https://via.placeholder.com/400x300.png?text=Real+Print+Coming+Soon"


### PR DESCRIPTION
## Summary
- outline all "What people are talking about" carousel slides on the Community Creations page

## Testing
- `npm run format` in `backend`
- `npm test` in `backend`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68685678ec70832d914eea5ad41ccc12