### PR TITLE
Add CloudFront distribution

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -73,3 +73,49 @@ output "print3_db_password" {
   value     = random_password.print3_db_password.result
   sensitive = true
 }
+
+# CloudFront distribution for model assets
+resource "aws_cloudfront_origin_access_identity" "model_oai" {
+  comment = "OAI for glb-models-prod"
+}
+
+resource "aws_cloudfront_distribution" "model_cdn" {
+  enabled = true
+
+  origin {
+    domain_name = "glb-models-prod.s3.amazonaws.com"
+    origin_id   = "glb-models-prod"
+
+    s3_origin_config {
+      origin_access_identity = aws_cloudfront_origin_access_identity.model_oai.cloudfront_access_identity_path
+    }
+  }
+
+  default_cache_behavior {
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = "glb-models-prod"
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 86400
+    max_ttl                = 604800
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+
+  tags = {
+    Project = "Print3"
+  }
+}
+
+output "cloudfront_model_domain" {
+  value = aws_cloudfront_distribution.model_cdn.domain_name
+}


### PR DESCRIPTION
## Summary
- add an origin access identity and CloudFront distribution for the model bucket
- expose the CloudFront domain via output

## Testing
- `npm run format`
- `npm test --silent`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_686b0c9ea5ec832dae27cce7d6de6ab0