### PR TITLE
Add Babel config for TypeScript tests

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  plugins: ['@babel/plugin-syntax-typescript'],
+};

--- a/backend/babel.config.js
+++ b/backend/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  plugins: ["@babel/plugin-syntax-typescript"],
+};


### PR DESCRIPTION
## Summary
- add `babel.config.js` files to support parsing TypeScript during tests

## Testing
- `npm run format` in `backend/`
- `npm test` *(fails: SPARC3D and textToImage tests cannot run due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686fbed41bcc832da2adc81ec5850c18