### PR TITLE
Fix GLB viewer caching issue

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,12 +1,8 @@
-const CACHE_NAME = "model-cache-v2";
+const CACHE_NAME = "model-cache-v3";
+// Cache only same-origin assets. Remote resources can fail to load when served
+// from the service worker cache, breaking the 3D viewer.
 const ASSETS = [
   "models/bag.glb",
-  "https://modelviewer.dev/shared-assets/environments/neutral.hdr",
-  "https://cdn.tailwindcss.com",
-  "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css",
-  "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css",
-  "https://cdn.jsdelivr.net/npm/@google/model-viewer@1.12.0/dist/model-viewer.min.js",
-  "https://cdn.jsdelivr.net/npm/@google/model-viewer@1.12.0/dist/model-viewer-legacy.js",
   "js/printclub.js",
   "js/rewardBadge.js",
   "js/basket.js",


### PR DESCRIPTION
## Summary
- avoid caching external assets in service worker

## Testing
- `npm run format`
- `npm test -- -i`
- `SKIP_PW_DEPS=1 npm run ci`
- `npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_686a50361a90832d84e7cca35b2767eb