### PR TITLE
Fix Add-Ons spacing

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -118,7 +118,7 @@
       </div>
 
       <!-- ROW: Luckybox (50%) | RIGHT COLUMN (50%) -->
-      <div class="flex gap-6 mt-12 items-stretch flex-1">
+      <div class="flex gap-6 mt-6 items-stretch flex-1">
         <!-- Luckybox (50%) -->
 
 


### PR DESCRIPTION
## Summary
- reduce top margin on Add-Ons grid to match Marketplace layout

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6869072b90fc832d818a00a2960ce767