### PR TITLE
Fix: fast sparse clone for Sparc3D-Space

### DIFF
--- a/scripts/sync-space.sh
+++ b/scripts/sync-space.sh
@@ -5,16 +5,21 @@ SPACE_DIR="Sparc3D-Space"
 SPACE_URL="https://huggingface.co/spaces/print2/Sparc3D"
 MODEL_URL="https://huggingface.co/print2/Sparc3D.git"
 
-# Clone the Space repository without heavy assets if it doesn't already exist
+# Ensure the workspace folder exists. If the repo hasn't been cloned yet, do a
+# lightweight clone that skips large LFS files.
 if [ ! -d "$SPACE_DIR" ]; then
-  git clone --depth 1 --filter=blob:none "$SPACE_URL" "$SPACE_DIR"
+  # Skip downloading large LFS blobs and only fetch minimal history.
+  GIT_LFS_SKIP_SMUDGE=1 git clone --depth 1 --filter=blob:none "$SPACE_URL" "$SPACE_DIR"
+  cd "$SPACE_DIR"
+  git sparse-checkout init --cone
+  # Limit checkout to application code and scripts needed by the Space
+  git sparse-checkout set src scripts app.py README.md
+else
+  cd "$SPACE_DIR"
 fi
 
-cd "$SPACE_DIR"
-
-# Only check out the code directories to avoid heavy assets
-git sparse-checkout init --cone
-git sparse-checkout set src scripts
+# Disable LFS smudge for future commands as well
+git lfs install --skip-smudge --local
 
 # Rename default remote to upstream
 if git remote | grep -q '^origin$'; then


### PR DESCRIPTION
## Summary
- avoid downloading large LFS files when cloning the Space repo
- checkout only the code and scripts we need
- disable LFS smudge filters

## Testing
- `npm run format` in `backend`
- `npm test --silent` in `backend`
- `npm run ci` *(fails: requires credentials for huggingface clone)*
- `npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_686d26602a14832d91dab7288be6e092