### PR TITLE
Fix minis basket thumbnails

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -216,17 +216,11 @@
           }
           const toShow = items.slice(0, 2);
           toShow.forEach((it) => {
-            const mv = document.createElement("model-viewer");
-            mv.src = it.modelUrl || "";
-            mv.alt = "Mini model";
-            mv.setAttribute(
-              "environment-image",
-              "https://modelviewer.dev/shared-assets/environments/neutral.hdr",
-            );
-            mv.setAttribute("camera-controls", "");
-            mv.className = "w-20 h-20 bg-[#2A2A2E] rounded";
-            if (it.snapshot) mv.setAttribute("poster", it.snapshot);
-            container.appendChild(mv);
+            const img = document.createElement("img");
+            img.src = it.snapshot || it.modelUrl || "";
+            img.alt = "Mini thumbnail";
+            img.className = "w-20 h-20 object-cover bg-[#2A2A2E] rounded";
+            container.appendChild(img);
           });
           if (items.length > 2) {
             const more = document.createElement("div");


### PR DESCRIPTION
## Summary
- show mini print thumbnails instead of 3D models on addons page

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_686969d82fb4832d9691f94edec220f6