### PR TITLE
Fix luckybox discount

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -28,7 +28,8 @@ if (window.location.pathname.endsWith("minis-checkout.html")) {
 
 
 const TWO_PRINT_DISCOUNT = 700;
-const THIRD_PRINT_DISCOUNT = 1500;
+const THIRD_PRINT_DISCOUNT =
+  window.location.pathname.endsWith("luckybox-payment.html") ? 0 : 1500;
 const MINI_SECOND_DISCOUNT = 500;
 let PRICING_VARIANT = localStorage.getItem("pricingVariant");
 if (!PRICING_VARIANT) {

--- a/luckybox-payment.html
+++ b/luckybox-payment.html
@@ -661,7 +661,6 @@
         <h2 class="text-xl font-semibold mb-2 text-white">Save on Prints</h2>
         <ul class="mb-4 text-gray-200 list-disc list-inside text-left">
           <li>£7 off your 2nd print</li>
-          <li>£15 off your 3rd print</li>
         </ul>
         <p class="text-gray-200 text-sm mb-4">
           Share this and get £5 credit on your next print.


### PR DESCRIPTION
## Summary
- remove 3rd print discount line from luckybox checkout
- disable third print discount logic on the luckybox page

## Testing
- `npm run format` in `backend`
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6869146ae4d8832d9f6232e65d3cdf95