### PR TITLE
feat: daily DB backups

### DIFF
--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -1,0 +1,23 @@
+name: DB Backup
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+jobs:
+  backup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run backup script
+        env:
+          DB_URL: ${{ secrets.DB_URL }}
+        run: |
+          ./scripts/backup-db.sh
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: db-backup-${{ github.run_id }}
+          path: backups/db-*.sql.gz
+          retention-days: 7

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -1,0 +1,20 @@
+# Database Backup and Restore
+
+## Backup
+
+Backups are created automatically each day by a GitHub Action that runs the
+`scripts/backup-db.sh` script. Dumps are compressed and stored as workflow
+artifacts for seven days.
+
+## Restore
+
+1. Download the desired `db-YYYY-MM-DD.sql.gz` artifact from the workflow run.
+2. Decompress the file:
+   ```bash
+   gunzip db-YYYY-MM-DD.sql.gz
+   ```
+3. Restore to your database:
+   ```bash
+   psql "$DB_URL" < db-YYYY-MM-DD.sql
+   ```
+   Make sure `$DB_URL` points to the target database instance.

--- a/scripts/backup-db.sh
+++ b/scripts/backup-db.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+
+date_str=$(date +%F)
+backup_dir="$(dirname "$0")/../backups"
+mkdir -p "$backup_dir"
+
+if [ -z "${DB_URL:-}" ]; then
+  echo "DB_URL is not set" >&2
+  exit 1
+fi
+
+pg_dump "$DB_URL" | gzip > "$backup_dir/db-$date_str.sql.gz"
+
+echo "Backup stored at $backup_dir/db-$date_str.sql.gz"


### PR DESCRIPTION
## Summary
- add a backup script dumping the DB_URL
- run backups nightly in GitHub Actions and store as artifacts
- document how to restore backups

## Testing
- `npm test`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_686c5189e9cc832db7b0758da8e1b219