### PR TITLE
feat: reposition public gallery placeholder

### DIFF
--- a/js/publicGalleries.js
+++ b/js/publicGalleries.js
@@ -140,10 +140,12 @@ async function init() {
     grid.innerHTML = "";
 
     stopAdvert();
-    grid.appendChild(createAdvert());
 
     visible.forEach((u, idx) => {
-      if (idx === 0) return;
+      if (idx === 4) {
+        grid.appendChild(createAdvert());
+        return;
+      }
       const img = document.createElement("img");
       img.src = u;
       img.loading = "lazy";


### PR DESCRIPTION
## Summary
- reposition the public galleries advert placeholder to appear after four images

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68690761c4e4832d80643e73098e6892