### PR TITLE
Add text-to-image utility

### DIFF
--- a/backend/src/lib/textToImage.js
+++ b/backend/src/lib/textToImage.js
@@ -1,0 +1,49 @@
+"use strict";
+var __importDefault =
+  (this && this.__importDefault) ||
+  function (mod) {
+    return mod && mod.__esModule ? mod : { default: mod };
+  };
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.textToImage = textToImage;
+const axios_1 = __importDefault(require("axios"));
+const fs_1 = __importDefault(require("fs"));
+const promises_1 = require("stream/promises");
+const path_1 = __importDefault(require("path"));
+const uploadS3_1 = require("./uploadS3");
+/**
+ * Generate an image from text using Stability AI and upload to S3.
+ * @param {string} prompt text prompt
+ * @returns {Promise<string>} Public URL of generated PNG
+ */
+async function textToImage(prompt) {
+  const key = process.env.STABILITY_KEY;
+  if (!key) throw new Error("STABILITY_KEY is not set");
+  const endpoint = "https://api.stability.ai/v2beta/stable-image/generate/core";
+  const res = await axios_1.default.post(
+    endpoint,
+    { text_prompts: [{ text: prompt }], output_format: "png" },
+    {
+      headers: { Authorization: `Bearer ${key}` },
+      responseType: "stream",
+      validateStatus: () => true,
+    },
+  );
+  if (res.status >= 400) {
+    const msg = res.data?.error || `request failed with status ${res.status}`;
+    throw new Error(msg);
+  }
+  const tmpPath = path_1.default.join(
+    "/tmp",
+    `${Date.now()}-${Math.random().toString(36).slice(2)}.png`,
+  );
+  await (0, promises_1.pipeline)(
+    res.data,
+    fs_1.default.createWriteStream(tmpPath),
+  );
+  try {
+    return await (0, uploadS3_1.uploadFile)(tmpPath, "image/png");
+  } finally {
+    fs_1.default.unlink(tmpPath, () => {});
+  }
+}

--- a/backend/src/lib/textToImage.ts
+++ b/backend/src/lib/textToImage.ts
@@ -1,0 +1,35 @@
+import axios from 'axios';
+import fs from 'fs';
+import { pipeline } from 'stream/promises';
+import path from 'path';
+import { uploadFile } from './uploadS3';
+
+/**
+ * Generate an image from text using Stability AI and upload to S3.
+ * @param {string} prompt text prompt
+ * @returns {Promise<string>} Public URL of generated PNG
+ */
+export async function textToImage(prompt: string): Promise<string> {
+  const key = process.env.STABILITY_KEY;
+  if (!key) throw new Error('STABILITY_KEY is not set');
+  const endpoint = 'https://api.stability.ai/v2beta/stable-image/generate/core';
+
+  const res = await axios.post(
+    endpoint,
+    { text_prompts: [{ text: prompt }], output_format: 'png' },
+    { headers: { Authorization: `Bearer ${key}` }, responseType: 'stream', validateStatus: () => true },
+  );
+
+  if (res.status >= 400) {
+    const msg = res.data?.error || `request failed with status ${res.status}`;
+    throw new Error(msg);
+  }
+
+  const tmpPath = path.join('/tmp', `${Date.now()}-${Math.random().toString(36).slice(2)}.png`);
+  await pipeline(res.data, fs.createWriteStream(tmpPath));
+  try {
+    return await uploadFile(tmpPath, 'image/png');
+  } finally {
+    fs.unlink(tmpPath, () => {});
+  }
+}

