### PR TITLE
Add preconnects for CDN resources

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -17,6 +17,9 @@
     <meta property="og:image" content="img/boxlogo.png" />
     <script src="js/applyColorScheme.js"></script>
     <link rel="preconnect" href="https://modelviewer.dev" crossorigin />
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
+    <link rel="preconnect" href="https://cdn.tailwindcss.com" crossorigin />
+    <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin />
     <script src="https://cdn.tailwindcss.com"></script>
     <link
       rel="preload"


### PR DESCRIPTION
## Summary
- improve CommunityCreations loading by preconnecting to CDN assets

## Testing
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6869764f8474832d95578564650d2adc