### PR TITLE
Add char limit to prompt input

### DIFF
--- a/index.html
+++ b/index.html
@@ -456,6 +456,7 @@
               <textarea
                 id="promptInput"
                 rows="1"
+                maxlength="200"
                 placeholder="Text, image, or both — we’ll 3D print it…"
                 aria-label="Prompt"
                 class="prompt-textarea w-full bg-transparent resize-none text-lg placeholder-gray-500 focus:outline-none"


### PR DESCRIPTION
## Summary
- limit index page prompt to 200 characters

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68690dec22d4832d9c061de323dc8a2b