### PR TITLE
Add pipeline smoke test workflow

### DIFF
--- a/.github/workflows/pipeline-smoke.yml
+++ b/.github/workflows/pipeline-smoke.yml
@@ -1,0 +1,37 @@
+name: Full Pipeline Smoke Test
+
+on:
+  push:
+    branches: [ dev, 00000production ]
+  workflow_dispatch:
+
+jobs:
+  smoke_test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Validate env
+        run: bash scripts/validate-env.sh
+
+      - name: Start server
+        run: pnpm dev &
+      - name: Wait for server
+        run: |
+          for i in {1..20}; do
+            nc -z localhost 3000 && break
+            echo "Waiting for port 3000..."
+            sleep 1
+          done
+
+      - name: Run full-pipeline test
+        run: node scripts/test-full-pipeline.js


### PR DESCRIPTION
## Summary
- add pipeline smoke test workflow triggered on dev and 00000production branches

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci` *(fails: STRIPE_TEST_KEY or STRIPE_LIVE_KEY must be set)*
- `npm run smoke` *(fails: STRIPE_TEST_KEY or STRIPE_LIVE_KEY must be set)*

------
https://chatgpt.com/codex/tasks/task_e_686fa9a55960832db90b231c160543d2