### PR TITLE
Fix Space restoration & add immediate sleep

### DIFF
--- a/.github/workflows/sync-space.yml
+++ b/.github/workflows/sync-space.yml
@@ -22,3 +22,8 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_API_KEY: ${{ secrets.HF_TOKEN }}
         run: bash scripts/sync-space.sh
+
+      - name: Force immediate sleep
+        run: bash scripts/set-sleep-zero.sh
+        env:
+          HF_TOKEN: ${{ secrets.HF_WRITE_TOKEN }}

--- a/restore_space.sh
+++ b/restore_space.sh
@@ -1,21 +1,28 @@
 #!/usr/bin/env bash
+set -euo pipefail
+HF_TOKEN="${HF_TOKEN:-${HF_API_KEY:-}}"
+if [[ -z "$HF_TOKEN" ]]; then
+  echo "HF_TOKEN or HF_API_KEY must be set" >&2
+  exit 1
+fi
+
 # Restore the Sparc3D Hugging Face Space and push local code.
 # This script recreates the Space on the free tier and syncs our local files.
-
-set -euo pipefail
-
-# Fetch the HF token and export it for downstream commands
-export HF_TOKEN=${HF_TOKEN}
-export HF_API_KEY="$HF_TOKEN"
 
 SPACE_REPO="print2/Sparc3D"
 LOCAL_DIR="Sparc3D-Space"
 SPACE_URL="https://user:${HF_TOKEN}@huggingface.co/spaces/${SPACE_REPO}.git"
 
 # Create or recreate the Space repository on Hugging Face
-huggingface-cli repo create "$SPACE_REPO" --type space --private -y
+huggingface-cli repo create "$SPACE_REPO" \
+  --repo-type space \
+  --sdk gradio \
+  --private \
+  --yes
 # Ensure the Space uses ZeroGPU hardware
 huggingface-cli repo update "$SPACE_REPO" \
+  --repo-type space \
+  --sdk gradio \
   --hardware zero-gpu \
   --sleep-after 0 \
   --token "$HF_TOKEN"

--- a/scripts/set-sleep-zero.sh
+++ b/scripts/set-sleep-zero.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+token="${HF_TOKEN:-${HF_API_KEY:-}}"
+if [[ -z "$token" ]]; then
+  echo "HF_TOKEN or HF_API_KEY must be set" >&2
+  exit 1
+fi
+owner="print2"; repo="Sparc3D"
+curl -X PATCH \
+  -H "Authorization: Bearer $token" \
+  -H "Content-Type: application/json" \
+  https://huggingface.co/api/spaces/$owner/$repo \
+  -d '{"sleep_after":0}' && \
+  echo "✅ sleep_after set to 0"

--- a/scripts/sync-space.sh
+++ b/scripts/sync-space.sh
@@ -1,6 +1,12 @@
-#!/bin/bash
-# Fail on any error, undefined variable, or pipe failure
+#!/usr/bin/env bash
 set -euo pipefail
+HF_TOKEN="${HF_TOKEN:-${HF_API_KEY:-}}"
+if [[ -z "$HF_TOKEN" ]]; then
+  echo "HF_TOKEN or HF_API_KEY must be set" >&2
+  exit 1
+fi
+
+# Fail on any error, undefined variable, or pipe failure
 
 # Disable LFS smudge during clone for speed
 export GIT_LFS_SKIP_SMUDGE=1
@@ -12,13 +18,6 @@ SPACE_DIR="${SPACE_DIR:-Sparc3D-Space}"
 # Base URLs for cloning and pushing (allow override via env)
 SPACE_URL="${SPACE_URL:-https://huggingface.co/spaces/print2/Sparc3D}"
 MODEL_URL="${MODEL_URL:-https://huggingface.co/print2/Sparc3D.git}"
-
-# Authentication token (required)
-HF_TOKEN="${HF_TOKEN:-${HF_API_KEY:-}}"
-if [ -z "$HF_TOKEN" ]; then
-  echo "HF_TOKEN or HF_API_KEY must be set for authentication" >&2
-  exit 1
-fi
 
 
 # Ensure URLs end with .git

--- a/setup_space.sh
+++ b/setup_space.sh
@@ -1,13 +1,11 @@
 #!/usr/bin/env bash
 set -euo pipefail
-
-# Verify token
-TOKEN="${HF_TOKEN:-${HF_API_KEY:-}}"
-if [[ -z "$TOKEN" ]]; then
+HF_TOKEN="${HF_TOKEN:-${HF_API_KEY:-}}"
+if [[ -z "$HF_TOKEN" ]]; then
   echo "HF_TOKEN or HF_API_KEY must be set" >&2
   exit 1
 fi
-SCOPES=$(huggingface-cli whoami --token "$TOKEN" 2>/dev/null | grep -i "scopes" || true)
+SCOPES=$(huggingface-cli whoami --token "$HF_TOKEN" 2>/dev/null | grep -i "scopes" || true)
 if ! echo "$SCOPES" | grep -q "write"; then
   echo "Token must have write scope" >&2
   exit 1


### PR DESCRIPTION
## Summary
- fix HF `repo create` flags in restore script
- ensure repo update uses gradio SDK
- enforce HF token checks in our space scripts
- add helper to set `sleep_after` to zero
- run new helper in the sync-space workflow

## Testing
- `npm run setup`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_686e5129f33c832d9d17fd7169ac0ab1