### PR TITLE
Add test for models POST route

### DIFF
--- a/backend/src/__tests__/app.test.js
+++ b/backend/src/__tests__/app.test.js
@@ -1,0 +1,25 @@
+process.env.DB_ENDPOINT = "postgres://user:pass@localhost/db";
+process.env.DB_PASSWORD = "pass";
+process.env.CLOUDFRONT_DOMAIN = "cloud.test";
+
+jest.mock("pg");
+const { Pool } = require("pg");
+const mPool = { query: jest.fn() };
+Pool.mockImplementation(() => mPool);
+
+const request = require("supertest");
+const app = require("../app");
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+test("POST /api/models returns 201 when insert succeeds", async () => {
+  mPool.query.mockResolvedValueOnce({
+    rows: [{ id: 1, prompt: "p", url: "u" }],
+  });
+  const res = await request(app)
+    .post("/api/models")
+    .send({ prompt: "p", fileKey: "f" });
+  expect(res.status).toBe(201);
+});


### PR DESCRIPTION
## Summary
- add integration test for POST /api/models using supertest

## Testing
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_686c2c7b2914832db7d139a9681d45d0