### PR TITLE
Add Trivy container scan

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -15,4 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: echo "Using npm"
       - name: Build Docker image
-        run: docker build .
+        run: docker build -t api:latest .
+      - name: Scan image for vulnerabilities
+        run: docker run --rm -v /var/run/docker.sock:/var/run/docker.sock \
+          aquasec/trivy:0.49.1 image --severity CRITICAL,HIGH --exit-code 1 api:latest

--- a/docs/security.md
+++ b/docs/security.md
@@ -5,3 +5,5 @@ This workflow uses Snyk to test for high-severity vulnerabilities.
 - **To enable**: add your Snyk API token as the `SNYK_TOKEN` secret in GitHub repo settings.
 - **Fallback**: if `SNYK_TOKEN` is missing, CI will automatically run `npm audit --audit-level=high`.
 - **Validation**: invalid tokens will error early with a clear message.
+- **Override**: to scan for low and medium vulnerabilities as well, append
+  `--severity LOW,MEDIUM,CRITICAL,HIGH` when running the Trivy command.


### PR DESCRIPTION
## Summary
- scan Docker image with Trivy during container build
- document how to override the severity threshold

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_686c5229de94832d85a803c35212a84b