### PR TITLE
Fix npm audit warnings during setup

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -44,10 +44,10 @@ if [ -z "$SKIP_PW_DEPS" ]; then
   done
 fi
 
-npm ci
-npm ci --prefix backend
+npm ci --no-audit
+npm ci --prefix backend --no-audit
 if [ -f backend/hunyuan_server/package.json ]; then
-  npm ci --prefix backend/hunyuan_server
+  npm ci --prefix backend/hunyuan_server --no-audit
 fi
 
 # Ensure dpkg is fully configured before Playwright installs dependencies


### PR DESCRIPTION
## Summary
- skip `npm audit` when running setup to reduce noise in test logs

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_686b0b85fa94832d8364765236cd5567