### PR TITLE
Remove Hunyuan env vars from backend tests

### DIFF
--- a/backend/tests/additionalApi.test.js
+++ b/backend/tests/additionalApi.test.js
@@ -1,8 +1,6 @@
 process.env.STRIPE_SECRET_KEY = "test";
 process.env.STRIPE_WEBHOOK_SECRET = "whsec";
 process.env.DB_URL = "postgres://user:pass@localhost/db";
-process.env.HUNYUAN_API_KEY = "test";
-process.env.HUNYUAN_SERVER_URL = "http://localhost:4000";
 
 jest.mock("../db", () => ({
   query: jest.fn().mockResolvedValue({ rows: [] }),

--- a/backend/tests/adminAds.test.js
+++ b/backend/tests/adminAds.test.js
@@ -3,8 +3,6 @@ process.env.DALLE_API_URL = 'http://localhost:5002/generate';
 process.env.LLM_API_URL = '';
 process.env.STRIPE_SECRET_KEY = 'test';
 process.env.STRIPE_WEBHOOK_SECRET = 'whsec';
-process.env.HUNYUAN_API_KEY = 'test';
-process.env.HUNYUAN_SERVER_URL = 'http://localhost:4000';
 
 jest.mock('axios');
 const axios = require('axios');

--- a/backend/tests/analytics.test.js
+++ b/backend/tests/analytics.test.js
@@ -1,8 +1,6 @@
 process.env.STRIPE_SECRET_KEY = "test";
 process.env.STRIPE_WEBHOOK_SECRET = "whsec";
 process.env.DB_URL = "postgres://user:pass@localhost/db";
-process.env.HUNYUAN_API_KEY = "test";
-process.env.HUNYUAN_SERVER_URL = "http://localhost:4000";
 
 jest.mock("../db", () => ({
   query: jest.fn(),

--- a/backend/tests/api.test.js
+++ b/backend/tests/api.test.js
@@ -1,8 +1,6 @@
 process.env.STRIPE_SECRET_KEY = "test";
 process.env.STRIPE_WEBHOOK_SECRET = "whsec";
 process.env.DB_URL = "postgres://user:pass@localhost/db";
-process.env.HUNYUAN_API_KEY = "test";
-process.env.HUNYUAN_SERVER_URL = "http://localhost:4000";
 
 jest.mock("../db", () => ({
   query: jest.fn().mockResolvedValue({ rows: [] }),

--- a/backend/tests/apiModels.test.js
+++ b/backend/tests/apiModels.test.js
@@ -1,8 +1,6 @@
 process.env.STRIPE_SECRET_KEY = "test";
 process.env.STRIPE_WEBHOOK_SECRET = "whsec";
 process.env.DB_URL = "postgres://user:pass@localhost/db";
-process.env.HUNYUAN_API_KEY = "test";
-process.env.HUNYUAN_SERVER_URL = "http://localhost:4000";
 process.env.CLOUDFRONT_MODEL_DOMAIN = "cdn.example.com";
 process.env.AWS_REGION = "us-east-1";
 process.env.S3_BUCKET = "bucket";

--- a/backend/tests/cart.test.js
+++ b/backend/tests/cart.test.js
@@ -1,8 +1,6 @@
 process.env.STRIPE_SECRET_KEY = "test";
 process.env.STRIPE_WEBHOOK_SECRET = "whsec";
 process.env.DB_URL = "postgres://user:pass@localhost/db";
-process.env.HUNYUAN_API_KEY = "test";
-process.env.HUNYUAN_SERVER_URL = "http://localhost:4000";
 
 jest.mock("../db", () => ({
   insertCartItem: jest.fn(),

--- a/backend/tests/commissions.test.js
+++ b/backend/tests/commissions.test.js
@@ -1,8 +1,6 @@
 process.env.STRIPE_SECRET_KEY = 'test';
 process.env.STRIPE_WEBHOOK_SECRET = 'whsec';
 process.env.DB_URL = 'postgres://user:pass@localhost/db';
-process.env.HUNYUAN_API_KEY = 'test';
-process.env.HUNYUAN_SERVER_URL = 'http://localhost:4000';
 
 jest.mock('../db', () => ({
   query: jest.fn().mockResolvedValue({ rows: [] }),

--- a/backend/tests/config.test.js
+++ b/backend/tests/config.test.js
@@ -1,7 +1,6 @@
 process.env.DB_URL = "postgres://user:pass@localhost/db";
 process.env.STRIPE_SECRET_KEY = "test";
 process.env.STRIPE_WEBHOOK_SECRET = "whsec";
-process.env.HUNYUAN_API_KEY = "test";
 process.env.CLOUDFRONT_MODEL_DOMAIN = "https://domain";
 
 const original = process.env.CLOUDFRONT_MODEL_DOMAIN;

--- a/backend/tests/engagement.test.js
+++ b/backend/tests/engagement.test.js
@@ -1,8 +1,6 @@
 process.env.STRIPE_SECRET_KEY = "test";
 process.env.STRIPE_WEBHOOK_SECRET = "whsec";
 process.env.DB_URL = "postgres://user:pass@localhost/db";
-process.env.HUNYUAN_API_KEY = "test";
-process.env.HUNYUAN_SERVER_URL = "http://localhost:4000";
 
 jest.mock("../db", () => ({
   query: jest.fn().mockResolvedValue({ rows: [] }),

--- a/backend/tests/flashSale.test.js
+++ b/backend/tests/flashSale.test.js
@@ -1,8 +1,6 @@
 process.env.STRIPE_SECRET_KEY = 'test';
 process.env.STRIPE_WEBHOOK_SECRET = 'whsec';
 process.env.DB_URL = 'postgres://user:pass@localhost/db';
-process.env.HUNYUAN_API_KEY = 'test';
-process.env.HUNYUAN_SERVER_URL = 'http://localhost:4000';
 
 jest.mock('../db', () => ({
   query: jest.fn().mockResolvedValue({ rows: [] }),

--- a/backend/tests/health.test.js
+++ b/backend/tests/health.test.js
@@ -1,8 +1,6 @@
 process.env.STRIPE_SECRET_KEY = "test";
 process.env.STRIPE_WEBHOOK_SECRET = "whsec";
 process.env.DB_URL = "postgres://user:pass@localhost/db";
-process.env.HUNYUAN_API_KEY = "test";
-process.env.HUNYUAN_SERVER_URL = "http://localhost:4000";
 process.env.AWS_REGION = "us-east-1";
 process.env.S3_BUCKET = "bucket";
 

--- a/backend/tests/hubAdmin.test.js
+++ b/backend/tests/hubAdmin.test.js
@@ -1,8 +1,6 @@
 process.env.STRIPE_SECRET_KEY = "test";
 process.env.STRIPE_WEBHOOK_SECRET = "whsec";
 process.env.DB_URL = "postgres://user:pass@localhost/db";
-process.env.HUNYUAN_API_KEY = "test";
-process.env.HUNYUAN_SERVER_URL = "http://localhost:4000";
 
 jest.mock("../db", () => ({
   query: jest.fn(),

--- a/backend/tests/mailingList.test.js
+++ b/backend/tests/mailingList.test.js
@@ -1,8 +1,6 @@
 process.env.STRIPE_SECRET_KEY = 'test';
 process.env.STRIPE_WEBHOOK_SECRET = 'whsec';
 process.env.DB_URL = 'postgres://user:pass@localhost/db';
-process.env.HUNYUAN_API_KEY = 'test';
-process.env.HUNYUAN_SERVER_URL = 'http://localhost:4000';
 
 jest.mock('../db', () => ({
   upsertMailingListEntry: jest.fn().mockResolvedValue({}),

--- a/backend/tests/operationsDashboard.test.js
+++ b/backend/tests/operationsDashboard.test.js
@@ -1,7 +1,6 @@
 process.env.STRIPE_SECRET_KEY = 'test';
 process.env.STRIPE_WEBHOOK_SECRET = 'whsec';
 process.env.DB_URL = 'postgres://user:pass@localhost/db';
-process.env.HUNYUAN_API_KEY = 'test';
 
 jest.mock('../db', () => ({
   listPrinterHubs: jest.fn(),

--- a/backend/tests/passwordReset.test.js
+++ b/backend/tests/passwordReset.test.js
@@ -1,8 +1,6 @@
 process.env.STRIPE_SECRET_KEY = 'test';
 process.env.STRIPE_WEBHOOK_SECRET = 'whsec';
 process.env.DB_URL = 'postgres://user:pass@localhost/db';
-process.env.HUNYUAN_API_KEY = 'test';
-process.env.HUNYUAN_SERVER_URL = 'http://localhost:4000';
 
 jest.mock('../db', () => ({
   query: jest.fn().mockResolvedValue({ rows: [] }),

--- a/backend/tests/payouts.test.js
+++ b/backend/tests/payouts.test.js
@@ -1,8 +1,6 @@
 process.env.STRIPE_SECRET_KEY = 'test';
 process.env.STRIPE_WEBHOOK_SECRET = 'whsec';
 process.env.DB_URL = 'postgres://user:pass@localhost/db';
-process.env.HUNYUAN_API_KEY = 'test';
-process.env.HUNYUAN_SERVER_URL = 'http://localhost:4000';
 
 jest.mock('../db', () => ({
   query: jest.fn().mockResolvedValue({ rows: [] }),

--- a/backend/tests/printJobs.test.js
+++ b/backend/tests/printJobs.test.js
@@ -1,8 +1,6 @@
 process.env.STRIPE_SECRET_KEY = 'test';
 process.env.STRIPE_WEBHOOK_SECRET = 'whsec';
 process.env.DB_URL = 'postgres://user:pass@localhost/db';
-process.env.HUNYUAN_API_KEY = 'test';
-process.env.HUNYUAN_SERVER_URL = 'http://localhost:4000';
 
 jest.mock('../db', () => ({
   query: jest.fn().mockResolvedValue({ rows: [] }),

--- a/backend/tests/printerWebhook.test.js
+++ b/backend/tests/printerWebhook.test.js
@@ -1,7 +1,6 @@
 process.env.STRIPE_SECRET_KEY = "test";
 process.env.STRIPE_WEBHOOK_SECRET = "whsec";
 process.env.DB_URL = "postgres://user:pass@localhost/db";
-process.env.HUNYUAN_API_KEY = "test";
 
 jest.mock("../db", () => ({
   query: jest.fn().mockResolvedValue({}),

--- a/backend/tests/referralPost.test.js
+++ b/backend/tests/referralPost.test.js
@@ -1,8 +1,6 @@
 process.env.STRIPE_SECRET_KEY = 'test';
 process.env.STRIPE_WEBHOOK_SECRET = 'whsec';
 process.env.DB_URL = 'postgres://user:pass@localhost/db';
-process.env.HUNYUAN_API_KEY = 'test';
-process.env.HUNYUAN_SERVER_URL = 'http://localhost:4000';
 
 const request = require('supertest');
 const jwt = require('jsonwebtoken');

--- a/backend/tests/rewards.test.js
+++ b/backend/tests/rewards.test.js
@@ -1,8 +1,6 @@
 process.env.STRIPE_SECRET_KEY = "test";
 process.env.STRIPE_WEBHOOK_SECRET = "whsec";
 process.env.DB_URL = "postgres://user:pass@localhost/db";
-process.env.HUNYUAN_API_KEY = "test";
-process.env.HUNYUAN_SERVER_URL = "http://localhost:4000";
 
 jest.mock("../db", () => ({
   query: jest.fn().mockResolvedValue({ rows: [] }),

--- a/backend/tests/saleCredits.test.js
+++ b/backend/tests/saleCredits.test.js
@@ -1,8 +1,6 @@
 process.env.STRIPE_SECRET_KEY = "test";
 process.env.STRIPE_WEBHOOK_SECRET = "whsec";
 process.env.DB_URL = "postgres://user:pass@localhost/db";
-process.env.HUNYUAN_API_KEY = "test";
-process.env.HUNYUAN_SERVER_URL = "http://localhost:4000";
 
 jest.mock("../db", () => ({
   query: jest.fn().mockResolvedValue({ rows: [] }),

--- a/backend/tests/setupGlobals.js
+++ b/backend/tests/setupGlobals.js
@@ -36,3 +36,11 @@ console.warn = (...args) => {
 if (!process.env.CLOUDFRONT_MODEL_DOMAIN) {
   process.env.CLOUDFRONT_MODEL_DOMAIN = "cdn.test";
 }
+
+// Provide defaults for Sparc3D tests
+if (!process.env.SPARC3D_ENDPOINT) {
+  process.env.SPARC3D_ENDPOINT = "http://localhost:5000/generate";
+}
+if (!process.env.SPARC3D_TOKEN) {
+  process.env.SPARC3D_TOKEN = "token";
+}

--- a/backend/tests/socialShares.test.js
+++ b/backend/tests/socialShares.test.js
@@ -1,8 +1,6 @@
 process.env.STRIPE_SECRET_KEY = 'test';
 process.env.STRIPE_WEBHOOK_SECRET = 'whsec';
 process.env.DB_URL = 'postgres://user:pass@localhost/db';
-process.env.HUNYUAN_API_KEY = 'test';
-process.env.HUNYUAN_SERVER_URL = 'http://localhost:4000';
 
 jest.mock('../db', () => ({
   query: jest.fn().mockResolvedValue({ rows: [] }),

--- a/backend/tests/spaceAdmin.test.js
+++ b/backend/tests/spaceAdmin.test.js
@@ -1,8 +1,6 @@
 process.env.STRIPE_SECRET_KEY = "test";
 process.env.STRIPE_WEBHOOK_SECRET = "whsec";
 process.env.DB_URL = "postgres://user:pass@localhost/db";
-process.env.HUNYUAN_API_KEY = "test";
-process.env.HUNYUAN_SERVER_URL = "http://localhost:4000";
 
 jest.mock("../db", () => ({
   query: jest.fn(),

--- a/backend/tests/subscriptions.test.js
+++ b/backend/tests/subscriptions.test.js
@@ -1,8 +1,6 @@
 process.env.STRIPE_SECRET_KEY = "test";
 process.env.STRIPE_WEBHOOK_SECRET = "whsec";
 process.env.DB_URL = "postgres://user:pass@localhost/db";
-process.env.HUNYUAN_API_KEY = "test";
-process.env.HUNYUAN_SERVER_URL = "http://localhost:4000";
 
 jest.mock("../db", () => ({
   query: jest.fn().mockResolvedValue({ rows: [] }),


### PR DESCRIPTION
## Summary
- drop `HUNYUAN_*` env variable setup from backend tests
- add default Sparc3D env vars in `tests/setupGlobals.js`

## Testing
- `npm test` *(fails: Missing required env vars: HUNYUAN_API_KEY)*
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_686f76e57930832d9072112d12d9e1b8