### PR TITLE
ci: ensure setup completed before running tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ coverage/
 *.jpg
 *.png
 *.pdf
+.setup-complete

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "coverage": "npm run coverage --prefix backend",
     "typecheck": "tsc --noEmit",
     "i18n:lint": "node scripts/i18n-lint.js",
-    "ci": "npm run format && npm run lint && npm run typecheck && npm run i18n:lint && npm run test:ci && npm run test:a11y",
+    "ci": "node scripts/assert-setup.js && npm run format && npm run lint && npm run typecheck && npm run i18n:lint && npm run test:ci && npm run test:a11y",
     "test:ci": "cross-env JEST_CI=true npm run test-ci --prefix backend",
     "test:update-threshold": "node scripts/update-coverage-threshold.js",
     "test:stability": "node scripts/test-stability.js",

--- a/scripts/assert-setup.js
+++ b/scripts/assert-setup.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+const fs = require('fs');
+if (!fs.existsSync('.setup-complete')) {
+  console.error("Setup has not been run. Please execute 'npm run setup' first.");
+  process.exit(1);
+}

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -54,3 +54,4 @@ if [ -z "$SKIP_PW_DEPS" ]; then
 else
   CI=1 npx playwright install
 fi
+touch .setup-complete


### PR DESCRIPTION
## Summary
- add `.setup-complete` sentinel file to mark successful setup
- update `setup.sh` to create the sentinel
- add `assert-setup.js` and call it from the `ci` script
- ignore the sentinel file in git

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68692b88e7bc832d92daf36b8fec36ba