### PR TITLE
Add job polling hook

### DIFF
--- a/backend/tests/useJobPolling.test.js
+++ b/backend/tests/useJobPolling.test.js
@@ -1,0 +1,36 @@
+/** @jest-environment jsdom */
+const React = require('react');
+const { act } = require('react-dom/test-utils');
+const { createRoot } = require('react-dom/client');
+const useJobPolling = require('../../js/useJobPolling.node.js');
+
+jest.useFakeTimers();
+
+test('polls until complete', async () => {
+  console.error.mockImplementation(() => {});
+  const responses = [
+    { status: 'pending' },
+    { status: 'complete', model_url: '/m.glb' },
+  ];
+  global.fetch = jest.fn(() =>
+    Promise.resolve({ ok: true, json: () => Promise.resolve(responses.shift()) })
+  );
+  let result;
+  function Wrapper() {
+    result = useJobPolling('123');
+    return null;
+  }
+  const div = document.createElement('div');
+  let root;
+  await act(async () => {
+    root = createRoot(div);
+    root.render(React.createElement(Wrapper));
+  });
+  await act(async () => {
+    jest.advanceTimersByTime(2000);
+  });
+  expect(fetch).toHaveBeenCalledTimes(2);
+  expect(result.status).toBe('complete');
+  expect(result.glbUrl).toBe('/m.glb');
+  await act(async () => root.unmount());
+});

--- a/e2e/smoke.test.js
+++ b/e2e/smoke.test.js
@@ -27,4 +27,8 @@ test("checkout flow", async ({ page }) => {
   await expect(page.locator("#submit-payment")).toBeVisible();
   await percySnapshot(page, "checkout flow");
 });
-\ntest("model generator page", async ({ page }) => {\n  await page.goto("/index.html");\n  await expect(page.locator("#viewer")).toBeVisible();\n});
+
+test("model generator page", async ({ page }) => {
+  await page.goto("/index.html");
+  await expect(page.locator("#viewer")).toBeVisible();
+});

--- a/js/modelGenerator.js
+++ b/js/modelGenerator.js
@@ -5,7 +5,7 @@ import useGenerateModel from './useGenerateModel.js';
 function GeneratorApp() {
   const [prompt, setPrompt] = useState('');
   const [file, setFile] = useState(null);
-  const { generate, loading, modelUrl, error } = useGenerateModel();
+  const { generate, loading, status, modelUrl, error } = useGenerateModel();
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -39,25 +39,20 @@ function GeneratorApp() {
           id: 'gen-submit',
           type: 'submit',
           className: 'px-4 py-2 bg-blue-600 text-white rounded',
-          disabled: loading,
+          disabled: loading || status === 'pending',
         },
-        loading ? 'Generating...' : 'Generate 3D'
+        loading || status === 'pending' ? 'Generating...' : 'Generate 3D'
       )
     ),
-    loading &&
+    (loading || status === 'pending') &&
       React.createElement('div', {
+        id: 'gen-progress',
         className:
           'animate-spin h-8 w-8 border-4 border-blue-500 border-t-transparent rounded-full',
       }),
     error && React.createElement('p', { className: 'text-red-500' }, error),
     modelUrl &&
-      React.createElement('model-viewer', {
-        id: 'gen-viewer',
-        src: modelUrl,
-        style: 'width: 100%; height: 300px;',
-        autoplay: true,
-        'camera-controls': true,
-      })
+      React.createElement('a', { id: 'download-glb', href: modelUrl }, 'Download .glb')
   );
 }
 

--- a/js/useJobPolling.js
+++ b/js/useJobPolling.js
@@ -1,0 +1,29 @@
+import { useEffect, useRef, useState } from 'https://esm.sh/react@18';
+export default function useJobPolling(jobId) {
+  const [status, setStatus] = useState(null);
+  const [glbUrl, setGlbUrl] = useState(null);
+  const [error, setError] = useState(null);
+  const timer = useRef(null);
+  useEffect(() => {
+    if (!jobId) return;
+    async function fetchStatus() {
+      try {
+        const res = await fetch(`/api/status/${jobId}`);
+        const data = await res.json();
+        if (!res.ok) throw new Error(data.error || 'Request failed');
+        setStatus(data.status);
+        if (data.status === 'complete') {
+          setGlbUrl(data.model_url);
+          clearInterval(timer.current);
+        }
+      } catch (err) {
+        setError(err.message || 'Error fetching status');
+        clearInterval(timer.current);
+      }
+    }
+    fetchStatus();
+    timer.current = setInterval(fetchStatus, 2000);
+    return () => clearInterval(timer.current);
+  }, [jobId]);
+  return { status, glbUrl, error };
+}

--- a/js/useJobPolling.node.js
+++ b/js/useJobPolling.node.js
@@ -1,0 +1,30 @@
+const { useEffect, useRef, useState } = require('react');
+function useJobPolling(jobId) {
+  const [status, setStatus] = useState(null);
+  const [glbUrl, setGlbUrl] = useState(null);
+  const [error, setError] = useState(null);
+  const timer = useRef(null);
+  useEffect(() => {
+    if (!jobId) return;
+    async function fetchStatus() {
+      try {
+        const res = await fetch(`/api/status/${jobId}`);
+        const data = await res.json();
+        if (!res.ok) throw new Error(data.error || 'Request failed');
+        setStatus(data.status);
+        if (data.status === 'complete') {
+          setGlbUrl(data.model_url);
+          clearInterval(timer.current);
+        }
+      } catch (err) {
+        setError(err.message || 'Error fetching status');
+        clearInterval(timer.current);
+      }
+    }
+    fetchStatus();
+    timer.current = setInterval(fetchStatus, 2000);
+    return () => clearInterval(timer.current);
+  }, [jobId]);
+  return { status, glbUrl, error };
+}
+module.exports = useJobPolling;


### PR DESCRIPTION
## Summary
- implement `useJobPolling` hook that polls `/api/status/:jobId`
- wire polling into `useGenerateModel`
- update generator demo to show progress and download link
- test hook behaviour with mocked fetch
- fix smoke test syntax

## Testing
- `npm test`
- `STRIPE_TEST_KEY=dummy npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6871316cb620832db0e7cfbb011725bb