### PR TITLE
Add models route tests

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -5,7 +5,10 @@ module.exports = {
   setupFilesAfterEnv: ["<rootDir>/tests/setup.js"],
   globalTeardown: "<rootDir>/tests/globalTeardown.js",
   testEnvironment: "node",
-  testMatch: ["<rootDir>/tests/**/*.test.js"],
+  testMatch: [
+    "<rootDir>/tests/**/*.test.js",
+    "<rootDir>/src/**/__tests__/**/*.test.js",
+  ],
   testTimeout: 10000,
   coverageDirectory: "coverage",
   coverageReporters: ["text", "lcov"],

--- a/backend/src/__tests__/models.test.js
+++ b/backend/src/__tests__/models.test.js
@@ -1,0 +1,47 @@
+process.env.DB_ENDPOINT = "postgres://user:pass@localhost/db";
+process.env.DB_PASSWORD = "pass";
+process.env.CLOUDFRONT_DOMAIN = "cdn.example.com";
+
+jest.mock("pg");
+const { Pool } = require("pg");
+const mPool = { query: jest.fn() };
+Pool.mockImplementation(() => mPool);
+
+const request = require("supertest");
+const app = require("../app");
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+test("POST /api/models inserts model and returns 201", async () => {
+  const rows = [
+    { id: 1, prompt: "p", url: "https://cdn.example.com/file.glb" },
+  ];
+  mPool.query.mockResolvedValueOnce({ rows });
+  const res = await request(app)
+    .post("/api/models")
+    .send({ prompt: "p", fileKey: "file.glb" });
+  expect(res.status).toBe(201);
+  expect(res.body).toEqual(rows[0]);
+  expect(mPool.query).toHaveBeenCalledWith(
+    "INSERT INTO models (prompt, url) VALUES ($1, $2) RETURNING *",
+    ["p", "https://cdn.example.com/file.glb"],
+  );
+});
+
+test("POST /api/models returns 400 when data missing", async () => {
+  let res = await request(app).post("/api/models").send({ prompt: "a" });
+  expect(res.status).toBe(400);
+  res = await request(app).post("/api/models").send({ fileKey: "f" });
+  expect(res.status).toBe(400);
+});
+
+test("POST /api/models returns 500 on db error", async () => {
+  mPool.query.mockRejectedValueOnce(new Error("fail"));
+  const res = await request(app)
+    .post("/api/models")
+    .send({ prompt: "p", fileKey: "file.glb" });
+  expect(res.status).toBe(500);
+  expect(res.body.error).toBe("Failed to insert model");
+});

--- a/backend/src/routes/models.js
+++ b/backend/src/routes/models.js
@@ -16,6 +16,9 @@ new S3Client();
 
 router.post("/api/models", async (req, res) => {
   const { prompt, fileKey } = req.body;
+  if (!prompt || !fileKey) {
+    return res.status(400).json({ error: "Missing prompt or fileKey" });
+  }
   const url = `https://${process.env.CLOUDFRONT_DOMAIN}/${fileKey}`;
   try {
     const result = await pool.query(


### PR DESCRIPTION
## Summary
- add error handling for missing fields on POST /api/models
- configure Jest to run tests from src/__tests__
- test /api/models route

## Testing
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_686c2c64fc68832d9f47bb11a6ee9535