### PR TITLE
Fix SSE progress test timeout

### DIFF
--- a/backend/tests/additionalApi.test.js
+++ b/backend/tests/additionalApi.test.js
@@ -564,6 +564,8 @@ test("POST /api/admin/competitions unauthorized", async () => {
 
 test("SSE progress endpoint streams updates", async () => {
   const req = request(app).get("/api/progress/job1");
+  // wait briefly to ensure the route attaches its listener
+  await new Promise((r) => setTimeout(r, 20));
   progressTimer = setTimeout(() => {
     progressEmitter.emit("progress", { jobId: "job1", progress: 100 });
   }, 50);


### PR DESCRIPTION
## Summary
- wait for listener registration before emitting progress in SSE progress test

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_686a76fd6478832da0625ff3831805eb