### PR TITLE
chore(dev): add husky + lint-staged pre-commit hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ This repository contains the early MVP code for print2's website and backend.
    `backend/hunyuan_server/` if present, then downloads the browsers
    required for the end-to-end tests. Set `SKIP_PW_DEPS=1` to skip the
    Playwright dependency installation when the browsers are already available.
+   It also installs the Husky git hooks used for pre-commit checks. If the hooks
+   are missing, run `npx husky install` manually.
 
 3. Initialize the database:
 
@@ -304,6 +306,12 @@ For a quick end-to-end sanity check, run:
 ```bash
 npm run smoke
 ```
+
+### Pre-commit Hook
+
+Husky installs a pre-commit hook that runs lint-staged. Staged `*.js`, `*.ts`,
+and `*.json` files are formatted with Prettier, backend JavaScript is linted
+with ESLint, and Jest runs against related tests.
 
 Avoid calling `npx playwright test` directly. Missing browsers can cause
 `"Playwright Test did not expect test() to be called here"` errors.

--- a/package.json
+++ b/package.json
@@ -74,7 +74,9 @@
     "wait-on": "^8.0.3"
   },
   "lint-staged": {
-    "*.{js,jsx,json,md,html}": "npm run format"
+    "*.{js,ts,json}": "prettier --write",
+    "backend/**/*.js": "eslint --fix",
+    "*.{js,ts}": "jest --bail --findRelatedTests"
   },
   "dependencies": {
     "react": "^18.2.0",


### PR DESCRIPTION
## Summary
- add lint-staged rules for prettier, eslint and jest
- document husky pre-commit hook installation and usage

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_686c522694c4832dbcfb65787e72561a