### PR TITLE
Add models listing endpoint

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -460,6 +460,23 @@ app.post("/api/upload-model", upload.single("model"), async (req, res) => {
   }
 });
 
+app.get("/api/models", async (req, res) => {
+  try {
+    const { rows } = await db.query(
+      "SELECT id, s3_key, uploaded_at FROM models ORDER BY uploaded_at DESC",
+    );
+    const models = rows.map((r) => ({
+      id: r.id,
+      key: r.s3_key,
+      uploaded_at: r.uploaded_at,
+    }));
+    res.json(models);
+  } catch (err) {
+    logError(err);
+    res.status(500).json({ error: "Failed to fetch models" });
+  }
+});
+
 /**
  * GET /api/status
  * List recent jobs with pagination

--- a/backend/tests/additionalApi.test.js
+++ b/backend/tests/additionalApi.test.js
@@ -175,6 +175,19 @@ test("GET /api/users/:username/models 404 when missing", async () => {
   expect(res.status).toBe(404);
 });
 
+test("GET /api/models returns list", async () => {
+  db.query.mockResolvedValueOnce({
+    rows: [{ id: 1, s3_key: "m1.glb", uploaded_at: "2024-01-01" }],
+  });
+  const res = await request(app).get("/api/models");
+  expect(res.status).toBe(200);
+  expect(res.body).toEqual([
+    { id: 1, key: "m1.glb", uploaded_at: "2024-01-01" },
+  ]);
+  const call = db.query.mock.calls[0][0];
+  expect(call).toContain("FROM models");
+});
+
 test("POST /api/models/:id/like adds like", async () => {
   db.query
     .mockResolvedValueOnce({ rows: [] })


### PR DESCRIPTION
## Summary
- expose `/api/models` to list uploaded models
- test new endpoint

## Testing
- `npm test --prefix backend`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_686af42ffdc0832db82107873a64d1e2