### PR TITLE
test(chaos): add Gremlin scripts for resilience

### DIFF
--- a/docs/chaos.md
+++ b/docs/chaos.md
@@ -1,0 +1,38 @@
+# Chaos Experiments
+
+This repository includes optional chaos engineering scripts using the [Gremlin](https://www.gremlin.com/) free tier. These scripts are **not** executed in CI and are intended for manual runs only.
+
+## Prerequisites
+
+1. Create a Gremlin account and obtain your `GREMLIN_TEAM_ID` and `GREMLIN_API_KEY`.
+2. Install dependencies:
+   ```bash
+   npm install https
+   ```
+
+## Available Experiments
+
+### Kill Database Connection
+
+`experiments/chaos/kill-db.js` terminates the database connection for 60 seconds to verify retry logic.
+
+Run with:
+
+```bash
+GREMLIN_TEAM_ID=your-team GREMLIN_API_KEY=your-key node experiments/chaos/kill-db.js
+```
+
+### Inject High Latency
+
+`experiments/chaos/high-latency.js` adds 3000ms of network latency on backend hosts for 60 seconds.
+
+Run with:
+
+```bash
+GREMLIN_TEAM_ID=your-team GREMLIN_API_KEY=your-key node experiments/chaos/high-latency.js
+```
+
+## Notes
+
+- These experiments affect live infrastructure. Use them only in staging or controlled environments.
+- The scripts send HTTP requests to Gremlin's API; ensure your network allows outbound HTTPS traffic.

--- a/experiments/chaos/high-latency.js
+++ b/experiments/chaos/high-latency.js
@@ -1,0 +1,49 @@
+// Introduces network latency to test service resilience.
+// Run manually with GREMLIN_TEAM_ID and GREMLIN_API_KEY env vars.
+
+const https = require("https");
+
+const teamId = process.env.GREMLIN_TEAM_ID;
+const apiKey = process.env.GREMLIN_API_KEY;
+
+if (!teamId || !apiKey) {
+  console.error("GREMLIN_TEAM_ID and GREMLIN_API_KEY must be set");
+  process.exit(1);
+}
+
+const attack = {
+  target: {
+    type: "Random",
+    hosts: [{ tags: { role: "backend" } }],
+  },
+  command: {
+    type: "latency",
+    args: { length: "60s", latency: 3000 },
+  },
+};
+
+const data = JSON.stringify(attack);
+
+const options = {
+  hostname: "api.gremlin.com",
+  path: "/v1/attacks/new",
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    "Content-Length": Buffer.byteLength(data),
+    Authorization: `Key ${apiKey}`,
+    "Gremlin-Team-Id": teamId,
+  },
+};
+
+const req = https.request(options, (res) => {
+  console.log(`status: ${res.statusCode}`);
+  res.on("data", (d) => process.stdout.write(d));
+});
+
+req.on("error", (error) => {
+  console.error(error);
+});
+
+req.write(data);
+req.end();

--- a/experiments/chaos/kill-db.js
+++ b/experiments/chaos/kill-db.js
@@ -1,0 +1,50 @@
+// This script triggers a Gremlin attack that terminates the database connection.
+// It is intended for manual chaos testing only and should not run in CI.
+// Set GREMLIN_TEAM_ID and GREMLIN_API_KEY environment variables before running.
+
+const https = require("https");
+
+const teamId = process.env.GREMLIN_TEAM_ID;
+const apiKey = process.env.GREMLIN_API_KEY;
+
+if (!teamId || !apiKey) {
+  console.error("GREMLIN_TEAM_ID and GREMLIN_API_KEY must be set");
+  process.exit(1);
+}
+
+const attack = {
+  target: {
+    type: "Random",
+    hosts: [{ tags: { role: "database" } }],
+  },
+  command: {
+    type: "shutdown",
+    args: { length: "60s" },
+  },
+};
+
+const data = JSON.stringify(attack);
+
+const options = {
+  hostname: "api.gremlin.com",
+  path: `/v1/attacks/new`,
+  method: "POST",
+  headers: {
+    "Content-Type": "application/json",
+    "Content-Length": Buffer.byteLength(data),
+    Authorization: `Key ${apiKey}`,
+    "Gremlin-Team-Id": teamId,
+  },
+};
+
+const req = https.request(options, (res) => {
+  console.log(`status: ${res.statusCode}`);
+  res.on("data", (d) => process.stdout.write(d));
+});
+
+req.on("error", (error) => {
+  console.error(error);
+});
+
+req.write(data);
+req.end();


### PR DESCRIPTION
## Summary
- add Gremlin kill-db and high-latency scripts
- document manual chaos experiments

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_686c523edf90832d9da600e39514bf3e