### PR TITLE
Fix Playwright setup check

### DIFF
--- a/scripts/assert-setup.js
+++ b/scripts/assert-setup.js
@@ -1,22 +1,26 @@
 #!/usr/bin/env node
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
 
 function browsersInstalled() {
   const envPath = process.env.PLAYWRIGHT_BROWSERS_PATH;
-  const defaultPath = path.join(os.homedir(), '.cache', 'ms-playwright');
+  const defaultPath = path.join(os.homedir(), ".cache", "ms-playwright");
   const browserPath = envPath || defaultPath;
   try {
-    return fs.existsSync(browserPath) && fs.readdirSync(browserPath).length > 0;
+    const entries = fs.readdirSync(browserPath);
+    const hasChromium = entries.some((e) => e.startsWith("chromium"));
+    const hasFirefox = entries.some((e) => e.startsWith("firefox"));
+    const hasWebkit = entries.some((e) => e.startsWith("webkit"));
+    return hasChromium && hasFirefox && hasWebkit;
   } catch {
     return false;
   }
 }
 
-if (!fs.existsSync('.setup-complete') || !browsersInstalled()) {
+if (!fs.existsSync(".setup-complete") || !browsersInstalled()) {
   console.error(
-    "Playwright browsers not installed. Please execute 'npm run setup' first."
+    "Playwright browsers not installed. Please execute 'npm run setup' first.",
   );
   process.exit(1);
 }


### PR DESCRIPTION
## Summary
- improve browser check logic in `assert-setup.js`

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_686a80a11378832d8a6841405964dd00