### PR TITLE
Fix node_modules cleanup errors

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -14,10 +14,13 @@ if ! npm ping >/dev/null 2>&1; then
 fi
 
 # Remove any existing node_modules directories to avoid ENOTEMPTY errors
-rm -rf node_modules backend/node_modules || sudo rm -rf node_modules backend/node_modules
+sudo rm -rf node_modules backend/node_modules
 if [ -d backend/hunyuan_server/node_modules ]; then
-  rm -rf backend/hunyuan_server/node_modules || sudo rm -rf backend/hunyuan_server/node_modules
+  sudo rm -rf backend/hunyuan_server/node_modules
 fi
+
+# Clear the npm cache to avoid cleanup warnings
+npm cache clean --force
 
 # Remove stale apt or dpkg locks that may prevent dependency installation
 if pgrep apt-get >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- ensure `scripts/setup.sh` removes node_modules with sudo and cleans npm cache

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_686913648d48832da82e757d14974527