### PR TITLE
Update troubleshooting guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ These guidelines apply to all automated agents (e.g. the Codex agent) working on
    script downloads packages and browsers from these domains. If they are
    blocked, adjust your environment or proxy settings.
 
-3. **Install dependencies** – run `npm run setup` at the repository root **before your first `npm run ci`**. Run it again whenever the container is restarted or if Playwright tests fail with "Test was interrupted". This script unsets proxy variables, checks registry connectivity, runs `npm ci` in the root, `backend/`, and `backend/hunyuan_server/` if present, and installs Playwright browsers.
+3. **Install dependencies** – run `npm run setup` at the repository root **before your first `npm run ci`**. Run it again whenever the container is restarted or if Playwright tests fail with messages like "Test was interrupted" or "page.evaluate: Test ended". This script unsets proxy variables, checks registry connectivity, runs `npm ci` in the root, `backend/`, and `backend/hunyuan_server/` if present, and installs Playwright browsers.
    - Set `SKIP_PW_DEPS=1` before running the setup script if Playwright dependencies are already installed. This skips the long `apt-get` step and reduces CI time. The `smoke` script automatically exports this variable.
 4. **Format code** – run `npm run format` in `backend/` to apply Prettier formatting.
 5. **Run tests** – execute `npm test` in `backend/`. If tests cannot run because of environment limitations, mention this in the PR.
@@ -28,7 +28,7 @@ These guidelines apply to all automated agents (e.g. the Codex agent) working on
 
 ## Troubleshooting
 
-If `npm run ci` outputs messages like `1 interrupted` or `2 did not run` during the Playwright tests, the browsers were likely not installed. You may also see errors such as `browser.newContext: Test ended` or `Test was interrupted` in `/tmp/ci.log`:
+If `npm run ci` outputs messages like `1 interrupted` or `2 did not run` during the Playwright tests, the browsers were likely not installed. You may also see errors such as `browser.newContext: Test ended`, `page.evaluate: Test ended`, or `Test was interrupted` in `/tmp/ci.log`:
 
 ```
 Test was interrupted.


### PR DESCRIPTION
## Summary
- expand setup instructions to mention the `page.evaluate: Test ended` error
- include `page.evaluate` in CI troubleshooting tips

## Testing
- `npm run format`
- `npm test`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_686e38f20370832da884e49cccc3b0c2