### PR TITLE
Add basic 3D generator hook

### DIFF
--- a/e2e/smoke.test.js
+++ b/e2e/smoke.test.js
@@ -27,3 +27,4 @@ test("checkout flow", async ({ page }) => {
   await expect(page.locator("#submit-payment")).toBeVisible();
   await percySnapshot(page, "checkout flow");
 });
+\ntest("model generator page", async ({ page }) => {\n  await page.goto("/index.html");\n  await expect(page.locator("#viewer")).toBeVisible();\n});

--- a/index.html
+++ b/index.html
@@ -298,6 +298,7 @@
     <main
       class="flex-1 flex flex-col items-center justify-start gap-4 px-4 lg:px-16"
       style="margin-top: -4rem"
+      <div id="gen-app" class="my-4 w-full max-w-md"></div>
     >
       <!-- 3-D preview ---------------------------------------------------- -->
       <div class="relative flex justify-center w-full max-w-lg">
@@ -666,6 +667,7 @@
     </div>
     <script></script>
     <script type="module" src="js/printclub.js"></script>
+    <script type="module" src="js/modelGenerator.js"></script>
     <script type="module" src="js/rewardBadge.js"></script>
     <script type="module" src="js/basket.js" defer></script>
     <div

--- a/js/modelGenerator.js
+++ b/js/modelGenerator.js
@@ -1,0 +1,67 @@
+import React, { useState } from 'https://esm.sh/react@18';
+import { createRoot } from 'https://esm.sh/react-dom@18/client';
+import useGenerateModel from './useGenerateModel.js';
+
+function GeneratorApp() {
+  const [prompt, setPrompt] = useState('');
+  const [file, setFile] = useState(null);
+  const { generate, loading, modelUrl, error } = useGenerateModel();
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    await generate(prompt, file);
+  };
+
+  return React.createElement(
+    'div',
+    { className: 'space-y-4' },
+    React.createElement(
+      'form',
+      { onSubmit: handleSubmit, className: 'space-y-2' },
+      React.createElement('input', {
+        id: 'gen-prompt',
+        type: 'text',
+        value: prompt,
+        onChange: (e) => setPrompt(e.target.value),
+        className: 'border p-2 w-full text-black',
+        placeholder: 'Enter prompt',
+        required: true,
+      }),
+      React.createElement('input', {
+        id: 'gen-image',
+        type: 'file',
+        accept: 'image/*',
+        onChange: (e) => setFile(e.target.files[0] || null),
+      }),
+      React.createElement(
+        'button',
+        {
+          id: 'gen-submit',
+          type: 'submit',
+          className: 'px-4 py-2 bg-blue-600 text-white rounded',
+          disabled: loading,
+        },
+        loading ? 'Generating...' : 'Generate 3D'
+      )
+    ),
+    loading &&
+      React.createElement('div', {
+        className:
+          'animate-spin h-8 w-8 border-4 border-blue-500 border-t-transparent rounded-full',
+      }),
+    error && React.createElement('p', { className: 'text-red-500' }, error),
+    modelUrl &&
+      React.createElement('model-viewer', {
+        id: 'gen-viewer',
+        src: modelUrl,
+        style: 'width: 100%; height: 300px;',
+        autoplay: true,
+        'camera-controls': true,
+      })
+  );
+}
+
+const rootEl = document.getElementById('gen-app');
+if (rootEl) {
+  createRoot(rootEl).render(React.createElement(GeneratorApp));
+}

--- a/js/useGenerateModel.js
+++ b/js/useGenerateModel.js
@@ -1,0 +1,28 @@
+import React, { useState } from 'https://esm.sh/react@18';
+
+export default function useGenerateModel() {
+  const [loading, setLoading] = useState(false);
+  const [modelUrl, setModelUrl] = useState(null);
+  const [error, setError] = useState(null);
+
+  const generate = async (prompt, imageFile) => {
+    setLoading(true);
+    setError(null);
+    setModelUrl(null);
+    try {
+      const formData = new FormData();
+      formData.append('prompt', prompt);
+      if (imageFile) formData.append('image', imageFile);
+      const res = await fetch('/api/generate', { method: 'POST', body: formData });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Request failed');
+      setModelUrl(data.glb_url);
+    } catch (err) {
+      setError(err.message || 'Error generating model');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { generate, loading, modelUrl, error };
+}


### PR DESCRIPTION
## Summary
- add `useGenerateModel` React hook
- add generator UI script and mount on homepage
- update smoke test to load homepage

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_687128e00cb8832d8ff141022df78db6