### PR TITLE
Fix duplicate script tag in CommunityCreations

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -602,7 +602,6 @@
     <script type="module" src="js/printingTicker.js"></script>
     <script type="module" src="js/publicGalleries.js"></script>
     <script type="module" src="js/carousel.js"></script>
-    <script type="module" src="js/rewardBadge.js"></script>
     <script type="module" src="js/trackingPixel.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- remove extra rewardBadge script from `CommunityCreations.html`

## Testing
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `SKIP_PW_DEPS=1 npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68697645e988832d93fec4628b6b57e0