### PR TITLE
Update Sparc3D env validation

### DIFF
--- a/backend/config.js
+++ b/backend/config.js
@@ -1,26 +1,27 @@
-'use strict';
+"use strict";
 const required = [
-  'DB_URL',
-  'STRIPE_SECRET_KEY',
-  'STRIPE_WEBHOOK_SECRET',
-  'HUNYUAN_API_KEY',
-  'CLOUDFRONT_MODEL_DOMAIN',
+  "DB_URL",
+  "STRIPE_SECRET_KEY",
+  "STRIPE_WEBHOOK_SECRET",
+  "CLOUDFRONT_MODEL_DOMAIN",
+  "SPARC3D_ENDPOINT",
+  "SPARC3D_TOKEN",
 ];
 const missing = required.filter((key) => !process.env[key]);
 if (missing.length) {
-  throw new Error(`Missing required env vars: ${missing.join(', ')}`);
+  throw new Error(`Missing required env vars: ${missing.join(", ")}`);
 }
 module.exports = {
   dbUrl: process.env.DB_URL,
   stripeKey: process.env.STRIPE_SECRET_KEY,
   stripeWebhook: process.env.STRIPE_WEBHOOK_SECRET,
-  stripePublishable: process.env.STRIPE_PUBLISHABLE_KEY || '',
-  hunyuanApiKey: process.env.HUNYUAN_API_KEY,
-  hunyuanServerUrl: process.env.HUNYUAN_SERVER_URL || 'http://localhost:4000',
-  dalleServerUrl: process.env.DALLE_SERVER_URL || 'http://localhost:5002',
+  stripePublishable: process.env.STRIPE_PUBLISHABLE_KEY || "",
+  dalleServerUrl: process.env.DALLE_SERVER_URL || "http://localhost:5002",
   port: process.env.PORT || 3000,
-  sendgridKey: process.env.SENDGRID_API_KEY || '',
-  emailFrom: process.env.EMAIL_FROM || 'noreply@example.com',
-  printerApiUrl: process.env.PRINTER_API_URL || 'http://localhost:5000/print',
+  sendgridKey: process.env.SENDGRID_API_KEY || "",
+  emailFrom: process.env.EMAIL_FROM || "noreply@example.com",
+  printerApiUrl: process.env.PRINTER_API_URL || "http://localhost:5000/print",
   cloudfrontModelDomain: process.env.CLOUDFRONT_MODEL_DOMAIN,
+  sparc3dEndpoint: process.env.SPARC3D_ENDPOINT,
+  sparc3dToken: process.env.SPARC3D_TOKEN,
 };

--- a/backend/server.js
+++ b/backend/server.js
@@ -30,7 +30,6 @@ const {
 } = require("@aws-sdk/client-s3");
 const config = require("./config");
 const prohibitedCountries = ["CU", "IR", "KP", "RU", "SY"];
-const generateTitle = require("./utils/generateTitle");
 const stripe = require("stripe")(config.stripeKey);
 const campaigns = require("./campaigns.json");
 const internalIPs = (process.env.INTERNAL_IPS || "127.0.0.1")
@@ -66,8 +65,6 @@ const { verifyTag } = require("./social");
 const QRCode = require("qrcode");
 const generateAdCopy = require("./utils/generateAdCopy");
 const generateShareCard = require("./utils/generateShareCard");
-const { generateModel } = require("./src/pipeline/generateModel");
-
 const { generateModel } = require("./src/pipeline/generateModel");
 
 const validateStl = require("./utils/validateStl");
@@ -443,7 +440,6 @@ app.post(
         "INSERT INTO jobs(job_id, prompt, image_ref, status, user_id, snapshot) VALUES ($1,$2,$3,$4,$5,$6)",
         [jobId, prompt, imageRef, "pending", userId, snapshot],
       );
