### PR TITLE
feat: add POST /api/models endpoint for metadata

### DIFF
--- a/backend/db/migrations/001_create_models_table.sql
+++ b/backend/db/migrations/001_create_models_table.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS models (
+  id SERIAL PRIMARY KEY,
+  prompt TEXT NOT NULL,
+  url TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT now()
+);

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -1,0 +1,8 @@
+const express = require("express");
+const modelsRouter = require("./routes/models");
+
+const app = express();
+app.use(express.json());
+app.use(modelsRouter);
+
+module.exports = app;

--- a/backend/src/routes/models.js
+++ b/backend/src/routes/models.js
@@ -1,0 +1,31 @@
+const express = require("express");
+const { S3Client } = require("@aws-sdk/client-s3");
+const { Pool } = require("pg");
+
+const router = express.Router();
+
+const pool = new Pool({
+  connectionString: process.env.DB_ENDPOINT,
+  user: "postgres",
+  password: process.env.DB_PASSWORD,
+  database: "postgres",
+});
+
+// Initialize an S3 client so the SDK is available if needed
+new S3Client();
+
+router.post("/api/models", async (req, res) => {
+  const { prompt, fileKey } = req.body;
+  const url = `https://${process.env.CLOUDFRONT_DOMAIN}/${fileKey}`;
+  try {
+    const result = await pool.query(
+      "INSERT INTO models (prompt, url) VALUES ($1, $2) RETURNING *",
+      [prompt, url],
+    );
+    res.status(201).json(result.rows[0]);
+  } catch (_err) {
+    res.status(500).json({ error: "Failed to insert model" });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- create models route with POST /api/models
- wire up router in new Express app
- add SQL migration for models metadata table

## Testing
- `npm test --prefix backend`
- `npm run ci`
- `npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_686bfcc75fb4832d88fbfa89d4ef2e6f