### PR TITLE
Add jest a11y script and CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,4 +136,15 @@ jobs:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '0'
         run: npm run test:a11y
 
+  a11y:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm install --no-audit --no-fund
+      - run: npm run a11y
+
       # ← you can add additional steps here, like your tests

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "smoke": "NODE_NO_WARNINGS=1 SKIP_PW_DEPS=1 npm run setup && NODE_NO_WARNINGS=1 npx playwright test e2e/smoke.test.js",
     "visual-test": "percy exec -- npm run e2e",
     "test:a11y": "node scripts/assert-setup.js && bash scripts/install-playwright.sh chromium && playwright test e2e/a11y.test.js",
+    "a11y": "jest --runTestsByPath tests/a11y",
     "netlify:deploy": "scripts/netlify-preflight.sh && netlify deploy"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- add a new `a11y` npm script
- run `npm run a11y` in CI

## Testing
- `npm test --prefix backend`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_686c52459734832da378b36b4ff3c265