### PR TITLE
feat: add POST /api/models endpoint

### DIFF
--- a/backend/config.js
+++ b/backend/config.js
@@ -1,5 +1,11 @@
 'use strict';
-const required = ['DB_URL', 'STRIPE_SECRET_KEY', 'STRIPE_WEBHOOK_SECRET', 'HUNYUAN_API_KEY'];
+const required = [
+  'DB_URL',
+  'STRIPE_SECRET_KEY',
+  'STRIPE_WEBHOOK_SECRET',
+  'HUNYUAN_API_KEY',
+  'CLOUDFRONT_MODEL_DOMAIN',
+];
 const missing = required.filter((key) => !process.env[key]);
 if (missing.length) {
   throw new Error(`Missing required env vars: ${missing.join(', ')}`);
@@ -16,4 +22,5 @@ module.exports = {
   sendgridKey: process.env.SENDGRID_API_KEY || '',
   emailFrom: process.env.EMAIL_FROM || 'noreply@example.com',
   printerApiUrl: process.env.PRINTER_API_URL || 'http://localhost:5000/print',
+  cloudfrontModelDomain: process.env.CLOUDFRONT_MODEL_DOMAIN,
 };

--- a/backend/server.js
+++ b/backend/server.js
@@ -491,6 +491,21 @@ app.get("/api/models", async (req, res) => {
   }
 });
 
+app.post("/api/models", async (req, res) => {
+  const { prompt, fileKey } = req.body || {};
+  const url = `https://${process.env.CLOUDFRONT_MODEL_DOMAIN}/${fileKey}`;
+  try {
+    const { rows } = await db.query(
+      "INSERT INTO models(prompt, file_key, url) VALUES($1,$2,$3) RETURNING id, prompt, url, created_at",
+      [prompt, fileKey, url],
+    );
+    res.status(201).json(rows[0]);
+  } catch (err) {
+    logError(err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
 /**
  * GET /api/status
  * List recent jobs with pagination


### PR DESCRIPTION
## Summary
- add CLOUDFRONT_MODEL_DOMAIN as a required config
- implement POST /api/models route
- store prompt, file key and URL for new models

## Testing
- `npm test`
- `npm run format`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_686c16cf5ec8832d9e7673b52eecd0f8