### PR TITLE
Fix print minis button and thumbnails

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -178,7 +178,7 @@
               <p class="text-sm font-semibold">£14.99 per mini</p>
               <div id="minis-basket" class="text-xs overflow-y-auto max-h-20"></div>
             </div>
-            <a href="minis-checkout.html" class="absolute bottom-4 right-4 font-bold py-2 px-5 rounded-full shadow-md transition border-2 border-black text-sm" style="background-color: #30d5c8; color: #1a1a1d" onmouseover="this.style.opacity='0.85'" onmouseout="this.style.opacity='1'">Print my basket in mini size →</a>
+            <a href="minis-checkout.html" class="absolute bottom-4 right-4 font-bold py-2 px-5 rounded-full shadow-md transition border-2 border-black" style="background-color: #30d5c8; color: #1a1a1d" onmouseover="this.style.opacity='0.85'" onmouseout="this.style.opacity='1'">Print my basket in mini size →</a>
           </div>
 
           <!-- Remix prints (50% of column) -->
@@ -214,10 +214,12 @@
             container.textContent = "Basket empty";
             return;
           }
+          const placeholder =
+            'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAEElEQVR4nGNg+M9QzwAEYBxVSvzdgAAAAABJRU5ErkJggg==';
           const toShow = items.slice(0, 2);
           toShow.forEach((it) => {
             const img = document.createElement("img");
-            img.src = it.snapshot || it.modelUrl || "";
+            img.src = it.snapshot || it.modelUrl || placeholder;
             img.alt = "Mini thumbnail";
             img.className = "w-20 h-20 object-cover bg-[#2A2A2E] rounded";
             container.appendChild(img);

--- a/backend/db.js
+++ b/backend/db.js
@@ -916,7 +916,11 @@ async function deleteCartItem(id) {
 
 async function getCartItems(userId) {
   const { rows } = await query(
-    `SELECT id, job_id, quantity FROM cart_items WHERE user_id=$1 ORDER BY id`,
+    `SELECT ci.id, ci.job_id, ci.quantity, j.model_url, j.snapshot
+     FROM cart_items ci
+     LEFT JOIN jobs j ON ci.job_id=j.job_id
+     WHERE ci.user_id=$1
+     ORDER BY ci.id`,
     [userId],
   );
   return rows;

--- a/js/basket.js
+++ b/js/basket.js
@@ -142,6 +142,8 @@ async function syncServerCart() {
         jobId: it.job_id,
         quantity: it.quantity,
         serverId: it.id,
+        modelUrl: it.model_url,
+        snapshot: it.snapshot,
       }));
       saveBasket(mapped);
       updateBadge();


### PR DESCRIPTION
## Summary
- enlarge the print minis button text on the add-ons page
- show a 1x1 placeholder image when a mini thumbnail is missing
- include `model_url` and `snapshot` when syncing the basket
- fetch thumbnails for server cart items

## Testing
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_686a67aa895c832d9305c49823ae720e