### PR TITLE
fix: clean npm cache tmp during setup

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -21,6 +21,8 @@ fi
 
 # Clear the npm cache to avoid cleanup warnings
 npm cache clean --force
+# Remove leftover tmp directories that can cause ENOTEMPTY errors
+rm -rf "$(npm config get cache)/_cacache/tmp" "$HOME/.npm/_cacache/tmp"
 
 # Remove stale apt or dpkg locks that may prevent dependency installation
 if pgrep apt-get >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- clear leftover tmp dirs from npm cache in setup script

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend --silent`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_686976c9fe28832da4cafec4a85c95f6