--- a/backend/src/lib/uploadS3.js
+++ b/backend/src/lib/uploadS3.js
@@ -1,0 +1,37 @@
+"use strict";
+var __importDefault =
+  (this && this.__importDefault) ||
+  function (mod) {
+    return mod && mod.__esModule ? mod : { default: mod };
+  };
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.uploadFile = uploadFile;
+const fs_1 = __importDefault(require("fs"));
+const client_s3_1 = require("@aws-sdk/client-s3");
+const path_1 = __importDefault(require("path"));
+/**
+ * Upload a file to S3 and return its public CloudFront URL
+ * @param {string} filePath local path of file to upload
+ * @param {string} contentType MIME type for the object
+ * @returns {Promise<string>} public URL of uploaded file
+ */
+async function uploadFile(filePath, contentType) {
+  const region = process.env.AWS_REGION;
+  const bucket = process.env.S3_BUCKET;
+  const domain =
+    process.env.CLOUDFRONT_DOMAIN || process.env.CLOUDFRONT_MODEL_DOMAIN;
+  if (!region) throw new Error("AWS_REGION is not set");
+  if (!bucket) throw new Error("S3_BUCKET is not set");
+  if (!domain) throw new Error("CLOUDFRONT_DOMAIN is not set");
+  const client = new client_s3_1.S3Client({ region });
+  const key = `images/${Date.now()}-${path_1.default.basename(filePath)}`;
+  await client.send(
+    new client_s3_1.PutObjectCommand({
+      Bucket: bucket,
+      Key: key,
+      Body: fs_1.default.createReadStream(filePath),
+      ContentType: contentType,
+    }),
+  );
+  return `https://${domain}/${key}`;
+}

--- a/backend/src/lib/uploadS3.ts
+++ b/backend/src/lib/uploadS3.ts
@@ -1,0 +1,24 @@
+import fs from 'fs';
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import path from 'path';
+
+/**
+ * Upload a file to S3 and return its public CloudFront URL
+ * @param {string} filePath local path of file to upload
+ * @param {string} contentType MIME type for the object
+ * @returns {Promise<string>} public URL of uploaded file
+ */
+export async function uploadFile(filePath: string, contentType: string): Promise<string> {
+  const region = process.env.AWS_REGION;
+  const bucket = process.env.S3_BUCKET;
+  const domain = process.env.CLOUDFRONT_DOMAIN || process.env.CLOUDFRONT_MODEL_DOMAIN;
+  if (!region) throw new Error('AWS_REGION is not set');
+  if (!bucket) throw new Error('S3_BUCKET is not set');
+  if (!domain) throw new Error('CLOUDFRONT_DOMAIN is not set');
+  const client = new S3Client({ region });
+  const key = `images/${Date.now()}-${path.basename(filePath)}`;
+  await client.send(
+    new PutObjectCommand({ Bucket: bucket, Key: key, Body: fs.createReadStream(filePath), ContentType: contentType }),
+  );
+  return `https://${domain}/${key}`;
+}

