### PR TITLE
Fix discount text in Marketplace

### DIFF
--- a/marketplace.html
+++ b/marketplace.html
@@ -106,7 +106,7 @@
       <section class="bg-[#2A2A2E] p-4 rounded-xl border border-white/10">
         <p class="text-center">
           Purchase items here to get
-          <span class="text-[#30D5C8]">£5 off</span>
+          <span class="text-[#30D5C8]">£7 off</span>
           your 2nd and
           <span class="text-[#30D5C8]">£15 off</span>
           your 3rd print. Add them to your


### PR DESCRIPTION
## Summary
- update Marketplace intro text to reflect £7 discount on second print

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68690bdcdc10832dbe6d8857057266d2