### PR TITLE
Add generate model placeholder API

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -265,6 +265,16 @@ app.post("/api/dalle", async (req, res) => {
   }
 });
 
+/**
+ * POST /api/generate-model
+ * Placeholder endpoint that returns a fake model id
+ */
+app.post("/api/generate-model", (req, res) => {
+  const { prompt } = req.body || {};
+  if (!prompt) return res.status(400).json({ error: "Prompt required" });
+  res.json({ success: true, modelId: "placeholder-id" });
+});
+
 app.post("/api/login", async (req, res) => {
   const { username, password } = req.body;
   if (!username || !password) {

--- a/backend/tests/api.test.js
+++ b/backend/tests/api.test.js
@@ -912,6 +912,19 @@ test("POST /api/dalle requires prompt", async () => {
   expect(res.status).toBe(400);
 });
 
+test("POST /api/generate-model returns placeholder", async () => {
+  const res = await request(app)
+    .post("/api/generate-model")
+    .send({ prompt: "cat" });
+  expect(res.status).toBe(200);
+  expect(res.body).toEqual({ success: true, modelId: "placeholder-id" });
+});
+
+test("POST /api/generate-model requires prompt", async () => {
+  const res = await request(app).post("/api/generate-model").send({});
+  expect(res.status).toBe(400);
+});
+
 test("GET /api/dashboard returns aggregated info", async () => {
   const token = jwt.sign({ id: "u1" }, "secret");
   db.query


### PR DESCRIPTION
## Summary
- add placeholder `/api/generate-model` endpoint
- test the new endpoint

## Testing
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_686b0286d44c832dbc7876087f88da1a