### PR TITLE
Add Stripe webhook smoke test

### DIFF
--- a/.github/workflows/pipeline-smoke.yml
+++ b/.github/workflows/pipeline-smoke.yml
@@ -51,6 +51,8 @@ jobs:
 
       - name: Test generate endpoint
         run: pnpm run test:generate
+      - name: Test Stripe webhook
+        run: pnpm run test:webhook
 
       - name: Stop backend
         run: pkill -f "node backend/server.js" || true

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "a11y": "jest --runTestsByPath tests/a11y",
     "netlify:deploy": "scripts/netlify-preflight.sh && netlify deploy",
     "diagnose": "bash scripts/diagnose.sh",
-    "test:generate": "node scripts/test-generate.js"
+    "test:generate": "node scripts/test-generate.js",
+    "test:webhook": "node scripts/test-webhook.js"
   },
   "keywords": [],
   "author": "",

--- a/scripts/test-webhook.js
+++ b/scripts/test-webhook.js
@@ -1,0 +1,48 @@
+const axios = require("axios");
+const Stripe = require("stripe");
+const { startServer } = require("../tests/util");
+const { orders } = require("../backend/src/routes/checkout");
+
+(async () => {
+  const port = 4001;
+  process.env.STRIPE_WEBHOOK_SECRET =
+    process.env.STRIPE_WEBHOOK_SECRET || "whsec_test";
+  const stripe = new Stripe("sk_test_dummy");
+  const { url, close } = await startServer(port);
+  const sessionId = `sess_${Date.now()}`;
+  orders.set(sessionId, {
+    slug: "test-model",
+    email: "user@example.com",
+    paid: false,
+  });
+
+  const event = {
+    id: "evt_test_webhook",
+    object: "event",
+    type: "checkout.session.completed",
+    data: { object: { id: sessionId } },
+  };
+  const payload = JSON.stringify(event);
+  const signature = stripe.webhooks.generateTestHeaderString({
+    payload,
+    secret: process.env.STRIPE_WEBHOOK_SECRET,
+  });
+
+  try {
+    const res = await axios.post(`${url}/api/stripe/webhook`, payload, {
+      headers: {
+        "Stripe-Signature": signature,
+        "Content-Type": "application/json",
+      },
+      validateStatus: () => true,
+    });
+    if (res.status !== 200) throw new Error(`status ${res.status}`);
+    if (!orders.get(sessionId)?.paid) throw new Error("order not marked paid");
+    console.log("✅ webhook test passed");
+  } catch (err) {
+    console.error("❌ webhook test failed:", err.message);
+    process.exit(1);
+  } finally {
+    await close();
+  }
+})();


### PR DESCRIPTION
## Summary
- add `scripts/test-webhook.js` to verify webhook processing
- expose `test:webhook` script
- run webhook check in CI pipeline smoke job

## Testing
- `npx prettier -w scripts/test-webhook.js`
- `npm test --prefix backend --silent`

------
https://chatgpt.com/codex/tasks/task_e_687128e4b120832db2b9963794608199