### PR TITLE
Add Stripe checkout routes

### DIFF
--- a/.github/workflows/sync-space.yml
+++ b/.github/workflows/sync-space.yml
@@ -28,3 +28,9 @@ jobs:
         run: bash scripts/set-sleep-zero.sh
         env:
           HF_TOKEN: ${{ secrets.HF_WRITE_TOKEN }}
+
+      - name: Run backend tests
+        run: npm test --prefix backend
+
+      - name: Run smoke tests
+        run: npm run smoke

--- a/README.md
+++ b/README.md
@@ -27,10 +27,13 @@ Run `docker compose up` to start the API and Postgres services.
 
    - `DB_URL` – connection string for your PostgreSQL database.
 
-- `STRIPE_SECRET_KEY` – secret key from your Stripe dashboard.
-- `STRIPE_PUBLISHABLE_KEY` – publishable key for Stripe.js on the frontend.
-- `STRIPE_WEBHOOK_SECRET` – signing secret for Stripe webhooks.
-- `HUNYUAN_API_KEY` – key for the Hunyuan3D API.
+  - `STRIPE_TEST_KEY` – test secret key for Stripe.
+  - `STRIPE_LIVE_KEY` – live secret key for Stripe.
+  - `STRIPE_PUBLISHABLE_KEY` – publishable key for Stripe.js on the frontend.
+  - `STRIPE_WEBHOOK_SECRET` – signing secret for Stripe webhooks.
+  - `HUNYUAN_API_KEY` – key for the Hunyuan3D API.
+
+The server uses `STRIPE_LIVE_KEY` when `NODE_ENV=production`; otherwise `STRIPE_TEST_KEY` is used.
 - `SENDGRID_API_KEY` – API key for sending email via SendGrid.
 - `EMAIL_FROM` – address used for the "from" field in outgoing mail.
 - Optional: `PORT` and `HUNYUAN_PORT` to override the default ports.

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -36,6 +36,7 @@
       "devDependencies": {
         "@eslint/js": "^9.30.1",
         "@types/jest": "^30.0.0",
+        "@types/stripe": "^8.0.417",
         "coverage-badges-cli": "^2.1.0",
         "eslint": "^9.30.1",
         "eslint-config-prettier": "^10.1.5",
@@ -5046,6 +5047,17 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/stripe": {
+      "version": "8.0.417",
+      "resolved": "https://registry.npmjs.org/@types/stripe/-/stripe-8.0.417.tgz",
+      "integrity": "sha512-PTuqskh9YKNENnOHGVJBm4sM0zE8B1jZw1JIskuGAPkMB+OH236QeN8scclhYGPA4nG6zTtPXgwpXdp+HPDTVw==",
+      "deprecated": "This is a stub types definition. stripe provides its own type definitions, so you do not need this installed.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "stripe": "*"
+      }
     },
     "node_modules/@types/tedious": {
       "version": "4.0.14",

--- a/backend/package.json
+++ b/backend/package.json
@@ -60,13 +60,14 @@
     "qrcode": "^1.5.4",
     "sharp": "^0.34.2",
     "stripe": "^18.3.0",
-    "uuid": "^11.1.0",
     "swagger-jsdoc": "^6.2.8",
-    "swagger-ui-express": "^5.0.1"
+    "swagger-ui-express": "^5.0.1",
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.1",
     "@types/jest": "^30.0.0",
+    "@types/stripe": "^8.0.417",
     "coverage-badges-cli": "^2.1.0",
     "eslint": "^9.30.1",
     "eslint-config-prettier": "^10.1.5",
@@ -81,13 +82,13 @@
     "jest-retries": "^1.0.1",
     "jsdom": "^26.1.0",
     "lighthouse": "^12.7.1",
+    "nock": "^13.3.3",
+    "openapi-to-postmanv2": "^3.0.0",
     "pg-mem": "^3.0.5",
     "prettier": "^3.6.2",
     "supertest": "^7.1.2",
     "tslib": "^2.8.1",
-    "openapi-to-postmanv2": "^3.0.0",
-    "yaml": "^2.3.4",
-    "nock": "^13.3.3"
+    "yaml": "^2.3.4"
   },
   "engines": {
     "node": ">=18"

--- a/backend/src/pricing.js
+++ b/backend/src/pricing.js
@@ -1,0 +1,8 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.PRODUCT = void 0;
+exports.PRODUCT = {
+  name: "3D Model",
+  priceCents: 499,
+  currency: "usd",
+};

--- a/backend/src/pricing.ts
+++ b/backend/src/pricing.ts
@@ -1,0 +1,5 @@
+export const PRODUCT = {
+  name: '3D Model',
+  priceCents: 499,
+  currency: 'usd',
+};

--- a/backend/src/routes/checkout.js
+++ b/backend/src/routes/checkout.js
@@ -1,0 +1,76 @@
+"use strict";
+var __importDefault =
+  (this && this.__importDefault) ||
+  function (mod) {
+    return mod && mod.__esModule ? mod : { default: mod };
+  };
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.orders = void 0;
+const express_1 = __importDefault(require("express"));
+const stripe_1 = __importDefault(require("stripe"));
+const pricing_1 = require("../pricing");
+const mail_1 = require("../../mail");
+exports.orders = new Map();
+const secretKey =
+  process.env.NODE_ENV === "production"
+    ? process.env.STRIPE_LIVE_KEY
+    : process.env.STRIPE_TEST_KEY;
+if (!secretKey) {
+  throw new Error("Stripe key not configured");
+}
+const stripe = new stripe_1.default(secretKey);
+const router = express_1.default.Router();
+router.post("/api/checkout", async (req, res) => {
+  const { slug, email } = req.body;
+  if (!slug || !email) return res.status(400).json({ error: "missing fields" });
+  try {
+    const session = await stripe.checkout.sessions.create({
+      mode: "payment",
+      line_items: [
+        {
+          price_data: {
+            currency: pricing_1.PRODUCT.currency,
+            product_data: { name: pricing_1.PRODUCT.name },
+            unit_amount: pricing_1.PRODUCT.priceCents,
+          },
+          quantity: 1,
+        },
+      ],
+      metadata: { slug, email },
+      success_url: `${req.headers.origin}/success?session_id={CHECKOUT_SESSION_ID}`,
+      cancel_url: `${req.headers.origin}/cancel`,
+    });
+    exports.orders.set(session.id, { slug, email, paid: false });
+    res.json({ checkoutUrl: session.url });
+  } catch (_err) {
+    res.status(500).json({ error: "Failed to create session" });
+  }
+});
+router.post(
+  "/api/stripe/webhook",
+  express_1.default.raw({ type: "application/json" }),
+  async (req, res) => {
+    const sig = req.headers["stripe-signature"];
+    let event;
+    try {
+      event = stripe.webhooks.constructEvent(
+        req.body,
+        sig,
+        process.env.STRIPE_WEBHOOK_SECRET || "",
+      );
+    } catch (_err) {
+      return res.status(400).send("Webhook Error");
+    }
+    if (event.type === "checkout.session.completed") {
+      const session = event.data.object;
+      const order = exports.orders.get(session.id);
+      if (order && !order.paid) {
+        order.paid = true;
+        const link = `https://huggingface.co/spaces/print2/Sparc3D/resolve/main/output/${order.slug}.glb`;
+        await (0, mail_1.sendMail)(order.email, "Your model is ready", link);
+      }
+    }
+    res.json({ received: true });
+  },
+);
+exports.default = router;

--- a/backend/src/routes/checkout.ts
+++ b/backend/src/routes/checkout.ts
@@ -1,0 +1,71 @@
+import express from 'express';
+import Stripe from 'stripe';
+import { PRODUCT } from '../pricing';
+import { sendMail } from '../../mail';
+
+export interface Order {
+  slug: string;
+  email: string;
+  paid?: boolean;
+}
+
+export const orders = new Map<string, Order>();
+
+const secretKey = process.env.NODE_ENV === 'production'
+  ? process.env.STRIPE_LIVE_KEY
+  : process.env.STRIPE_TEST_KEY;
+if (!secretKey) {
+  throw new Error('Stripe key not configured');
+}
+const stripe = new Stripe(secretKey);
+
+const router = express.Router();
+
+router.post('/api/checkout', async (req, res) => {
+  const { slug, email } = req.body as Order;
+  if (!slug || !email) return res.status(400).json({ error: 'missing fields' });
+  try {
+    const session = await stripe.checkout.sessions.create({
+      mode: 'payment',
+      line_items: [
+        {
+          price_data: {
+            currency: PRODUCT.currency,
+            product_data: { name: PRODUCT.name },
+            unit_amount: PRODUCT.priceCents,
+          },
+          quantity: 1,
+        },
+      ],
+      metadata: { slug, email },
+      success_url: `${req.headers.origin}/success?session_id={CHECKOUT_SESSION_ID}`,
+      cancel_url: `${req.headers.origin}/cancel`,
+    });
+    orders.set(session.id, { slug, email, paid: false });
+    res.json({ checkoutUrl: session.url });
+  } catch (_err) {
+    res.status(500).json({ error: 'Failed to create session' });
+  }
+});
+
+router.post('/api/stripe/webhook', express.raw({ type: 'application/json' }), async (req, res) => {
+  const sig = req.headers['stripe-signature'] as string;
+  let event: Stripe.Event;
+  try {
+    event = stripe.webhooks.constructEvent(req.body, sig, process.env.STRIPE_WEBHOOK_SECRET || '');
+  } catch (_err) {
+    return res.status(400).send('Webhook Error');
+  }
+  if (event.type === 'checkout.session.completed') {
+    const session = event.data.object as Stripe.Checkout.Session;
+    const order = orders.get(session.id);
+    if (order && !order.paid) {
+      order.paid = true;
+      const link = `https://huggingface.co/spaces/print2/Sparc3D/resolve/main/output/${order.slug}.glb`;
+      await sendMail(order.email, 'Your model is ready', link);
+    }
+  }
+  res.json({ received: true });
+});
+
+export default router;

--- a/backend/tests/checkout.test.ts
+++ b/backend/tests/checkout.test.ts
@@ -1,0 +1,44 @@
+process.env.STRIPE_TEST_KEY = 'sk_test';
+process.env.STRIPE_LIVE_KEY = 'sk_live';
+process.env.STRIPE_WEBHOOK_SECRET = 'whsec';
+
+jest.mock('../mail', () => ({ sendMail: jest.fn() }));
+const { sendMail } = require('../mail');
+
+jest.mock('stripe');
+const Stripe = require('stripe');
+const stripeMock = {
+  checkout: { sessions: { create: jest.fn().mockResolvedValue({ id: 'cs_test', url: 'http://checkout' }) } },
+  webhooks: { constructEvent: jest.fn() },
+};
+Stripe.mockImplementation(() => stripeMock);
+
+const request = require('supertest');
+const app = require('../src/app');
+const { orders } = require('../src/routes/checkout.js');
+
+afterEach(() => {
+  orders.clear();
+  jest.clearAllMocks();
+});
+
+test('POST /api/checkout creates session', async () => {
+  const res = await request(app).post('/api/checkout').send({ slug: 'm1', email: 'a@a.com' });
+  expect(res.status).toBe(200);
+  expect(stripeMock.checkout.sessions.create).toHaveBeenCalled();
+  expect(orders.get('cs_test')).toBeDefined();
+  expect(res.body.checkoutUrl).toBe('http://checkout');
+});
+
+test('POST /api/stripe/webhook marks paid and emails', async () => {
+  orders.set('cs_test', { slug: 'm1', email: 'a@a.com' });
+  const payload = JSON.stringify({ id: 'evt', type: 'checkout.session.completed', data: { object: { id: 'cs_test' } } });
+  stripeMock.webhooks.constructEvent.mockReturnValueOnce(JSON.parse(payload));
+  const res = await request(app)
+    .post('/api/stripe/webhook')
+    .set('stripe-signature', 'sig')
+    .send(payload);
+  expect(res.status).toBe(200);
+  expect(orders.get('cs_test')?.paid).toBe(true);
+  expect(sendMail).toHaveBeenCalled();
+});

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -13,6 +13,12 @@ cleanup_npm_cache
 unset npm_config_http_proxy npm_config_https_proxy
 export npm_config_fund=false
 
+# Validate required Stripe env vars
+if [[ -z "$STRIPE_TEST_KEY" && -z "$STRIPE_LIVE_KEY" ]]; then
+  echo "STRIPE_TEST_KEY or STRIPE_LIVE_KEY must be set" >&2
+  exit 1
+fi
+
 # Persist proxy removal so new shells start clean
 if ! grep -q "unset npm_config_http_proxy" ~/.bashrc 2>/dev/null; then
   echo "unset npm_config_http_proxy npm_config_https_proxy" >> ~/.bashrc


### PR DESCRIPTION
- integrate Stripe SDK and feature flag
- add /api/checkout and webhook routes with tests
- document Stripe environment variables
- enforce env var check in setup script
- run backend tests in sync workflow

`npm test` and `npm run format` were executed locally.

------
https://chatgpt.com/codex/tasks/task_e_686e61749978832da8260d4036d2a65d