### PR TITLE
Fix npm cache cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,18 @@ This resolves any partially configured packages left over from an interrupted `a
 If `eslint` fails with this error, it usually means dependencies aren't installed.
 Run `npm run setup` in the repository root to install them.
 
+### ENOTEMPTY errors from npm
+
+If `npm` reports `ENOTEMPTY: directory not empty` while cleaning the cache, remove the
+cache directory manually:
+
+```bash
+rm -rf "$(npm config get cache)/_cacache"
+```
+
+The `npm run setup` script now performs this cleanup automatically, but manual
+removal may be required on older clones.
+
 ## Contributing
 
 ⚠️ **Note:** this project uses OpenAI Codex to generate PRs;

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -21,7 +21,9 @@ fi
 
 # Clear the npm cache to avoid cleanup warnings
 npm cache clean --force
-# Remove leftover tmp directories that can cause ENOTEMPTY errors
+# Remove leftover cache directories that can cause ENOTEMPTY errors
+rm -rf "$(npm config get cache)/_cacache" "$HOME/.npm/_cacache"
+# Remove tmp directories that sometimes linger after cache clean
 rm -rf "$(npm config get cache)/_cacache/tmp" "$HOME/.npm/_cacache/tmp"
 
 # Remove stale apt or dpkg locks that may prevent dependency installation


### PR DESCRIPTION
## Summary
- improve cleanup steps in setup script to wipe npm cache dirs
- document fixing ENOTEMPTY errors from npm

## Testing
- `npm run format`
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`
- `npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_686a772dd62c832d8dfebdd13895b94b