### PR TITLE
docs(api): generate and serve OpenAPI spec + Postman collection

### DIFF
--- a/.github/workflows/openapi-lint.yml
+++ b/.github/workflows/openapi-lint.yml
@@ -1,0 +1,17 @@
+name: OpenAPI Lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npx @ibm/openapi-validator docs/openapi.yaml

--- a/backend/package.json
+++ b/backend/package.json
@@ -60,7 +60,9 @@
     "qrcode": "^1.5.3",
     "sharp": "^0.34.2",
     "stripe": "^18.2.1",
-    "uuid": "^11.1.0"
+    "uuid": "^11.1.0",
+    "swagger-jsdoc": "^6.2.8",
+    "swagger-ui-express": "^5.0.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.28.0",
@@ -82,7 +84,9 @@
     "pg-mem": "^3.0.5",
     "prettier": "^3.1.0",
     "supertest": "^7.1.1",
-    "tslib": "^2.8.1"
+    "tslib": "^2.8.1",
+    "openapi-to-postmanv2": "^3.0.0",
+    "yaml": "^2.3.4"
   },
   "engines": {
     "node": ">=18"

--- a/backend/scripts/generate-openapi.js
+++ b/backend/scripts/generate-openapi.js
@@ -1,0 +1,52 @@
+const path = require("path");
+const fs = require("fs");
+const swaggerJSDoc = require("swagger-jsdoc");
+const YAML = require("yaml");
+const { convert } = require("openapi-to-postmanv2");
+const serverSource = fs.readFileSync(
+  path.join(__dirname, "..", "server.js"),
+  "utf8",
+);
+
+const options = {
+  definition: {
+    openapi: "3.0.0",
+    info: { title: "print2 API", version: "1.0.0" },
+  },
+  apis: [
+    path.join(__dirname, "..", "server.js"),
+    path.join(__dirname, "..", "src", "routes", "*.js"),
+  ],
+};
+
+const spec = swaggerJSDoc(options);
+spec.paths = spec.paths || {};
+const regex = /app\.(get|post|put|delete|patch)\(\s*"(\/api[^"\s]*)"/g;
+let match;
+while ((match = regex.exec(serverSource))) {
+  const method = match[1];
+  const pathVal = match[2];
+  if (!spec.paths[pathVal]) spec.paths[pathVal] = {};
+  spec.paths[pathVal][method] = { responses: { 200: { description: "OK" } } };
+}
+const outDir = path.join(__dirname, "..", "..", "docs");
+fs.mkdirSync(outDir, { recursive: true });
+const yamlPath = path.join(outDir, "openapi.yaml");
+fs.writeFileSync(yamlPath, YAML.stringify(spec));
+
+convert(
+  { type: "string", data: YAML.stringify(spec) },
+  {},
+  (err, conversion) => {
+    if (!err && conversion.result) {
+      fs.writeFileSync(
+        path.join(outDir, "api.postman_collection.json"),
+        JSON.stringify(conversion.output[0].data, null, 2),
+      );
+      console.log("Postman collection written");
+    } else {
+      console.error("Failed to convert to Postman:", err || conversion);
+      process.exit(1);
+    }
+  },
+);

