### PR TITLE
Add UI smoke test

### DIFF
--- a/.github/workflows/pipeline-smoke.yml
+++ b/.github/workflows/pipeline-smoke.yml
@@ -59,3 +59,17 @@ jobs:
 
       - name: Run diagnostics
         run: pnpm diagnose
+
+  ui_smoke:
+    needs: smoke_test
+    runs-on: ubuntu-latest
+    env:
+      PREVIEW_URL: ${{ secrets.PREVIEW_URL }}
+      AUTH_TOKEN: ${{ secrets.AUTH_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npx playwright test --config=playwright.smoke.config.ts

--- a/e2e/smoke.test.js
+++ b/e2e/smoke.test.js
@@ -27,4 +27,8 @@ test("checkout flow", async ({ page }) => {
   await expect(page.locator("#submit-payment")).toBeVisible();
   await percySnapshot(page, "checkout flow");
 });
-\ntest("model generator page", async ({ page }) => {\n  await page.goto("/index.html");\n  await expect(page.locator("#viewer")).toBeVisible();\n});
+
+test("model generator page", async ({ page }) => {
+  await page.goto("/index.html");
+  await expect(page.locator("#viewer")).toBeVisible();
+});

--- a/index.html
+++ b/index.html
@@ -298,8 +298,8 @@
     <main
       class="flex-1 flex flex-col items-center justify-start gap-4 px-4 lg:px-16"
       style="margin-top: -4rem"
-      <div id="gen-app" class="my-4 w-full max-w-md"></div>
     >
+      <div id="gen-app" class="my-4 w-full max-w-md"></div>
       <!-- 3-D preview ---------------------------------------------------- -->
       <div class="relative flex justify-center w-full max-w-lg">
         <section

--- a/playwright.smoke.config.ts
+++ b/playwright.smoke.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: 'tests/ui',
+  use: {
+    baseURL: process.env.PREVIEW_URL,
+    headless: true,
+  },
+});

--- a/tests/ui/generate.spec.ts
+++ b/tests/ui/generate.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+
+test('generate workflow', async ({ page }) => {
+  await page.goto('/index.html');
+  await page.fill('#promptInput', 'smoke test');
+  await page.click('#submit-button');
+  await page.waitForFunction(() => {
+    const url = localStorage.getItem('print3Model');
+    return url && !url.includes('bag.glb');
+  }, null, { timeout: 120000 });
+  const modelUrl = await page.evaluate(() => localStorage.getItem('print3Model'));
+  await expect(page.locator('#viewer')).toHaveAttribute('src', modelUrl || '');
+});


### PR DESCRIPTION
## Summary
- extend pipeline-smoke workflow with `ui_smoke` job
- add basic Playwright smoke test for preview deployments

## Testing
- `npm test --prefix backend`
- `STRIPE_TEST_KEY=dummy npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_687131703278832dad432606c0d701fb