### PR TITLE
Add env var check test

### DIFF
--- a/backend/tests/config.test.js
+++ b/backend/tests/config.test.js
@@ -1,0 +1,22 @@
+process.env.DB_URL = "postgres://user:pass@localhost/db";
+process.env.STRIPE_SECRET_KEY = "test";
+process.env.STRIPE_WEBHOOK_SECRET = "whsec";
+process.env.HUNYUAN_API_KEY = "test";
+process.env.CLOUDFRONT_MODEL_DOMAIN = "https://domain";
+
+const original = process.env.CLOUDFRONT_MODEL_DOMAIN;
+
+test("throws if CLOUDFRONT_MODEL_DOMAIN missing", () => {
+  jest.isolateModules(() => {
+    delete process.env.CLOUDFRONT_MODEL_DOMAIN;
+    expect(() => require("../config")).toThrow(/CLOUDFRONT_MODEL_DOMAIN/);
+  });
+});
+
+test("loads when CLOUDFRONT_MODEL_DOMAIN restored", () => {
+  jest.isolateModules(() => {
+    process.env.CLOUDFRONT_MODEL_DOMAIN = original;
+    const cfg = require("../config");
+    expect(cfg.cloudfrontModelDomain).toBe(original);
+  });
+});


### PR DESCRIPTION
## Summary
- add regression test for CLOUDFRONT_MODEL_DOMAIN in config

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_686c2c70b6c8832d9dc9e9cd9078a6b7