### PR TITLE
Add health check endpoint

### DIFF
--- a/backend/tests/health.test.js
+++ b/backend/tests/health.test.js
@@ -1,0 +1,35 @@
+process.env.STRIPE_SECRET_KEY = "test";
+process.env.STRIPE_WEBHOOK_SECRET = "whsec";
+process.env.DB_URL = "postgres://user:pass@localhost/db";
+process.env.HUNYUAN_API_KEY = "test";
+process.env.HUNYUAN_SERVER_URL = "http://localhost:4000";
+process.env.AWS_REGION = "us-east-1";
+process.env.S3_BUCKET = "bucket";
+
+jest.mock("../db", () => ({
+  query: jest.fn(),
+}));
+const db = require("../db");
+
+jest.mock("@aws-sdk/client-s3", () => {
+  const actual = jest.requireActual("@aws-sdk/client-s3");
+  const send = jest.fn().mockResolvedValue({});
+  return {
+    ...actual,
+    S3Client: jest.fn().mockImplementation(() => ({ send })),
+  };
+});
+const request = require("supertest");
+const app = require("../server");
+
+beforeEach(() => {
+  db.query.mockClear();
+});
+
+test("GET /api/health returns ok", async () => {
+  db.query.mockResolvedValueOnce({ rows: [] });
+  const res = await request(app).get("/api/health");
+  expect(res.status).toBe(200);
+  expect(res.body).toEqual({ db: "ok", s3: "ok" });
+  expect(db.query).toHaveBeenCalledWith("SELECT 1");
+});


### PR DESCRIPTION
## Summary
- add `/api/health` endpoint that checks Postgres and S3
- test the new endpoint

## Testing
- `npm test --prefix backend`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_686afac9de2c832daa0b09380f4fa986