### PR TITLE
Move API constants to top of index.js

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1,6 +1,15 @@
 "use strict";
 import { shareOn } from "./share.js";
 
+const API_BASE = (window.API_ORIGIN || "") + "/api";
+const TZ = "America/New_York";
+// Local fallback model used when generation fails or the viewer hasn't loaded a model yet.
+const FALLBACK_GLB_LOW = "models/bag.glb";
+const FALLBACK_GLB_HIGH =
+  "https://modelviewer.dev/shared-assets/models/Astronaut.glb";
+const FALLBACK_GLB = FALLBACK_GLB_LOW;
+const LOW_POLY_GLB = FALLBACK_GLB_LOW;
+
 // Save referrer ID from query string for later checkout discount
 (() => {
   try {
@@ -151,16 +160,6 @@ if (
 ) {
   document.documentElement.classList.add("has-generated");
 }
-
-const API_BASE = (window.API_ORIGIN || "") + "/api";
-const TZ = "America/New_York";
-// Local fallback model used when generation fails or the viewer hasn't loaded a model yet.
-
-const FALLBACK_GLB_LOW = "models/bag.glb";
-const FALLBACK_GLB_HIGH =
-  "https://modelviewer.dev/shared-assets/models/Astronaut.glb";
-const FALLBACK_GLB = FALLBACK_GLB_LOW;
-const LOW_POLY_GLB = FALLBACK_GLB_LOW;
 
 const EXAMPLES = [
   "cute robot figurine",


### PR DESCRIPTION
## Summary
- define `API_BASE`, `TZ`, and fallback model constants before any IIFEs
- keep model viewer pointing to `models/bag.glb`

## Testing
- `npm test --silent` in `backend/`
- `SKIP_PW_DEPS=1 npm run ci`
- `npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_686976706c24832d8a04ff9f282fb7b5