### PR TITLE
Fix .glb loading paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
     <!-- Preload default model assets -->
     <link
       rel="preload"
-      href="/models/bag.glb"
+      href="models/bag.glb"
       as="fetch"
       type="model/gltf-binary"
       fetchpriority="high"
@@ -318,12 +318,12 @@
           <!-- 3-D Astronaut (always visible) -->
           <model-viewer
             id="viewer"
-            src="/models/bag.glb"
+            src="models/bag.glb"
             alt="3D model preview"
             environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
             camera-controls
             auto-rotate
-            crossorigin="anonymous"
+            crossOrigin="anonymous"
             fetchpriority="high"
             style="width: 100%; height: 100%; display: block"
           ></model-viewer>

--- a/js/index.js
+++ b/js/index.js
@@ -4,7 +4,7 @@ import { shareOn } from "./share.js";
 const API_BASE = (window.API_ORIGIN || "") + "/api";
 const TZ = "America/New_York";
 // Local fallback model used when generation fails or the viewer hasn't loaded a model yet.
-const FALLBACK_GLB_LOW = "/models/bag.glb";
+const FALLBACK_GLB_LOW = "models/bag.glb";
 const FALLBACK_GLB_HIGH =
   "https://modelviewer.dev/shared-assets/models/Astronaut.glb";
 const FALLBACK_GLB = FALLBACK_GLB_LOW;

--- a/js/payment.js
+++ b/js/payment.js
@@ -4,7 +4,7 @@
 let stripe = null;
 
 // Use a lightweight fallback model and upgrade to the high detail version after load.
-const FALLBACK_GLB_LOW = "/models/bag.glb";
+const FALLBACK_GLB_LOW = "models/bag.glb";
 const FALLBACK_GLB_HIGH =
   "https://modelviewer.dev/shared-assets/models/Astronaut.glb";
 const FALLBACK_GLB = FALLBACK_GLB_LOW;

--- a/minis-checkout.html
+++ b/minis-checkout.html
@@ -13,12 +13,7 @@
     <link rel="preconnect" href="https://modelviewer.dev" crossorigin />
 
     <!-- Preload 3D assets -->
-    <link
-      rel="preload"
-      href="/models/bag.glb"
-      as="fetch"
-      fetchpriority="high"
-    />
+    <link rel="preload" href="models/bag.glb" as="fetch" fetchpriority="high" />
     <link
       rel="preload"
       href="https://modelviewer.dev/shared-assets/environments/neutral.hdr"

--- a/payment.html
+++ b/payment.html
@@ -15,7 +15,7 @@
     <!-- Preload 3D assets -->
     <link
       rel="preload"
-      href="/models/bag.glb"
+      href="models/bag.glb"
       as="fetch"
       fetchpriority="high"
     />
@@ -235,7 +235,7 @@
             style="display: none"
             alt="Preview image"
           />
-        <model-viewer src="models/bag.glb" crossorigin="anonymous"
+        <model-viewer src="models/bag.glb" crossOrigin="anonymous"
           id="viewer"
           alt="3D astronaut"
           environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,6 +1,6 @@
 const CACHE_NAME = "model-cache-v2";
 const ASSETS = [
-  "/models/bag.glb",
+  "models/bag.glb",
   "https://modelviewer.dev/shared-assets/environments/neutral.hdr",
   "https://cdn.tailwindcss.com",
   "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css",


### PR DESCRIPTION
## Summary
- use relative paths for fallback `.glb` files
- restore `crossOrigin` attribute on model viewers

## Testing
- `npm run format` in `backend/`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6869b377bbf0832db59916f4b452c192