### PR TITLE
Add Lighthouse CI workflow

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,26 @@
+name: Lighthouse
+
+on:
+  deployment_status:
+    types: [success]
+
+jobs:
+  lighthouse:
+    if: ${{ github.event.deployment_status.environment == 'preview' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm install --no-audit --no-fund
+      - name: Run Lighthouse CI
+        env:
+          PREVIEW_URL: ${{ github.event.deployment_status.environment_url }}
+        run: npx lhci autorun --config=lighthouserc-preview.json
+      - name: Upload HTML report
+        uses: actions/upload-artifact@v4
+        with:
+          name: lighthouse-report
+          path: .lighthouseci/*report.html

--- a/lighthouserc-preview.json
+++ b/lighthouserc-preview.json
@@ -1,0 +1,17 @@
+{
+  "ci": {
+    "collect": {
+      "url": ["$PREVIEW_URL"],
+      "numberOfRuns": 1
+    },
+    "assert": {
+      "assertions": {
+        "categories:performance": ["error", { "minScore": 0.85 }],
+        "categories:accessibility": ["error", { "minScore": 0.9 }]
+      }
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- audit Cloudflare Pages preview with Lighthouse
- set perf & a11y score thresholds

## Testing
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_686c5247b148832db932e45ada56bcdc