### PR TITLE
Implement S3 upload and unit test

### DIFF
--- a/backend/tests/storeGlb.test.ts
+++ b/backend/tests/storeGlb.test.ts
@@ -1,0 +1,37 @@
+const { storeGlb } = require('../src/lib/storeGlb.js');
+const aws = require('@aws-sdk/client-s3');
+
+jest.mock('@aws-sdk/client-s3', () => ({
+  S3Client: jest.fn(),
+  PutObjectCommand: jest.fn(),
+}));
+
+describe('storeGlb', () => {
+  beforeEach(() => {
+    process.env.AWS_REGION = 'us-east-1';
+    process.env.S3_BUCKET = 'bucket';
+    process.env.CLOUDFRONT_DOMAIN = 'cdn';
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('uploads buffer to s3 and returns url', async () => {
+    const send = jest.fn().mockResolvedValue({});
+    aws.S3Client.mockImplementation(() => ({ send }));
+    const data = Buffer.from('glb');
+
+    const url = await storeGlb(data);
+
+    expect(aws.PutObjectCommand).toHaveBeenCalledWith({
+      Bucket: 'bucket',
+      Key: expect.stringMatching(/^models\/\d+-[a-z0-9]+\.glb$/),
+      Body: data,
+      ContentType: 'model/gltf-binary',
+      ACL: 'public-read',
+    });
+    expect(url).toMatch(/^https:\/\/cdn\/models\/\d+-[a-z0-9]+\.glb$/);
+    expect(send).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit test for storeGlb upload logic
- ensure S3 upload stores GLB with public-read ACL

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`
- `npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_687128dc0d1c832d90a3d90d1ca42b49