### PR TITLE
Preserve vertex colors in generated GLB models

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.842.0",
+        "@gltf-transform/core": "^3.3.1",
         "@sendgrid/mail": "^8.1.5",
         "axios": "^1.10.0",
         "bcryptjs": "^3.0.2",
@@ -1914,6 +1915,18 @@
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@gltf-transform/core": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@gltf-transform/core/-/core-3.10.1.tgz",
+      "integrity": "sha512-50OYemknGNxjBmiOM6iJp04JAu0bl9jvXJfN/gFt9QdJO02cPDcoXlTfSPJG6TVWDcfl0xPlsx1vybcbPVGFcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "property-graph": "^1.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/donmccurdy"
       }
     },
     "node_modules/@humanfs/core": {
@@ -11836,6 +11849,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/property-graph": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/property-graph/-/property-graph-1.3.1.tgz",
+      "integrity": "sha512-gei3N/bHWJdCItJ4blnlGWd9iauEZI+JZYj/A0D177XSI01+QhiJGAVscYBhe3Yywow3A2QJzVtsO2P+UgrRRQ==",
+      "license": "MIT"
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",

--- a/backend/package.json
+++ b/backend/package.json
@@ -41,6 +41,7 @@
   "description": "",
   "dependencies": {
     "@aws-sdk/client-s3": "^3.842.0",
+    "@gltf-transform/core": "^3.3.1",
     "@sendgrid/mail": "^8.1.5",
     "axios": "^1.10.0",
     "bcryptjs": "^3.0.2",

--- a/backend/src/lib/preserveColors.js
+++ b/backend/src/lib/preserveColors.js
@@ -1,0 +1,28 @@
+const { NodeIO } = require('@gltf-transform/core');
+
+async function preserveColors(glb) {
+  const io = new NodeIO();
+  const doc = io.readBinary(glb);
+  const root = doc.getRoot();
+  for (const mesh of root.listMeshes()) {
+    for (const prim of mesh.listPrimitives()) {
+      const extras = prim.getExtras() || {};
+      if (!prim.getAttribute('COLOR_0')) {
+        if (Array.isArray(extras.vertexColors)) {
+          const accessor = doc
+            .createAccessor()
+            .setType('VEC4')
+            .setArray(new Float32Array(extras.vertexColors));
+          prim.setAttribute('COLOR_0', accessor);
+        } else if (Array.isArray(extras.flatColor)) {
+          const mat = prim.getMaterial() || doc.createMaterial();
+          mat.setBaseColorFactor(extras.flatColor);
+          prim.setMaterial(mat);
+        }
+      }
+    }
+  }
+  return io.writeBinary(doc);
+}
+
+module.exports = { preserveColors };

--- a/backend/src/lib/preserveColors.ts
+++ b/backend/src/lib/preserveColors.ts
@@ -1,0 +1,32 @@
+import { NodeIO } from '@gltf-transform/core';
+
+/**
+ * Convert vertexColors or flatColor metadata stored in primitive extras
+ * to standard COLOR_0 attributes or material color factors.
+ */
+export async function preserveColors(glb: Buffer): Promise<Buffer> {
+  const io = new NodeIO();
+  const doc = io.readBinary(glb);
+  const root = doc.getRoot();
+
+  for (const mesh of root.listMeshes()) {
+    for (const prim of mesh.listPrimitives()) {
+      const extras: any = prim.getExtras() || {};
+      if (!prim.getAttribute('COLOR_0')) {
+        if (Array.isArray(extras.vertexColors)) {
+          const accessor = doc
+            .createAccessor()
+            .setType('VEC4')
+            .setArray(new Float32Array(extras.vertexColors));
+          prim.setAttribute('COLOR_0', accessor);
+        } else if (Array.isArray(extras.flatColor)) {
+          const mat = prim.getMaterial() ?? doc.createMaterial();
+          mat.setBaseColorFactor(extras.flatColor as [number, number, number, number]);
+          prim.setMaterial(mat);
+        }
+      }
+    }
+  }
+
+  return io.writeBinary(doc);
+}

--- a/backend/src/pipeline/generateModel.ts
+++ b/backend/src/pipeline/generateModel.ts
@@ -2,6 +2,7 @@ import { textToImage } from '../lib/textToImage';
 import { imageToText } from '../lib/imageToText';
 import { prepareImage } from '../lib/prepareImage';
 import { generateGlb } from '../lib/sparc3dClient';
+import { preserveColors } from '../lib/preserveColors';
 import { storeGlb } from '../lib/storeGlb';
 import { capture } from '../lib/logger';
 
@@ -31,7 +32,8 @@ export async function generateModel({ prompt, image }: GenerateModelParams): Pro
   }
 
   const glbData = await generateGlb({ prompt, imageURL });
-  const url = await storeGlb(glbData);
+  const colored = await preserveColors(glbData);
+  const url = await storeGlb(colored);
   console.timeEnd('pipeline');
   return url;
 }

--- a/backend/tests/preserveColors.test.ts
+++ b/backend/tests/preserveColors.test.ts
@@ -1,0 +1,31 @@
+const { preserveColors } = require('../src/lib/preserveColors.js');
+const { NodeIO, Document } = require('@gltf-transform/core');
+
+describe('preserveColors', () => {
+  function makeGlb() {
+    const doc = new Document();
+    const position = doc.createAccessor().setType('VEC3').setArray(new Float32Array([0,0,0,1,0,0,0,1,0]));
+    const prim = doc.createPrimitive();
+    prim.setAttribute('POSITION', position);
+    prim.setExtras({ vertexColors: [1,0,0,1,0,1,0,1,0,0,1,1] });
+    const mesh = doc.createMesh().addPrimitive(prim);
+    doc.createNode('n').setMesh(mesh);
+    const io = new NodeIO();
+    return io.writeBinary(doc);
+  }
+
+  test('promotes vertexColors extras to COLOR_0 attribute', async () => {
+    const buf = makeGlb();
+    const out = await preserveColors(buf);
+    const io = new NodeIO();
+    const doc = io.readBinary(out);
+    const prim = doc.getRoot().listMeshes()[0].listPrimitives()[0];
+    const attr = prim.getAttribute('COLOR_0');
+    expect(attr).toBeDefined();
+    expect(Array.from(attr.getArray())).toEqual([
+      1,0,0,1,
+      0,1,0,1,
+      0,0,1,1,
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure any RGBA metadata is kept when generating models
- provide `preserveColors` helper for GLB buffers
- test color preservation
- fix smoke test file

## Testing
- `npm test --prefix backend`
- `npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_6871315bd0d8832da73806b759ee87df