### PR TITLE
feat: unified model-generation pipeline

### DIFF
--- a/backend/src/lib/storeGlb.ts
+++ b/backend/src/lib/storeGlb.ts
@@ -1,0 +1,21 @@
+import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+
+/**
+ * Upload GLB data to S3 and return its public CloudFront URL
+ * @param data Buffer containing .glb bytes
+ * @returns {Promise<string>} public URL of uploaded model
+ */
+export async function storeGlb(data: Buffer): Promise<string> {
+  const region = process.env.AWS_REGION;
+  const bucket = process.env.S3_BUCKET;
+  const domain = process.env.CLOUDFRONT_DOMAIN || process.env.CLOUDFRONT_MODEL_DOMAIN;
+  if (!region) throw new Error('AWS_REGION is not set');
+  if (!bucket) throw new Error('S3_BUCKET is not set');
+  if (!domain) throw new Error('CLOUDFRONT_DOMAIN is not set');
+  const client = new S3Client({ region });
+  const key = `models/${Date.now()}-${Math.random().toString(36).slice(2)}.glb`;
+  await client.send(
+    new PutObjectCommand({ Bucket: bucket, Key: key, Body: data, ContentType: 'model/gltf-binary' }),
+  );
+  return `https://${domain}/${key}`;
+}

--- a/backend/src/pipeline/generateModel.ts
+++ b/backend/src/pipeline/generateModel.ts
@@ -1,0 +1,23 @@
+import { textToImage } from '../lib/textToImage';
+import { generateGlb } from '../lib/sparc3dClient';
+import { storeGlb } from '../lib/storeGlb';
+
+export interface GenerateModelParams {
+  prompt: string;
+  imageURL?: string;
+}
+
+/**
+ * Generate a model from a prompt and optional image and upload to S3.
+ * Returns the public URL of the stored .glb file.
+ */
+export async function generateModel({ prompt, imageURL }: GenerateModelParams): Promise<string> {
+  console.time('pipeline');
+  if (!imageURL) {
+    imageURL = await textToImage(prompt);
+  }
+  const glbData = await generateGlb({ prompt, imageURL });
+  const url = await storeGlb(glbData);
+  console.timeEnd('pipeline');
+  return url;
+}

--- a/backend/tests/generateModel.test.ts
+++ b/backend/tests/generateModel.test.ts
@@ -1,0 +1,34 @@
+import { generateModel } from '../src/pipeline/generateModel';
+import * as text from '../src/lib/textToImage';
+import * as sparc from '../src/lib/sparc3dClient';
+import * as s3 from '../src/lib/storeGlb';
+
+describe('generateModel', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'time').mockImplementation(() => {});
+    jest.spyOn(console, 'timeEnd').mockImplementation(() => {});
+    jest.spyOn(text, 'textToImage').mockResolvedValue('https://img');
+    jest.spyOn(sparc, 'generateGlb').mockResolvedValue(Buffer.from('glb'));
+    jest.spyOn(s3, 'storeGlb').mockResolvedValue('https://cdn/model.glb');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('generates image when missing and stores model', async () => {
+    const url = await generateModel({ prompt: 'p' });
+    expect(text.textToImage).toHaveBeenCalledWith('p');
+    expect(sparc.generateGlb).toHaveBeenCalledWith({ prompt: 'p', imageURL: 'https://img' });
+    expect(s3.storeGlb).toHaveBeenCalledWith(expect.any(Buffer));
+    expect(url).toBe('https://cdn/model.glb');
+  });
+
+  test('uses provided imageURL', async () => {
+    const url = await generateModel({ prompt: 'p', imageURL: 'http://img' });
+    expect(text.textToImage).not.toHaveBeenCalled();
+    expect(sparc.generateGlb).toHaveBeenCalledWith({ prompt: 'p', imageURL: 'http://img' });
+    expect(s3.storeGlb).toHaveBeenCalledWith(expect.any(Buffer));
+    expect(url).toBe('https://cdn/model.glb');
+  });
+});


### PR DESCRIPTION
## Summary
- add `storeGlb` utility for uploading model buffers to S3
- implement `generateModel` pipeline combining text-to-image and GLB generation
- include pipeline timing metrics
- test both pipeline paths

## Testing
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_686da5c5cf90832d9b74c54d1ed901bd