### PR TITLE
Fix gift two price display

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -841,7 +841,7 @@ async function initPaymentPage() {
       `<span class="text-white">save ${amount}</span>` +
       (showGiftTwo
         ?
-          '<br><span class="invisible">Popular: keep one, </span><span class="text-gray-400">gift two – </span><span class="text-white">save £22</span>'
+          '<br><span class="invisible">Popular: keep one, </span><span class="text-gray-400">gift two – </span><span class="text-white">save £22.00</span>'
         : "");
     bulkMsg.classList.remove("hidden");
   }


### PR DESCRIPTION
## Summary
- show decimal amount in "gift two" bulk discount message

## Testing
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68692282869c832dbe5de40cb9759d85