### PR TITLE
Fix SSE progress test timers

### DIFF
--- a/backend/tests/additionalApi.test.js
+++ b/backend/tests/additionalApi.test.js
@@ -563,6 +563,7 @@ test("POST /api/admin/competitions unauthorized", async () => {
 });
 
 test("SSE progress endpoint streams updates", async () => {
+  jest.useRealTimers();
   const req = request(app).get("/api/progress/job1");
   progressTimer = setTimeout(() => {
     progressEmitter.emit("progress", { jobId: "job1", progress: 100 });


### PR DESCRIPTION
## Summary
- ensure `SSE progress endpoint streams updates` test uses real timers

## Testing
- `npm test`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_686a771a2010832d8d493b4e68b81b3e