### PR TITLE
Fix accessibility label regression

### DIFF
--- a/e2e/a11y-baseline.json
+++ b/e2e/a11y-baseline.json
@@ -2,5 +2,5 @@
   "/index.html": ["button-name"],
   "/login.html": ["button-name"],
   "/signup.html": ["button-name"],
-  "/payment.html": ["button-name", "label"]
+  "/payment.html": ["button-name"]
 }

--- a/payment.html
+++ b/payment.html
@@ -476,7 +476,7 @@
                   type="number"
                   min="1"
                   value="2"
-
+                  aria-label="Quantity"
                   class="w-[2.1rem] text-center bg-transparent appearance-none text-[0.875rem]"
                 />
                 <button


### PR DESCRIPTION
## Summary
- add an explicit `aria-label` for the quantity input on the payment page
- update the accessibility baseline accordingly

## Testing
- `npm test --prefix backend`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_686913bfbecc832da67730914279d9a9