### PR TITLE
infra(cost): add AWS Budget alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,10 @@ Use the Netlify CLI via `npx netlify-cli` or the
 [`netlify/actions/cli`](https://github.com/netlify/actions) action and then
 run `netlify deploy` as usual once the preflight passes.
 
+## Cost Alerts
+
+The Terraform configuration sets up a budget that emails you if monthly AWS spend exceeds $20. Set `COST_ALERT_EMAIL` before running `terraform apply` to receive these notifications.
+
 ## Troubleshooting
 
 ### dpkg was interrupted

--- a/infra/cost-alert.tf
+++ b/infra/cost-alert.tf
@@ -1,0 +1,25 @@
+variable "cost_alert_email" {
+  type        = string
+  default     = ""
+  description = "Email address for budget notifications"
+}
+
+resource "aws_budgets_budget" "monthly" {
+  name         = "monthly-budget"
+  budget_type  = "COST"
+  limit_amount = "20"
+  limit_unit   = "USD"
+  time_unit    = "MONTHLY"
+
+  notification {
+    comparison_operator = "GREATER_THAN"
+    threshold           = 100
+    threshold_type      = "PERCENTAGE"
+    notification_type   = "ACTUAL"
+
+    subscriber {
+      subscription_type = "EMAIL"
+      address           = var.cost_alert_email != "" ? var.cost_alert_email : env("COST_ALERT_EMAIL")
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add monthly cost alert budget in `infra/`
- document cost alert email setup in README

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_686c523b17c8832db1440a588ae57df6