### PR TITLE
feat: implement POST /api/models endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,7 @@ PRINTER_API_URL=http://localhost:5000/print
 
 # Enable HTTP/2 for the backend server
 HTTP2=true
+CLOUDFRONT_MODEL_DOMAIN=https://your-cloudfront-domain
 
 # Optional admin user setup
 # ADMIN_USERNAME=admin


### PR DESCRIPTION
## Summary
- validate `CLOUDFRONT_MODEL_DOMAIN` on startup
- create `/api/models` endpoint with input validation and stored URL
- document `CLOUDFRONT_MODEL_DOMAIN` in `.env.example`

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_686c21065c14832da709b92fef6853fb