### PR TITLE
Fix .glb pipeline tests

### DIFF
--- a/backend/tests/generateModel.test.ts
+++ b/backend/tests/generateModel.test.ts
@@ -1,11 +1,17 @@
-import { generateModel } from '../src/pipeline/generateModel';
-import * as text from '../src/lib/textToImage';
-import * as img2text from '../src/lib/imageToText';
-import * as prep from '../src/lib/prepareImage';
-import * as sparc from '../src/lib/sparc3dClient';
-import * as s3 from '../src/lib/storeGlb';
-import fs from 'fs';
-import path from 'path';
+jest.mock('../src/lib/textToImage.js', () => ({ textToImage: jest.fn() }));
+jest.mock('../src/lib/imageToText.js', () => ({ imageToText: jest.fn() }));
+jest.mock('../src/lib/prepareImage.js', () => ({ prepareImage: jest.fn() }));
+jest.mock('../src/lib/sparc3dClient.js', () => ({ generateGlb: jest.fn() }));
+jest.mock('../src/lib/storeGlb.js', () => ({ storeGlb: jest.fn() }));
+
+const { generateModel } = require('../src/pipeline/generateModel.js');
+const text = require('../src/lib/textToImage.js');
+const img2text = require('../src/lib/imageToText.js');
+const prep = require('../src/lib/prepareImage.js');
+const sparc = require('../src/lib/sparc3dClient.js');
+const s3 = require('../src/lib/storeGlb.js');
+const fs = require('fs');
+const path = require('path');
 
 describe('generateModel', () => {
   const fixture = path.join(__dirname, 'tmp.png');
@@ -19,17 +25,20 @@ describe('generateModel', () => {
   });
 
   beforeEach(() => {
+    process.env.STABILITY_KEY = 'key';
+    process.env.SPARC3D_TOKEN = 'token';
+    process.env.AWS_REGION = 'us-east-1';
     jest.spyOn(console, 'time').mockImplementation(() => {});
     jest.spyOn(console, 'timeEnd').mockImplementation(() => {});
-    jest.spyOn(text, 'textToImage').mockResolvedValue('https://img');
-    jest.spyOn(img2text, 'imageToText').mockResolvedValue('prompt');
-    jest.spyOn(prep, 'prepareImage').mockResolvedValue('https://img');
-    jest.spyOn(sparc, 'generateGlb').mockResolvedValue(Buffer.from('glb'));
-    jest.spyOn(s3, 'storeGlb').mockResolvedValue('https://cdn/model.glb');
+    text.textToImage.mockResolvedValue('https://img');
+    img2text.imageToText.mockResolvedValue('prompt');
+    prep.prepareImage.mockResolvedValue('https://img');
+    sparc.generateGlb.mockResolvedValue(Buffer.from('glb'));
+    s3.storeGlb.mockResolvedValue('https://cdn/model.glb');
   });
 
   afterEach(() => {
-    jest.restoreAllMocks();
+    jest.resetAllMocks();
   });
 
   test('generates image when missing and stores model', async () => {

--- a/backend/tests/sparc3dClient.test.ts
+++ b/backend/tests/sparc3dClient.test.ts
@@ -1,5 +1,5 @@
-import nock from 'nock';
-import { generateGlb } from '../src/lib/sparc3dClient';
+const nock = require('nock');
+const { generateGlb } = require('../src/lib/sparc3dClient.js');
 
 describe('generateGlb', () => {
   const endpoint = 'https://api.example.com/generate';

--- a/backend/tests/textToImage.test.ts
+++ b/backend/tests/textToImage.test.ts
@@ -1,6 +1,6 @@
-import nock from 'nock';
-import { textToImage } from '../src/lib/textToImage';
-import * as s3 from '../src/lib/uploadS3';
+const nock = require('nock');
+const { textToImage } = require('../src/lib/textToImage.js');
+const s3 = require('../src/lib/uploadS3.js');
 
 describe('textToImage', () => {
   const endpoint = 'https://api.stability.ai';


### PR DESCRIPTION
## Summary
- convert TypeScript tests to CommonJS so Jest doesn't choke
- inject required env vars in generateModel tests
- mock dependencies before loading generateModel

## Testing
- `npx jest tests/generateModel.test.ts tests/sparc3dClient.test.ts tests/textToImage.test.ts --coverage=false`

------
https://chatgpt.com/codex/tasks/task_e_6870f5d67984832db8fd6f1eb69ff551