### PR TITLE
Fix alignment of gift two discount message

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -840,7 +840,7 @@ async function initPaymentPage() {
       `<span class="text-white">save ${amount}</span>` +
       (showGiftTwo
         ?
-          '<br><span class="text-gray-400">gift two – </span><span class="text-white">save £22</span>'
+          '<br><span class="invisible">Popular: keep one, </span><span class="text-gray-400">gift two – </span><span class="text-white">save £22</span>'
         : "");
     bulkMsg.classList.remove("hidden");
   }


### PR DESCRIPTION
## Summary
- align the "gift two" discount text with the line above using an invisible span

## Testing
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68691248e45c832d9bc5f1ae483cc0d1