### PR TITLE
Add Artillery load test

### DIFF
--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -1,0 +1,21 @@
+name: Load Test
+
+on:
+  workflow_dispatch:
+
+jobs:
+  load:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+      - run: npm install --no-audit --no-fund
+      - run: npm run load -- -o artillery-report.json
+      - name: Upload Artillery report
+        uses: actions/upload-artifact@v4
+        with:
+          name: artillery-report
+          path: artillery-report.json

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "setup": "scripts/setup.sh",
     "e2e": "playwright test",
     "smoke": "NODE_NO_WARNINGS=1 SKIP_PW_DEPS=1 npm run setup && NODE_NO_WARNINGS=1 npx playwright test e2e/smoke.test.js",
+    "load": "artillery run tests/load/models.yml",
     "visual-test": "percy exec -- npm run e2e",
     "test:a11y": "node scripts/assert-setup.js && bash scripts/install-playwright.sh chromium && playwright test e2e/a11y.test.js",
     "netlify:deploy": "scripts/netlify-preflight.sh && netlify deploy"

--- a/tests/load/models.yml
+++ b/tests/load/models.yml
@@ -1,0 +1,16 @@
+config:
+  target: "http://localhost:3000"
+  phases:
+    - duration: 60
+      arrivalRate: 10
+  ensure:
+    thresholds:
+      http.response_time:
+        p95: 300
+scenarios:
+  - flow:
+      - post:
+          url: "/api/models"
+          json:
+            prompt: "load-test"
+            fileKey: "file.glb"


### PR DESCRIPTION
## Summary
- add Artillery scenario for POST `/api/models`
- expose `load` npm script
- create optional workflow to run the load test

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`
- `npm run smoke` *(failed: log truncated)*

------
https://chatgpt.com/codex/tasks/task_e_686c517bc924832d91d32e37ac555a76