--- a/backend/tests/textToImage.test.js
+++ b/backend/tests/textToImage.test.js
@@ -1,0 +1,98 @@
+"use strict";
+var __createBinding =
+  (this && this.__createBinding) ||
+  (Object.create
+    ? function (o, m, k, k2) {
+        if (k2 === undefined) k2 = k;
+        var desc = Object.getOwnPropertyDescriptor(m, k);
+        if (
+          !desc ||
+          ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)
+        ) {
+          desc = {
+            enumerable: true,
+            get: function () {
+              return m[k];
+            },
+          };
+        }
+        Object.defineProperty(o, k2, desc);
+      }
+    : function (o, m, k, k2) {
+        if (k2 === undefined) k2 = k;
+        o[k2] = m[k];
+      });
+var __setModuleDefault =
+  (this && this.__setModuleDefault) ||
+  (Object.create
+    ? function (o, v) {
+        Object.defineProperty(o, "default", { enumerable: true, value: v });
+      }
+    : function (o, v) {
+        o["default"] = v;
+      });
+var __importStar =
+  (this && this.__importStar) ||
+  (function () {
+    var ownKeys = function (o) {
+      ownKeys =
+        Object.getOwnPropertyNames ||
+        function (o) {
+          var ar = [];
+          for (var k in o)
+            if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+          return ar;
+        };
+      return ownKeys(o);
+    };
+    return function (mod) {
+      if (mod && mod.__esModule) return mod;
+      var result = {};
+      if (mod != null)
+        for (var k = ownKeys(mod), i = 0; i < k.length; i++)
+          if (k[i] !== "default") __createBinding(result, mod, k[i]);
+      __setModuleDefault(result, mod);
+      return result;
+    };
+  })();
+var __importDefault =
+  (this && this.__importDefault) ||
+  function (mod) {
+    return mod && mod.__esModule ? mod : { default: mod };
+  };
+Object.defineProperty(exports, "__esModule", { value: true });
+const nock_1 = __importDefault(require("nock"));
+const textToImage_1 = require("../src/lib/textToImage");
+const s3 = __importStar(require("../src/lib/uploadS3"));
+describe("textToImage", () => {
+  const endpoint = "https://api.stability.ai";
+  const token = "abc";
+  beforeEach(() => {
+    process.env.STABILITY_KEY = token;
+    process.env.AWS_REGION = "us-east-1";
+    process.env.S3_BUCKET = "bucket";
+    process.env.CLOUDFRONT_DOMAIN = "cdn.test";
+    delete process.env.http_proxy;
+    delete process.env.https_proxy;
+    delete process.env.HTTP_PROXY;
+    delete process.env.HTTPS_PROXY;
+    nock_1.default.disableNetConnect();
+    jest
+      .spyOn(s3, "uploadFile")
+      .mockResolvedValue("https://cdn.test/image.png");
+  });
+  afterEach(() => {
+    nock_1.default.cleanAll();
+    nock_1.default.enableNetConnect();
+    jest.restoreAllMocks();
+  });
+  test("uploads generated image and returns url", async () => {
+    const png = Buffer.from("png");
+    (0, nock_1.default)(endpoint)
+      .post("/v2beta/stable-image/generate/core")
+      .reply(200, png, { "Content-Type": "image/png" });
+    const url = await (0, textToImage_1.textToImage)("hello");
+    expect(url).toBe("https://cdn.test/image.png");
+    expect(s3.uploadFile).toHaveBeenCalledWith(expect.any(String), "image/png");
+  });
+});

--- a/backend/tests/textToImage.test.ts
+++ b/backend/tests/textToImage.test.ts
@@ -1,0 +1,37 @@
+import nock from 'nock';
+import { textToImage } from '../src/lib/textToImage';
+import * as s3 from '../src/lib/uploadS3';
+
+describe('textToImage', () => {
+  const endpoint = 'https://api.stability.ai';
+  const token = 'abc';
+
+  beforeEach(() => {
+    process.env.STABILITY_KEY = token;
+    process.env.AWS_REGION = 'us-east-1';
+    process.env.S3_BUCKET = 'bucket';
+    process.env.CLOUDFRONT_DOMAIN = 'cdn.test';
+    delete process.env.http_proxy;
+    delete process.env.https_proxy;
+    delete process.env.HTTP_PROXY;
+    delete process.env.HTTPS_PROXY;
+    nock.disableNetConnect();
+    jest.spyOn(s3, 'uploadFile').mockResolvedValue('https://cdn.test/image.png');
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+    nock.enableNetConnect();
+    jest.restoreAllMocks();
+  });
+
+  test('uploads generated image and returns url', async () => {
+    const png = Buffer.from('png');
+    nock(endpoint)
+      .post('/v2beta/stable-image/generate/core')
+      .reply(200, png, { 'Content-Type': 'image/png' });
+    const url = await textToImage('hello');
+    expect(url).toBe('https://cdn.test/image.png');
+    expect(s3.uploadFile).toHaveBeenCalledWith(expect.any(String), 'image/png');
+  });
+});


### PR DESCRIPTION
## Summary
- implement `textToImage` for Stability AI text-to-image generation
- upload resulting image to S3 via new helper
- test `textToImage` with nock and mocked S3

## Testing
- `npm test --prefix backend`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_686d9dc7e1ec832d833399f08347c80f