### PR TITLE
Add guarantee badge to print2pro checkout

### DIFF
--- a/js/printclubCheckout.js
+++ b/js/printclubCheckout.js
@@ -74,4 +74,19 @@ document.addEventListener("DOMContentLoaded", () => {
   } else if (qs("cancel")) {
     cancelMsg?.classList.remove("hidden");
   }
+
+  const badge = document.getElementById("money-back-badge");
+  const alignBadge = () => {
+    if (!badge || !payBtn) return;
+    const btnRect = payBtn.getBoundingClientRect();
+    const container = badge.parentElement;
+    const containerRect = container && container.getBoundingClientRect();
+    if (!containerRect) return;
+    const offset = btnRect.top + btnRect.height / 2 - containerRect.top;
+    badge.style.transform = "translateY(-50%)";
+    badge.style.top = offset + "px";
+    badge.style.visibility = "visible";
+  };
+  alignBadge();
+  window.addEventListener("resize", alignBadge);
 });

--- a/print2pro-checkout.html
+++ b/print2pro-checkout.html
@@ -94,9 +94,21 @@
               Join print2 Pro
             </button>
           </form>
-          <div class="flex justify-center gap-4 mt-4 text-2xl text-white">
-            <i class="fas fa-lock" aria-label="Secure checkout"></i>
-            <i class="fas fa-shield-alt" aria-label="Money-back guarantee"></i>
+          <!-- repositioned badge -->
+          <div
+            id="money-back-badge"
+            style="
+              position: absolute;
+              left: calc(100% + 0.55cm);
+              top: 85%;
+              transform: translateY(-72%);
+              visibility: hidden;
+            "
+            class="whitespace-nowrap text-sm pointer-events-none"
+          >
+            <p>🔒 Secure Checkout</p>
+            <p>🛡️ Money-Back Guarantee</p>
+            <p>🚚 Free UK Shipping</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add guarantee badge text to `print2pro-checkout.html`
- align the badge beside the pay button via `printclubCheckout.js`

## Testing
- `npm run format` in `backend`
- `npm test` in `backend`
- `npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_6869069648b8832da6ec501a70f49475