### PR TITLE
ci: add gitleaks secret scanning

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,17 @@
+name: Secret Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Scan for secrets
+        uses: gitleaks/gitleaks-action@v2
+        with:
+          args: detect --no-banner --redact

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,6 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
+gitleaks protect --staged --no-banner --redact
 npm audit --audit-level=high
 npx lint-staged

--- a/docs/security.md
+++ b/docs/security.md
@@ -5,3 +5,9 @@ This workflow uses Snyk to test for high-severity vulnerabilities.
 - **To enable**: add your Snyk API token as the `SNYK_TOKEN` secret in GitHub repo settings.
 - **Fallback**: if `SNYK_TOKEN` is missing, CI will automatically run `npm audit --audit-level=high`.
 - **Validation**: invalid tokens will error early with a clear message.
+
+### Secret Scanning
+
+Our CI pipeline runs `gitleaks detect --no-banner --redact` to catch hard-coded secrets.
+
+False positives can be suppressed by adding entries to the `allowlist` section of `.gitleaks.toml`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "eslint-plugin-jsdoc": "^51.1.1",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-promise": "^7.2.1",
+        "gitleaks": "^1.0.0",
         "http-server": "^14.1.1",
         "husky": "^9.1.7",
         "i18next-parser": "^9.3.0",
@@ -7303,6 +7304,13 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/gitleaks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gitleaks/-/gitleaks-1.0.0.tgz",
+      "integrity": "sha512-mTtKkWCAeHnTiBmRzjKnot8D8zX/JVDuRffuvSCr+z93vuBXygeifGZ7lXOB8Hjxto+DikSoF0XXfxntd1BZSQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -19647,6 +19655,12 @@
         "meow": "^12.0.1",
         "split2": "^4.0.0"
       }
+    },
+    "gitleaks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gitleaks/-/gitleaks-1.0.0.tgz",
+      "integrity": "sha512-mTtKkWCAeHnTiBmRzjKnot8D8zX/JVDuRffuvSCr+z93vuBXygeifGZ7lXOB8Hjxto+DikSoF0XXfxntd1BZSQ==",
+      "dev": true
     },
     "glob": {
       "version": "7.2.3",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "eslint-plugin-jsdoc": "^51.1.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^7.2.1",
+    "gitleaks": "^1.0.0",
     "http-server": "^14.1.1",
     "husky": "^9.1.7",
     "i18next-parser": "^9.3.0",


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow running `gitleaks detect`
- run gitleaks in husky pre-commit hook
- document secret scanning and how to suppress false positives
- install gitleaks as a dev dependency

## Testing
- `npm run format` in `backend`
- `npm test` in `backend`
- `npm run ci`
- `npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_686c521cd5ec832db675ab013a1da3e2