### PR TITLE
fix: avoid duplicate service worker init

### DIFF
--- a/index.html
+++ b/index.html
@@ -665,12 +665,6 @@
       </div>
     </div>
     <script>
-      if ("serviceWorker" in navigator) {
-        navigator.serviceWorker.register("service-worker.js");
-        navigator.serviceWorker.ready.then((reg) => {
-          reg.active?.postMessage({ type: "prefetch-models" });
-        });
-      }
     </script>
     <script type="module" src="js/printclub.js"></script>
     <script type="module" src="js/rewardBadge.js"></script>


### PR DESCRIPTION
## Summary
- remove duplicate service worker block in `index.html`

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_686a57fe728c832db7a2f0a6d215f52a