### PR TITLE
Fix setup assertion for Playwright browsers

### DIFF
--- a/scripts/assert-setup.js
+++ b/scripts/assert-setup.js
@@ -1,6 +1,19 @@
 #!/usr/bin/env node
-const fs = require('fs');
-if (!fs.existsSync('.setup-complete')) {
-  console.error("Setup has not been run. Please execute 'npm run setup' first.");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+if (!fs.existsSync(".setup-complete")) {
+  console.error(
+    "Setup has not been run. Please execute 'npm run setup' first.",
+  );
+  process.exit(1);
+}
+
+// Ensure Playwright browsers are available before running tests.
+const pwDir = path.join(os.homedir(), ".cache", "ms-playwright");
+if (!fs.existsSync(pwDir) || fs.readdirSync(pwDir).length === 0) {
+  console.error(
+    "Playwright browsers are missing. Please run 'npm run setup' to install them.",
+  );
   process.exit(1);
 }


### PR DESCRIPTION
## Summary
- ensure CI fails early if Playwright browsers are missing

## Testing
- `npm test --prefix backend`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_686975e4e458832db6d3031a3cbb3d59