### PR TITLE
Improve HF space setup script

### DIFF
--- a/scripts/setup_space.sh
+++ b/scripts/setup_space.sh
@@ -1,20 +1,43 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Verify HuggingFace token and write scope
+trap 'echo "\e[31mError on line $LINENO: $BASH_COMMAND\e[0m" >&2' ERR
+
+# Ensure the script lives under scripts/
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ "$(basename "$SCRIPT_DIR")" != "scripts" ]]; then
+  echo "setup_space.sh must reside in the scripts/ directory" >&2
+  exit 1
+fi
+
+# Pull environment variables once
 TOKEN="${HF_TOKEN:-${HF_API_KEY:-}}"
+SPACE_REPO="${SPACE_REPO:-print2/Sparc3D}"
+SPACE_URL="${SPACE_URL:-https://huggingface.co/spaces/${SPACE_REPO}.git}"
+
+# Validate token
 if [[ -z "$TOKEN" ]]; then
   echo "\u274c HF_TOKEN or HF_API_KEY must be set" >&2
   exit 1
 fi
+
+# Install required tools if missing
+if ! command -v huggingface-cli >/dev/null 2>&1; then
+  echo "huggingface-cli not found. Installing..." >&2
+  pip install --user --quiet huggingface_hub
+fi
+
+if ! command -v git-lfs >/dev/null 2>&1; then
+  echo "git-lfs not found. Installing..." >&2
+  sudo apt-get update -y && sudo apt-get install -y git-lfs
+fi
+
+# Verify write scope on the token
 SCOPES=$(huggingface-cli whoami --token "$TOKEN" 2>/dev/null | grep -i scopes || true)
 if ! echo "$SCOPES" | grep -q write; then
   echo "\u274c token lacks write scope" >&2
   exit 1
 fi
-
-SPACE_REPO="print2/Sparc3D"
-SPACE_URL="https://huggingface.co/spaces/${SPACE_REPO}.git"
 
 # Create the Space if missing
 if ! huggingface-cli repo info "$SPACE_REPO" --repo-type space >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- check that setup_space.sh lives in `scripts/`
- install HF CLI or git-lfs when missing
- load environment variables once
- print helpful errors on failure

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend --silent -- --json --outputFile=/tmp/jest.json`
- `npm run ci`
- `npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_686e410d5a70832d88d758a7fbe97795