### PR TITLE
docs: add Codex sync step to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # MVP Website
 
+## 🤖 Codex Integration
+
+Before you run any Codex-driven prompts, always sync your code and Hugging Face Space:
+```bash
+bash scripts/sync_space.sh
+```
+
+This ensures Codex sees the latest local changes and model artifacts.
+
 This repository contains the early MVP code for print2's website and backend.
 
 - Frontend HTML pages are in the repository root.


### PR DESCRIPTION
## Summary
- include a Codex integration snippet in README so everyone runs `bash scripts/sync_space.sh`

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_686d8fd36dd8832d85b920a09ed7cdd8