### PR TITLE
Add login gating for rewards panel

### DIFF
--- a/earn-rewards.html
+++ b/earn-rewards.html
@@ -137,6 +137,7 @@
                   readonly
                 />
                 <button
+                  id="copy-referral"
                   aria-label="Copy referral link"
                   class="font-bold px-4 w-24 rounded-r-xl shadow-md transition border-2 border-black"
                   style="background-color: #30d5c8; color: #1a1a1d"
@@ -161,6 +162,7 @@
                   class="flex-1 bg-[#1A1A1D] border border-white/10 rounded-l-xl px-3 py-2 placeholder-gray-500 appearance-none"
                 />
                 <button
+                  id="redeem-button"
                   class="font-bold px-4 w-24 rounded-r-xl shadow-md transition border-2 border-black"
                   style="background-color: #30d5c8; color: #1a1a1d"
                   onmouseover="this.style.opacity='0.85'"

--- a/js/rewards.js
+++ b/js/rewards.js
@@ -154,9 +154,24 @@ window.redeemReward = redeemReward;
 window.shareReferral = shareReferral;
 export { shareReferral };
 window.addEventListener("DOMContentLoaded", () => {
+  const loggedIn = !!localStorage.getItem("token");
   const reminder = document.getElementById("login-reminder");
-  if (localStorage.getItem("token") && reminder) {
+  if (loggedIn && reminder) {
     reminder.classList.add("hidden");
+  }
+  if (!loggedIn) {
+    document
+      .getElementById("referral-link")
+      ?.classList.add("cursor-default", "pointer-events-none");
+    document
+      .getElementById("copy-referral")
+      ?.classList.add("opacity-50", "cursor-default", "pointer-events-none");
+    document
+      .getElementById("reward-input")
+      ?.classList.add("cursor-default", "pointer-events-none");
+    document
+      .getElementById("redeem-button")
+      ?.classList.add("opacity-50", "cursor-default", "pointer-events-none");
   }
   loadRewardOptions().then(() => {
     loadRewards();


### PR DESCRIPTION
## Summary
- disable referral copy and reward redemption when not logged in

## Testing
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_686905df4cd0832d9533776975e156fa