### PR TITLE
Add monitoring & Sentry integration

### DIFF
--- a/.github/workflows/endpoint-health.yml
+++ b/.github/workflows/endpoint-health.yml
@@ -1,0 +1,12 @@
+name: Endpoint Health
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check homepage
+        run: curl -fsS https://print2.io/ > /dev/null

--- a/.github/workflows/schedule-check.yml
+++ b/.github/workflows/schedule-check.yml
@@ -1,0 +1,17 @@
+name: Check HF Space Sleep
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify sleep_after
+        env:
+          HF_TOKEN: ${{ secrets.HF_WRITE_TOKEN }}
+          HF_API_KEY: ${{ secrets.HF_WRITE_TOKEN }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        run: bash scripts/check_sleep_zero.sh

--- a/.github/workflows/sync-space.yml
+++ b/.github/workflows/sync-space.yml
@@ -27,3 +27,11 @@ jobs:
         run: bash scripts/set-sleep-zero.sh
         env:
           HF_TOKEN: ${{ secrets.HF_WRITE_TOKEN }}
+
+      - name: Slack failure alert
+        if: failure()
+        run: |
+          curl -X POST -H 'Content-Type: application/json' \
+            --data '{"text":"Sync HF Space failed"}' "$SLACK_WEBHOOK"
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Run `docker compose up` to start the API and Postgres services.
 - `STRIPE_WEBHOOK_SECRET` – signing secret for Stripe webhooks.
 - `HUNYUAN_API_KEY` – key for the Hunyuan3D API.
 - `SENDGRID_API_KEY` – API key for sending email via SendGrid.
+- `SENTRY_DSN` – connection string for sending errors to Sentry.
 - `EMAIL_FROM` – address used for the "from" field in outgoing mail.
 - Optional: `PORT` and `HUNYUAN_PORT` to override the default ports.
 - Optional: `HUNYUAN_SERVER_URL` if your Hunyuan API runs on a custom URL.

--- a/backend/server.js
+++ b/backend/server.js
@@ -71,6 +71,7 @@ const generateShareCard = require("./utils/generateShareCard");
 const validateStl = require("./utils/validateStl");
 const syncMailingList = require("./scripts/sync-mailing-list");
 const runScalingEngine = require("./scalingEngine");
+const { capture } = require("./src/lib/logger");
 
 const ADMIN_TOKEN = process.env.ADMIN_TOKEN || "admin";
 
@@ -81,6 +82,7 @@ function logError(...args) {
   if (process.env.NODE_ENV !== "test") {
     console.error(...args);
   }
+  capture(args[0] instanceof Error ? args[0] : new Error(args.join(" ")));
 }
 
 function isValidEmail(email) {
@@ -3434,6 +3436,11 @@ if (require.main === module) {
     24 * 3600 * 1000,
   );
 }
+
+app.use((err, _req, res, _next) => {
+  capture(err);
+  res.status(500).json({ error: 'Internal Server Error' });
+});
 
 module.exports = app;
 module.exports.checkCompetitionStart = checkCompetitionStart;

--- a/backend/src/lib/logger.js
+++ b/backend/src/lib/logger.js
@@ -1,0 +1,11 @@
+const Sentry = require('@sentry/node');
+const dsn = process.env.SENTRY_DSN;
+if (dsn) {
+  Sentry.init({ dsn });
+}
+function capture(error) {
+  if (dsn) {
+    Sentry.captureException(error);
+  }
+}
+module.exports = { capture };

--- a/backend/src/lib/logger.ts
+++ b/backend/src/lib/logger.ts
@@ -1,0 +1,1 @@
+export * from './logger.js';

--- a/backend/src/pipeline/generateModel.ts
+++ b/backend/src/pipeline/generateModel.ts
@@ -1,6 +1,7 @@
 import { textToImage } from '../lib/textToImage';
 import { generateGlb } from '../lib/sparc3dClient';
 import { storeGlb } from '../lib/storeGlb';
+import { capture } from '../lib/logger';
 
 export interface GenerateModelParams {
   prompt: string;
@@ -13,11 +14,17 @@ export interface GenerateModelParams {
  */
 export async function generateModel({ prompt, imageURL }: GenerateModelParams): Promise<string> {
   console.time('pipeline');
-  if (!imageURL) {
-    imageURL = await textToImage(prompt);
+  try {
+    if (!imageURL) {
+      imageURL = await textToImage(prompt);
+    }
+    const glbData = await generateGlb({ prompt, imageURL });
+    const url = await storeGlb(glbData);
+    console.timeEnd('pipeline');
+    return url;
+  } catch (err) {
+    console.timeEnd('pipeline');
+    capture(err);
+    throw err;
   }
-  const glbData = await generateGlb({ prompt, imageURL });
-  const url = await storeGlb(glbData);
-  console.timeEnd('pipeline');
-  return url;
 }

--- a/backend/tests/checkSleepZero.test.js
+++ b/backend/tests/checkSleepZero.test.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+test('script exits with 1 when sleep_after not zero', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'curl-'));
+  const fakeCurl = path.join(tmp, 'curl');
+  fs.writeFileSync(fakeCurl, '#!/bin/sh\necho "{\\"sleep_after\\":60}"\n');
+  fs.chmodSync(fakeCurl, 0o755);
+  let code = 0;
+  try {
+    const script = path.join(__dirname, '..', '..', 'scripts', 'check_sleep_zero.sh');
+    execFileSync('bash', [script], {
+      env: { ...process.env, PATH: `${tmp}:${process.env.PATH}`, SLACK_WEBHOOK: '' },
+      stdio: 'ignore',
+    });
+  } catch (err) {
+    code = err.status;
+  }
+  expect(code).toBe(1);
+});

--- a/backend/tests/logger.test.js
+++ b/backend/tests/logger.test.js
@@ -1,0 +1,5 @@
+const { capture } = require('../src/lib/logger');
+
+test('capture does not throw without DSN', () => {
+  expect(() => capture(new Error('boom'))).not.toThrow();
+});

--- a/scripts/check_sleep_zero.sh
+++ b/scripts/check_sleep_zero.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SPACE_REPO="${SPACE_REPO:-print2/Sparc3D}"
+API_URL="https://huggingface.co/api/spaces/$SPACE_REPO"
+current=$(curl -sf "$API_URL" | jq -r '.sleep_after')
+if [[ "$current" == "0" ]]; then
+  echo "sleep_after already 0"
+  exit 0
+fi
+if [[ -n "${HF_TOKEN:-${HF_API_KEY:-}}" ]]; then
+  token="${HF_TOKEN:-${HF_API_KEY:-}}"
+  curl -sf -X PATCH -H "Authorization: Bearer $token" -H "Content-Type: application/json" "$API_URL" -d '{"sleep_after":0}' >/dev/null || true
+fi
+new_val=$(curl -sf "$API_URL" | jq -r '.sleep_after')
+msg="sleep_after was $current, now $new_val on $SPACE_REPO"
+if [[ "$new_val" != "0" ]]; then
+  [[ -n "${SLACK_WEBHOOK:-}" ]] && curl -s -X POST -H "Content-Type: application/json" --data "{\"text\":\"$msg\"}" "$SLACK_WEBHOOK"
+  echo "$msg" >&2
+  exit 1
+fi
+[[ -n "${SLACK_WEBHOOK:-}" ]] && curl -s -X POST -H "Content-Type: application/json" --data "{\"text\":\"$msg\"}" "$SLACK_WEBHOOK"
+echo "$msg"

--- a/scripts/setup_space.sh
+++ b/scripts/setup_space.sh
@@ -67,5 +67,8 @@ fi
 
 git push origin HEAD:main --tags
 
+# Ensure the Space stays awake
+bash "$(dirname "$0")/check_sleep_zero.sh" || true
+
 # Green success banner
 printf '\e[32m%s\e[0m\n' 'Space setup completed successfully'


### PR DESCRIPTION
## Summary
- monitor HF Space sleep_after via check_sleep_zero script
- run daily and 15‑minute endpoint checks
- ensure Space stay awake after deploying
- add minimal Sentry logger and integrate in pipeline and server
- alert Slack when sync-space workflow fails
- document `SENTRY_DSN`
- test Sentry logger and sleep checker

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_686e6258c988832db1dfc84893c300a9