### PR TITLE
Robust CI enhancements

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,0 +1,39 @@
+.env
+node_modules/
+models/*
+!models/astronaut_low.glb
+uploads/
+backend/hunyuan_server/uploads/
+*.log
+.DS_Store
+reports/
+backend/coverage/
+coverage/
+# ignore compiled and binary files
+*.exe
+*.dll
+*.so
+*.bin
+*.o
+*.pyc
+/build/
+/dist/
+*.jpg
+*.png
+*.pdf
+.setup-complete
+
+# Terraform local files
+infra/.terraform/
+infra/*.tfstate
+infra/*.tfstate.backup
+
+# Terraform runtime files
+infra/.terraform/
+infra/*.tfstate*
+infra/AWSCLIV2.pkg
+infra/awscliv2.zip
+
+coverage/
+node_modules/
+infra/**/*.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,47 @@ on:
     branches: [main]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Fail if files exceed 25 MiB
+        run: |
+          max=$((25 * 1024 * 1024))
+          git ls-files -z | while IFS= read -r -d '' f; do
+            size=$(stat -c%s "$f")
+            if [ "$size" -gt "$max" ]; then
+              echo "$f is $(du -h "$f" | cut -f1) (>25MiB)" && exit 1
+            fi
+          done
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: |
+            package-lock.json
+            backend/package-lock.json
+            backend/hunyuan_server/package-lock.json
+      - name: Cache npm
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-
+      - name: Cache yarn
+        if: hashFiles('**/yarn.lock') != ''
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/yarn
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - run: npm install --no-audit --no-fund
+      - run: npx eslint . --max-warnings=0
+
   build:
+    needs: lint
     runs-on: ubuntu-latest
     services:
       docker:
@@ -20,10 +60,38 @@ jobs:
             sudo apt-get update && sudo apt-get install -y docker.io
           fi
       - uses: actions/checkout@v4
+      - name: Fail if files exceed 25 MiB
+        run: |
+          max=$((25 * 1024 * 1024))
+          git ls-files -z | while IFS= read -r -d '' f; do
+            size=$(stat -c%s "$f")
+            if [ "$size" -gt "$max" ]; then
+              echo "$f is $(du -h "$f" | cut -f1) (>25MiB)" && exit 1
+            fi
+          done
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'npm'
+          cache-dependency-path: |
+            package-lock.json
+            backend/package-lock.json
+            backend/hunyuan_server/package-lock.json
+      - name: Cache npm
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-
+      - name: Cache yarn
+        if: hashFiles('**/yarn.lock') != ''
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/yarn
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
       - name: Clean npm proxy settings
         run: |
           unset NPM_CONFIG_HTTP_PROXY NPM_CONFIG_HTTPS_PROXY


### PR DESCRIPTION
## Summary
- add lint job with strict eslint
- fail CI when any committed file exceeds 25 MiB
- cache npm and yarn folders
- mirror `.gitignore` to new `.cfignore` and ignore large artifacts

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_686c511cb498832dae78ad0be5a03469