--- a/docs/api.postman_collection.json
+++ b/docs/api.postman_collection.json
@@ -1,0 +1,6352 @@
+{
+  "item": [
+    {
+      "id": "8e24513c-6590-4722-b488-a9807a78d436",
+      "name": "/api-docs",
+      "request": {
+        "name": "/api-docs",
+        "description": {},
+        "url": {
+          "path": ["api-docs"],
+          "host": ["{{baseUrl}}"],
+          "query": [],
+          "variable": []
+        },
+        "method": "GET",
+        "auth": null
+      },
+      "response": [
+        {
+          "id": "b40ab21d-513c-40c5-b0b8-fbe796fd66fc",
+          "name": "OK",
+          "originalRequest": {
+            "url": {
+              "path": ["api-docs"],
+              "host": ["{{baseUrl}}"],
+              "query": [],
+              "variable": []
+            },
+            "method": "GET",
+            "body": {}
+          },
+          "status": "OK",
+          "code": 200,
+          "header": [
+            {
+              "key": "Content-Type",
+              "value": "text/plain"
+            }
+          ],
+          "body": "",
+          "cookie": [],
+          "_postman_previewlanguage": "text"
+        }
+      ],
+      "event": []
+    },
+    {
+      "id": "2bf56af0-f515-4e63-9019-b5283294cd4c",
+      "name": "api",
+      "item": [
+        {
+          "id": "9220af74-dadd-4c08-8f46-87036d24323b",
+          "name": "/api/register",
+          "request": {
+            "name": "/api/register",
+            "description": {},
+            "url": {
+              "path": ["api", "register"],
+              "host": ["{{baseUrl}}"],
+              "query": [],
+              "variable": []
+            },
+            "method": "POST",
+            "auth": null
+          },
+          "response": [
+            {
+              "id": "4b7674ab-86de-44e4-80a3-f6f1be4e9215",
+              "name": "OK",
+              "originalRequest": {
+                "url": {
+                  "path": ["api", "register"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "POST",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "c8264c0e-2bcc-41e8-b5ac-2795106d9d4e",
+          "name": "/api/dalle",
+          "request": {
+            "name": "/api/dalle",
+            "description": {},
+            "url": {
+              "path": ["api", "dalle"],
+              "host": ["{{baseUrl}}"],
+              "query": [],
+              "variable": []
+            },
+            "method": "POST",
+            "auth": null
+          },
+          "response": [
+            {
+              "id": "0d48cb4c-de39-427a-a333-5d73391a6596",
+              "name": "OK",
+              "originalRequest": {
+                "url": {
+                  "path": ["api", "dalle"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "POST",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "c6918a39-1abc-4b4e-a793-4c68a8774d22",
+          "name": "/api/generate-model",
+          "request": {
+            "name": "/api/generate-model",
+            "description": {},
+            "url": {
+              "path": ["api", "generate-model"],
+              "host": ["{{baseUrl}}"],
+              "query": [],
+              "variable": []
+            },
+            "method": "POST",
+            "auth": null
+          },
+          "response": [
+            {
+              "id": "be842777-453c-4559-b63c-38e5abd2a070",
+              "name": "OK",
+              "originalRequest": {
+                "url": {
+                  "path": ["api", "generate-model"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "POST",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "78fbbef6-fd0c-44d5-a654-7c331b929101",
+          "name": "/api/login",
+          "request": {
+            "name": "/api/login",
+            "description": {},
+            "url": {
+              "path": ["api", "login"],
+              "host": ["{{baseUrl}}"],
+              "query": [],
+              "variable": []
+            },
+            "method": "POST",
+            "auth": null
+          },
+          "response": [
+            {
+              "id": "d2bbbc24-5654-4a0b-94ef-b98f8ef9db79",
+              "name": "OK",
+              "originalRequest": {
+                "url": {
+                  "path": ["api", "login"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "POST",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "efdb21ae-80d1-40e5-9622-dcb390ee999b",
+          "name": "/api/request-password-reset",
+          "request": {
+            "name": "/api/request-password-reset",
+            "description": {},
+            "url": {
+              "path": ["api", "request-password-reset"],
+              "host": ["{{baseUrl}}"],
+              "query": [],
+              "variable": []
+            },
+            "method": "POST",
+            "auth": null
+          },
+          "response": [
+            {
+              "id": "df4e5b2d-7865-4d73-bb53-6947042632a7",
+              "name": "OK",
+              "originalRequest": {
+                "url": {
+                  "path": ["api", "request-password-reset"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "POST",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "444b42ba-d3e4-4779-978c-68aa79fae981",
+          "name": "/api/reset-password",
+          "request": {
+            "name": "/api/reset-password",
+            "description": {},
+            "url": {
+              "path": ["api", "reset-password"],
+              "host": ["{{baseUrl}}"],
+              "query": [],
+              "variable": []
+            },
+            "method": "POST",
+            "auth": null
+          },
+          "response": [
+            {
+              "id": "9481b0d6-6328-4d13-8b65-32777b969aa0",
+              "name": "OK",
+              "originalRequest": {
+                "url": {
+                  "path": ["api", "reset-password"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "POST",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "65e1adb6-3197-43f4-93f5-bb0e4ecbff96",
+          "name": "/api/me",
+          "request": {
+            "name": "/api/me",
+            "description": {},
+            "url": {
+              "path": ["api", "me"],
+              "host": ["{{baseUrl}}"],
+              "query": [],
+              "variable": []
+            },
+            "method": "GET",
+            "auth": null
+          },
+          "response": [
+            {
+              "id": "99fbca18-019d-42ea-92e1-c35b28f7e77a",
+              "name": "OK",
+              "originalRequest": {
+                "url": {
+                  "path": ["api", "me"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "228cf548-73cb-4645-8641-2fa95d492808",
+          "name": "/api/generate",
+          "request": {
+            "name": "/api/generate",
+            "description": {},
+            "url": {
+              "path": ["api", "generate"],
+              "host": ["{{baseUrl}}"],
+              "query": [],
+              "variable": []
+            },
+            "method": "POST",
+            "auth": null
+          },
+          "response": [
+            {
+              "id": "eecba905-2471-4393-8df6-5109a4f4ac54",
+              "name": "OK",
+              "originalRequest": {
+                "url": {
+                  "path": ["api", "generate"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "POST",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "5408a187-ade5-4ea1-a9f7-5e7f5da93e84",
+          "name": "/api/upload-model",
+          "request": {
+            "name": "/api/upload-model",
+            "description": {},
+            "url": {
+              "path": ["api", "upload-model"],
+              "host": ["{{baseUrl}}"],
+              "query": [],
+              "variable": []
+            },
+            "method": "POST",
+            "auth": null
+          },
+          "response": [
+            {
+              "id": "738a0e37-4c3e-4269-88c8-2259a6557fc2",
+              "name": "OK",
+              "originalRequest": {
+                "url": {
+                  "path": ["api", "upload-model"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "POST",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "4f02a58f-583d-4271-a9d3-6b5bd339db03",
+          "name": "models",
+          "item": [
+            {
+              "id": "a7bb02af-0ca4-4697-be96-12655ec2230b",
+              "name": "/api/models",
+              "request": {
+                "name": "/api/models",
+                "description": {},
+                "url": {
+                  "path": ["api", "models"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "7d103930-0719-4f1d-983c-3f0e1b0e0fef",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "models"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "GET",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "c3f89935-ef4b-4393-a1fa-4b371bf5b66b",
+              "name": ":id",
+              "item": [
+                {
+                  "id": "cb10138d-1dea-429c-a178-1efd36481f01",
+                  "name": "/api/models/:id",
+                  "request": {
+                    "name": "/api/models/:id",
+                    "description": {},
+                    "url": {
+                      "path": ["api", "models", ":id"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "DELETE",
+                    "auth": null
+                  },
+                  "response": [
+                    {
+                      "id": "84c8492b-b140-4c38-babb-1963c10e712a",
+                      "name": "OK",
+                      "originalRequest": {
+                        "url": {
+                          "path": ["api", "models", ":id"],
+                          "host": ["{{baseUrl}}"],
+                          "query": [],
+                          "variable": []
+                        },
+                        "method": "DELETE",
+                        "body": {}
+                      },
+                      "status": "OK",
+                      "code": 200,
+                      "header": [
+                        {
+                          "key": "Content-Type",
+                          "value": "text/plain"
+                        }
+                      ],
+                      "body": "",
+                      "cookie": [],
+                      "_postman_previewlanguage": "text"
+                    }
+                  ],
+                  "event": []
+                },
+                {
+                  "id": "dd68bab9-3b67-4e33-8a60-18224e742ba1",
+                  "name": "/api/models/:id/like",
+                  "request": {
+                    "name": "/api/models/:id/like",
+                    "description": {},
+                    "url": {
+                      "path": ["api", "models", ":id", "like"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "POST",
+                    "auth": null
+                  },
+                  "response": [
+                    {
+                      "id": "6fa1f073-7efb-4588-b5b6-5d315f4ce372",
+                      "name": "OK",
+                      "originalRequest": {
+                        "url": {
+                          "path": ["api", "models", ":id", "like"],
+                          "host": ["{{baseUrl}}"],
+                          "query": [],
+                          "variable": []
+                        },
+                        "method": "POST",
+                        "body": {}
+                      },
+                      "status": "OK",
+                      "code": 200,
+                      "header": [
+                        {
+                          "key": "Content-Type",
+                          "value": "text/plain"
+                        }
+                      ],
+                      "body": "",
+                      "cookie": [],
+                      "_postman_previewlanguage": "text"
+                    }
+                  ],
+                  "event": []
+                },
+                {
+                  "id": "1be478e6-f029-45fb-aa80-878b03225685",
+                  "name": "/api/models/:id/public",
+                  "request": {
+                    "name": "/api/models/:id/public",
+                    "description": {},
+                    "url": {
+                      "path": ["api", "models", ":id", "public"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "POST",
+                    "auth": null
+                  },
+                  "response": [
+                    {
+                      "id": "01f38abc-0a9d-4590-8f04-3d49eec52b40",
+                      "name": "OK",
+                      "originalRequest": {
+                        "url": {
+                          "path": ["api", "models", ":id", "public"],
+                          "host": ["{{baseUrl}}"],
+                          "query": [],
+                          "variable": []
+                        },
+                        "method": "POST",
+                        "body": {}
+                      },
+                      "status": "OK",
+                      "code": 200,
+                      "header": [
+                        {
+                          "key": "Content-Type",
+                          "value": "text/plain"
+                        }
+                      ],
+                      "body": "",
+                      "cookie": [],
+                      "_postman_previewlanguage": "text"
+                    }
+                  ],
+                  "event": []
+                },
+                {
+                  "id": "f55ae976-9cf3-4749-9289-1390c568a593",
+                  "name": "/api/models/:id/share",
+                  "request": {
+                    "name": "/api/models/:id/share",
+                    "description": {},
+                    "url": {
+                      "path": ["api", "models", ":id", "share"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "POST",
+                    "auth": null
+                  },
+                  "response": [
+                    {
+                      "id": "b94fa6e6-6b88-45eb-aeb7-c4dc31f508af",
+                      "name": "OK",
+                      "originalRequest": {
+                        "url": {
+                          "path": ["api", "models", ":id", "share"],
+                          "host": ["{{baseUrl}}"],
+                          "query": [],
+                          "variable": []
+                        },
+                        "method": "POST",
+                        "body": {}
+                      },
+                      "status": "OK",
+                      "code": 200,
+                      "header": [
+                        {
+                          "key": "Content-Type",
+                          "value": "text/plain"
+                        }
+                      ],
+                      "body": "",
+                      "cookie": [],
+                      "_postman_previewlanguage": "text"
+                    }
+                  ],
+                  "event": []
+                }
+              ],
+              "event": []
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "e88aa466-4edf-4bec-9848-adff724be76d",
+          "name": "status",
+          "item": [
+            {
+              "id": "24930cfd-c81c-48c9-aa8b-d6f3b6b767a4",
+              "name": "/api/status",
+              "request": {
+                "name": "/api/status",
+                "description": {},
+                "url": {
+                  "path": ["api", "status"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "7237aee3-19f3-4a76-a21a-c6e357e770d1",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "status"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "GET",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "e23bfbc0-39ce-4d6f-8622-8986251ecc31",
+              "name": "/api/status/:jobId",
+              "request": {
+                "name": "/api/status/:jobId",
+                "description": {},
+                "url": {
+                  "path": ["api", "status", ":jobId"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "604b3e5c-b5d8-4a7a-ad80-d3d4b971bf9b",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "status", ":jobId"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "GET",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "0faaef6a-eaf7-4f20-a5d5-ffafed454fe5",
+          "name": "/api/config/stripe",
+          "request": {
+            "name": "/api/config/stripe",
+            "description": {},
+            "url": {
+              "path": ["api", "config", "stripe"],
+              "host": ["{{baseUrl}}"],
+              "query": [],
+              "variable": []
+            },
+            "method": "GET",
+            "auth": null
+          },
+          "response": [
+            {
+              "id": "4e6d33b5-b519-4beb-b96b-1c2258e16278",
+              "name": "OK",
+              "originalRequest": {
+                "url": {
+                  "path": ["api", "config", "stripe"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "838ea0ee-1216-4851-92af-a7f14b034fb1",
+          "name": "/api/print-slots",
+          "request": {
+            "name": "/api/print-slots",
+            "description": {},
+            "url": {
+              "path": ["api", "print-slots"],
+              "host": ["{{baseUrl}}"],
+              "query": [],
+              "variable": []
+            },
+            "method": "GET",
+            "auth": null
+          },
+          "response": [
+            {
+              "id": "0559e109-35f5-4614-be57-080dbcc32196",
+              "name": "OK",
+              "originalRequest": {
+                "url": {
+                  "path": ["api", "print-slots"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "295da7a5-d55b-48bd-931b-ba0c28d5cec5",
+          "name": "/api/stats",
+          "request": {
+            "name": "/api/stats",
+            "description": {},
+            "url": {
+              "path": ["api", "stats"],
+              "host": ["{{baseUrl}}"],
+              "query": [],
+              "variable": []
+            },
+            "method": "GET",
+            "auth": null
+          },
+          "response": [
+            {
+              "id": "c365f1f1-2e73-4353-9ec5-8feceb5484d5",
+              "name": "OK",
+              "originalRequest": {
+                "url": {
+                  "path": ["api", "stats"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "54675065-f4e7-4b96-9767-e4aea9d65a3d",
+          "name": "/api/usernames",
+          "request": {
+            "name": "/api/usernames",
+            "description": {},
+            "url": {
+              "path": ["api", "usernames"],
+              "host": ["{{baseUrl}}"],
+              "query": [],
+              "variable": []
+            },
+            "method": "GET",
+            "auth": null
+          },
+          "response": [
+            {
+              "id": "b9dbd69e-894d-459d-b9db-7a079d95fbd8",
+              "name": "OK",
+              "originalRequest": {
+                "url": {
+                  "path": ["api", "usernames"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "6ee3fcf9-4a42-4618-80c2-025834a2454f",
+          "name": "/api/recent-purchases",
+          "request": {
+            "name": "/api/recent-purchases",
+            "description": {},
+            "url": {
+              "path": ["api", "recent-purchases"],
+              "host": ["{{baseUrl}}"],
+              "query": [],
+              "variable": []
+            },
+            "method": "GET",
+            "auth": null
+          },
+          "response": [
+            {
+              "id": "dab233fd-28a3-45a5-81f1-28d5369e1ae9",
+              "name": "OK",
+              "originalRequest": {
+                "url": {
+                  "path": ["api", "recent-purchases"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "06dd78dd-bff0-4a4f-9efd-38ab8728a1eb",
+          "name": "/api/campaign",
+          "request": {
+            "name": "/api/campaign",
+            "description": {},
+            "url": {
+              "path": ["api", "campaign"],
+              "host": ["{{baseUrl}}"],
+              "query": [],
+              "variable": []
+            },
+            "method": "GET",
+            "auth": null
+          },
+          "response": [
+            {
+              "id": "29919575-61cb-4e08-91fd-5fee1264904c",
+              "name": "OK",
+              "originalRequest": {
+                "url": {
+                  "path": ["api", "campaign"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "6d541411-9f91-4eee-94b3-664c8e19163d",
+          "name": "/api/health",
+          "request": {
+            "name": "/api/health",
+            "description": {},
+            "url": {
+              "path": ["api", "health"],
+              "host": ["{{baseUrl}}"],
+              "query": [],
+              "variable": []
+            },
+            "method": "GET",
+            "auth": null
+          },
+          "response": [
+            {
+              "id": "710160a9-8d93-4909-96d2-2dfb2f11d466",
+              "name": "OK",
+              "originalRequest": {
+                "url": {
+                  "path": ["api", "health"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "81a02aed-f4c7-4a06-8160-cf4fdb574da8",
+          "name": "/api/init-data",
+          "request": {
+            "name": "/api/init-data",
+            "description": {},
+            "url": {
+              "path": ["api", "init-data"],
+              "host": ["{{baseUrl}}"],
+              "query": [],
+              "variable": []
+            },
+            "method": "GET",
+            "auth": null
+          },
+          "response": [
+            {
+              "id": "960ae9c6-9062-4f3b-8437-9839320b256e",
+              "name": "OK",
+              "originalRequest": {
+                "url": {
+                  "path": ["api", "init-data"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "5ecf4b4c-d60a-4b8c-822e-14bbfd381ec7",
+          "name": "/api/payment-init",
+          "request": {
+            "name": "/api/payment-init",
+            "description": {},
+            "url": {
+              "path": ["api", "payment-init"],
+              "host": ["{{baseUrl}}"],
+              "query": [],
+              "variable": []
+            },
+            "method": "GET",
+            "auth": null
+          },
+          "response": [
+            {
+              "id": "38d6ff85-84b5-4968-aa7d-42c0a65cd5db",
+              "name": "OK",
+              "originalRequest": {
+                "url": {
+                  "path": ["api", "payment-init"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "60989c11-3f71-4380-b7b3-0e2fce354143",
+          "name": "/api/subreddit/:name",
+          "request": {
+            "name": "/api/subreddit/:name",
+            "description": {},
+            "url": {
+              "path": ["api", "subreddit", ":name"],
+              "host": ["{{baseUrl}}"],
+              "query": [],
+              "variable": []
+            },
+            "method": "GET",
+            "auth": null
+          },
+          "response": [
+            {
+              "id": "8570d96a-eff4-49e0-87d0-3ea968de865b",
+              "name": "OK",
+              "originalRequest": {
+                "url": {
+                  "path": ["api", "subreddit", ":name"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "93c97bb7-9b60-4874-8d1e-b922b9d2c94f",
+          "name": "/api/progress/:jobId",
+          "request": {
+            "name": "/api/progress/:jobId",
+            "description": {},
+            "url": {
+              "path": ["api", "progress", ":jobId"],
+              "host": ["{{baseUrl}}"],
+              "query": [],
+              "variable": []
+            },
+            "method": "GET",
+            "auth": null
+          },
+          "response": [
+            {
+              "id": "05e76d49-6366-4ed8-bbf1-88e58c8cf636",
+              "name": "OK",
+              "originalRequest": {
+                "url": {
+                  "path": ["api", "progress", ":jobId"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "ff8f0fef-e7ff-4303-b81d-96266328def0",
+          "name": "my",
+          "item": [
+            {
+              "id": "57b97bfb-956f-4505-a02b-745ad5ff074e",
+              "name": "/api/my/models",
+              "request": {
+                "name": "/api/my/models",
+                "description": {},
+                "url": {
+                  "path": ["api", "my", "models"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "9ecea76a-2f80-474b-9dcf-0f2a2fd3627c",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "my", "models"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "GET",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "9cd33757-4e1e-47e0-b5f3-babef2a19479",
+              "name": "/api/my/orders",
+              "request": {
+                "name": "/api/my/orders",
+                "description": {},
+                "url": {
+                  "path": ["api", "my", "orders"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "4b4b0f4b-4a05-4bb4-9e1f-b7d7e3c38848",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "my", "orders"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "GET",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "0139fde9-7993-42e3-a3f3-24d1f2058c8d",
+          "name": "commissions",
+          "item": [
+            {
+              "id": "3253387d-598f-48ea-95bd-5e370d408d47",
+              "name": "/api/commissions",
+              "request": {
+                "name": "/api/commissions",
+                "description": {},
+                "url": {
+                  "path": ["api", "commissions"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "e08bd75d-da4b-4478-8897-2cac6b8cb001",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "commissions"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "GET",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "d242b19b-f6cf-4f98-95dd-52d03ef37ade",
+              "name": "/api/commissions/:id/mark-paid",
+              "request": {
+                "name": "/api/commissions/:id/mark-paid",
+                "description": {},
+                "url": {
+                  "path": ["api", "commissions", ":id", "mark-paid"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "POST",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "afbbef36-a2c1-44be-964e-f25e435410d8",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "commissions", ":id", "mark-paid"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "POST",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "c009e88b-62fd-4905-afe2-8f176b777498",
+          "name": "profile",
+          "item": [
+            {
+              "id": "0640137d-4a84-4960-92f6-a912bbc38e36",
+              "name": "/api/profile",
+              "request": {
+                "name": "/api/profile",
+                "description": {},
+                "url": {
+                  "path": ["api", "profile"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "343ab20b-baf9-4aa4-bfb7-36ce9e254f47",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "profile"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "GET",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "e2c302a6-3d8e-4bd7-bfa5-1f6ee63eea95",
+              "name": "/api/profile",
+              "request": {
+                "name": "/api/profile",
+                "description": {},
+                "url": {
+                  "path": ["api", "profile"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "POST",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "e0b74d4a-dd11-413f-9662-c87f1f7e4192",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "profile"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "POST",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "e02d1ffc-c2b6-4160-bace-4e246a98ae27",
+              "name": "/api/profile/avatar",
+              "request": {
+                "name": "/api/profile/avatar",
+                "description": {},
+                "url": {
+                  "path": ["api", "profile", "avatar"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "POST",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "8c8580c3-3d2d-41c9-83cc-0b9fe71b8941",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "profile", "avatar"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "POST",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "ef8d3d01-d744-4547-9e8a-49548c226b51",
+          "name": "/api/account",
+          "request": {
+            "name": "/api/account",
+            "description": {},
+            "url": {
+              "path": ["api", "account"],
+              "host": ["{{baseUrl}}"],
+              "query": [],
+              "variable": []
+            },
+            "method": "DELETE",
+            "auth": null
+          },
+          "response": [
+            {
+              "id": "6f69a71a-23e8-42e4-a1a6-5cee6cdf9285",
+              "name": "OK",
+              "originalRequest": {
+                "url": {
+                  "path": ["api", "account"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "DELETE",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "d1fe29ca-78da-4860-9e64-792c69487547",
+          "name": "/api/stripe/connect",
+          "request": {
+            "name": "/api/stripe/connect",
+            "description": {},
+            "url": {
+              "path": ["api", "stripe", "connect"],
+              "host": ["{{baseUrl}}"],
+              "query": [],
+              "variable": []
+            },
+            "method": "POST",
+            "auth": null
+          },
+          "response": [
+            {
+              "id": "228bef74-193c-4f22-ad3e-73d37b3ae3e8",
+              "name": "OK",
+              "originalRequest": {
+                "url": {
+                  "path": ["api", "stripe", "connect"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "POST",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "d05f65d6-deba-444d-960a-b22f95463d95",
+          "name": "subscription",
+          "item": [
+            {
+              "id": "7e50711b-6c8a-4825-a8cd-1fb6f0801ea0",
+              "name": "/api/subscription",
+              "request": {
+                "name": "/api/subscription",
+                "description": {},
+                "url": {
+                  "path": ["api", "subscription"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "54e48b09-e0d1-4cb3-bf34-8df7736623f5",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "subscription"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "GET",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "e8d2834c-804e-4200-9a33-75beee37aaf6",
+              "name": "/api/subscription",
+              "request": {
+                "name": "/api/subscription",
+                "description": {},
+                "url": {
+                  "path": ["api", "subscription"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "POST",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "9eee77a7-00e8-49c6-ba5f-f2cad231853e",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "subscription"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "POST",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "c0a7c3af-2a5f-4674-ac3a-e0b1de28176f",
+              "name": "/api/subscription/cancel",
+              "request": {
+                "name": "/api/subscription/cancel",
+                "description": {},
+                "url": {
+                  "path": ["api", "subscription", "cancel"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "POST",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "28340632-c00f-4ac7-a3e1-2504f0f4d369",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "subscription", "cancel"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "POST",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "66558c88-15db-473b-acc0-f5609cbd74ca",
+              "name": "/api/subscription/portal",
+              "request": {
+                "name": "/api/subscription/portal",
+                "description": {},
+                "url": {
+                  "path": ["api", "subscription", "portal"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "POST",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "0bd138c4-0e71-41a5-b733-213aba40445f",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "subscription", "portal"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "POST",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "4068114e-d0b4-428f-ac78-4081acd507d2",
+              "name": "/api/subscription/credits",
+              "request": {
+                "name": "/api/subscription/credits",
+                "description": {},
+                "url": {
+                  "path": ["api", "subscription", "credits"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "5b6e77ed-68e6-4c7d-a524-9a5ba3337b04",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "subscription", "credits"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "GET",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "aa93317a-2348-4bd8-9d5d-b70e81c9bce0",
+              "name": "/api/subscription/summary",
+              "request": {
+                "name": "/api/subscription/summary",
+                "description": {},
+                "url": {
+                  "path": ["api", "subscription", "summary"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "084b2f79-180c-4dff-a845-970a8d54dc6d",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "subscription", "summary"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "GET",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "7635cda1-ad80-40c0-adce-273c6b5a4ac5",
+          "name": "/api/dashboard",
+          "request": {
+            "name": "/api/dashboard",
+            "description": {},
+            "url": {
+              "path": ["api", "dashboard"],
+              "host": ["{{baseUrl}}"],
+              "query": [],
+              "variable": []
+            },
+            "method": "GET",
+            "auth": null
+          },
+          "response": [
+            {
+              "id": "265fabdf-a95d-48f4-aa47-1483d16532f3",
+              "name": "OK",
+              "originalRequest": {
+                "url": {
+                  "path": ["api", "dashboard"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "4abca96b-42a3-4374-bcf3-0ff2f2da30be",
+          "name": "/api/referral-link",
+          "request": {
+            "name": "/api/referral-link",
+            "description": {},
+            "url": {
+              "path": ["api", "referral-link"],
+              "host": ["{{baseUrl}}"],
+              "query": [],
+              "variable": []
+            },
+            "method": "GET",
+            "auth": null
+          },
+          "response": [
+            {
+              "id": "57572ec3-1a85-4c4d-be1e-499c929148d8",
+              "name": "OK",
+              "originalRequest": {
+                "url": {
+                  "path": ["api", "referral-link"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "bce9bd0a-99a6-4d5a-b653-323df6108b38",
+          "name": "orders/:id",
+          "item": [
+            {
+              "id": "27f3f623-7373-4f23-9f00-fb60e2ff3572",
+              "name": "/api/orders/:id/referral-link",
+              "request": {
+                "name": "/api/orders/:id/referral-link",
+                "description": {},
+                "url": {
+                  "path": ["api", "orders", ":id", "referral-link"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "fce8a376-69c8-4132-a6ef-b6a4ce9f7f3f",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "orders", ":id", "referral-link"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "GET",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "4e28de38-eb6a-42a7-9c13-69fd8e864d8e",
+              "name": "/api/orders/:id/referral-qr",
+              "request": {
+                "name": "/api/orders/:id/referral-qr",
+                "description": {},
+                "url": {
+                  "path": ["api", "orders", ":id", "referral-qr"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "b1293d6a-f92b-4baf-bceb-15272154db05",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "orders", ":id", "referral-qr"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "GET",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "e5a2a35a-8e61-46e0-afec-1e7f86629da2",
+          "name": "/api/referral-click",
+          "request": {
+            "name": "/api/referral-click",
+            "description": {},
+            "url": {
+              "path": ["api", "referral-click"],
+              "host": ["{{baseUrl}}"],
+              "query": [],
+              "variable": []
+            },
+            "method": "POST",
+            "auth": null
+          },
+          "response": [
+            {
+              "id": "3df0da53-50db-41cc-b30e-dbbd11abca21",
+              "name": "OK",
+              "originalRequest": {
+                "url": {
+                  "path": ["api", "referral-click"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "POST",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "ebd8559d-7f45-48c9-b404-3fd1759008e1",
+          "name": "/api/referral-signup",
+          "request": {
+            "name": "/api/referral-signup",
+            "description": {},
+            "url": {
+              "path": ["api", "referral-signup"],
+              "host": ["{{baseUrl}}"],
+              "query": [],
+              "variable": []
+            },
+            "method": "POST",
+            "auth": null
+          },
+          "response": [
+            {
+              "id": "f9bf79c8-5209-4fd7-b9e4-10768f5f874c",
+              "name": "OK",
+              "originalRequest": {
+                "url": {
+                  "path": ["api", "referral-signup"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "POST",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "b27e3b10-b3fd-4d21-87c2-6fd699b6812b",
+          "name": "/api/referral-post",
+          "request": {
+            "name": "/api/referral-post",
+            "description": {},
+            "url": {
+              "path": ["api", "referral-post"],
+              "host": ["{{baseUrl}}"],
+              "query": [],
+              "variable": []
+            },
+            "method": "POST",
+            "auth": null
+          },
+          "response": [
+            {
+              "id": "952a3981-0563-4695-a150-26bb58e5461f",
+              "name": "OK",
+              "originalRequest": {
+                "url": {
+                  "path": ["api", "referral-post"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "POST",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "1b666b2d-983c-4c4a-8675-12152da9209c",
+          "name": "/api/social-shares",
+          "request": {
+            "name": "/api/social-shares",
+            "description": {},
+            "url": {
+              "path": ["api", "social-shares"],
+              "host": ["{{baseUrl}}"],
+              "query": [],
+              "variable": []
+            },
+            "method": "POST",
+            "auth": null
+          },
+          "response": [
+            {
+              "id": "cc0a83b7-fa1e-4235-92be-750a597ee3f7",
+              "name": "OK",
+              "originalRequest": {
+                "url": {
+                  "path": ["api", "social-shares"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "POST",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "f87181e8-ea31-4af5-b406-50930f407889",
+          "name": "admin",
+          "item": [
+            {
+              "id": "aa128c31-e0b5-4c2d-b48f-33193726c572",
+              "name": "/api/admin/social-shares/:id/verify",
+              "request": {
+                "name": "/api/admin/social-shares/:id/verify",
+                "description": {},
+                "url": {
+                  "path": ["api", "admin", "social-shares", ":id", "verify"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "POST",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "3255dd13-90d2-4dd1-88f2-2d5835d806fe",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": [
+                        "api",
+                        "admin",
+                        "social-shares",
+                        ":id",
+                        "verify"
+                      ],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "POST",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "760428d4-4b16-4a5c-9fcf-f9d8f43b1416",
+              "name": "/api/admin/designer-submissions/:id/approve",
+              "request": {
+                "name": "/api/admin/designer-submissions/:id/approve",
+                "description": {},
+                "url": {
+                  "path": [
+                    "api",
+                    "admin",
+                    "designer-submissions",
+                    ":id",
+                    "approve"
+                  ],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "POST",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "06a9c6ae-94ba-4e8f-8096-395b1a181adb",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": [
+                        "api",
+                        "admin",
+                        "designer-submissions",
+                        ":id",
+                        "approve"
+                      ],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "POST",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "68c0c138-0219-445d-9920-53373ea7eeb5",
+              "name": "competitions",
+              "item": [
+                {
+                  "id": "1c7197cf-58a6-4928-a893-247ba1af34ba",
+                  "name": "/api/admin/competitions",
+                  "request": {
+                    "name": "/api/admin/competitions",
+                    "description": {},
+                    "url": {
+                      "path": ["api", "admin", "competitions"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "POST",
+                    "auth": null
+                  },
+                  "response": [
+                    {
+                      "id": "b29171d3-ed03-4bb4-9d2c-9c047ad5d8ca",
+                      "name": "OK",
+                      "originalRequest": {
+                        "url": {
+                          "path": ["api", "admin", "competitions"],
+                          "host": ["{{baseUrl}}"],
+                          "query": [],
+                          "variable": []
+                        },
+                        "method": "POST",
+                        "body": {}
+                      },
+                      "status": "OK",
+                      "code": 200,
+                      "header": [
+                        {
+                          "key": "Content-Type",
+                          "value": "text/plain"
+                        }
+                      ],
+                      "body": "",
+                      "cookie": [],
+                      "_postman_previewlanguage": "text"
+                    }
+                  ],
+                  "event": []
+                },
+                {
+                  "id": "d389533b-a4e7-4a88-814d-3c3c2365b3c4",
+                  "name": ":id",
+                  "item": [
+                    {
+                      "id": "76994319-3813-40b6-9511-c197c478449f",
+                      "name": "/api/admin/competitions/:id",
+                      "request": {
+                        "name": "/api/admin/competitions/:id",
+                        "description": {},
+                        "url": {
+                          "path": ["api", "admin", "competitions", ":id"],
+                          "host": ["{{baseUrl}}"],
+                          "query": [],
+                          "variable": []
+                        },
+                        "method": "PUT",
+                        "auth": null
+                      },
+                      "response": [
+                        {
+                          "id": "fa3d824e-5357-4ccd-a26e-b07a8d47eeb1",
+                          "name": "OK",
+                          "originalRequest": {
+                            "url": {
+                              "path": ["api", "admin", "competitions", ":id"],
+                              "host": ["{{baseUrl}}"],
+                              "query": [],
+                              "variable": []
+                            },
+                            "method": "PUT",
+                            "body": {}
+                          },
+                          "status": "OK",
+                          "code": 200,
+                          "header": [
+                            {
+                              "key": "Content-Type",
+                              "value": "text/plain"
+                            }
+                          ],
+                          "body": "",
+                          "cookie": [],
+                          "_postman_previewlanguage": "text"
+                        }
+                      ],
+                      "event": []
+                    },
+                    {
+                      "id": "bf600c4b-73fd-4dfc-b49f-becce54b98dc",
+                      "name": "/api/admin/competitions/:id",
+                      "request": {
+                        "name": "/api/admin/competitions/:id",
+                        "description": {},
+                        "url": {
+                          "path": ["api", "admin", "competitions", ":id"],
+                          "host": ["{{baseUrl}}"],
+                          "query": [],
+                          "variable": []
+                        },
+                        "method": "DELETE",
+                        "auth": null
+                      },
+                      "response": [
+                        {
+                          "id": "83fd62bc-abf5-4a13-9e47-94fd8d78e54c",
+                          "name": "OK",
+                          "originalRequest": {
+                            "url": {
+                              "path": ["api", "admin", "competitions", ":id"],
+                              "host": ["{{baseUrl}}"],
+                              "query": [],
+                              "variable": []
+                            },
+                            "method": "DELETE",
+                            "body": {}
+                          },
+                          "status": "OK",
+                          "code": 200,
+                          "header": [
+                            {
+                              "key": "Content-Type",
+                              "value": "text/plain"
+                            }
+                          ],
+                          "body": "",
+                          "cookie": [],
+                          "_postman_previewlanguage": "text"
+                        }
+                      ],
+                      "event": []
+                    }
+                  ],
+                  "event": []
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "1457ab89-8b79-443e-96b2-66c0c3bc9b74",
+              "name": "flash-sale",
+              "item": [
+                {
+                  "id": "472c122e-f6a1-4d38-9b6d-6ae886bf54e0",
+                  "name": "/api/admin/flash-sale",
+                  "request": {
+                    "name": "/api/admin/flash-sale",
+                    "description": {},
+                    "url": {
+                      "path": ["api", "admin", "flash-sale"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "POST",
+                    "auth": null
+                  },
+                  "response": [
+                    {
+                      "id": "9ec99f87-e6bf-4eca-bdcd-0ffc4ece5cc2",
+                      "name": "OK",
+                      "originalRequest": {
+                        "url": {
+                          "path": ["api", "admin", "flash-sale"],
+                          "host": ["{{baseUrl}}"],
+                          "query": [],
+                          "variable": []
+                        },
+                        "method": "POST",
+                        "body": {}
+                      },
+                      "status": "OK",
+                      "code": 200,
+                      "header": [
+                        {
+                          "key": "Content-Type",
+                          "value": "text/plain"
+                        }
+                      ],
+                      "body": "",
+                      "cookie": [],
+                      "_postman_previewlanguage": "text"
+                    }
+                  ],
+                  "event": []
+                },
+                {
+                  "id": "dd0067ed-9f95-4334-83f3-9d7a78f74870",
+                  "name": "/api/admin/flash-sale/:id",
+                  "request": {
+                    "name": "/api/admin/flash-sale/:id",
+                    "description": {},
+                    "url": {
+                      "path": ["api", "admin", "flash-sale", ":id"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "DELETE",
+                    "auth": null
+                  },
+                  "response": [
+                    {
+                      "id": "b685e26b-3b86-4572-85fd-b75dbe0285ac",
+                      "name": "OK",
+                      "originalRequest": {
+                        "url": {
+                          "path": ["api", "admin", "flash-sale", ":id"],
+                          "host": ["{{baseUrl}}"],
+                          "query": [],
+                          "variable": []
+                        },
+                        "method": "DELETE",
+                        "body": {}
+                      },
+                      "status": "OK",
+                      "code": 200,
+                      "header": [
+                        {
+                          "key": "Content-Type",
+                          "value": "text/plain"
+                        }
+                      ],
+                      "body": "",
+                      "cookie": [],
+                      "_postman_previewlanguage": "text"
+                    }
+                  ],
+                  "event": []
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "6487258d-8e1c-4b2e-8a37-3d3a5afcf6d6",
+              "name": "spaces",
+              "item": [
+                {
+                  "id": "87e1da05-8b6a-4a13-abe1-ab2bc167b3d2",
+                  "name": "/api/admin/spaces",
+                  "request": {
+                    "name": "/api/admin/spaces",
+                    "description": {},
+                    "url": {
+                      "path": ["api", "admin", "spaces"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "GET",
+                    "auth": null
+                  },
+                  "response": [
+                    {
+                      "id": "2c4167e9-5185-4115-ad82-468ecee7bd48",
+                      "name": "OK",
+                      "originalRequest": {
+                        "url": {
+                          "path": ["api", "admin", "spaces"],
+                          "host": ["{{baseUrl}}"],
+                          "query": [],
+                          "variable": []
+                        },
+                        "method": "GET",
+                        "body": {}
+                      },
+                      "status": "OK",
+                      "code": 200,
+                      "header": [
+                        {
+                          "key": "Content-Type",
+                          "value": "text/plain"
+                        }
+                      ],
+                      "body": "",
+                      "cookie": [],
+                      "_postman_previewlanguage": "text"
+                    }
+                  ],
+                  "event": []
+                },
+                {
+                  "id": "52bbf6c0-7caa-4490-b873-cedfaf7551c8",
+                  "name": "/api/admin/spaces",
+                  "request": {
+                    "name": "/api/admin/spaces",
+                    "description": {},
+                    "url": {
+                      "path": ["api", "admin", "spaces"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "POST",
+                    "auth": null
+                  },
+                  "response": [
+                    {
+                      "id": "58559f79-bf9c-466c-b4cc-c567f63f9d49",
+                      "name": "OK",
+                      "originalRequest": {
+                        "url": {
+                          "path": ["api", "admin", "spaces"],
+                          "host": ["{{baseUrl}}"],
+                          "query": [],
+                          "variable": []
+                        },
+                        "method": "POST",
+                        "body": {}
+                      },
+                      "status": "OK",
+                      "code": 200,
+                      "header": [
+                        {
+                          "key": "Content-Type",
+                          "value": "text/plain"
+                        }
+                      ],
+                      "body": "",
+                      "cookie": [],
+                      "_postman_previewlanguage": "text"
+                    }
+                  ],
+                  "event": []
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "88119acb-1766-4fde-8ea0-a7dd631c8643",
+              "name": "hubs",
+              "item": [
+                {
+                  "id": "dd1f4ff8-f5ab-4e1f-a9c9-76af184cbbbf",
+                  "name": "/api/admin/hubs",
+                  "request": {
+                    "name": "/api/admin/hubs",
+                    "description": {},
+                    "url": {
+                      "path": ["api", "admin", "hubs"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "GET",
+                    "auth": null
+                  },
+                  "response": [
+                    {
+                      "id": "c8bbbaed-c542-4dfd-94f5-a49129a422ce",
+                      "name": "OK",
+                      "originalRequest": {
+                        "url": {
+                          "path": ["api", "admin", "hubs"],
+                          "host": ["{{baseUrl}}"],
+                          "query": [],
+                          "variable": []
+                        },
+                        "method": "GET",
+                        "body": {}
+                      },
+                      "status": "OK",
+                      "code": 200,
+                      "header": [
+                        {
+                          "key": "Content-Type",
+                          "value": "text/plain"
+                        }
+                      ],
+                      "body": "",
+                      "cookie": [],
+                      "_postman_previewlanguage": "text"
+                    }
+                  ],
+                  "event": []
+                },
+                {
+                  "id": "701afad3-e392-4421-8893-06a477b6645f",
+                  "name": "/api/admin/hubs",
+                  "request": {
+                    "name": "/api/admin/hubs",
+                    "description": {},
+                    "url": {
+                      "path": ["api", "admin", "hubs"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "POST",
+                    "auth": null
+                  },
+                  "response": [
+                    {
+                      "id": "0ab159f8-ed8d-4a23-a778-88b60bac7458",
+                      "name": "OK",
+                      "originalRequest": {
+                        "url": {
+                          "path": ["api", "admin", "hubs"],
+                          "host": ["{{baseUrl}}"],
+                          "query": [],
+                          "variable": []
+                        },
+                        "method": "POST",
+                        "body": {}
+                      },
+                      "status": "OK",
+                      "code": 200,
+                      "header": [
+                        {
+                          "key": "Content-Type",
+                          "value": "text/plain"
+                        }
+                      ],
+                      "body": "",
+                      "cookie": [],
+                      "_postman_previewlanguage": "text"
+                    }
+                  ],
+                  "event": []
+                },
+                {
+                  "id": "a8502b4d-cb5f-43ad-be10-ac9c74b966e5",
+                  "name": ":id",
+                  "item": [
+                    {
+                      "id": "f4d9a027-72cb-4d68-a8b9-7cd08cb51afb",
+                      "name": "/api/admin/hubs/:id",
+                      "request": {
+                        "name": "/api/admin/hubs/:id",
+                        "description": {},
+                        "url": {
+                          "path": ["api", "admin", "hubs", ":id"],
+                          "host": ["{{baseUrl}}"],
+                          "query": [],
+                          "variable": []
+                        },
+                        "method": "PUT",
+                        "auth": null
+                      },
+                      "response": [
+                        {
+                          "id": "d9545275-9fae-4679-b2c4-88c95672af21",
+                          "name": "OK",
+                          "originalRequest": {
+                            "url": {
+                              "path": ["api", "admin", "hubs", ":id"],
+                              "host": ["{{baseUrl}}"],
+                              "query": [],
+                              "variable": []
+                            },
+                            "method": "PUT",
+                            "body": {}
+                          },
+                          "status": "OK",
+                          "code": 200,
+                          "header": [
+                            {
+                              "key": "Content-Type",
+                              "value": "text/plain"
+                            }
+                          ],
+                          "body": "",
+                          "cookie": [],
+                          "_postman_previewlanguage": "text"
+                        }
+                      ],
+                      "event": []
+                    },
+                    {
+                      "id": "c691803f-def9-42fe-b6c9-ca5cbb42dac1",
+                      "name": "/api/admin/hubs/:id/printers",
+                      "request": {
+                        "name": "/api/admin/hubs/:id/printers",
+                        "description": {},
+                        "url": {
+                          "path": ["api", "admin", "hubs", ":id", "printers"],
+                          "host": ["{{baseUrl}}"],
+                          "query": [],
+                          "variable": []
+                        },
+                        "method": "POST",
+                        "auth": null
+                      },
+                      "response": [
+                        {
+                          "id": "1b5178c8-8bfd-423d-a3a4-078018b7723b",
+                          "name": "OK",
+                          "originalRequest": {
+                            "url": {
+                              "path": [
+                                "api",
+                                "admin",
+                                "hubs",
+                                ":id",
+                                "printers"
+                              ],
+                              "host": ["{{baseUrl}}"],
+                              "query": [],
+                              "variable": []
+                            },
+                            "method": "POST",
+                            "body": {}
+                          },
+                          "status": "OK",
+                          "code": 200,
+                          "header": [
+                            {
+                              "key": "Content-Type",
+                              "value": "text/plain"
+                            }
+                          ],
+                          "body": "",
+                          "cookie": [],
+                          "_postman_previewlanguage": "text"
+                        }
+                      ],
+                      "event": []
+                    },
+                    {
+                      "id": "2d93dad8-f696-4269-b191-9274e08216ed",
+                      "name": "shipments",
+                      "item": [
+                        {
+                          "id": "9c1853d2-28e7-4b66-9feb-52538e032e5c",
+                          "name": "/api/admin/hubs/:id/shipments",
+                          "request": {
+                            "name": "/api/admin/hubs/:id/shipments",
+                            "description": {},
+                            "url": {
+                              "path": [
+                                "api",
+                                "admin",
+                                "hubs",
+                                ":id",
+                                "shipments"
+                              ],
+                              "host": ["{{baseUrl}}"],
+                              "query": [],
+                              "variable": []
+                            },
+                            "method": "GET",
+                            "auth": null
+                          },
+                          "response": [
+                            {
+                              "id": "f6ad9c1f-ef21-43d0-839a-c99dfdb13383",
+                              "name": "OK",
+                              "originalRequest": {
+                                "url": {
+                                  "path": [
+                                    "api",
+                                    "admin",
+                                    "hubs",
+                                    ":id",
+                                    "shipments"
+                                  ],
+                                  "host": ["{{baseUrl}}"],
+                                  "query": [],
+                                  "variable": []
+                                },
+                                "method": "GET",
+                                "body": {}
+                              },
+                              "status": "OK",
+                              "code": 200,
+                              "header": [
+                                {
+                                  "key": "Content-Type",
+                                  "value": "text/plain"
+                                }
+                              ],
+                              "body": "",
+                              "cookie": [],
+                              "_postman_previewlanguage": "text"
+                            }
+                          ],
+                          "event": []
+                        },
+                        {
+                          "id": "48b1257a-a830-4ebd-9c0a-28fa0e0ad13c",
+                          "name": "/api/admin/hubs/:id/shipments",
+                          "request": {
+                            "name": "/api/admin/hubs/:id/shipments",
+                            "description": {},
+                            "url": {
+                              "path": [
+                                "api",
+                                "admin",
+                                "hubs",
+                                ":id",
+                                "shipments"
+                              ],
+                              "host": ["{{baseUrl}}"],
+                              "query": [],
+                              "variable": []
+                            },
+                            "method": "POST",
+                            "auth": null
+                          },
+                          "response": [
+                            {
+                              "id": "64094168-c98e-4898-8867-4133deb5a1fa",
+                              "name": "OK",
+                              "originalRequest": {
+                                "url": {
+                                  "path": [
+                                    "api",
+                                    "admin",
+                                    "hubs",
+                                    ":id",
+                                    "shipments"
+                                  ],
+                                  "host": ["{{baseUrl}}"],
+                                  "query": [],
+                                  "variable": []
+                                },
+                                "method": "POST",
+                                "body": {}
+                              },
+                              "status": "OK",
+                              "code": 200,
+                              "header": [
+                                {
+                                  "key": "Content-Type",
+                                  "value": "text/plain"
+                                }
+                              ],
+                              "body": "",
+                              "cookie": [],
+                              "_postman_previewlanguage": "text"
+                            }
+                          ],
+                          "event": []
+                        }
+                      ],
+                      "event": []
+                    }
+                  ],
+                  "event": []
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "8f795bec-3f34-4208-9937-c0dafdd9fcfd",
+              "name": "ads",
+              "item": [
+                {
+                  "id": "673a8154-9e74-4f6e-bca7-b6a11ae44071",
+                  "name": "/api/admin/ads/generate",
+                  "request": {
+                    "name": "/api/admin/ads/generate",
+                    "description": {},
+                    "url": {
+                      "path": ["api", "admin", "ads", "generate"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "POST",
+                    "auth": null
+                  },
+                  "response": [
+                    {
+                      "id": "806247e6-44ef-4c01-801f-e9a4e66fb90a",
+                      "name": "OK",
+                      "originalRequest": {
+                        "url": {
+                          "path": ["api", "admin", "ads", "generate"],
+                          "host": ["{{baseUrl}}"],
+                          "query": [],
+                          "variable": []
+                        },
+                        "method": "POST",
+                        "body": {}
+                      },
+                      "status": "OK",
+                      "code": 200,
+                      "header": [
+                        {
+                          "key": "Content-Type",
+                          "value": "text/plain"
+                        }
+                      ],
+                      "body": "",
+                      "cookie": [],
+                      "_postman_previewlanguage": "text"
+                    }
+                  ],
+                  "event": []
+                },
+                {
+                  "id": "e6e96e1b-b0de-496e-b443-effe8be98612",
+                  "name": "/api/admin/ads/pending",
+                  "request": {
+                    "name": "/api/admin/ads/pending",
+                    "description": {},
+                    "url": {
+                      "path": ["api", "admin", "ads", "pending"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "GET",
+                    "auth": null
+                  },
+                  "response": [
+                    {
+                      "id": "098e534e-a7f9-4cd2-a5ff-e9a1f835833a",
+                      "name": "OK",
+                      "originalRequest": {
+                        "url": {
+                          "path": ["api", "admin", "ads", "pending"],
+                          "host": ["{{baseUrl}}"],
+                          "query": [],
+                          "variable": []
+                        },
+                        "method": "GET",
+                        "body": {}
+                      },
+                      "status": "OK",
+                      "code": 200,
+                      "header": [
+                        {
+                          "key": "Content-Type",
+                          "value": "text/plain"
+                        }
+                      ],
+                      "body": "",
+                      "cookie": [],
+                      "_postman_previewlanguage": "text"
+                    }
+                  ],
+                  "event": []
+                },
+                {
+                  "id": "51d795f2-4623-4517-b987-f478180a8bd0",
+                  "name": ":id",
+                  "item": [
+                    {
+                      "id": "026f7e5d-f719-4ab8-9d56-e1ab2079d1f5",
+                      "name": "/api/admin/ads/:id/approve",
+                      "request": {
+                        "name": "/api/admin/ads/:id/approve",
+                        "description": {},
+                        "url": {
+                          "path": ["api", "admin", "ads", ":id", "approve"],
+                          "host": ["{{baseUrl}}"],
+                          "query": [],
+                          "variable": []
+                        },
+                        "method": "POST",
+                        "auth": null
+                      },
+                      "response": [
+                        {
+                          "id": "7a437218-1918-4e38-9b20-44f9d92d3835",
+                          "name": "OK",
+                          "originalRequest": {
+                            "url": {
+                              "path": ["api", "admin", "ads", ":id", "approve"],
+                              "host": ["{{baseUrl}}"],
+                              "query": [],
+                              "variable": []
+                            },
+                            "method": "POST",
+                            "body": {}
+                          },
+                          "status": "OK",
+                          "code": 200,
+                          "header": [
+                            {
+                              "key": "Content-Type",
+                              "value": "text/plain"
+                            }
+                          ],
+                          "body": "",
+                          "cookie": [],
+                          "_postman_previewlanguage": "text"
+                        }
+                      ],
+                      "event": []
+                    },
+                    {
+                      "id": "21adcf82-8824-427d-bfe5-e2e396cd8e88",
+                      "name": "/api/admin/ads/:id/reject",
+                      "request": {
+                        "name": "/api/admin/ads/:id/reject",
+                        "description": {},
+                        "url": {
+                          "path": ["api", "admin", "ads", ":id", "reject"],
+                          "host": ["{{baseUrl}}"],
+                          "query": [],
+                          "variable": []
+                        },
+                        "method": "POST",
+                        "auth": null
+                      },
+                      "response": [
+                        {
+                          "id": "2ddeec3f-eef6-4233-8f08-105711349ca8",
+                          "name": "OK",
+                          "originalRequest": {
+                            "url": {
+                              "path": ["api", "admin", "ads", ":id", "reject"],
+                              "host": ["{{baseUrl}}"],
+                              "query": [],
+                              "variable": []
+                            },
+                            "method": "POST",
+                            "body": {}
+                          },
+                          "status": "OK",
+                          "code": 200,
+                          "header": [
+                            {
+                              "key": "Content-Type",
+                              "value": "text/plain"
+                            }
+                          ],
+                          "body": "",
+                          "cookie": [],
+                          "_postman_previewlanguage": "text"
+                        }
+                      ],
+                      "event": []
+                    }
+                  ],
+                  "event": []
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "ec072c96-ba31-48c9-8fb0-067174e4f73e",
+              "name": "/api/admin/subscription-metrics",
+              "request": {
+                "name": "/api/admin/subscription-metrics",
+                "description": {},
+                "url": {
+                  "path": ["api", "admin", "subscription-metrics"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "120e27b5-e7cd-4960-ac67-80a5869feb9c",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "admin", "subscription-metrics"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "GET",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "f3cb161b-6631-4c2e-bd21-ea9388aa62ac",
+              "name": "/api/admin/scaling-events",
+              "request": {
+                "name": "/api/admin/scaling-events",
+                "description": {},
+                "url": {
+                  "path": ["api", "admin", "scaling-events"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "28188124-d4e7-430e-a1f3-ebb8217df96a",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "admin", "scaling-events"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "GET",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "e7d47d78-9f2f-4f78-958c-34cf17b0d2d2",
+              "name": "/api/admin/operations",
+              "request": {
+                "name": "/api/admin/operations",
+                "description": {},
+                "url": {
+                  "path": ["api", "admin", "operations"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "fa6269ea-1925-4b29-839b-743353c7db71",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "admin", "operations"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "GET",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "8c6ee557-bf14-4068-8268-5f5a02be778c",
+          "name": "rewards",
+          "item": [
+            {
+              "id": "43f8d04f-4441-4391-b35e-8cdda2fa5697",
+              "name": "/api/rewards",
+              "request": {
+                "name": "/api/rewards",
+                "description": {},
+                "url": {
+                  "path": ["api", "rewards"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "f0f2cd3e-a931-4bc7-a59e-3254301c692d",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "rewards"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "GET",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "003d82ae-576e-45cd-89c4-d53712af6199",
+              "name": "/api/rewards/options",
+              "request": {
+                "name": "/api/rewards/options",
+                "description": {},
+                "url": {
+                  "path": ["api", "rewards", "options"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "966b4945-9af5-4c8e-a16b-e7aadad1a2bd",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "rewards", "options"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "GET",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "41dcb77b-ed19-4493-9887-f19dbcd196ae",
+              "name": "/api/rewards/redeem",
+              "request": {
+                "name": "/api/rewards/redeem",
+                "description": {},
+                "url": {
+                  "path": ["api", "rewards", "redeem"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "POST",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "57e5282a-b834-4d81-acf3-9c349b844004",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "rewards", "redeem"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "POST",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "4e17ca3b-abac-4aa3-8574-470548413603",
+          "name": "credits",
+          "item": [
+            {
+              "id": "0d64f9d4-6c60-4b8d-bd93-988381211558",
+              "name": "/api/credits",
+              "request": {
+                "name": "/api/credits",
+                "description": {},
+                "url": {
+                  "path": ["api", "credits"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "b56d08e7-a62e-40f3-94c5-58a010977fb5",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "credits"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "GET",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "6561252a-c8b0-4b7d-94de-409fe3c4220f",
+              "name": "/api/credits/redeem",
+              "request": {
+                "name": "/api/credits/redeem",
+                "description": {},
+                "url": {
+                  "path": ["api", "credits", "redeem"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "POST",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "f6318194-32a9-427c-a8d0-2288001ae882",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "credits", "redeem"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "POST",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "ba6c39e9-bd1f-4657-95e6-5bf9e00e4537",
+          "name": "/api/leaderboard",
+          "request": {
+            "name": "/api/leaderboard",
+            "description": {},
+            "url": {
+              "path": ["api", "leaderboard"],
+              "host": ["{{baseUrl}}"],
+              "query": [],
+              "variable": []
+            },
+            "method": "GET",
+            "auth": null
+          },
+          "response": [
+            {
+              "id": "ddb8fbcc-e112-49b3-8f4c-4b22b313f743",
+              "name": "OK",
+              "originalRequest": {
+                "url": {
+                  "path": ["api", "leaderboard"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "6db8a690-9968-4743-8ea4-aaa424cbe22b",
+          "name": "/api/achievements",
+          "request": {
+            "name": "/api/achievements",
+            "description": {},
+            "url": {
+              "path": ["api", "achievements"],
+              "host": ["{{baseUrl}}"],
+              "query": [],
+              "variable": []
+            },
+            "method": "GET",
+            "auth": null
+          },
+          "response": [
+            {
+              "id": "41d22840-f610-43cd-aade-0a5d64613d7f",
+              "name": "OK",
+              "originalRequest": {
+                "url": {
+                  "path": ["api", "achievements"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "6689cea3-0e15-4443-a7e2-8402cac1fa84",
+          "name": "gifts",
+          "item": [
+            {
+              "id": "c3d023b8-d676-443d-86c0-fdeb9a20edc1",
+              "name": "/api/gifts",
+              "request": {
+                "name": "/api/gifts",
+                "description": {},
+                "url": {
+                  "path": ["api", "gifts"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "POST",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "e9ec6086-d1ef-4d89-9234-b89354ebf4ad",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "gifts"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "POST",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "4a449067-b8ab-4cce-9f73-fcdcf4b9664a",
+              "name": "/api/gifts/:id/claim",
+              "request": {
+                "name": "/api/gifts/:id/claim",
+                "description": {},
+                "url": {
+                  "path": ["api", "gifts", ":id", "claim"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "POST",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "cd31b192-9f10-49c5-b781-7c5edb642a2e",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "gifts", ":id", "claim"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "POST",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "23d19315-4cff-4024-b1db-d2d12536c602",
+          "name": "track",
+          "item": [
+            {
+              "id": "85e6b6a5-4dbb-4cae-8be7-745e1110bf85",
+              "name": "/api/track/ad-click",
+              "request": {
+                "name": "/api/track/ad-click",
+                "description": {},
+                "url": {
+                  "path": ["api", "track", "ad-click"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "POST",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "85fac719-faf2-4c2f-9f48-6b44d0b06711",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "track", "ad-click"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "POST",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "f38b706e-4a89-4f0f-bd34-da98b72be12d",
+              "name": "/api/track/page",
+              "request": {
+                "name": "/api/track/page",
+                "description": {},
+                "url": {
+                  "path": ["api", "track", "page"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "POST",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "efab1fb6-7347-4c22-afd5-69b44d8671fe",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "track", "page"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "POST",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "4bd4eda5-32ed-47d9-bbe6-7441b25870ce",
+              "name": "/api/track/cart",
+              "request": {
+                "name": "/api/track/cart",
+                "description": {},
+                "url": {
+                  "path": ["api", "track", "cart"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "POST",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "e4525940-8be3-4222-959c-125e7da33848",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "track", "cart"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "POST",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "abc4c7d5-9f84-4dbc-9f94-460d0034fc28",
+              "name": "/api/track/checkout",
+              "request": {
+                "name": "/api/track/checkout",
+                "description": {},
+                "url": {
+                  "path": ["api", "track", "checkout"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "POST",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "d4216cf5-55e0-49b9-9890-75b6c946e3bc",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "track", "checkout"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "POST",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "610f5767-e925-41fa-bf31-e8e23a033508",
+              "name": "/api/track/share",
+              "request": {
+                "name": "/api/track/share",
+                "description": {},
+                "url": {
+                  "path": ["api", "track", "share"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "POST",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "c984613c-0746-421f-9b54-1993a1de8bfc",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "track", "share"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "POST",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "533c370e-596f-466f-83bc-d1a2666927c6",
+          "name": "metrics",
+          "item": [
+            {
+              "id": "b6330ad0-500d-4de4-9151-d4d3d9d3ce5e",
+              "name": "/api/metrics/conversion",
+              "request": {
+                "name": "/api/metrics/conversion",
+                "description": {},
+                "url": {
+                  "path": ["api", "metrics", "conversion"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "102dede6-05c2-4f1d-b8b1-6a392b151aa4",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "metrics", "conversion"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "GET",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "16ab39ea-7530-402e-a82c-6e9658019105",
+              "name": "/api/metrics/profit",
+              "request": {
+                "name": "/api/metrics/profit",
+                "description": {},
+                "url": {
+                  "path": ["api", "metrics", "profit"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "a32e133d-381b-4145-8701-f55593054ff0",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "metrics", "profit"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "GET",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "13756f66-0153-4aa0-89af-c5a5f087985d",
+              "name": "/api/metrics/business-intel",
+              "request": {
+                "name": "/api/metrics/business-intel",
+                "description": {},
+                "url": {
+                  "path": ["api", "metrics", "business-intel"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "9790b0bd-2f32-4519-8e89-1767e0f33b20",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "metrics", "business-intel"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "GET",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "5bc29e72-8404-4fb7-a88f-9486146bea0f",
+              "name": "/api/metrics/marginal-cac",
+              "request": {
+                "name": "/api/metrics/marginal-cac",
+                "description": {},
+                "url": {
+                  "path": ["api", "metrics", "marginal-cac"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "ded445df-566e-40cf-b666-6f866290c125",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "metrics", "marginal-cac"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "GET",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "90da4043-c74a-46cc-a7fc-74a7e5d46d8b",
+              "name": "/api/metrics/daily-profit",
+              "request": {
+                "name": "/api/metrics/daily-profit",
+                "description": {},
+                "url": {
+                  "path": ["api", "metrics", "daily-profit"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "bda7c950-e3e3-4d94-9e9d-98ab6963a4ee",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "metrics", "daily-profit"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "GET",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "f4f1eadb-4d66-4bb3-bc88-452d725157a1",
+              "name": "/api/metrics/daily-capacity",
+              "request": {
+                "name": "/api/metrics/daily-capacity",
+                "description": {},
+                "url": {
+                  "path": ["api", "metrics", "daily-capacity"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "9f74bc12-3d3d-4a57-889a-762376941b46",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "metrics", "daily-capacity"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "GET",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "b0919a00-d5c8-4f62-bab5-eb65ea18b062",
+              "name": "/api/metrics/demand-forecast",
+              "request": {
+                "name": "/api/metrics/demand-forecast",
+                "description": {},
+                "url": {
+                  "path": ["api", "metrics", "demand-forecast"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "0f6c93f6-c0e1-4d20-9254-2001474fe2df",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "metrics", "demand-forecast"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "GET",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "fd3d102a-9ec3-4196-b326-e19c3833757f",
+          "name": "users/:username",
+          "item": [
+            {
+              "id": "1431eb6e-2a9f-4b59-b0f2-440ef530731b",
+              "name": "/api/users/:username/models",
+              "request": {
+                "name": "/api/users/:username/models",
+                "description": {},
+                "url": {
+                  "path": ["api", "users", ":username", "models"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "9eac8639-7f9a-40ca-9730-5b09f816c275",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "users", ":username", "models"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "GET",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "fcf98fb5-de26-498b-8566-c9df336f1e5f",
+              "name": "/api/users/:username/profile",
+              "request": {
+                "name": "/api/users/:username/profile",
+                "description": {},
+                "url": {
+                  "path": ["api", "users", ":username", "profile"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "c31762a9-31b8-4e7b-a432-525e0b31c00e",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "users", ":username", "profile"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "GET",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "45e8fda3-5953-4e31-9cf7-f5be5c1d463e",
+          "name": "/api/shared/:slug",
+          "request": {
+            "name": "/api/shared/:slug",
+            "description": {},
+            "url": {
+              "path": ["api", "shared", ":slug"],
+              "host": ["{{baseUrl}}"],
+              "query": [],
+              "variable": []
+            },
+            "method": "GET",
+            "auth": null
+          },
+          "response": [
+            {
+              "id": "a395f759-f689-4419-9c25-750318d6f427",
+              "name": "OK",
+              "originalRequest": {
+                "url": {
+                  "path": ["api", "shared", ":slug"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "b41a32a2-9fbd-439e-a568-149d53f94afe",
+          "name": "community",
+          "item": [
+            {
+              "id": "939edcc0-d410-4236-a0b0-a67f3adf74f1",
+              "name": "/api/community",
+              "request": {
+                "name": "/api/community",
+                "description": {},
+                "url": {
+                  "path": ["api", "community"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "POST",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "beb15449-a61f-4118-97b7-094f7e92b401",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "community"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "POST",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "e7dd0157-66e1-495f-8b00-382d7a066410",
+              "name": "/api/community/recent",
+              "request": {
+                "name": "/api/community/recent",
+                "description": {},
+                "url": {
+                  "path": ["api", "community", "recent"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "28f21fb6-cf62-4812-8ec1-05b7913b00d3",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "community", "recent"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "GET",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "097bf2c4-38f3-475a-b0c7-2749a4d9e249",
+              "name": "/api/community/popular",
+              "request": {
+                "name": "/api/community/popular",
+                "description": {},
+                "url": {
+                  "path": ["api", "community", "popular"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "2e232200-bad7-493d-b8ed-aa778d7e9a5d",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "community", "popular"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "GET",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "c4cd099e-c682-4edd-a263-f30a18c178a2",
+              "name": "/api/community/mine",
+              "request": {
+                "name": "/api/community/mine",
+                "description": {},
+                "url": {
+                  "path": ["api", "community", "mine"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "6076aa17-fad5-4fab-be5b-055d16aeb620",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "community", "mine"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "GET",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "aae6c9b5-bae6-49b3-ac19-57e752bcbf21",
+              "name": ":id",
+              "item": [
+                {
+                  "id": "0b56a646-41e7-40ee-bbd5-024692528de4",
+                  "name": "/api/community/:id",
+                  "request": {
+                    "name": "/api/community/:id",
+                    "description": {},
+                    "url": {
+                      "path": ["api", "community", ":id"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "DELETE",
+                    "auth": null
+                  },
+                  "response": [
+                    {
+                      "id": "8cb7b27e-e971-4f46-abe6-d8148955fb20",
+                      "name": "OK",
+                      "originalRequest": {
+                        "url": {
+                          "path": ["api", "community", ":id"],
+                          "host": ["{{baseUrl}}"],
+                          "query": [],
+                          "variable": []
+                        },
+                        "method": "DELETE",
+                        "body": {}
+                      },
+                      "status": "OK",
+                      "code": 200,
+                      "header": [
+                        {
+                          "key": "Content-Type",
+                          "value": "text/plain"
+                        }
+                      ],
+                      "body": "",
+                      "cookie": [],
+                      "_postman_previewlanguage": "text"
+                    }
+                  ],
+                  "event": []
+                },
+                {
+                  "id": "5f613334-fd57-463c-ba13-0170f726fadc",
+                  "name": "/api/community/:id/comments",
+                  "request": {
+                    "name": "/api/community/:id/comments",
+                    "description": {},
+                    "url": {
+                      "path": ["api", "community", ":id", "comments"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "GET",
+                    "auth": null
+                  },
+                  "response": [
+                    {
+                      "id": "ed4edb41-e7a3-4891-9d1a-474b00e93f21",
+                      "name": "OK",
+                      "originalRequest": {
+                        "url": {
+                          "path": ["api", "community", ":id", "comments"],
+                          "host": ["{{baseUrl}}"],
+                          "query": [],
+                          "variable": []
+                        },
+                        "method": "GET",
+                        "body": {}
+                      },
+                      "status": "OK",
+                      "code": 200,
+                      "header": [
+                        {
+                          "key": "Content-Type",
+                          "value": "text/plain"
+                        }
+                      ],
+                      "body": "",
+                      "cookie": [],
+                      "_postman_previewlanguage": "text"
+                    }
+                  ],
+                  "event": []
+                },
+                {
+                  "id": "4d795909-5ff2-48a6-9647-5d7ccb2a8294",
+                  "name": "/api/community/:id/comment",
+                  "request": {
+                    "name": "/api/community/:id/comment",
+                    "description": {},
+                    "url": {
+                      "path": ["api", "community", ":id", "comment"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "POST",
+                    "auth": null
+                  },
+                  "response": [
+                    {
+                      "id": "130ebab0-6392-42fe-98eb-97e91daf283b",
+                      "name": "OK",
+                      "originalRequest": {
+                        "url": {
+                          "path": ["api", "community", ":id", "comment"],
+                          "host": ["{{baseUrl}}"],
+                          "query": [],
+                          "variable": []
+                        },
+                        "method": "POST",
+                        "body": {}
+                      },
+                      "status": "OK",
+                      "code": 200,
+                      "header": [
+                        {
+                          "key": "Content-Type",
+                          "value": "text/plain"
+                        }
+                      ],
+                      "body": "",
+                      "cookie": [],
+                      "_postman_previewlanguage": "text"
+                    }
+                  ],
+                  "event": []
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "f1065186-2ed4-435b-886d-ec8821c6a650",
+              "name": "/api/community/model/:id",
+              "request": {
+                "name": "/api/community/model/:id",
+                "description": {},
+                "url": {
+                  "path": ["api", "community", "model", ":id"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "b150d25d-e88e-4a20-8a1f-5c6919af7f04",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "community", "model", ":id"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "GET",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "4388b65d-2df4-4a84-8553-ba89e85dca7b",
+          "name": "competitions",
+          "item": [
+            {
+              "id": "33fdd92b-e349-4c98-afb3-97f8e3d14b37",
+              "name": "/api/competitions/active",
+              "request": {
+                "name": "/api/competitions/active",
+                "description": {},
+                "url": {
+                  "path": ["api", "competitions", "active"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "2afa452f-eb6c-48c4-b9f9-b6bce4a8ee80",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "competitions", "active"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "GET",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "00e57efb-da82-473f-b7c2-d085add0d7dd",
+              "name": "/api/competitions/past",
+              "request": {
+                "name": "/api/competitions/past",
+                "description": {},
+                "url": {
+                  "path": ["api", "competitions", "past"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "77a82609-c04e-4c79-a8b5-4412f0cbdbe3",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "competitions", "past"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "GET",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "0f3108a5-b58d-4503-83bf-dd91ff0f3d5e",
+              "name": "/api/competitions/winners",
+              "request": {
+                "name": "/api/competitions/winners",
+                "description": {},
+                "url": {
+                  "path": ["api", "competitions", "winners"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "390fc09c-64b9-41b4-8633-908aa1ae3e46",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "competitions", "winners"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "GET",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "5e50a853-44a1-47a6-a08f-68a29f53c782",
+              "name": ":id",
+              "item": [
+                {
+                  "id": "12e60db2-86d7-45b5-8bec-9b4b4f9df30f",
+                  "name": "/api/competitions/:id/entries",
+                  "request": {
+                    "name": "/api/competitions/:id/entries",
+                    "description": {},
+                    "url": {
+                      "path": ["api", "competitions", ":id", "entries"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "GET",
+                    "auth": null
+                  },
+                  "response": [
+                    {
+                      "id": "2d687352-cdbf-4318-a490-95c3c0647727",
+                      "name": "OK",
+                      "originalRequest": {
+                        "url": {
+                          "path": ["api", "competitions", ":id", "entries"],
+                          "host": ["{{baseUrl}}"],
+                          "query": [],
+                          "variable": []
+                        },
+                        "method": "GET",
+                        "body": {}
+                      },
+                      "status": "OK",
+                      "code": 200,
+                      "header": [
+                        {
+                          "key": "Content-Type",
+                          "value": "text/plain"
+                        }
+                      ],
+                      "body": "",
+                      "cookie": [],
+                      "_postman_previewlanguage": "text"
+                    }
+                  ],
+                  "event": []
+                },
+                {
+                  "id": "e5eb3965-2d42-4432-965a-503015508b91",
+                  "name": "comments",
+                  "item": [
+                    {
+                      "id": "7cda2ff5-b864-4d7f-854c-cdbc54b6c5e5",
+                      "name": "/api/competitions/:id/comments",
+                      "request": {
+                        "name": "/api/competitions/:id/comments",
+                        "description": {},
+                        "url": {
+                          "path": ["api", "competitions", ":id", "comments"],
+                          "host": ["{{baseUrl}}"],
+                          "query": [],
+                          "variable": []
+                        },
+                        "method": "GET",
+                        "auth": null
+                      },
+                      "response": [
+                        {
+                          "id": "0f453b38-defd-4639-b2b1-717ca4c1629d",
+                          "name": "OK",
+                          "originalRequest": {
+                            "url": {
+                              "path": [
+                                "api",
+                                "competitions",
+                                ":id",
+                                "comments"
+                              ],
+                              "host": ["{{baseUrl}}"],
+                              "query": [],
+                              "variable": []
+                            },
+                            "method": "GET",
+                            "body": {}
+                          },
+                          "status": "OK",
+                          "code": 200,
+                          "header": [
+                            {
+                              "key": "Content-Type",
+                              "value": "text/plain"
+                            }
+                          ],
+                          "body": "",
+                          "cookie": [],
+                          "_postman_previewlanguage": "text"
+                        }
+                      ],
+                      "event": []
+                    },
+                    {
+                      "id": "ee7aa11e-ba69-489c-a8ff-d39dec7425a2",
+                      "name": "/api/competitions/:id/comments",
+                      "request": {
+                        "name": "/api/competitions/:id/comments",
+                        "description": {},
+                        "url": {
+                          "path": ["api", "competitions", ":id", "comments"],
+                          "host": ["{{baseUrl}}"],
+                          "query": [],
+                          "variable": []
+                        },
+                        "method": "POST",
+                        "auth": null
+                      },
+                      "response": [
+                        {
+                          "id": "ec1e595b-d4c7-4b9d-a5d7-639e596b3b13",
+                          "name": "OK",
+                          "originalRequest": {
+                            "url": {
+                              "path": [
+                                "api",
+                                "competitions",
+                                ":id",
+                                "comments"
+                              ],
+                              "host": ["{{baseUrl}}"],
+                              "query": [],
+                              "variable": []
+                            },
+                            "method": "POST",
+                            "body": {}
+                          },
+                          "status": "OK",
+                          "code": 200,
+                          "header": [
+                            {
+                              "key": "Content-Type",
+                              "value": "text/plain"
+                            }
+                          ],
+                          "body": "",
+                          "cookie": [],
+                          "_postman_previewlanguage": "text"
+                        }
+                      ],
+                      "event": []
+                    }
+                  ],
+                  "event": []
+                },
+                {
+                  "id": "fd450700-ae71-4bcf-be7c-3be8f6dcd3fa",
+                  "name": "/api/competitions/:id/enter",
+                  "request": {
+                    "name": "/api/competitions/:id/enter",
+                    "description": {},
+                    "url": {
+                      "path": ["api", "competitions", ":id", "enter"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "POST",
+                    "auth": null
+                  },
+                  "response": [
+                    {
+                      "id": "df132130-6b29-4abc-b1f2-5d4d06cd5577",
+                      "name": "OK",
+                      "originalRequest": {
+                        "url": {
+                          "path": ["api", "competitions", ":id", "enter"],
+                          "host": ["{{baseUrl}}"],
+                          "query": [],
+                          "variable": []
+                        },
+                        "method": "POST",
+                        "body": {}
+                      },
+                      "status": "OK",
+                      "code": 200,
+                      "header": [
+                        {
+                          "key": "Content-Type",
+                          "value": "text/plain"
+                        }
+                      ],
+                      "body": "",
+                      "cookie": [],
+                      "_postman_previewlanguage": "text"
+                    }
+                  ],
+                  "event": []
+                },
+                {
+                  "id": "c74eee52-34b1-49fe-9c00-ed533e75ee89",
+                  "name": "/api/competitions/:id/discount",
+                  "request": {
+                    "name": "/api/competitions/:id/discount",
+                    "description": {},
+                    "url": {
+                      "path": ["api", "competitions", ":id", "discount"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "POST",
+                    "auth": null
+                  },
+                  "response": [
+                    {
+                      "id": "9cbe29d3-dc4e-4fd4-9569-bea120be52df",
+                      "name": "OK",
+                      "originalRequest": {
+                        "url": {
+                          "path": ["api", "competitions", ":id", "discount"],
+                          "host": ["{{baseUrl}}"],
+                          "query": [],
+                          "variable": []
+                        },
+                        "method": "POST",
+                        "body": {}
+                      },
+                      "status": "OK",
+                      "code": 200,
+                      "header": [
+                        {
+                          "key": "Content-Type",
+                          "value": "text/plain"
+                        }
+                      ],
+                      "body": "",
+                      "cookie": [],
+                      "_postman_previewlanguage": "text"
+                    }
+                  ],
+                  "event": []
+                },
+                {
+                  "id": "fe9a8001-c4b5-4f02-bdee-9a21a9606e2c",
+                  "name": "/api/competitions/:id/vote",
+                  "request": {
+                    "name": "/api/competitions/:id/vote",
+                    "description": {},
+                    "url": {
+                      "path": ["api", "competitions", ":id", "vote"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "POST",
+                    "auth": null
+                  },
+                  "response": [
+                    {
+                      "id": "70eb99e4-6cd1-42b9-9f24-a0b96f0a48ca",
+                      "name": "OK",
+                      "originalRequest": {
+                        "url": {
+                          "path": ["api", "competitions", ":id", "vote"],
+                          "host": ["{{baseUrl}}"],
+                          "query": [],
+                          "variable": []
+                        },
+                        "method": "POST",
+                        "body": {}
+                      },
+                      "status": "OK",
+                      "code": 200,
+                      "header": [
+                        {
+                          "key": "Content-Type",
+                          "value": "text/plain"
+                        }
+                      ],
+                      "body": "",
+                      "cookie": [],
+                      "_postman_previewlanguage": "text"
+                    }
+                  ],
+                  "event": []
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "f6ea815b-2ba0-49ac-94b7-7c9905ab04a0",
+              "name": "/api/competitions/subscribe",
+              "request": {
+                "name": "/api/competitions/subscribe",
+                "description": {},
+                "url": {
+                  "path": ["api", "competitions", "subscribe"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "POST",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "01587d20-5cdb-4623-b7dd-fa8e10d733bf",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "competitions", "subscribe"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "POST",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "bb55a3ab-89f1-4ae3-885d-1099b4afba53",
+              "name": "/api/competitions/notify",
+              "request": {
+                "name": "/api/competitions/notify",
+                "description": {},
+                "url": {
+                  "path": ["api", "competitions", "notify"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "POST",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "4699eb6f-8ff2-4450-bde9-ee7860e574e1",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "competitions", "notify"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "POST",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "996b30c8-4f46-4fa3-b3f3-f1e0db18aa4e",
+          "name": "designer-submissions",
+          "item": [
+            {
+              "id": "5aea1584-0515-4bc3-94ec-19cf969b108c",
+              "name": "/api/designer-submissions",
+              "request": {
+                "name": "/api/designer-submissions",
+                "description": {},
+                "url": {
+                  "path": ["api", "designer-submissions"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "POST",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "d7de235d-b049-431b-bd4c-77ac71850a97",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "designer-submissions"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "POST",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "f41d16c3-8bdf-447b-8cfc-be16d2cd5ee2",
+              "name": "/api/designer-submissions/approved",
+              "request": {
+                "name": "/api/designer-submissions/approved",
+                "description": {},
+                "url": {
+                  "path": ["api", "designer-submissions", "approved"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "e16e8d53-c3b3-4236-bc59-734e3ff1c14f",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "designer-submissions", "approved"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "GET",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "07fd241a-bc0a-4a5d-88b6-ccc9c7ea111d",
+          "name": "/api/payouts",
+          "request": {
+            "name": "/api/payouts",
+            "description": {},
+            "url": {
+              "path": ["api", "payouts"],
+              "host": ["{{baseUrl}}"],
+              "query": [],
+              "variable": []
+            },
+            "method": "POST",
+            "auth": null
+          },
+          "response": [
+            {
+              "id": "c3e8c564-22c4-41e3-8510-834e9a980e4b",
+              "name": "OK",
+              "originalRequest": {
+                "url": {
+                  "path": ["api", "payouts"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "POST",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "0b59ca35-51ca-4144-bf54-4811cef1e232",
+          "name": "/api/shipping-estimate",
+          "request": {
+            "name": "/api/shipping-estimate",
+            "description": {},
+            "url": {
+              "path": ["api", "shipping-estimate"],
+              "host": ["{{baseUrl}}"],
+              "query": [],
+              "variable": []
+            },
+            "method": "POST",
+            "auth": null
+          },
+          "response": [
+            {
+              "id": "46ed26b1-36ec-40a1-be08-388066a48729",
+              "name": "OK",
+              "originalRequest": {
+                "url": {
+                  "path": ["api", "shipping-estimate"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "POST",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "5f5135b2-c711-412c-bf40-0f5a8ad16b19",
+          "name": "/api/discount-code",
+          "request": {
+            "name": "/api/discount-code",
+            "description": {},
+            "url": {
+              "path": ["api", "discount-code"],
+              "host": ["{{baseUrl}}"],
+              "query": [],
+              "variable": []
+            },
+            "method": "POST",
+            "auth": null
+          },
+          "response": [
+            {
+              "id": "5e0de0f2-3b3e-4e38-b392-7ed12780534a",
+              "name": "OK",
+              "originalRequest": {
+                "url": {
+                  "path": ["api", "discount-code"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "POST",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "7d32a09a-3ec8-4ce1-b28c-c9d483ebc932",
+          "name": "/api/generate-discount",
+          "request": {
+            "name": "/api/generate-discount",
+            "description": {},
+            "url": {
+              "path": ["api", "generate-discount"],
+              "host": ["{{baseUrl}}"],
+              "query": [],
+              "variable": []
+            },
+            "method": "POST",
+            "auth": null
+          },
+          "response": [
+            {
+              "id": "4352b4ce-dcd7-4076-8e32-9e08ed8e3348",
+              "name": "OK",
+              "originalRequest": {
+                "url": {
+                  "path": ["api", "generate-discount"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "POST",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "921f5c9b-5ac1-4e6f-9a2e-43467aba8950",
+          "name": "/api/flash-sale",
+          "request": {
+            "name": "/api/flash-sale",
+            "description": {},
+            "url": {
+              "path": ["api", "flash-sale"],
+              "host": ["{{baseUrl}}"],
+              "query": [],
+              "variable": []
+            },
+            "method": "GET",
+            "auth": null
+          },
+          "response": [
+            {
+              "id": "752d03b4-e841-4083-8a6b-def724174ed4",
+              "name": "OK",
+              "originalRequest": {
+                "url": {
+                  "path": ["api", "flash-sale"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "d9e97a14-8cf3-419d-ae81-deac1a374f35",
+          "name": "/api/create-order",
+          "request": {
+            "name": "/api/create-order",
+            "description": {},
+            "url": {
+              "path": ["api", "create-order"],
+              "host": ["{{baseUrl}}"],
+              "query": [],
+              "variable": []
+            },
+            "method": "POST",
+            "auth": null
+          },
+          "response": [
+            {
+              "id": "e68f7bf2-2c8c-4f8f-82f9-d167b07c2900",
+              "name": "OK",
+              "originalRequest": {
+                "url": {
+                  "path": ["api", "create-order"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "POST",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "5e54a307-1e3b-4b20-acb9-80254b52ed0d",
+          "name": "cart",
+          "item": [
+            {
+              "id": "dedaf1e4-f2f7-4db9-8202-29cd9fb7346b",
+              "name": "/api/cart",
+              "request": {
+                "name": "/api/cart",
+                "description": {},
+                "url": {
+                  "path": ["api", "cart"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "80b60822-31f2-4cd5-b518-bb98d5831fa4",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "cart"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "GET",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "113660b8-8614-4a32-a7f0-dfffb942bf7a",
+              "name": "/api/cart",
+              "request": {
+                "name": "/api/cart",
+                "description": {},
+                "url": {
+                  "path": ["api", "cart"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "DELETE",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "d734bb97-0b81-45e4-91fa-f89d2719b129",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "cart"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "DELETE",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "991d9b5f-5db6-4ae1-ba79-2d4709a59dce",
+              "name": "items",
+              "item": [
+                {
+                  "id": "aabe95a7-defc-4f7f-9810-3fa1e0fe1033",
+                  "name": "/api/cart/items",
+                  "request": {
+                    "name": "/api/cart/items",
+                    "description": {},
+                    "url": {
+                      "path": ["api", "cart", "items"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "POST",
+                    "auth": null
+                  },
+                  "response": [
+                    {
+                      "id": "515bd664-58ed-4a0d-a336-4f355a2cca56",
+                      "name": "OK",
+                      "originalRequest": {
+                        "url": {
+                          "path": ["api", "cart", "items"],
+                          "host": ["{{baseUrl}}"],
+                          "query": [],
+                          "variable": []
+                        },
+                        "method": "POST",
+                        "body": {}
+                      },
+                      "status": "OK",
+                      "code": 200,
+                      "header": [
+                        {
+                          "key": "Content-Type",
+                          "value": "text/plain"
+                        }
+                      ],
+                      "body": "",
+                      "cookie": [],
+                      "_postman_previewlanguage": "text"
+                    }
+                  ],
+                  "event": []
+                },
+                {
+                  "id": "23ae5033-6a6d-46bf-9825-8c344e749cb3",
+                  "name": ":id",
+                  "item": [
+                    {
+                      "id": "44bb4cfb-4b2a-4a3e-afdd-15800d546e61",
+                      "name": "/api/cart/items/:id",
+                      "request": {
+                        "name": "/api/cart/items/:id",
+                        "description": {},
+                        "url": {
+                          "path": ["api", "cart", "items", ":id"],
+                          "host": ["{{baseUrl}}"],
+                          "query": [],
+                          "variable": []
+                        },
+                        "method": "PATCH",
+                        "auth": null
+                      },
+                      "response": [
+                        {
+                          "id": "04ff8e5a-c099-4126-9f1c-1c589f771cb4",
+                          "name": "OK",
+                          "originalRequest": {
+                            "url": {
+                              "path": ["api", "cart", "items", ":id"],
+                              "host": ["{{baseUrl}}"],
+                              "query": [],
+                              "variable": []
+                            },
+                            "method": "PATCH",
+                            "body": {}
+                          },
+                          "status": "OK",
+                          "code": 200,
+                          "header": [
+                            {
+                              "key": "Content-Type",
+                              "value": "text/plain"
+                            }
+                          ],
+                          "body": "",
+                          "cookie": [],
+                          "_postman_previewlanguage": "text"
+                        }
+                      ],
+                      "event": []
+                    },
+                    {
+                      "id": "10013f7b-f0a6-4050-9c54-867673465dd1",
+                      "name": "/api/cart/items/:id",
+                      "request": {
+                        "name": "/api/cart/items/:id",
+                        "description": {},
+                        "url": {
+                          "path": ["api", "cart", "items", ":id"],
+                          "host": ["{{baseUrl}}"],
+                          "query": [],
+                          "variable": []
+                        },
+                        "method": "DELETE",
+                        "auth": null
+                      },
+                      "response": [
+                        {
+                          "id": "3ab0c7d0-2447-43ba-9bc6-383123ffa4f5",
+                          "name": "OK",
+                          "originalRequest": {
+                            "url": {
+                              "path": ["api", "cart", "items", ":id"],
+                              "host": ["{{baseUrl}}"],
+                              "query": [],
+                              "variable": []
+                            },
+                            "method": "DELETE",
+                            "body": {}
+                          },
+                          "status": "OK",
+                          "code": 200,
+                          "header": [
+                            {
+                              "key": "Content-Type",
+                              "value": "text/plain"
+                            }
+                          ],
+                          "body": "",
+                          "cookie": [],
+                          "_postman_previewlanguage": "text"
+                        }
+                      ],
+                      "event": []
+                    }
+                  ],
+                  "event": []
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "92f8c7fe-186f-4a59-a5f4-9d0779b0a46c",
+              "name": "/api/cart/checkout",
+              "request": {
+                "name": "/api/cart/checkout",
+                "description": {},
+                "url": {
+                  "path": ["api", "cart", "checkout"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "POST",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "bda25fd4-ffa8-461e-ba78-1a74b4f94c20",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "cart", "checkout"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "POST",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "6ff23cb0-ea08-46ef-891f-31e58803e5dc",
+          "name": "/api/subscribe",
+          "request": {
+            "name": "/api/subscribe",
+            "description": {},
+            "url": {
+              "path": ["api", "subscribe"],
+              "host": ["{{baseUrl}}"],
+              "query": [],
+              "variable": []
+            },
+            "method": "POST",
+            "auth": null
+          },
+          "response": [
+            {
+              "id": "0c683db2-40cb-4e12-beef-b927e0479c66",
+              "name": "OK",
+              "originalRequest": {
+                "url": {
+                  "path": ["api", "subscribe"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "POST",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "a0eea272-d79f-4822-adac-595807b17f2f",
+          "name": "/api/confirm-subscription",
+          "request": {
+            "name": "/api/confirm-subscription",
+            "description": {},
+            "url": {
+              "path": ["api", "confirm-subscription"],
+              "host": ["{{baseUrl}}"],
+              "query": [],
+              "variable": []
+            },
+            "method": "GET",
+            "auth": null
+          },
+          "response": [
+            {
+              "id": "7a3a8dea-94c4-4bfa-80e6-c33a8034dd2c",
+              "name": "OK",
+              "originalRequest": {
+                "url": {
+                  "path": ["api", "confirm-subscription"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "c6de0c1f-99bf-4ff9-a779-0a5c95576e9a",
+          "name": "/api/unsubscribe",
+          "request": {
+            "name": "/api/unsubscribe",
+            "description": {},
+            "url": {
+              "path": ["api", "unsubscribe"],
+              "host": ["{{baseUrl}}"],
+              "query": [],
+              "variable": []
+            },
+            "method": "GET",
+            "auth": null
+          },
+          "response": [
+            {
+              "id": "25cfa5ef-80d6-46db-a376-45d73462fa12",
+              "name": "OK",
+              "originalRequest": {
+                "url": {
+                  "path": ["api", "unsubscribe"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "315e4f74-42fc-4688-b9ae-27c53a973f0f",
+          "name": "webhook",
+          "item": [
+            {
+              "id": "80442b12-7d2c-4e1a-adda-54e3a8b40b32",
+              "name": "/api/webhook/sendgrid",
+              "request": {
+                "name": "/api/webhook/sendgrid",
+                "description": {},
+                "url": {
+                  "path": ["api", "webhook", "sendgrid"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "POST",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "638a41a7-3777-4656-b617-8e5961757b48",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "webhook", "sendgrid"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "POST",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "a86715cc-6433-49c7-902c-b731bafb3d9d",
+              "name": "/api/webhook/stripe",
+              "request": {
+                "name": "/api/webhook/stripe",
+                "description": {},
+                "url": {
+                  "path": ["api", "webhook", "stripe"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "POST",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "65ff691a-244a-4ac4-8189-0007f842c3a3",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "webhook", "stripe"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "POST",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            },
+            {
+              "id": "e8ef29b7-af7a-4d3a-808a-2dce5e525d1d",
+              "name": "/api/webhook/printer-complete",
+              "request": {
+                "name": "/api/webhook/printer-complete",
+                "description": {},
+                "url": {
+                  "path": ["api", "webhook", "printer-complete"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "POST",
+                "auth": null
+              },
+              "response": [
+                {
+                  "id": "f0d3d0c4-045c-4cb1-bcdf-82d5f38d676a",
+                  "name": "OK",
+                  "originalRequest": {
+                    "url": {
+                      "path": ["api", "webhook", "printer-complete"],
+                      "host": ["{{baseUrl}}"],
+                      "query": [],
+                      "variable": []
+                    },
+                    "method": "POST",
+                    "body": {}
+                  },
+                  "status": "OK",
+                  "code": 200,
+                  "header": [
+                    {
+                      "key": "Content-Type",
+                      "value": "text/plain"
+                    }
+                  ],
+                  "body": "",
+                  "cookie": [],
+                  "_postman_previewlanguage": "text"
+                }
+              ],
+              "event": []
+            }
+          ],
+          "event": []
+        },
+        {
+          "id": "93b7b142-8b03-4faa-986c-0215d9d8ba52",
+          "name": "/api/print-jobs/:id",
+          "request": {
+            "name": "/api/print-jobs/:id",
+            "description": {},
+            "url": {
+              "path": ["api", "print-jobs", ":id"],
+              "host": ["{{baseUrl}}"],
+              "query": [],
+              "variable": []
+            },
+            "method": "GET",
+            "auth": null
+          },
+          "response": [
+            {
+              "id": "25f63fc5-1d12-4dbf-8a15-442fae657baf",
+              "name": "OK",
+              "originalRequest": {
+                "url": {
+                  "path": ["api", "print-jobs", ":id"],
+                  "host": ["{{baseUrl}}"],
+                  "query": [],
+                  "variable": []
+                },
+                "method": "GET",
+                "body": {}
+              },
+              "status": "OK",
+              "code": 200,
+              "header": [
+                {
+                  "key": "Content-Type",
+                  "value": "text/plain"
+                }
+              ],
+              "body": "",
+              "cookie": [],
+              "_postman_previewlanguage": "text"
+            }
+          ],
+          "event": []
+        }
+      ],
+      "event": []
+    }
+  ],
+  "event": [],
+  "variable": [
+    {
+      "type": "string",
+      "value": "/",
+      "key": "baseUrl"
+    }
+  ],
+  "info": {
+    "_postman_id": "6418d41a-f58d-48ef-a83a-b1c1642650f2",
+    "name": "print2 API",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "description": {
+      "content": "",
+      "type": "text/plain"
+    }
+  }
+}

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,683 @@
+openapi: 3.0.0
+info:
+  title: print2 API
+  version: 1.0.0
+paths:
+  /api-docs:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/register:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/dalle:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/generate-model:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/login:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/request-password-reset:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/reset-password:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/me:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/generate:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/upload-model:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/models:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/status:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/status/:jobId:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/config/stripe:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/print-slots:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/stats:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/usernames:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/recent-purchases:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/campaign:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/health:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/init-data:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/payment-init:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/subreddit/:name:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/progress/:jobId:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/my/models:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/my/orders:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/commissions:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/profile:
+    get:
+      responses:
+        "200":
+          description: OK
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/profile/avatar:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/account:
+    delete:
+      responses:
+        "200":
+          description: OK
+  /api/stripe/connect:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/subscription:
+    get:
+      responses:
+        "200":
+          description: OK
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/subscription/cancel:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/subscription/portal:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/subscription/credits:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/subscription/summary:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/dashboard:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/referral-link:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/orders/:id/referral-link:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/orders/:id/referral-qr:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/referral-click:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/referral-signup:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/referral-post:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/social-shares:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/admin/social-shares/:id/verify:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/rewards:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/rewards/options:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/rewards/redeem:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/credits:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/credits/redeem:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/leaderboard:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/achievements:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/gifts/:id/claim:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/track/ad-click:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/track/page:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/track/cart:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/track/checkout:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/track/share:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/metrics/conversion:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/metrics/profit:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/metrics/business-intel:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/metrics/marginal-cac:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/metrics/daily-profit:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/metrics/daily-capacity:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/metrics/demand-forecast:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/users/:username/models:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/users/:username/profile:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/models/:id/like:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/models/:id/public:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/models/:id/share:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/models/:id:
+    delete:
+      responses:
+        "200":
+          description: OK
+  /api/shared/:slug:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/community:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/community/recent:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/community/popular:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/community/mine:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/community/:id:
+    delete:
+      responses:
+        "200":
+          description: OK
+  /api/community/model/:id:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/community/:id/comments:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/community/:id/comment:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/competitions/active:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/competitions/past:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/competitions/winners:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/competitions/:id/entries:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/competitions/:id/comments:
+    get:
+      responses:
+        "200":
+          description: OK
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/competitions/:id/enter:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/competitions/:id/discount:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/competitions/:id/vote:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/designer-submissions:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/designer-submissions/approved:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/admin/designer-submissions/:id/approve:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/admin/competitions:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/admin/competitions/:id:
+    put:
+      responses:
+        "200":
+          description: OK
+    delete:
+      responses:
+        "200":
+          description: OK
+  /api/commissions/:id/mark-paid:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/payouts:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/shipping-estimate:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/discount-code:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/generate-discount:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/flash-sale:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/admin/flash-sale:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/admin/flash-sale/:id:
+    delete:
+      responses:
+        "200":
+          description: OK
+  /api/admin/spaces:
+    get:
+      responses:
+        "200":
+          description: OK
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/admin/hubs:
+    get:
+      responses:
+        "200":
+          description: OK
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/admin/hubs/:id/printers:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/admin/hubs/:id:
+    put:
+      responses:
+        "200":
+          description: OK
+  /api/admin/hubs/:id/shipments:
+    get:
+      responses:
+        "200":
+          description: OK
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/admin/ads/generate:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/admin/ads/pending:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/admin/ads/:id/approve:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/admin/ads/:id/reject:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/admin/subscription-metrics:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/admin/scaling-events:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/admin/operations:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/create-order:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/gifts:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/cart/items:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/cart/items/:id:
+    patch:
+      responses:
+        "200":
+          description: OK
+    delete:
+      responses:
+        "200":
+          description: OK
+  /api/cart:
+    get:
+      responses:
+        "200":
+          description: OK
+    delete:
+      responses:
+        "200":
+          description: OK
+  /api/cart/checkout:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/subscribe:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/competitions/subscribe:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/competitions/notify:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/confirm-subscription:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/unsubscribe:
+    get:
+      responses:
+        "200":
+          description: OK
+  /api/webhook/sendgrid:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/webhook/stripe:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/webhook/printer-complete:
+    post:
+      responses:
+        "200":
+          description: OK
+  /api/print-jobs/:id:
+    get:
+      responses:
+        "200":
+          description: OK
+components: {}
+tags: []


### PR DESCRIPTION
## Summary
- document /api routes via swagger-jsdoc
- serve spec at `/api-docs` and UI at `/docs`
- export Postman collection
- lint OpenAPI spec in CI

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_686c5222daf4832dbff008f221a2f418