### PR TITLE
Fix login back link loop

### DIFF
--- a/login.html
+++ b/login.html
@@ -199,6 +199,9 @@
           ) {
             target = ref.href;
           }
+          if (target.includes("signup.html")) {
+            target = "index.html";
+          }
         } catch {
           if (from === "1") target = "CommunityCreations.html";
         }


### PR DESCRIPTION
## Summary
- avoid redirecting login back button to signup

## Testing
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6870b5cea1e4832db5df8107dff77475