### PR TITLE
feat: Sparc3D TS client + tests

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,12 @@
+# Backend Library
+
+## Sparc3D Client
+
+Example usage:
+
+```ts
+import { generateGlb } from "./src/lib/sparc3dClient";
+
+const glb = await generateGlb({ prompt: "a red cube" });
+// const glb = await generateGlb({ prompt: 'a red cube', imageURL: 'https://...' });
+```

--- a/backend/src/lib/sparc3dClient.js
+++ b/backend/src/lib/sparc3dClient.js
@@ -1,0 +1,51 @@
+"use strict";
+var __importDefault =
+  (this && this.__importDefault) ||
+  function (mod) {
+    return mod && mod.__esModule ? mod : { default: mod };
+  };
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.generateGlb = generateGlb;
+const axios_1 = __importDefault(require("axios"));
+/**
+ * Generate a GLB model using the Sparc3D API.
+ *
+ * @param options - generation parameters
+ * @param options.prompt - text prompt
+ * @param options.imageURL - optional image URL
+ * @returns raw .glb bytes as a Buffer
+ */
+async function generateGlb({ prompt, imageURL }) {
+  const endpoint = process.env.SPARC3D_ENDPOINT;
+  const token = process.env.SPARC3D_TOKEN;
+  if (!endpoint) {
+    throw new Error("SPARC3D_ENDPOINT is not set");
+  }
+  if (!token) {
+    throw new Error("SPARC3D_TOKEN is not set");
+  }
+  try {
+    const res = await axios_1.default.post(
+      endpoint,
+      { prompt, ...(imageURL ? { imageURL } : {}) },
+      {
+        headers: { Authorization: `Bearer ${token}` },
+        responseType: "arraybuffer",
+        validateStatus: () => true,
+      },
+    );
+    if (res.status >= 400) {
+      let errMsg = `SPARC3D request failed with status ${res.status}`;
+      try {
+        const json = JSON.parse(Buffer.from(res.data).toString("utf8"));
+        if (json && json.error) errMsg = json.error;
+      } catch {
+        // ignore parse errors
+      }
+      throw new Error(errMsg);
+    }
+    return Buffer.from(res.data);
+  } catch (err) {
+    throw new Error(`SPARC3D request failed: ${err.message}`);
+  }
+}

--- a/backend/src/lib/sparc3dClient.ts
+++ b/backend/src/lib/sparc3dClient.ts
@@ -1,0 +1,52 @@
+import axios from 'axios';
+
+export interface GenerateGlbParams {
+  prompt: string;
+  imageURL?: string;
+}
+
+/**
+ * Generate a GLB model using the Sparc3D API.
+ *
+ * @param options - generation parameters
+ * @param options.prompt - text prompt
+ * @param options.imageURL - optional image URL
+ * @returns raw .glb bytes as a Buffer
+ */
+export async function generateGlb({ prompt, imageURL }: GenerateGlbParams): Promise<Buffer> {
+  const endpoint = process.env.SPARC3D_ENDPOINT;
+  const token = process.env.SPARC3D_TOKEN;
+  if (!endpoint) {
+    throw new Error('SPARC3D_ENDPOINT is not set');
+  }
+  if (!token) {
+    throw new Error('SPARC3D_TOKEN is not set');
+  }
+
+  try {
+    const res = await axios.post(
+      endpoint,
+      { prompt, ...(imageURL ? { imageURL } : {}) },
+      {
+        headers: { Authorization: `Bearer ${token}` },
+        responseType: 'arraybuffer',
+        validateStatus: () => true,
+      },
+    );
+
+    if (res.status >= 400) {
+      let errMsg = `SPARC3D request failed with status ${res.status}`;
+      try {
+        const json = JSON.parse(Buffer.from(res.data).toString('utf8'));
+        if (json && json.error) errMsg = json.error;
+      } catch {
+        // ignore parse errors
+      }
+      throw new Error(errMsg);
+    }
+
+    return Buffer.from(res.data);
+  } catch (err: any) {
+    throw new Error(`SPARC3D request failed: ${err.message}`);
+  }
+}

