### PR TITLE
fix dev server reliability

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -50,6 +50,7 @@
         "jest-retries": "^1.0.1",
         "jsdom": "^26.1.0",
         "lighthouse": "^12.7.1",
+        "nock": "^13.3.3",
         "openapi-to-postmanv2": "^3.0.0",
         "pg-mem": "^3.0.5",
         "prettier": "^3.6.2",
@@ -9897,6 +9898,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -10709,6 +10717,21 @@
       "dev": true,
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/nock": {
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.6.tgz",
+      "integrity": "sha512-o2zOYiCpzRqSzPj0Zt/dQ/DqZeYoaQ7TUonc/xUPjCGl9WeHpNbxgVvOquXYAaJzI0M9BXV3HTzG0p8IUAbBTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13"
       }
     },
     "node_modules/node-fetch-h2": {
@@ -11790,6 +11813,16 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/proxy-addr": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -86,7 +86,8 @@
     "supertest": "^7.1.2",
     "tslib": "^2.8.1",
     "openapi-to-postmanv2": "^3.0.0",
-    "yaml": "^2.3.4"
+    "yaml": "^2.3.4",
+    "nock": "^13.3.3"
   },
   "engines": {
     "node": ">=18"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -24,6 +24,11 @@ if ! npm ping >/dev/null 2>&1; then
   exit 1
 fi
 
+# Kill any lingering dev server processes to avoid port conflicts
+if pgrep -f "node scripts/dev-server.js" >/dev/null 2>&1; then
+  pkill -f "node scripts/dev-server.js" || true
+fi
+
 # Remove any existing node_modules directories to avoid ENOTEMPTY errors
 sudo rm -rf node_modules backend/node_modules
 if [ -d backend/hunyuan_server/node_modules ]; then


### PR DESCRIPTION
## Summary
- terminate lingering dev server processes in setup script
- add missing `nock` dev dependency for backend tests

## Testing
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_686d9d66d898832da7c70995560d6406