### PR TITLE
Add Playwright E2E for /api/models

### DIFF
--- a/e2e/api-models.test.js
+++ b/e2e/api-models.test.js
@@ -1,0 +1,35 @@
+const { test, expect } = require("@playwright/test");
+const { startServer } = require("../tests/util");
+
+let server;
+
+test.beforeAll(async () => {
+  server = await startServer(3100);
+});
+
+test.afterAll(async () => {
+  await server.close();
+});
+
+test("POST /api/models happy path", async ({ request }) => {
+  const res = await request.post(`${server.url}/api/models`, {
+    data: { prompt: "e2e", fileKey: "e2e.txt" },
+  });
+  expect(res.status()).toBe(201);
+  const json = await res.json();
+  expect(json.url).toContain(process.env.CLOUDFRONT_MODEL_DOMAIN);
+});
+
+test("missing prompt returns 400", async ({ request }) => {
+  const res = await request.post(`${server.url}/api/models`, {
+    data: { fileKey: "e2e.txt" },
+  });
+  expect(res.status()).toBe(400);
+});
+
+test("missing fileKey returns 400", async ({ request }) => {
+  const res = await request.post(`${server.url}/api/models`, {
+    data: { prompt: "e2e" },
+  });
+  expect(res.status()).toBe(400);
+});

--- a/tests/util.js
+++ b/tests/util.js
@@ -1,0 +1,49 @@
+const fs = require("fs");
+const path = require("path");
+const { newDb } = require("../backend/node_modules/pg-mem");
+const pg = require("../backend/node_modules/pg");
+
+/**
+ * Start the backend server on the given port using an in-memory Postgres DB.
+ * @param {number} port test port to listen on
+ * @returns {Promise<{url: string, close: () => Promise<void>}>} server helpers
+ */
+async function startServer(port = 4001) {
+  // Prepare in-memory Postgres
+  const db = newDb();
+  const { Pool } = db.adapters.createPg();
+  const pool = new Pool();
+  const sql = fs.readFileSync(
+    path.join(
+      __dirname,
+      "..",
+      "backend",
+      "db",
+      "migrations",
+      "001_create_models_table.sql",
+    ),
+    "utf8",
+  );
+  await pool.query(sql);
+  pg.Pool = Pool; // stub pg to use in-memory DB
+
+  // Map env vars used by route
+  process.env.CLOUDFRONT_MODEL_DOMAIN =
+    process.env.CLOUDFRONT_MODEL_DOMAIN || "cdn.test";
+  process.env.CLOUDFRONT_DOMAIN = process.env.CLOUDFRONT_MODEL_DOMAIN;
+  process.env.DB_ENDPOINT = "mem";
+  process.env.DB_PASSWORD = "mem";
+
+  const app = require("../backend/src/app");
+
+  return new Promise((resolve) => {
+    const server = app.listen(port, () =>
+      resolve({
+        url: `http://localhost:${port}`,
+        close: () => new Promise((r) => server.close(r)),
+      }),
+    );
+  });
+}
+
+module.exports = { startServer };


### PR DESCRIPTION
## Summary
- add test helper to spin up backend with pg-mem
- test happy and error paths for POST `/api/models`

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`
- `npm run smoke`
- `npm run e2e`

------
https://chatgpt.com/codex/tasks/task_e_686c51102044832d8e95a9d4d17406ee