### PR TITLE
Fix layout shift on marketplace 3D viewer

### DIFF
--- a/marketplace.html
+++ b/marketplace.html
@@ -145,6 +145,7 @@
             auto-rotate
             crossOrigin="anonymous"
             class="w-full flex-grow bg-[#2A2A2E] rounded-xl mt-4"
+            style="width: 100%; height: 100%; display: block"
           ></model-viewer>
           <input id="glbUpload" type="file" accept=".glb" class="hidden" />
         </div>


### PR DESCRIPTION
## Summary
- prevent marketplace <model-viewer> from changing size when it loads

## Testing
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_686923076104832d983a610ccdc9223c