### PR TITLE
Update service worker asset caching

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -2,6 +2,15 @@ const CACHE_NAME = "model-cache-v1";
 const ASSETS = [
   "models/bag.glb",
   "https://modelviewer.dev/shared-assets/environments/neutral.hdr",
+  "https://cdn.tailwindcss.com",
+  "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css",
+  "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css",
+  "https://cdn.jsdelivr.net/npm/@google/model-viewer@1.12.0/dist/model-viewer.min.js",
+  "https://cdn.jsdelivr.net/npm/@google/model-viewer@1.12.0/dist/model-viewer-legacy.js",
+  "js/printclub.js",
+  "js/rewardBadge.js",
+  "js/basket.js",
+  "js/trackingPixel.js",
 ];
 
 self.addEventListener("install", (event) => {


### PR DESCRIPTION
## Summary
- include various CDN and local assets in service worker cache

## Testing
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6869765efae4832db7366ccb6dbc034d