### PR TITLE
Add tests for /api/models endpoint

### DIFF
--- a/backend/tests/apiModels.test.js
+++ b/backend/tests/apiModels.test.js
@@ -1,0 +1,51 @@
+process.env.STRIPE_SECRET_KEY = "test";
+process.env.STRIPE_WEBHOOK_SECRET = "whsec";
+process.env.DB_URL = "postgres://user:pass@localhost/db";
+process.env.HUNYUAN_API_KEY = "test";
+process.env.HUNYUAN_SERVER_URL = "http://localhost:4000";
+process.env.CLOUDFRONT_MODEL_DOMAIN = "cdn.example.com";
+process.env.AWS_REGION = "us-east-1";
+process.env.S3_BUCKET = "bucket";
+
+jest.mock("../db", () => ({
+  query: jest.fn(),
+}));
+const db = require("../db");
+
+const request = require("supertest");
+const app = require("../server");
+
+afterEach(() => {
+  db.query.mockReset();
+});
+
+test("GET /api/models returns list", async () => {
+  db.query.mockResolvedValueOnce({
+    rows: [{ id: 1, s3_key: "m1.glb", uploaded_at: "2024-01-01" }],
+  });
+  const res = await request(app).get("/api/models");
+  expect(res.status).toBe(200);
+  expect(res.body).toEqual([
+    { id: 1, key: "m1.glb", uploaded_at: "2024-01-01" },
+  ]);
+});
+
+test("POST /api/models creates model with CDN url", async () => {
+  db.query.mockResolvedValueOnce({
+    rows: [{ id: 2, created_at: "2024-01-02" }],
+  });
+  const body = { prompt: "cat", fileKey: "cat.glb" };
+  const res = await request(app).post("/api/models").send(body);
+  expect(res.status).toBe(201);
+  expect(res.body.url).toBe(
+    `https://${process.env.CLOUDFRONT_MODEL_DOMAIN}/${body.fileKey}`,
+  );
+  const call = db.query.mock.calls[0];
+  expect(call[0]).toContain("INSERT INTO models");
+  expect(call[1]).toEqual([body.prompt, body.fileKey]);
+});
+
+test("POST /api/models requires fields", async () => {
+  const res = await request(app).post("/api/models").send({});
+  expect(res.status).toBe(400);
+});

--- a/backend/tests/setupGlobals.js
+++ b/backend/tests/setupGlobals.js
@@ -27,3 +27,7 @@ console.warn = (...args) => {
   }
   return originalConsoleWarn(...args);
 };
+
+if (!process.env.CLOUDFRONT_MODEL_DOMAIN) {
+  process.env.CLOUDFRONT_MODEL_DOMAIN = "cdn.test";
+}


### PR DESCRIPTION
## Summary
- add apiModels.test.js covering /api/models endpoints
- default CLOUDFRONT_MODEL_DOMAIN for tests

## Testing
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: npm run smoke output truncated)*


------
https://chatgpt.com/codex/tasks/task_e_686c2c6aac0c832d9e2458278182c164