### PR TITLE
fix: suppress deprecated _headers usage

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -7,7 +7,7 @@ module.exports = defineConfig({
   webServer: process.env.PLAYWRIGHT_BASE_URL
     ? undefined
     : {
-        command: "npx http-server -c-1 -p 3000",
+        command: "node scripts/dev-server.js",
         port: 3000,
         timeout: 120 * 1000,
         reuseExistingServer: true,

--- a/scripts/dev-server.js
+++ b/scripts/dev-server.js
@@ -1,0 +1,19 @@
+const express = require("express");
+const path = require("path");
+
+const app = express();
+const root = path.join(__dirname, "..");
+
+app.use(
+  express.static(root, {
+    index: "index.html",
+    setHeaders(res) {
+      res.setHeader("Cache-Control", "no-store");
+    },
+  }),
+);
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`Dev server listening on http://localhost:${port}`);
+});


### PR DESCRIPTION
## Summary
- add an Express-based dev server
- start Playwright tests with the new dev server

## Testing
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`
- `NODE_NO_WARNINGS=1 SKIP_PW_DEPS=1 npx playwright test e2e/smoke.test.js`


------
https://chatgpt.com/codex/tasks/task_e_686a76af70dc832d9f0a153c9d9b46fb