### PR TITLE
Add auto-setup fallback for Playwright

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,9 @@ Install dependencies and Playwright browsers:
 npm run setup
 ```
 
+If the browsers are missing, the CI scripts will automatically invoke this
+command for you. Running it manually first speeds up subsequent test runs.
+
 Run the full CI suite for linting, type checks, backend tests and accessibility checks:
 
 ```bash

--- a/scripts/assert-setup.js
+++ b/scripts/assert-setup.js
@@ -15,8 +15,13 @@ function browsersInstalled() {
 }
 
 if (!fs.existsSync('.setup-complete') || !browsersInstalled()) {
-  console.error(
-    "Playwright browsers not installed. Please execute 'npm run setup' first."
+  console.log(
+    "Playwright browsers not installed. Running 'npm run setup' to install them"
   );
-  process.exit(1);
+  try {
+    require('child_process').execSync('npm run setup', { stdio: 'inherit' });
+  } catch (err) {
+    console.error('Failed to run setup:', err.message);
+    process.exit(1);
+  }
 }


### PR DESCRIPTION
## Summary
- auto-run `npm run setup` from `scripts/assert-setup.js` if browsers are missing
- document the automatic setup step in README

## Testing
- `npm run format`
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_686a76dd6aa4832da202309f7a6aa644