### PR TITLE
Fix reward input highlighting

### DIFF
--- a/js/rewards.js
+++ b/js/rewards.js
@@ -164,11 +164,17 @@ window.addEventListener("DOMContentLoaded", () => {
       .getElementById("referral-link")
       ?.classList.add("cursor-default", "pointer-events-none");
     document
+      .querySelector('label[for="referral-link"]')
+      ?.classList.add("opacity-50", "cursor-default", "pointer-events-none");
+    document
       .getElementById("copy-referral")
       ?.classList.add("opacity-50", "cursor-default", "pointer-events-none");
     document
       .getElementById("reward-input")
       ?.classList.add("cursor-default", "pointer-events-none");
+    document
+      .querySelector('label[for="reward-input"]')
+      ?.classList.add("opacity-50", "cursor-default", "pointer-events-none");
     document
       .getElementById("redeem-button")
       ?.classList.add("opacity-50", "cursor-default", "pointer-events-none");


### PR DESCRIPTION
## Summary
- disable clicks on reward inputs and labels when user is logged out

## Testing
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_686a6a68863c832db5cf0539c3baaa29