### PR TITLE
feat(deploy): add Helm chart + release packaging

### DIFF
--- a/.github/workflows/package-helm.yml
+++ b/.github/workflows/package-helm.yml
@@ -1,0 +1,20 @@
+name: Package Helm Chart
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: azure/setup-helm@v3
+      - name: Package chart
+        run: |
+          helm package deploy/helm/print3 --destination chart
+      - name: Upload release asset
+        uses: softprops/action-gh-release@v1
+        with:
+          files: chart/print3-*.tgz

--- a/deploy/helm/print3/Chart.yaml
+++ b/deploy/helm/print3/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: print3
+version: 0.1.0
+appVersion: "1.0"
+description: Helm chart for the Print3 service

--- a/deploy/helm/print3/templates/_helpers.tpl
+++ b/deploy/helm/print3/templates/_helpers.tpl
@@ -1,0 +1,7 @@
+{{- define "print3.name" -}}
+{{ .Chart.Name }}
+{{- end -}}
+
+{{- define "print3.fullname" -}}
+{{ include "print3.name" . }}
+{{- end -}}

--- a/deploy/helm/print3/templates/deployment.yaml
+++ b/deploy/helm/print3/templates/deployment.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "print3.fullname" . }}
+  labels:
+    app: {{ include "print3.name" . }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ include "print3.name" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "print3.name" . }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          env:
+            - name: DATABASE_URL
+              value: {{ .Values.db.url | quote }}
+            - name: STRIPE_PUBLISHABLE_KEY
+              value: {{ .Values.stripe.publishableKey | quote }}
+            - name: STRIPE_SECRET_KEY
+              value: {{ .Values.stripe.secretKey | quote }}
+            - name: AI_KEY
+              value: {{ .Values.ai.key | quote }}
+            - name: NODE_ENV
+              value: {{ .Values.env | quote }}

--- a/deploy/helm/print3/values.yaml
+++ b/deploy/helm/print3/values.yaml
@@ -1,0 +1,15 @@
+image:
+  repository: ghcr.io/print3/print3
+  tag: "latest"
+
+db:
+  url: "postgres://user:pass@db:5432/print3"
+
+stripe:
+  publishableKey: "pk_test"
+  secretKey: "sk_test"
+
+ai:
+  key: "ai-key"
+
+env: "production"

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,0 +1,17 @@
+# Deploying with Helm
+
+This project includes a Helm chart under `deploy/helm/print3`. Tagged releases (`v*.*.*`) package the chart and upload it as a release asset.
+
+Download the package from the release page and install it with:
+
+```bash
+helm install my-print3 print3-0.1.0.tgz \
+  --set image.tag=<version> \
+  --set db.url=<database-url> \
+  --set stripe.publishableKey=<key> \
+  --set stripe.secretKey=<key> \
+  --set ai.key=<key> \
+  --set env=production
+```
+
+Adjust the values to suit your environment.


### PR DESCRIPTION
## Summary
- add `print3` Helm chart
- package chart on `v*.*.*` tags via GitHub Actions
- document Helm installation steps

## Testing
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_686c5231bc14832db75369040a7a0ea1