### PR TITLE
Fix a11y test flakiness

### DIFF
--- a/e2e/a11y.test.js
+++ b/e2e/a11y.test.js
@@ -9,6 +9,11 @@ const baseline = fs.existsSync(baselinePath)
   ? JSON.parse(fs.readFileSync(baselinePath, "utf8"))
   : {};
 
+// Normalize stored baseline arrays so ordering doesn't cause test failures
+for (const url of Object.keys(baseline)) {
+  baseline[url] = baseline[url].sort();
+}
+
 for (const url of pages) {
   test(`a11y check ${url}`, async ({ page }) => {
     await page.goto(url);


### PR DESCRIPTION
## Summary
- normalize a11y baseline arrays before asserting

## Testing
- `npm run format` (root)
- `npm run format` in `backend/`
- `SKIP_PW_DEPS=1 npm run ci`
- `npm run smoke`
- `npm test` in `backend/`


------
https://chatgpt.com/codex/tasks/task_e_686913a4245c832dbfbf28682efc9904