### PR TITLE
Fix a11y script check

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "e2e": "playwright test",
     "smoke": "NODE_NO_WARNINGS=1 SKIP_PW_DEPS=1 npm run setup && NODE_NO_WARNINGS=1 npx playwright test e2e/smoke.test.js",
     "visual-test": "percy exec -- npm run e2e",
-    "test:a11y": "bash scripts/install-playwright.sh chromium && playwright test e2e/a11y.test.js",
+    "test:a11y": "node scripts/assert-setup.js && bash scripts/install-playwright.sh chromium && playwright test e2e/a11y.test.js",
     "netlify:deploy": "scripts/netlify-preflight.sh && netlify deploy"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- ensure Playwright setup ran before running accessibility tests

## Testing
- `npm test`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_686a78164e78832d956ea93f0df3bf8a