### PR TITLE
Remove name etching from minis checkout

### DIFF
--- a/minis-checkout.html
+++ b/minis-checkout.html
@@ -360,10 +360,6 @@
                 >
                   <span class="font-semibold">£14.99</span>
                   <span class="text-xs">multi-colour</span>
-                  <span
-                    class="text-[10px] leading-tight text-center mt-2 text-[#30D5C8]"
-                    >+ (optional) name<br />etching</span
-                  >
                 </span>
                 <span
                   class="absolute -top-2 left-1/2 -translate-x-16 text-base line-through whitespace-nowrap pointer-events-none z-10 no-transform"
@@ -521,25 +517,6 @@
                 autocomplete="name"
                 aria-label="Name"
               />
-            </div>
-            <div id="etch-name-container" class="relative">
-              <input
-                id="etch-name"
-                class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10"
-                placeholder="Name for etching (optional)"
-                maxlength="20"
-                aria-label="Etched Name"
-                disabled
-              />
-              <div
-                id="etch-warning"
-                class="pointer-events-none absolute inset-y-0 left-0 flex items-center gap-2 pl-2 hidden"
-              >
-                <div class="border-t-2 border-[#30D5C8] w-[20ch]"></div>
-                <span class="text-sm text-[#30D5C8] whitespace-nowrap"
-                  >Multi-colour required</span
-                >
-              </div>
             </div>
             <div>
               <input


### PR DESCRIPTION
## Summary
- remove reference to name etching in the multi-colour option
- drop the name etching input field

## Testing
- `npm test` in `backend/`
- `SKIP_PW_DEPS=1 npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_686a73638f48832d9b0a847858ae4c9a