### PR TITLE
fix: correct sync-space script path

### DIFF
--- a/.github/workflows/sync-space.yml
+++ b/.github/workflows/sync-space.yml
@@ -21,4 +21,4 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_API_KEY: ${{ secrets.HF_TOKEN }}
-        run: bash scripts/sync_space.sh
+        run: bash scripts/sync-space.sh

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Before you run any Codex-driven prompts, always sync your code and Hugging Face Space:
 ```bash
-bash scripts/sync_space.sh
+bash scripts/sync-space.sh
 ```
 
 This ensures Codex sees the latest local changes and model artifacts.


### PR DESCRIPTION
## Summary
- update the HF Space sync workflow to use the right script name
- fix Codex integration instructions to match the workflow

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_686da8c61390832d9e790ab5534b0434