### PR TITLE
Fix luckybox layout and banner border

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -124,9 +124,9 @@
 
         <div id="luckybox" class="model-card w-1/2 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 pb-20 flex flex-col space-y-2 relative h-full flex-1 min-h-[33.5rem]">
           <span class="font-semibold text-xl self-center text-center">Luckybox</span>
-          <div class="flex items-start justify-between gap-4">
+          <div class="flex items-start gap-4">
             <img src="img/luckybox-preview.png" alt="Luckybox preview" class="w-44 h-44 ml-10 rounded-lg object-cover" />
-            <fieldset id="luckybox-tiers" class="flex gap-4 justify-between">
+            <fieldset id="luckybox-tiers" class="flex flex-1 gap-4 justify-center">
               <!-- premium -->
               <label class="cursor-not-allowed flex flex-col items-center text-center opacity-50">
                 <input type="radio" name="luckybox-tier" value="premium" class="sr-only peer" disabled />
@@ -222,7 +222,7 @@
     </script>
     <div
       id="addons-banner"
-      class="fixed bottom-0 left-0 right-0 text-center py-8 bg-[#1A1A1D] text-white font-semibold z-40 border border-white/20"
+      class="fixed bottom-0 left-0 right-0 text-center py-8 bg-[#1A1A1D] text-white font-semibold z-40 border-t border-white/20"
     >
       Discover more add-ons in the marketplace!
     </div>


### PR DESCRIPTION
## Summary
- adjust luckybox tiers layout on Add‑Ons page
- keep only top border on the marketplace banner

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_686904995114832db9d12278b2ea6ecd