-
 
       try {
         const url = await generateModel({

--- a/backend/tests/additionalApi.test.js
+++ b/backend/tests/additionalApi.test.js
@@ -1,8 +1,6 @@
 process.env.STRIPE_SECRET_KEY = "test";
 process.env.STRIPE_WEBHOOK_SECRET = "whsec";
 process.env.DB_URL = "postgres://user:pass@localhost/db";
-process.env.HUNYUAN_API_KEY = "test";
-process.env.HUNYUAN_SERVER_URL = "http://localhost:4000";
 
 jest.mock("../db", () => ({
   query: jest.fn().mockResolvedValue({ rows: [] }),

--- a/backend/tests/adminAds.test.js
+++ b/backend/tests/adminAds.test.js
@@ -1,42 +1,42 @@
-process.env.DB_URL = 'postgres://user:pass@localhost/db';
-process.env.DALLE_API_URL = 'http://localhost:5002/generate';
-process.env.LLM_API_URL = '';
-process.env.STRIPE_SECRET_KEY = 'test';
-process.env.STRIPE_WEBHOOK_SECRET = 'whsec';
-process.env.HUNYUAN_API_KEY = 'test';
-process.env.HUNYUAN_SERVER_URL = 'http://localhost:4000';
+process.env.DB_URL = "postgres://user:pass@localhost/db";
+process.env.DALLE_API_URL = "http://localhost:5002/generate";
+process.env.LLM_API_URL = "";
+process.env.STRIPE_SECRET_KEY = "test";
+process.env.STRIPE_WEBHOOK_SECRET = "whsec";
 
-jest.mock('axios');
-const axios = require('axios');
-axios.post.mockResolvedValue({ data: { image: 'imgdata' } });
+jest.mock("axios");
+const axios = require("axios");
+axios.post.mockResolvedValue({ data: { image: "imgdata" } });
 
-const fs = require('fs');
-const writeSpy = jest.spyOn(fs, 'writeFileSync').mockImplementation(() => {});
+const fs = require("fs");
+const writeSpy = jest.spyOn(fs, "writeFileSync").mockImplementation(() => {});
 
-const app = require('../server');
+const app = require("../server");
 
 beforeEach(() => {
   axios.post.mockClear();
   writeSpy.mockClear();
 });
 
-test('POST /api/admin/ads/generate returns ad', async () => {
-  const res = await require('supertest')(app)
-    .post('/api/admin/ads/generate')
-    .set('x-admin-token', 'admin')
-    .send({ subreddit: 'test' });
+test("POST /api/admin/ads/generate returns ad", async () => {
+  const res = await require("supertest")(app)
+    .post("/api/admin/ads/generate")
+    .set("x-admin-token", "admin")
+    .send({ subreddit: "test" });
   expect(res.status).toBe(200);
-  expect(res.body.subreddit).toBe('test');
+  expect(res.body.subreddit).toBe("test");
 });
 
-test('Ad approval updates status', async () => {
-  const req = require('supertest')(app);
+test("Ad approval updates status", async () => {
+  const req = require("supertest")(app);
   const gen = await req
-    .post('/api/admin/ads/generate')
-    .set('x-admin-token', 'admin')
-    .send({ subreddit: 'test' });
+    .post("/api/admin/ads/generate")
+    .set("x-admin-token", "admin")
+    .send({ subreddit: "test" });
   const id = gen.body.id;
-  const approve = await req.post(`/api/admin/ads/${id}/approve`).set('x-admin-token', 'admin');
+  const approve = await req
+    .post(`/api/admin/ads/${id}/approve`)
+    .set("x-admin-token", "admin");
   expect(approve.status).toBe(200);
-  expect(approve.body.status).toBe('approved');
+  expect(approve.body.status).toBe("approved");
 });

--- a/backend/tests/analytics.test.js
+++ b/backend/tests/analytics.test.js
@@ -1,8 +1,6 @@
 process.env.STRIPE_SECRET_KEY = "test";
 process.env.STRIPE_WEBHOOK_SECRET = "whsec";
 process.env.DB_URL = "postgres://user:pass@localhost/db";
-process.env.HUNYUAN_API_KEY = "test";
-process.env.HUNYUAN_SERVER_URL = "http://localhost:4000";
 
 jest.mock("../db", () => ({
   query: jest.fn(),

--- a/backend/tests/api.test.js
+++ b/backend/tests/api.test.js
@@ -1,8 +1,6 @@
 process.env.STRIPE_SECRET_KEY = "test";
 process.env.STRIPE_WEBHOOK_SECRET = "whsec";
 process.env.DB_URL = "postgres://user:pass@localhost/db";
-process.env.HUNYUAN_API_KEY = "test";
-process.env.HUNYUAN_SERVER_URL = "http://localhost:4000";
 
 jest.mock("../db", () => ({
   query: jest.fn().mockResolvedValue({ rows: [] }),

--- a/backend/tests/apiModels.test.js
+++ b/backend/tests/apiModels.test.js
@@ -1,8 +1,6 @@
 process.env.STRIPE_SECRET_KEY = "test";
 process.env.STRIPE_WEBHOOK_SECRET = "whsec";
 process.env.DB_URL = "postgres://user:pass@localhost/db";
-process.env.HUNYUAN_API_KEY = "test";
-process.env.HUNYUAN_SERVER_URL = "http://localhost:4000";
 process.env.CLOUDFRONT_MODEL_DOMAIN = "cdn.example.com";
 process.env.AWS_REGION = "us-east-1";
 process.env.S3_BUCKET = "bucket";

--- a/backend/tests/cart.test.js
+++ b/backend/tests/cart.test.js
@@ -1,8 +1,6 @@
 process.env.STRIPE_SECRET_KEY = "test";
 process.env.STRIPE_WEBHOOK_SECRET = "whsec";
 process.env.DB_URL = "postgres://user:pass@localhost/db";
-process.env.HUNYUAN_API_KEY = "test";
-process.env.HUNYUAN_SERVER_URL = "http://localhost:4000";
 
 jest.mock("../db", () => ({
   insertCartItem: jest.fn(),

--- a/backend/tests/commissions.test.js
+++ b/backend/tests/commissions.test.js
@@ -1,59 +1,59 @@
-process.env.STRIPE_SECRET_KEY = 'test';
-process.env.STRIPE_WEBHOOK_SECRET = 'whsec';
-process.env.DB_URL = 'postgres://user:pass@localhost/db';
-process.env.HUNYUAN_API_KEY = 'test';
-process.env.HUNYUAN_SERVER_URL = 'http://localhost:4000';
+process.env.STRIPE_SECRET_KEY = "test";
+process.env.STRIPE_WEBHOOK_SECRET = "whsec";
+process.env.DB_URL = "postgres://user:pass@localhost/db";
 
-jest.mock('../db', () => ({
+jest.mock("../db", () => ({
   query: jest.fn().mockResolvedValue({ rows: [] }),
   insertCommission: jest.fn().mockResolvedValue({}),
   getOrCreateOrderReferralLink: jest.fn(),
   insertReferredOrder: jest.fn(),
 }));
-const db = require('../db');
+const db = require("../db");
 
-const request = require('supertest');
-const jwt = require('jsonwebtoken');
-const app = require('../server');
+const request = require("supertest");
+const jwt = require("jsonwebtoken");
+const app = require("../server");
 
 beforeEach(() => {
   db.query.mockClear();
 });
 
-test('GET /api/commissions requires auth', async () => {
-  const res = await request(app).get('/api/commissions');
+test("GET /api/commissions requires auth", async () => {
+  const res = await request(app).get("/api/commissions");
   expect(res.status).toBe(401);
 });
 
-test('GET /api/commissions returns totals', async () => {
+test("GET /api/commissions returns totals", async () => {
   db.query.mockResolvedValueOnce({
     rows: [
-      { id: 'c1', commission_cents: 100, status: 'pending' },
-      { id: 'c2', commission_cents: 50, status: 'paid' },
+      { id: "c1", commission_cents: 100, status: "pending" },
+      { id: "c2", commission_cents: 50, status: "paid" },
     ],
   });
-  const token = jwt.sign({ id: 'seller' }, 'secret');
-  const res = await request(app).get('/api/commissions').set('authorization', `Bearer ${token}`);
+  const token = jwt.sign({ id: "seller" }, "secret");
+  const res = await request(app)
+    .get("/api/commissions")
+    .set("authorization", `Bearer ${token}`);
   expect(res.status).toBe(200);
   expect(res.body.totalPending).toBe(100);
   expect(res.body.totalPaid).toBe(50);
   expect(res.body.commissions).toHaveLength(2);
 });
 
-test('POST /api/commissions/:id/mark-paid admin token required', async () => {
-  const res = await request(app).post('/api/commissions/c1/mark-paid');
+test("POST /api/commissions/:id/mark-paid admin token required", async () => {
+  const res = await request(app).post("/api/commissions/c1/mark-paid");
   expect(res.status).toBe(401);
 });
 
-test('POST /api/commissions/:id/mark-paid updates status', async () => {
-  db.query.mockResolvedValueOnce({ rows: [{ id: 'c1', status: 'paid' }] });
+test("POST /api/commissions/:id/mark-paid updates status", async () => {
+  db.query.mockResolvedValueOnce({ rows: [{ id: "c1", status: "paid" }] });
   const res = await request(app)
-    .post('/api/commissions/c1/mark-paid')
-    .set('x-admin-token', 'admin');
+    .post("/api/commissions/c1/mark-paid")
+    .set("x-admin-token", "admin");
   expect(res.status).toBe(200);
-  expect(res.body.status).toBe('paid');
+  expect(res.body.status).toBe("paid");
   expect(db.query).toHaveBeenCalledWith(
-    'UPDATE model_commissions SET status=$1 WHERE id=$2 RETURNING *',
-    ['paid', 'c1']
+    "UPDATE model_commissions SET status=$1 WHERE id=$2 RETURNING *",
+    ["paid", "c1"],
   );
 });

--- a/backend/tests/config.test.js
+++ b/backend/tests/config.test.js
@@ -1,7 +1,6 @@
 process.env.DB_URL = "postgres://user:pass@localhost/db";
 process.env.STRIPE_SECRET_KEY = "test";
 process.env.STRIPE_WEBHOOK_SECRET = "whsec";
-process.env.HUNYUAN_API_KEY = "test";
 process.env.CLOUDFRONT_MODEL_DOMAIN = "https://domain";
 
 const original = process.env.CLOUDFRONT_MODEL_DOMAIN;

--- a/backend/tests/engagement.test.js
+++ b/backend/tests/engagement.test.js
@@ -1,8 +1,6 @@
 process.env.STRIPE_SECRET_KEY = "test";
 process.env.STRIPE_WEBHOOK_SECRET = "whsec";
 process.env.DB_URL = "postgres://user:pass@localhost/db";
-process.env.HUNYUAN_API_KEY = "test";
-process.env.HUNYUAN_SERVER_URL = "http://localhost:4000";
 
 jest.mock("../db", () => ({
   query: jest.fn().mockResolvedValue({ rows: [] }),

--- a/backend/tests/flashSale.test.js
+++ b/backend/tests/flashSale.test.js
@@ -1,73 +1,77 @@
-process.env.STRIPE_SECRET_KEY = 'test';
-process.env.STRIPE_WEBHOOK_SECRET = 'whsec';
-process.env.DB_URL = 'postgres://user:pass@localhost/db';
-process.env.HUNYUAN_API_KEY = 'test';
-process.env.HUNYUAN_SERVER_URL = 'http://localhost:4000';
+process.env.STRIPE_SECRET_KEY = "test";
+process.env.STRIPE_WEBHOOK_SECRET = "whsec";
+process.env.DB_URL = "postgres://user:pass@localhost/db";
 
-jest.mock('../db', () => ({
+jest.mock("../db", () => ({
   query: jest.fn().mockResolvedValue({ rows: [] }),
   insertCommission: jest.fn().mockResolvedValue({}),
   getOrCreateOrderReferralLink: jest.fn(),
   insertReferredOrder: jest.fn(),
 }));
-const db = require('../db');
+const db = require("../db");
 
-const request = require('supertest');
-const app = require('../server');
+const request = require("supertest");
+const app = require("../server");
 
 beforeEach(() => {
   db.query.mockClear();
 });
 
-test('GET /api/flash-sale returns sale', async () => {
+test("GET /api/flash-sale returns sale", async () => {
   db.query.mockResolvedValueOnce({ rows: [{ id: 1 }] });
-  const res = await request(app).get('/api/flash-sale');
+  const res = await request(app).get("/api/flash-sale");
   expect(res.status).toBe(200);
   expect(res.body.id).toBe(1);
 });
 
-test('GET /api/flash-sale 404 when none', async () => {
+test("GET /api/flash-sale 404 when none", async () => {
   db.query.mockResolvedValueOnce({ rows: [] });
-  const res = await request(app).get('/api/flash-sale');
+  const res = await request(app).get("/api/flash-sale");
   expect(res.status).toBe(404);
 });
 
-test('POST /api/admin/flash-sale requires admin', async () => {
-  const res = await request(app).post('/api/admin/flash-sale').send({});
+test("POST /api/admin/flash-sale requires admin", async () => {
+  const res = await request(app).post("/api/admin/flash-sale").send({});
   expect(res.status).toBe(401);
 });
 
-test('POST /api/admin/flash-sale creates sale', async () => {
+test("POST /api/admin/flash-sale creates sale", async () => {
   db.query.mockResolvedValueOnce({ rows: [{ id: 2 }] });
   const body = {
     discount_percent: 5,
-    product_type: 'single',
-    start_time: '2024-01-01T00:00:00Z',
-    end_time: '2024-01-02T00:00:00Z',
+    product_type: "single",
+    start_time: "2024-01-01T00:00:00Z",
+    end_time: "2024-01-02T00:00:00Z",
   };
   const res = await request(app)
-    .post('/api/admin/flash-sale')
-    .set('x-admin-token', 'admin')
+    .post("/api/admin/flash-sale")
+    .set("x-admin-token", "admin")
     .send(body);
   expect(res.status).toBe(200);
   expect(db.query).toHaveBeenNthCalledWith(
     1,
-    'UPDATE flash_sales SET active=FALSE WHERE active=TRUE'
+    "UPDATE flash_sales SET active=FALSE WHERE active=TRUE",
   );
-  expect(db.query).toHaveBeenNthCalledWith(2, expect.stringContaining('INSERT INTO flash_sales'), [
-    5,
-    'single',
-    new Date(body.start_time).toISOString(),
-    new Date(body.end_time).toISOString(),
-  ]);
+  expect(db.query).toHaveBeenNthCalledWith(
+    2,
+    expect.stringContaining("INSERT INTO flash_sales"),
+    [
+      5,
+      "single",
+      new Date(body.start_time).toISOString(),
+      new Date(body.end_time).toISOString(),
+    ],
+  );
 });
 
-test('DELETE /api/admin/flash-sale/:id ends sale', async () => {
+test("DELETE /api/admin/flash-sale/:id ends sale", async () => {
   db.query.mockResolvedValueOnce({ rows: [{ id: 3 }] });
-  const res = await request(app).delete('/api/admin/flash-sale/3').set('x-admin-token', 'admin');
+  const res = await request(app)
+    .delete("/api/admin/flash-sale/3")
+    .set("x-admin-token", "admin");
   expect(res.status).toBe(200);
   expect(db.query).toHaveBeenCalledWith(
-    'UPDATE flash_sales SET active=FALSE WHERE id=$1 RETURNING *',
-    ['3']
+    "UPDATE flash_sales SET active=FALSE WHERE id=$1 RETURNING *",
+    ["3"],
   );
 });

--- a/backend/tests/health.test.js
+++ b/backend/tests/health.test.js
@@ -1,8 +1,6 @@
 process.env.STRIPE_SECRET_KEY = "test";
 process.env.STRIPE_WEBHOOK_SECRET = "whsec";
 process.env.DB_URL = "postgres://user:pass@localhost/db";
-process.env.HUNYUAN_API_KEY = "test";
-process.env.HUNYUAN_SERVER_URL = "http://localhost:4000";
 process.env.AWS_REGION = "us-east-1";
 process.env.S3_BUCKET = "bucket";
 

--- a/backend/tests/hubAdmin.test.js
+++ b/backend/tests/hubAdmin.test.js
@@ -1,8 +1,6 @@
 process.env.STRIPE_SECRET_KEY = "test";
 process.env.STRIPE_WEBHOOK_SECRET = "whsec";
 process.env.DB_URL = "postgres://user:pass@localhost/db";
-process.env.HUNYUAN_API_KEY = "test";
-process.env.HUNYUAN_SERVER_URL = "http://localhost:4000";
 
 jest.mock("../db", () => ({
   query: jest.fn(),

--- a/backend/tests/mailingList.test.js
+++ b/backend/tests/mailingList.test.js
@@ -1,10 +1,8 @@
-process.env.STRIPE_SECRET_KEY = 'test';
-process.env.STRIPE_WEBHOOK_SECRET = 'whsec';
-process.env.DB_URL = 'postgres://user:pass@localhost/db';
-process.env.HUNYUAN_API_KEY = 'test';
-process.env.HUNYUAN_SERVER_URL = 'http://localhost:4000';
+process.env.STRIPE_SECRET_KEY = "test";
+process.env.STRIPE_WEBHOOK_SECRET = "whsec";
+process.env.DB_URL = "postgres://user:pass@localhost/db";
 
-jest.mock('../db', () => ({
+jest.mock("../db", () => ({
   upsertMailingListEntry: jest.fn().mockResolvedValue({}),
   confirmMailingListEntry: jest.fn().mockResolvedValue({}),
   unsubscribeMailingListEntry: jest.fn().mockResolvedValue({}),
@@ -13,13 +11,13 @@ jest.mock('../db', () => ({
   getOrCreateOrderReferralLink: jest.fn(),
   insertReferredOrder: jest.fn(),
 }));
-const db = require('../db');
+const db = require("../db");
 
-jest.mock('../mail', () => ({ sendMail: jest.fn() }));
-const { sendMail } = require('../mail');
+jest.mock("../mail", () => ({ sendMail: jest.fn() }));
+const { sendMail } = require("../mail");
 
-const request = require('supertest');
-const app = require('../server');
+const request = require("supertest");
+const app = require("../server");
 
 beforeEach(() => {
   db.upsertMailingListEntry.mockClear();
@@ -29,43 +27,45 @@ beforeEach(() => {
   db.query.mockClear();
 });
 
-test('POST /api/subscribe stores address and sends email', async () => {
-  const res = await request(app).post('/api/subscribe').send({ email: 'a@a.com' });
+test("POST /api/subscribe stores address and sends email", async () => {
+  const res = await request(app)
+    .post("/api/subscribe")
+    .send({ email: "a@a.com" });
   expect(res.status).toBe(204);
   expect(db.upsertMailingListEntry).toHaveBeenCalled();
   expect(sendMail).toHaveBeenCalledWith(
-    'a@a.com',
-    'Confirm Subscription',
-    expect.stringContaining('/api/confirm-subscription?token=')
+    "a@a.com",
+    "Confirm Subscription",
+    expect.stringContaining("/api/confirm-subscription?token="),
   );
 });
 
-test('GET /api/unsubscribe marks unsubscribed', async () => {
-  const res = await request(app).get('/api/unsubscribe?token=t1');
+test("GET /api/unsubscribe marks unsubscribed", async () => {
+  const res = await request(app).get("/api/unsubscribe?token=t1");
   expect(res.text).toMatch(/unsubscribed/i);
-  expect(db.unsubscribeMailingListEntry).toHaveBeenCalledWith('t1');
+  expect(db.unsubscribeMailingListEntry).toHaveBeenCalledWith("t1");
 });
 
-test('GET /api/confirm-subscription marks confirmed', async () => {
-  const res = await request(app).get('/api/confirm-subscription?token=c1');
+test("GET /api/confirm-subscription marks confirmed", async () => {
+  const res = await request(app).get("/api/confirm-subscription?token=c1");
   expect(res.text).toMatch(/confirmed/i);
-  expect(db.confirmMailingListEntry).toHaveBeenCalledWith('c1');
+  expect(db.confirmMailingListEntry).toHaveBeenCalledWith("c1");
 });
 
-test('POST /api/webhook/sendgrid unsubscribes bounces', async () => {
+test("POST /api/webhook/sendgrid unsubscribes bounces", async () => {
   const events = [
-    { event: 'bounce', email: 'a@a.com' },
-    { event: 'delivered', email: 'b@b.com' },
-    { event: 'spamreport', email: 'c@c.com' },
+    { event: "bounce", email: "a@a.com" },
+    { event: "delivered", email: "b@b.com" },
+    { event: "spamreport", email: "c@c.com" },
   ];
-  const res = await request(app).post('/api/webhook/sendgrid').send(events);
+  const res = await request(app).post("/api/webhook/sendgrid").send(events);
   expect(res.status).toBe(204);
   expect(db.query).toHaveBeenCalledWith(
-    expect.stringContaining('UPDATE mailing_list SET unsubscribed=TRUE'),
-    ['a@a.com']
+    expect.stringContaining("UPDATE mailing_list SET unsubscribed=TRUE"),
+    ["a@a.com"],
   );
   expect(db.query).toHaveBeenCalledWith(
-    expect.stringContaining('UPDATE mailing_list SET unsubscribed=TRUE'),
-    ['c@c.com']
+    expect.stringContaining("UPDATE mailing_list SET unsubscribed=TRUE"),
+    ["c@c.com"],
   );
 });

--- a/backend/tests/operationsDashboard.test.js
+++ b/backend/tests/operationsDashboard.test.js
@@ -1,39 +1,38 @@
-process.env.STRIPE_SECRET_KEY = 'test';
-process.env.STRIPE_WEBHOOK_SECRET = 'whsec';
-process.env.DB_URL = 'postgres://user:pass@localhost/db';
-process.env.HUNYUAN_API_KEY = 'test';
+process.env.STRIPE_SECRET_KEY = "test";
+process.env.STRIPE_WEBHOOK_SECRET = "whsec";
+process.env.DB_URL = "postgres://user:pass@localhost/db";
 
-jest.mock('../db', () => ({
+jest.mock("../db", () => ({
   listPrinterHubs: jest.fn(),
   getPrintersByHub: jest.fn(),
   getLatestPrinterMetrics: jest.fn(),
   getAverageJobCompletionSeconds: jest.fn(),
 }));
-const db = require('../db');
+const db = require("../db");
 
-const request = require('supertest');
-const app = require('../server');
+const request = require("supertest");
+const app = require("../server");
 
-describe('operations dashboard', () => {
+describe("operations dashboard", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  test('requires admin token', async () => {
-    const res = await request(app).get('/api/admin/operations');
+  test("requires admin token", async () => {
+    const res = await request(app).get("/api/admin/operations");
     expect(res.status).toBe(401);
   });
 
-  test('returns metrics by hub', async () => {
-    db.listPrinterHubs.mockResolvedValueOnce([{ id: 1, name: 'Hub A' }]);
-    db.getPrintersByHub.mockResolvedValueOnce([{ id: 2, serial: 'p1' }]);
+  test("returns metrics by hub", async () => {
+    db.listPrinterHubs.mockResolvedValueOnce([{ id: 1, name: "Hub A" }]);
+    db.getPrintersByHub.mockResolvedValueOnce([{ id: 2, serial: "p1" }]);
     db.getLatestPrinterMetrics.mockResolvedValueOnce([
       { printer_id: 2, queue_length: 3, error: null },
     ]);
     db.getAverageJobCompletionSeconds.mockResolvedValueOnce(3600);
     const res = await request(app)
-      .get('/api/admin/operations')
-      .set('x-admin-token', 'admin');
+      .get("/api/admin/operations")
+      .set("x-admin-token", "admin");
     expect(res.status).toBe(200);
     expect(res.body.hubs[0].backlog).toBe(3);
     expect(res.body.hubs[0].dailyCapacity).toBe(24);

--- a/backend/tests/passwordReset.test.js
+++ b/backend/tests/passwordReset.test.js
@@ -1,22 +1,20 @@
-process.env.STRIPE_SECRET_KEY = 'test';
-process.env.STRIPE_WEBHOOK_SECRET = 'whsec';
-process.env.DB_URL = 'postgres://user:pass@localhost/db';
-process.env.HUNYUAN_API_KEY = 'test';
-process.env.HUNYUAN_SERVER_URL = 'http://localhost:4000';
+process.env.STRIPE_SECRET_KEY = "test";
+process.env.STRIPE_WEBHOOK_SECRET = "whsec";
+process.env.DB_URL = "postgres://user:pass@localhost/db";
 
-jest.mock('../db', () => ({
+jest.mock("../db", () => ({
   query: jest.fn().mockResolvedValue({ rows: [] }),
   getOrCreateOrderReferralLink: jest.fn(),
   insertReferredOrder: jest.fn(),
 }));
-const db = require('../db');
+const db = require("../db");
 
-jest.mock('../mail', () => ({ sendTemplate: jest.fn() }));
-const { sendTemplate } = require('../mail');
+jest.mock("../mail", () => ({ sendTemplate: jest.fn() }));
+const { sendTemplate } = require("../mail");
 
-const bcrypt = require('bcryptjs');
-const request = require('supertest');
-const app = require('../server');
+const bcrypt = require("bcryptjs");
+const request = require("supertest");
+const app = require("../server");
 
 beforeEach(() => {
   db.query.mockClear();
@@ -24,67 +22,80 @@ beforeEach(() => {
 });
 
 /** Test request-password-reset endpoint */
-test('POST /api/request-password-reset inserts record and sends email', async () => {
+test("POST /api/request-password-reset inserts record and sends email", async () => {
   db.query
-    .mockResolvedValueOnce({ rows: [{ id: 'u1', username: 'alice' }] })
+    .mockResolvedValueOnce({ rows: [{ id: "u1", username: "alice" }] })
     .mockResolvedValueOnce({});
 
   const res = await request(app)
-    .post('/api/request-password-reset')
-    .set('origin', 'http://test.com')
-    .send({ email: 'a@a.com' });
+    .post("/api/request-password-reset")
+    .set("origin", "http://test.com")
+    .send({ email: "a@a.com" });
 
   expect(res.status).toBe(204);
 
-  const insertCall = db.query.mock.calls.find((c) => c[0].includes('INSERT INTO password_resets'));
+  const insertCall = db.query.mock.calls.find((c) =>
+    c[0].includes("INSERT INTO password_resets"),
+  );
   expect(insertCall).toBeTruthy();
   const token = insertCall[1][1];
   expect(sendTemplate).toHaveBeenCalledWith(
-    'a@a.com',
-    'Password Reset',
-    'password_reset.txt',
-    expect.objectContaining({ username: 'alice', reset_url: expect.stringContaining(token) })
+    "a@a.com",
+    "Password Reset",
+    "password_reset.txt",
+    expect.objectContaining({
+      username: "alice",
+      reset_url: expect.stringContaining(token),
+    }),
   );
 });
 
 /** Test reset-password invalid token */
-test('POST /api/reset-password rejects invalid token', async () => {
+test("POST /api/reset-password rejects invalid token", async () => {
   db.query.mockResolvedValueOnce({ rows: [] });
   const res = await request(app)
-    .post('/api/reset-password')
-    .send({ token: 'bad', password: 'new' });
+    .post("/api/reset-password")
+    .send({ token: "bad", password: "new" });
   expect(res.status).toBe(400);
-  expect(res.body.error).toBe('Invalid token');
+  expect(res.body.error).toBe("Invalid token");
 });
 
 /** Test reset-password expired token */
-test('POST /api/reset-password rejects expired token', async () => {
+test("POST /api/reset-password rejects expired token", async () => {
   const past = new Date(Date.now() - 1000).toISOString();
-  db.query.mockResolvedValueOnce({ rows: [{ user_id: 'u1', expires_at: past }] });
-  const res = await request(app).post('/api/reset-password').send({ token: 't', password: 'new' });
+  db.query.mockResolvedValueOnce({
+    rows: [{ user_id: "u1", expires_at: past }],
+  });
+  const res = await request(app)
+    .post("/api/reset-password")
+    .send({ token: "t", password: "new" });
   expect(res.status).toBe(400);
-  expect(res.body.error).toBe('Token expired');
+  expect(res.body.error).toBe("Token expired");
 });
 
 /** Test reset-password success path */
-test('POST /api/reset-password updates password and clears token', async () => {
+test("POST /api/reset-password updates password and clears token", async () => {
   const future = new Date(Date.now() + 1000).toISOString();
   db.query
-    .mockResolvedValueOnce({ rows: [{ user_id: 'u1', expires_at: future }] })
+    .mockResolvedValueOnce({ rows: [{ user_id: "u1", expires_at: future }] })
     .mockResolvedValueOnce({})
     .mockResolvedValueOnce({});
 
   const res = await request(app)
-    .post('/api/reset-password')
-    .send({ token: 't1', password: 'secret' });
+    .post("/api/reset-password")
+    .send({ token: "t1", password: "secret" });
 
   expect(res.status).toBe(204);
 
-  const updateCall = db.query.mock.calls.find((c) => c[0].includes('UPDATE users'));
+  const updateCall = db.query.mock.calls.find((c) =>
+    c[0].includes("UPDATE users"),
+  );
   const hashed = updateCall[1][0];
-  expect(await bcrypt.compare('secret', hashed)).toBe(true);
-  expect(updateCall[1][1]).toBe('u1');
+  expect(await bcrypt.compare("secret", hashed)).toBe(true);
+  expect(updateCall[1][1]).toBe("u1");
 
-  const deleteCall = db.query.mock.calls.find((c) => c[0].includes('DELETE FROM password_resets'));
-  expect(deleteCall[1][0]).toBe('t1');
+  const deleteCall = db.query.mock.calls.find((c) =>
+    c[0].includes("DELETE FROM password_resets"),
+  );
+  expect(deleteCall[1][0]).toBe("t1");
 });

--- a/backend/tests/payouts.test.js
+++ b/backend/tests/payouts.test.js
@@ -1,19 +1,17 @@
-process.env.STRIPE_SECRET_KEY = 'test';
-process.env.STRIPE_WEBHOOK_SECRET = 'whsec';
-process.env.DB_URL = 'postgres://user:pass@localhost/db';
-process.env.HUNYUAN_API_KEY = 'test';
-process.env.HUNYUAN_SERVER_URL = 'http://localhost:4000';
+process.env.STRIPE_SECRET_KEY = "test";
+process.env.STRIPE_WEBHOOK_SECRET = "whsec";
+process.env.DB_URL = "postgres://user:pass@localhost/db";
 
-jest.mock('../db', () => ({
+jest.mock("../db", () => ({
   query: jest.fn().mockResolvedValue({ rows: [] }),
   insertCommission: jest.fn().mockResolvedValue({}),
   getOrCreateOrderReferralLink: jest.fn(),
   insertReferredOrder: jest.fn(),
 }));
-const db = require('../db');
+const db = require("../db");
 
-jest.mock('stripe');
-const Stripe = require('stripe');
+jest.mock("stripe");
+const Stripe = require("stripe");
 const stripeMock = {
   transfers: { create: jest.fn() },
   accounts: { create: jest.fn() },
@@ -21,9 +19,9 @@ const stripeMock = {
 };
 Stripe.mockImplementation(() => stripeMock);
 
-const request = require('supertest');
-const jwt = require('jsonwebtoken');
-const app = require('../server');
+const request = require("supertest");
+const jwt = require("jsonwebtoken");
+const app = require("../server");
 
 beforeEach(() => {
   db.query.mockClear();
@@ -32,50 +30,58 @@ beforeEach(() => {
   stripeMock.accountLinks.create.mockReset();
 });
 
-test('POST /api/payouts requires auth', async () => {
-  const res = await request(app).post('/api/payouts');
+test("POST /api/payouts requires auth", async () => {
+  const res = await request(app).post("/api/payouts");
   expect(res.status).toBe(401);
 });
 
-test('POST /api/payouts 400 without account', async () => {
+test("POST /api/payouts 400 without account", async () => {
   db.query.mockResolvedValueOnce({ rows: [{ stripe_account_id: null }] });
-  const token = jwt.sign({ id: 'u1' }, 'secret');
-  const res = await request(app).post('/api/payouts').set('authorization', `Bearer ${token}`);
+  const token = jwt.sign({ id: "u1" }, "secret");
+  const res = await request(app)
+    .post("/api/payouts")
+    .set("authorization", `Bearer ${token}`);
   expect(res.status).toBe(400);
 });
 
-test('POST /api/payouts transfers funds', async () => {
+test("POST /api/payouts transfers funds", async () => {
   db.query
-    .mockResolvedValueOnce({ rows: [{ stripe_account_id: 'acct_1' }] })
-    .mockResolvedValueOnce({ rows: [{ commission_cents: 100 }, { commission_cents: 50 }] })
+    .mockResolvedValueOnce({ rows: [{ stripe_account_id: "acct_1" }] })
+    .mockResolvedValueOnce({
+      rows: [{ commission_cents: 100 }, { commission_cents: 50 }],
+    })
     .mockResolvedValueOnce({});
-  stripeMock.transfers.create.mockResolvedValue({ id: 'tr_1' });
-  const token = jwt.sign({ id: 'u1' }, 'secret');
-  const res = await request(app).post('/api/payouts').set('authorization', `Bearer ${token}`);
+  stripeMock.transfers.create.mockResolvedValue({ id: "tr_1" });
+  const token = jwt.sign({ id: "u1" }, "secret");
+  const res = await request(app)
+    .post("/api/payouts")
+    .set("authorization", `Bearer ${token}`);
   expect(res.status).toBe(200);
   expect(res.body.totalPaid).toBe(150);
   expect(stripeMock.transfers.create).toHaveBeenCalledWith({
     amount: 150,
-    currency: 'usd',
-    destination: 'acct_1',
-    description: 'Commission payout',
+    currency: "usd",
+    destination: "acct_1",
+    description: "Commission payout",
   });
-  const call = db.query.mock.calls.find((c) => c[0].includes('UPDATE model_commissions'));
-  expect(call[1]).toEqual(['u1']);
+  const call = db.query.mock.calls.find((c) =>
+    c[0].includes("UPDATE model_commissions"),
+  );
+  expect(call[1]).toEqual(["u1"]);
 });
 
-test('POST /api/stripe/connect creates link', async () => {
+test("POST /api/stripe/connect creates link", async () => {
   db.query
     .mockResolvedValueOnce({ rows: [{ stripe_account_id: null }] })
-    .mockResolvedValueOnce({ rows: [{ email: 'a@b.com' }] })
+    .mockResolvedValueOnce({ rows: [{ email: "a@b.com" }] })
     .mockResolvedValueOnce({});
-  stripeMock.accounts.create.mockResolvedValue({ id: 'acct_2' });
-  stripeMock.accountLinks.create.mockResolvedValue({ url: 'https://connect' });
-  const token = jwt.sign({ id: 'u1' }, 'secret');
+  stripeMock.accounts.create.mockResolvedValue({ id: "acct_2" });
+  stripeMock.accountLinks.create.mockResolvedValue({ url: "https://connect" });
+  const token = jwt.sign({ id: "u1" }, "secret");
   const res = await request(app)
-    .post('/api/stripe/connect')
-    .set('authorization', `Bearer ${token}`)
-    .set('origin', 'http://localhost');
+    .post("/api/stripe/connect")
+    .set("authorization", `Bearer ${token}`)
+    .set("origin", "http://localhost");
   expect(res.status).toBe(200);
-  expect(res.body.url).toBe('https://connect');
+  expect(res.body.url).toBe("https://connect");
 });

--- a/backend/tests/printJobs.test.js
+++ b/backend/tests/printJobs.test.js
@@ -1,36 +1,34 @@
-process.env.STRIPE_SECRET_KEY = 'test';
-process.env.STRIPE_WEBHOOK_SECRET = 'whsec';
-process.env.DB_URL = 'postgres://user:pass@localhost/db';
-process.env.HUNYUAN_API_KEY = 'test';
-process.env.HUNYUAN_SERVER_URL = 'http://localhost:4000';
+process.env.STRIPE_SECRET_KEY = "test";
+process.env.STRIPE_WEBHOOK_SECRET = "whsec";
+process.env.DB_URL = "postgres://user:pass@localhost/db";
 
-jest.mock('../db', () => ({
+jest.mock("../db", () => ({
   query: jest.fn().mockResolvedValue({ rows: [] }),
   getOrCreateOrderReferralLink: jest.fn(),
   insertReferredOrder: jest.fn(),
 }));
-const db = require('../db');
+const db = require("../db");
 
-jest.mock('stripe');
-const Stripe = require('stripe');
+jest.mock("stripe");
+const Stripe = require("stripe");
 Stripe.mockImplementation(() => ({}));
 
-const request = require('supertest');
-const app = require('../server');
+const request = require("supertest");
+const app = require("../server");
 
 beforeEach(() => {
   db.query.mockClear();
 });
 
-test('GET /api/print-jobs/:id 404 when missing', async () => {
+test("GET /api/print-jobs/:id 404 when missing", async () => {
   db.query.mockResolvedValueOnce({ rows: [] });
-  const res = await request(app).get('/api/print-jobs/p1');
+  const res = await request(app).get("/api/print-jobs/p1");
   expect(res.status).toBe(404);
 });
 
-test('GET /api/print-jobs/:id returns status', async () => {
-  db.query.mockResolvedValueOnce({ rows: [{ status: 'queued' }] });
-  const res = await request(app).get('/api/print-jobs/p1');
+test("GET /api/print-jobs/:id returns status", async () => {
+  db.query.mockResolvedValueOnce({ rows: [{ status: "queued" }] });
+  const res = await request(app).get("/api/print-jobs/p1");
   expect(res.status).toBe(200);
-  expect(res.body.status).toBe('queued');
+  expect(res.body.status).toBe("queued");
 });

--- a/backend/tests/printerWebhook.test.js
+++ b/backend/tests/printerWebhook.test.js
@@ -1,7 +1,6 @@
 process.env.STRIPE_SECRET_KEY = "test";
 process.env.STRIPE_WEBHOOK_SECRET = "whsec";
 process.env.DB_URL = "postgres://user:pass@localhost/db";
-process.env.HUNYUAN_API_KEY = "test";
 
 jest.mock("../db", () => ({
   query: jest.fn().mockResolvedValue({}),

--- a/backend/tests/referralPost.test.js
+++ b/backend/tests/referralPost.test.js
@@ -1,40 +1,38 @@
-process.env.STRIPE_SECRET_KEY = 'test';
-process.env.STRIPE_WEBHOOK_SECRET = 'whsec';
-process.env.DB_URL = 'postgres://user:pass@localhost/db';
-process.env.HUNYUAN_API_KEY = 'test';
-process.env.HUNYUAN_SERVER_URL = 'http://localhost:4000';
+process.env.STRIPE_SECRET_KEY = "test";
+process.env.STRIPE_WEBHOOK_SECRET = "whsec";
+process.env.DB_URL = "postgres://user:pass@localhost/db";
 
-const request = require('supertest');
-const jwt = require('jsonwebtoken');
+const request = require("supertest");
+const jwt = require("jsonwebtoken");
 
-jest.mock('../social', () => ({ verifyTag: jest.fn() }));
-const { verifyTag } = require('../social');
+jest.mock("../social", () => ({ verifyTag: jest.fn() }));
+const { verifyTag } = require("../social");
 
-jest.mock('../discountCodes', () => ({
-  createTimedCode: jest.fn().mockResolvedValue('DISC1'),
+jest.mock("../discountCodes", () => ({
+  createTimedCode: jest.fn().mockResolvedValue("DISC1"),
 }));
-const { createTimedCode } = require('../discountCodes');
+const { createTimedCode } = require("../discountCodes");
 
-const app = require('../server');
+const app = require("../server");
 
-test('POST /api/referral-post returns code when verified', async () => {
+test("POST /api/referral-post returns code when verified", async () => {
   verifyTag.mockResolvedValue(true);
-  const token = jwt.sign({ id: 'u1' }, 'secret');
+  const token = jwt.sign({ id: "u1" }, "secret");
   const res = await request(app)
-    .post('/api/referral-post')
-    .set('authorization', `Bearer ${token}`)
-    .send({ url: 'http://example.com/post' });
+    .post("/api/referral-post")
+    .set("authorization", `Bearer ${token}`)
+    .send({ url: "http://example.com/post" });
   expect(res.status).toBe(200);
-  expect(res.body.code).toBe('DISC1');
+  expect(res.body.code).toBe("DISC1");
   expect(createTimedCode).toHaveBeenCalledWith(500, 168);
 });
 
-test('POST /api/referral-post rejects invalid tag', async () => {
+test("POST /api/referral-post rejects invalid tag", async () => {
   verifyTag.mockResolvedValue(false);
-  const token = jwt.sign({ id: 'u1' }, 'secret');
+  const token = jwt.sign({ id: "u1" }, "secret");
   const res = await request(app)
-    .post('/api/referral-post')
-    .set('authorization', `Bearer ${token}`)
-    .send({ url: 'http://example.com/post' });
+    .post("/api/referral-post")
+    .set("authorization", `Bearer ${token}`)
+    .send({ url: "http://example.com/post" });
   expect(res.status).toBe(400);
 });

--- a/backend/tests/rewards.test.js
+++ b/backend/tests/rewards.test.js
@@ -1,8 +1,6 @@
 process.env.STRIPE_SECRET_KEY = "test";
 process.env.STRIPE_WEBHOOK_SECRET = "whsec";
 process.env.DB_URL = "postgres://user:pass@localhost/db";
-process.env.HUNYUAN_API_KEY = "test";
-process.env.HUNYUAN_SERVER_URL = "http://localhost:4000";
 
 jest.mock("../db", () => ({
   query: jest.fn().mockResolvedValue({ rows: [] }),

--- a/backend/tests/saleCredits.test.js
+++ b/backend/tests/saleCredits.test.js
@@ -1,8 +1,6 @@
 process.env.STRIPE_SECRET_KEY = "test";
 process.env.STRIPE_WEBHOOK_SECRET = "whsec";
 process.env.DB_URL = "postgres://user:pass@localhost/db";
-process.env.HUNYUAN_API_KEY = "test";
-process.env.HUNYUAN_SERVER_URL = "http://localhost:4000";
 
 jest.mock("../db", () => ({
   query: jest.fn().mockResolvedValue({ rows: [] }),

--- a/backend/tests/setupGlobals.js
+++ b/backend/tests/setupGlobals.js
@@ -36,3 +36,9 @@ console.warn = (...args) => {
 if (!process.env.CLOUDFRONT_MODEL_DOMAIN) {
   process.env.CLOUDFRONT_MODEL_DOMAIN = "cdn.test";
 }
+if (!process.env.SPARC3D_ENDPOINT) {
+  process.env.SPARC3D_ENDPOINT = "http://sparc3d.test";
+}
+if (!process.env.SPARC3D_TOKEN) {
+  process.env.SPARC3D_TOKEN = "token";
+}

--- a/backend/tests/socialShares.test.js
+++ b/backend/tests/socialShares.test.js
@@ -1,51 +1,53 @@
-process.env.STRIPE_SECRET_KEY = 'test';
-process.env.STRIPE_WEBHOOK_SECRET = 'whsec';
-process.env.DB_URL = 'postgres://user:pass@localhost/db';
-process.env.HUNYUAN_API_KEY = 'test';
-process.env.HUNYUAN_SERVER_URL = 'http://localhost:4000';
+process.env.STRIPE_SECRET_KEY = "test";
+process.env.STRIPE_WEBHOOK_SECRET = "whsec";
+process.env.DB_URL = "postgres://user:pass@localhost/db";
 
-jest.mock('../db', () => ({
+jest.mock("../db", () => ({
   query: jest.fn().mockResolvedValue({ rows: [] }),
   insertSocialShare: jest.fn(),
   verifySocialShare: jest.fn(),
   getOrCreateOrderReferralLink: jest.fn(),
   insertReferredOrder: jest.fn(),
 }));
-const db = require('../db');
+const db = require("../db");
 
-jest.mock('../discountCodes', () => ({
-  createTimedCode: jest.fn().mockResolvedValue('DISC999'),
+jest.mock("../discountCodes", () => ({
+  createTimedCode: jest.fn().mockResolvedValue("DISC999"),
 }));
-const { createTimedCode } = require('../discountCodes');
+const { createTimedCode } = require("../discountCodes");
 
-const jwt = require('jsonwebtoken');
-const request = require('supertest');
-const app = require('../server');
+const jwt = require("jsonwebtoken");
+const request = require("supertest");
+const app = require("../server");
 
 beforeEach(() => {
   jest.clearAllMocks();
 });
 
-test('POST /api/social-shares stores submission', async () => {
+test("POST /api/social-shares stores submission", async () => {
   db.insertSocialShare.mockResolvedValue({ id: 1, verified: false });
-  const token = jwt.sign({ id: 'u1' }, 'secret');
+  const token = jwt.sign({ id: "u1" }, "secret");
   const res = await request(app)
-    .post('/api/social-shares')
-    .set('authorization', `Bearer ${token}`)
-    .send({ orderId: 'o1', url: 'https://example.com/post' });
+    .post("/api/social-shares")
+    .set("authorization", `Bearer ${token}`)
+    .send({ orderId: "o1", url: "https://example.com/post" });
   expect(res.status).toBe(201);
   expect(res.body.id).toBe(1);
-  expect(db.insertSocialShare).toHaveBeenCalledWith('u1', 'o1', 'https://example.com/post');
+  expect(db.insertSocialShare).toHaveBeenCalledWith(
+    "u1",
+    "o1",
+    "https://example.com/post",
+  );
 });
 
-test('POST /api/admin/social-shares/:id/verify issues discount', async () => {
-  db.verifySocialShare.mockResolvedValue({ user_id: 'u1' });
+test("POST /api/admin/social-shares/:id/verify issues discount", async () => {
+  db.verifySocialShare.mockResolvedValue({ user_id: "u1" });
   db.query.mockResolvedValueOnce({});
   const res = await request(app)
-    .post('/api/admin/social-shares/1/verify')
-    .set('x-admin-token', 'admin');
+    .post("/api/admin/social-shares/1/verify")
+    .set("x-admin-token", "admin");
   expect(res.status).toBe(200);
-  expect(res.body.code).toBe('DISC999');
+  expect(res.body.code).toBe("DISC999");
   expect(createTimedCode).toHaveBeenCalledWith(500, 168);
-  expect(db.verifySocialShare).toHaveBeenCalledWith('1', 'DISC999');
+  expect(db.verifySocialShare).toHaveBeenCalledWith("1", "DISC999");
 });

--- a/backend/tests/spaceAdmin.test.js
+++ b/backend/tests/spaceAdmin.test.js
@@ -1,8 +1,6 @@
 process.env.STRIPE_SECRET_KEY = "test";
 process.env.STRIPE_WEBHOOK_SECRET = "whsec";
 process.env.DB_URL = "postgres://user:pass@localhost/db";
-process.env.HUNYUAN_API_KEY = "test";
-process.env.HUNYUAN_SERVER_URL = "http://localhost:4000";
 
 jest.mock("../db", () => ({
   query: jest.fn(),

--- a/backend/tests/subscriptions.test.js
+++ b/backend/tests/subscriptions.test.js
@@ -1,8 +1,6 @@
 process.env.STRIPE_SECRET_KEY = "test";
 process.env.STRIPE_WEBHOOK_SECRET = "whsec";
 process.env.DB_URL = "postgres://user:pass@localhost/db";
-process.env.HUNYUAN_API_KEY = "test";
-process.env.HUNYUAN_SERVER_URL = "http://localhost:4000";
 
 jest.mock("../db", () => ({
   query: jest.fn().mockResolvedValue({ rows: [] }),


### PR DESCRIPTION
## Summary
- validate SPARC3D env vars in backend config
- drop unused Hunyuan vars from config and tests
- set default SPARC3D vars in test setup
- clean duplicate generateModel import

## Testing
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_686f76c95410832da64d403581d977a2