### PR TITLE
Suppress Node warnings during smoke tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "bundle:size": "size-limit",
     "setup": "scripts/setup.sh",
     "e2e": "playwright test",
-    "smoke": "SKIP_PW_DEPS=1 npm run setup && npx playwright test e2e/smoke.test.js",
+    "smoke": "NODE_NO_WARNINGS=1 SKIP_PW_DEPS=1 npm run setup && NODE_NO_WARNINGS=1 npx playwright test e2e/smoke.test.js",
     "visual-test": "percy exec -- npm run e2e",
     "test:a11y": "bash scripts/install-playwright.sh chromium && playwright test e2e/a11y.test.js",
     "netlify:deploy": "scripts/netlify-preflight.sh && netlify deploy"


### PR DESCRIPTION
## Summary
- silence Node.js deprecation warnings in smoke test script

## Testing
- `npm test --prefix backend --silent`
- `npm run ci`
- `npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_68697620f96c832da17c6824b09c3e26