### PR TITLE
Fix luckybox button alignment

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -133,9 +133,9 @@
 
         <div id="luckybox" class="model-card w-1/2 bg-[#2A2A2E] border border-white/10 rounded-xl p-4 pb-20 flex flex-col space-y-2 relative h-full flex-1 min-h-[33.5rem]">
           <span class="font-semibold text-xl self-center text-center">Luckybox</span>
-          <div class="flex items-start gap-4 mt-2">
+          <div class="flex items-start gap-10 mt-2 px-10">
             <img src="img/luckybox-preview.png" alt="Luckybox preview" class="w-44 h-44 rounded-lg object-cover" />
-            <fieldset id="luckybox-tiers" class="flex flex-1 gap-4 justify-between">
+            <fieldset id="luckybox-tiers" class="flex flex-1 gap-4 justify-center">
               <!-- premium -->
               <label class="cursor-not-allowed flex flex-col items-center text-center opacity-50">
                 <input type="radio" name="luckybox-tier" value="premium" class="sr-only peer" disabled />


### PR DESCRIPTION
## Summary
- realign Luckybox tier buttons on addons page

## Testing
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_686969842168832d8579a9eac4085a16