--- a/backend/tests/sparc3dClient.test.js
+++ b/backend/tests/sparc3dClient.test.js
@@ -1,0 +1,53 @@
+"use strict";
+var __importDefault =
+  (this && this.__importDefault) ||
+  function (mod) {
+    return mod && mod.__esModule ? mod : { default: mod };
+  };
+Object.defineProperty(exports, "__esModule", { value: true });
+const nock_1 = __importDefault(require("nock"));
+const sparc3dClient_1 = require("../src/lib/sparc3dClient");
+describe("generateGlb", () => {
+  const endpoint = "https://api.example.com/generate";
+  const token = "t0k";
+  beforeEach(() => {
+    process.env.SPARC3D_ENDPOINT = endpoint;
+    process.env.SPARC3D_TOKEN = token;
+    delete process.env.http_proxy;
+    delete process.env.https_proxy;
+    delete process.env.HTTP_PROXY;
+    delete process.env.HTTPS_PROXY;
+  });
+  afterEach(() => {
+    nock_1.default.cleanAll();
+  });
+  test("sends prompt and returns buffer", async () => {
+    const data = Buffer.from("glbdata");
+    (0, nock_1.default)("https://api.example.com")
+      .post("/generate", { prompt: "hello" })
+      .matchHeader("Authorization", `Bearer ${token}`)
+      .reply(200, data, { "Content-Type": "model/gltf-binary" });
+    const buf = await (0, sparc3dClient_1.generateGlb)({ prompt: "hello" });
+    expect(buf).toEqual(data);
+  });
+  test("sends prompt and imageURL", async () => {
+    const data = Buffer.from("xyz");
+    (0, nock_1.default)("https://api.example.com")
+      .post("/generate", { prompt: "p", imageURL: "http://img" })
+      .matchHeader("Authorization", `Bearer ${token}`)
+      .reply(200, data, { "Content-Type": "model/gltf-binary" });
+    const buf = await (0, sparc3dClient_1.generateGlb)({
+      prompt: "p",
+      imageURL: "http://img",
+    });
+    expect(buf).toEqual(data);
+  });
+  test("throws on http error", async () => {
+    (0, nock_1.default)("https://api.example.com")
+      .post("/generate")
+      .reply(400, { error: "bad" });
+    await expect(
+      (0, sparc3dClient_1.generateGlb)({ prompt: "x" }),
+    ).rejects.toThrow("bad");
+  });
+});

--- a/backend/tests/sparc3dClient.test.ts
+++ b/backend/tests/sparc3dClient.test.ts
@@ -1,0 +1,50 @@
+import nock from 'nock';
+import { generateGlb } from '../src/lib/sparc3dClient';
+
+describe('generateGlb', () => {
+  const endpoint = 'https://api.example.com/generate';
+  const token = 't0k';
+
+  beforeEach(() => {
+    process.env.SPARC3D_ENDPOINT = endpoint;
+    process.env.SPARC3D_TOKEN = token;
+    delete process.env.http_proxy;
+    delete process.env.https_proxy;
+    delete process.env.HTTP_PROXY;
+    delete process.env.HTTPS_PROXY;
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  test('sends prompt and returns buffer', async () => {
+    const data = Buffer.from('glbdata');
+    nock('https://api.example.com')
+      .post('/generate', { prompt: 'hello' })
+      .matchHeader('Authorization', `Bearer ${token}`)
+      .reply(200, data, { 'Content-Type': 'model/gltf-binary' });
+
+    const buf = await generateGlb({ prompt: 'hello' });
+    expect(buf).toEqual(data);
+  });
+
+  test('sends prompt and imageURL', async () => {
+    const data = Buffer.from('xyz');
+    nock('https://api.example.com')
+      .post('/generate', { prompt: 'p', imageURL: 'http://img' })
+      .matchHeader('Authorization', `Bearer ${token}`)
+      .reply(200, data, { 'Content-Type': 'model/gltf-binary' });
+
+    const buf = await generateGlb({ prompt: 'p', imageURL: 'http://img' });
+    expect(buf).toEqual(data);
+  });
+
+  test('throws on http error', async () => {
+    nock('https://api.example.com')
+      .post('/generate')
+      .reply(400, { error: 'bad' });
+
+    await expect(generateGlb({ prompt: 'x' })).rejects.toThrow('bad');
+  });
+});


### PR DESCRIPTION
## Summary
- add Sparc3D client in TypeScript
- provide Jest tests using nock
- document usage in backend README

## Validation
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_686d950364e0832d8b7a54a863a5efc1