### PR TITLE
feat: Sparc3D TS client + tests

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,18 @@
+# Backend
+
+## Sparc3D Client
+
+The `generateGlb` function wraps the Sparc3D inference endpoint.
+
+```ts
+import { generateGlb } from './src/lib/sparc3dClient';
+
+const buffer = await generateGlb({ prompt: 'low poly tree' });
+// with image guidance
+const withImg = await generateGlb({
+  prompt: 'wooden chair',
+  imageURL: 'https://example.com/chair.jpg'
+});
+```
+
+The returned `Buffer` contains the generated `.glb` data.

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -7,7 +7,9 @@ module.exports = {
   testEnvironment: "node",
   testMatch: [
     "<rootDir>/tests/**/*.test.js",
+    "<rootDir>/tests/**/*.test.ts",
     "<rootDir>/src/**/__tests__/**/*.test.js",
+    "<rootDir>/src/**/__tests__/**/*.test.ts",
   ],
   testTimeout: 10000,
   coverageDirectory: "coverage",
@@ -23,6 +25,7 @@ module.exports = {
     "<rootDir>/backend/shipping.js",
     "<rootDir>/backend/social.js",
     "<rootDir>/backend/utils/validateStl.js",
+    "<rootDir>/src/lib/sparc3dClient.ts",
   ],
   coverageThreshold: {
     global: {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -50,6 +50,7 @@
         "jest-retries": "^1.0.1",
         "jsdom": "^26.1.0",
         "lighthouse": "^12.7.1",
+        "nock": "^13.5.6",
         "openapi-to-postmanv2": "^3.0.0",
         "pg-mem": "^3.0.5",
         "prettier": "^3.6.2",
@@ -9897,6 +9898,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -10709,6 +10717,21 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/nock": {
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.6.tgz",
+      "integrity": "sha512-o2zOYiCpzRqSzPj0Zt/dQ/DqZeYoaQ7TUonc/xUPjCGl9WeHpNbxgVvOquXYAaJzI0M9BXV3HTzG0p8IUAbBTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13"
       }
     },
     "node_modules/node-fetch-h2": {
@@ -11790,6 +11813,16 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/proxy-addr": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -80,6 +80,7 @@
     "jest-localstorage-mock": "^2.4.26",
     "jest-retries": "^1.0.1",
     "jsdom": "^26.1.0",
+    "nock": "^13.5.6",
     "lighthouse": "^12.7.1",
     "pg-mem": "^3.0.5",
     "prettier": "^3.6.2",

--- a/backend/src/lib/sparc3dClient.js
+++ b/backend/src/lib/sparc3dClient.js
@@ -1,0 +1,33 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.generateGlb = generateGlb;
+const axios_1 = require("axios");
+/**
+ * Generate a GLB model from a text prompt and optional image URL using
+ * the Sparc3D API.
+ *
+ * @param options prompt text and optional image URL
+ * @returns model data as a Buffer
+ */
+async function generateGlb({ prompt, imageURL }) {
+    const endpoint = process.env.SPARC3D_ENDPOINT;
+    const token = process.env.SPARC3D_TOKEN;
+    if (!endpoint)
+        throw new Error("Missing SPARC3D_ENDPOINT environment variable");
+    if (!token)
+        throw new Error("Missing SPARC3D_TOKEN environment variable");
+    const payload = { prompt };
+    if (imageURL)
+        payload.image_url = imageURL;
+    const res = await axios_1.default.post(endpoint, payload, {
+        headers: { Authorization: `Bearer ${token}` },
+        responseType: "arraybuffer",
+        validateStatus: () => true,
+    });
+    if (res.status >= 400) {
+        const msg = (typeof res.data === "object" && res.data && res.data.error) ||
+            (typeof res.data === "string" ? res.data : `status ${res.status}`);
+        throw new Error(`SPARC3D request failed (${msg})`);
+    }
+    return Buffer.from(res.data);
+}

--- a/backend/src/lib/sparc3dClient.ts
+++ b/backend/src/lib/sparc3dClient.ts
@@ -1,0 +1,38 @@
+import axios from "axios";
+
+export interface GenerateGlbOptions {
+  prompt: string;
+  imageURL?: string;
+}
+
+/**
+ * Generate a GLB model from a text prompt and optional image URL using
+ * the Sparc3D API.
+ *
+ * @param options prompt text and optional image URL
+ * @returns model data as a Buffer
+ */
+export async function generateGlb({ prompt, imageURL }: GenerateGlbOptions): Promise<Buffer> {
+  const endpoint = process.env.SPARC3D_ENDPOINT;
+  const token = process.env.SPARC3D_TOKEN;
+  if (!endpoint) throw new Error("Missing SPARC3D_ENDPOINT environment variable");
+  if (!token) throw new Error("Missing SPARC3D_TOKEN environment variable");
+
+  const payload: Record<string, string> = { prompt };
+  if (imageURL) payload.image_url = imageURL;
+
+  const res = await axios.post(endpoint, payload, {
+    headers: { Authorization: `Bearer ${token}` },
+    responseType: "arraybuffer",
+    validateStatus: () => true,
+  });
+
+  if (res.status >= 400) {
+    const msg =
+      (typeof res.data === "object" && res.data && (res.data as any).error) ||
+      (typeof res.data === "string" ? res.data : `status ${res.status}`);
+    throw new Error(`SPARC3D request failed (${msg})`);
+  }
+
+  return Buffer.from(res.data);
+}

--- a/backend/tests/sparc3dClient.test.ts
+++ b/backend/tests/sparc3dClient.test.ts
@@ -1,0 +1,45 @@
+const nock = require('nock');
+const { generateGlb } = require('../src/lib/sparc3dClient.js');
+
+const endpoint = 'http://sparc.test';
+const path = '/';
+const token = 'secret';
+
+describe('generateGlb', () => {
+  beforeEach(() => {
+    process.env.http_proxy = '';
+    process.env.HTTP_PROXY = '';
+    process.env.https_proxy = '';
+    process.env.HTTPS_PROXY = '';
+    process.env.SPARC3D_ENDPOINT = endpoint + path;
+    process.env.SPARC3D_TOKEN = token;
+  });
+
+  afterEach(() => {
+    delete process.env.SPARC3D_ENDPOINT;
+    delete process.env.SPARC3D_TOKEN;
+    nock.cleanAll();
+  });
+
+  test('sends prompt and image and returns buffer', async () => {
+    const reply = Buffer.from('data');
+    const scope = nock(endpoint)
+      .post(path, { prompt: 'tree', image_url: 'img' })
+      .matchHeader('authorization', `Bearer ${token}`)
+      .reply(200, reply, { 'Content-Type': 'model/gltf-binary' });
+
+    const buf = await generateGlb({ prompt: 'tree', imageURL: 'img' });
+    expect(buf.equals(reply)).toBe(true);
+    scope.done();
+  });
+
+  test('throws on http error', async () => {
+    const scope = nock(endpoint)
+      .post(path, { prompt: 'bad' })
+      .matchHeader('authorization', `Bearer ${token}`)
+      .reply(400, { error: 'invalid prompt' });
+
+    await expect(generateGlb({ prompt: 'bad' })).rejects.toThrow(/status 400/);
+    scope.done();
+  });
+});


### PR DESCRIPTION
## Summary
- add Sparc3D client in TypeScript
- cover client with jest using nock
- document usage in backend README

## Testing
- `npm run format --prefix backend`
- `npm test --silent --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_686d950364e0832d8b7a54a863a5efc1