### PR TITLE
Fix a11y test syntax

### DIFF
--- a/e2e/a11y.test.js
+++ b/e2e/a11y.test.js
@@ -19,7 +19,7 @@ for (const url of pages) {
     await page.goto(url);
     const results = await new AxeBuilder({ page }).analyze();
     const violations = results.violations.filter((v) =>
-      ["critical", "serious"].includes(v.impact),
+      ["critical", "serious"].includes(v.impact)
     );
     const ids = violations.map((v) => v.id).sort();
 


### PR DESCRIPTION
## Summary
- correct syntax error in the a11y Playwright test

## Testing
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68692640e0e0832d8538627baffde2b5