### PR TITLE
Fix NPM cache warnings

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -21,6 +21,7 @@ fi
 
 # Clear the npm cache to avoid cleanup warnings
 npm cache clean --force
+npm cache verify >/dev/null
 # Remove leftover tmp directories that can cause ENOTEMPTY errors
 rm -rf "$(npm config get cache)/_cacache/tmp" "$HOME/.npm/_cacache/tmp"
 


### PR DESCRIPTION
## Summary
- verify the npm cache during setup to avoid corrupted tarball errors

## Testing
- `npm test --prefix backend tests/accounting.test.js`
- `npm run format --prefix backend`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_686a76c79330832dbedf74c318b6fae8