### PR TITLE
fix: keep discount panel at top

### DIFF
--- a/marketplace.html
+++ b/marketplace.html
@@ -102,7 +102,7 @@
         </div>
       </div>
     </header>
-    <main class="flex-1 p-4 space-y-6">
+    <main class="flex-1 flex flex-col p-4 space-y-6">
       <section class="bg-[#2A2A2E] p-4 rounded-xl border border-white/10">
         <p class="text-center">
           Purchase items here to get
@@ -120,7 +120,9 @@
           <a href="payment.html" class="font-bold text-[#30D5C8]">Buy Here</a>.
         </p>
       </section>
-      <section class="grid grid-cols-1 md:grid-cols-2 gap-6 h-full">
+      <section
+        class="grid grid-cols-1 md:grid-cols-2 gap-6 h-full mt-auto mb-6"
+      >
         <div
           class="bg-[#2A2A2E] p-4 rounded-xl border border-white/10 flex flex-col h-[36vh]"
         >


### PR DESCRIPTION
## Summary
- keep rewards banner at the top of Marketplace
- move the marketplace panels down with flexbox
- restore card heights

## Testing
- `npm run setup`
- `npm run format` in backend
- `npm test` in backend
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_686a6a20354c832db3a004f424699cb1