### PR TITLE
fix: suppress dotenv logs

### DIFF
--- a/backend/tests/setupGlobals.js
+++ b/backend/tests/setupGlobals.js
@@ -2,6 +2,11 @@
 // Disable Jest global object deletion warnings by turning off the deletion mode
 global[Symbol.for("$$jest-deletion-mode")] = "off";
 
+const dotenv = require("dotenv");
+const originalDotenvConfig = dotenv.config;
+dotenv.config = (options = {}) =>
+  originalDotenvConfig({ quiet: true, ...options });
+
 const originalEmitWarning = process.emitWarning;
 process.emitWarning = (warning, ...args) => {
   const msg = typeof warning === "string" ? warning : warning?.message;


### PR DESCRIPTION
## Summary
- avoid noisy dotenv output during tests by wrapping `dotenv.config`

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_686d25367224832d9399b2af11be17b8