### PR TITLE
Add analytics dashboard

### DIFF
--- a/admin/analytics.html
+++ b/admin/analytics.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Analytics Dashboard</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  </head>
+  <body class="bg-[#1A1A1D] text-white font-sans flex flex-col min-h-screen">
+    <header class="relative flex items-center justify-between py-4 px-6">
+      <a
+        href="../index.html"
+        class="bg-[#2A2A2E] border border-white/10 rounded-3xl px-4 py-2 hover:bg-[#3A3A3E] transition-shape"
+        >Back</a
+      >
+      <h1 class="absolute inset-x-0 top-1/2 -translate-y-1/2 text-center text-2xl font-semibold">
+        Analytics Dashboard
+      </h1>
+      <span class="w-16"></span>
+    </header>
+    <main id="app" class="flex-1 p-4 space-y-4"></main>
+    <script type="module" src="../js/adminAnalytics.js"></script>
+  </body>
+</html>

--- a/backend/db.js
+++ b/backend/db.js
@@ -1040,6 +1040,27 @@ async function getDemandForecast(days = 7) {
   }
   return arr;
 }
+
+async function startGenerationLog(prompt, source, costCents = 0) {
+  const { rows } = await query(
+    `INSERT INTO generation_logs(prompt, source, cost_cents, started_at)
+     VALUES($1,$2,$3,NOW()) RETURNING id`,
+    [prompt, source, costCents],
+  );
+  return rows[0];
+}
+
+async function finishGenerationLog(id) {
+  await query("UPDATE generation_logs SET finished_at=NOW() WHERE id=$1", [id]);
+}
+
+async function getGenerationLogs(limit = 50) {
+  const { rows } = await query(
+    "SELECT * FROM generation_logs ORDER BY started_at DESC LIMIT $1",
+    [limit],
+  );
+  return rows;
+}
 //
 // async function listSpaces() {
 //   const { rows } = await query('SELECT * FROM spaces ORDER BY id');
@@ -1133,6 +1154,9 @@ module.exports = {
   getDailyProfitSeries,
   getDailyCapacityUtilizationSeries,
   getDemandForecast,
+  startGenerationLog,
+  finishGenerationLog,
+  getGenerationLogs,
 
   // newly exposed helpers
   insertAdSpend,

--- a/backend/db/migrations/002_create_generation_logs.sql
+++ b/backend/db/migrations/002_create_generation_logs.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS generation_logs (
+  id SERIAL PRIMARY KEY,
+  prompt TEXT,
+  source TEXT,
+  cost_cents INTEGER DEFAULT 0,
+  started_at TIMESTAMPTZ DEFAULT NOW(),
+  finished_at TIMESTAMPTZ
+);

--- a/backend/migrations/060_create_generation_logs.sql
+++ b/backend/migrations/060_create_generation_logs.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS generation_logs (
+  id SERIAL PRIMARY KEY,
+  prompt TEXT,
+  source TEXT,
+  cost_cents INTEGER DEFAULT 0,
+  started_at TIMESTAMPTZ DEFAULT NOW(),
+  finished_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS generation_logs_started_idx ON generation_logs(started_at);

--- a/backend/tests/analyticsDashboard.test.js
+++ b/backend/tests/analyticsDashboard.test.js
@@ -1,0 +1,28 @@
+process.env.STRIPE_SECRET_KEY = 'test';
+process.env.STRIPE_WEBHOOK_SECRET = 'whsec';
+process.env.DB_URL = 'postgres://user:pass@localhost/db';
+
+jest.mock('../db', () => ({
+  getGenerationLogs: jest.fn(),
+}));
+const db = require('../db');
+const request = require('supertest');
+const app = require('../server');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('requires admin token', async () => {
+  const res = await request(app).get('/api/admin/analytics');
+  expect(res.status).toBe(401);
+});
+
+test('returns logs', async () => {
+  db.getGenerationLogs.mockResolvedValueOnce([{ id: 1 }]);
+  const res = await request(app)
+    .get('/api/admin/analytics')
+    .set('x-admin-token', 'admin');
+  expect(res.status).toBe(200);
+  expect(res.body[0].id).toBe(1);
+});

--- a/backend/tests/api.test.js
+++ b/backend/tests/api.test.js
@@ -23,6 +23,8 @@ jest.mock("../db", () => ({
   getOrCreateOrderReferralLink: jest.fn(),
   insertReferredOrder: jest.fn(),
   updateWeeklyOrderStreak: jest.fn(),
+  startGenerationLog: jest.fn().mockResolvedValue({ id: 1 }),
+  finishGenerationLog: jest.fn(),
 }));
 const db = require("../db");
 

--- a/e2e/smoke.test.js
+++ b/e2e/smoke.test.js
@@ -1,30 +1,39 @@
 if (require.main === module) {
-  console.error(
-    'This file is a Playwright test. Run it with "npx playwright test e2e/smoke.test.js".',
-  );
+  console.error('This file is a Playwright test. Run it with "npx playwright test e2e/smoke.test.js".');
   process.exit(1);
 }
 
-const { test, expect } = require("@playwright/test");
-const { percySnapshot } = require("@percy/playwright");
+const { test, expect } = require('@playwright/test');
+const { percySnapshot } = require('@percy/playwright');
 
-test("login flow", async ({ page }) => {
-  await page.goto("/login.html");
+test('login flow', async ({ page }) => {
+  await page.goto('/login.html');
   await expect(page).toHaveTitle(/Login/i);
-  await percySnapshot(page, "login flow");
+  await percySnapshot(page, 'login flow');
 });
 
-test("dashboard loads", async ({ page }) => {
-  await page.addInitScript(() => localStorage.setItem("token", "test-token"));
-  const response = await page.goto("/my_profile.html");
+test('dashboard loads', async ({ page }) => {
+  await page.addInitScript(() => localStorage.setItem('token', 'test-token'));
+  const response = await page.goto('/my_profile.html');
   expect(response?.status()).toBe(200);
   await expect(page).toHaveTitle(/My Profile/i);
-  await percySnapshot(page, "dashboard loads");
+  await percySnapshot(page, 'dashboard loads');
 });
 
-test("checkout flow", async ({ page }) => {
-  await page.goto("/payment.html");
-  await expect(page.locator("#submit-payment")).toBeVisible();
-  await percySnapshot(page, "checkout flow");
+test('checkout flow', async ({ page }) => {
+  await page.goto('/payment.html');
+  await expect(page.locator('#submit-payment')).toBeVisible();
+  await percySnapshot(page, 'checkout flow');
 });
-\ntest("model generator page", async ({ page }) => {\n  await page.goto("/index.html");\n  await expect(page.locator("#viewer")).toBeVisible();\n});
+
+test('model generator page', async ({ page }) => {
+  await page.goto('/index.html');
+  await expect(page.locator('#viewer')).toBeVisible();
+});
+
+test('admin analytics dashboard', async ({ page }) => {
+  await page.addInitScript(() => localStorage.setItem('adminToken', 'admin'));
+  const res = await page.goto('/admin/analytics.html');
+  expect(res?.status()).toBe(200);
+  await expect(page).toHaveTitle(/Analytics Dashboard/i);
+});

--- a/js/adminAnalytics.js
+++ b/js/adminAnalytics.js
@@ -1,0 +1,58 @@
+import { API_BASE, authHeaders } from './api.js';
+
+function formatCurrency(cents) {
+  return `$${(cents / 100).toFixed(2)}`;
+}
+
+async function load() {
+  const app = document.getElementById('app');
+  app.textContent = 'Loading...';
+  const res = await fetch(`${API_BASE}/admin/analytics`, { headers: authHeaders() });
+  if (!res.ok) {
+    app.textContent = 'Failed to load analytics';
+    return;
+  }
+  const logs = await res.json();
+  const table = document.createElement('table');
+  table.className = 'w-full text-sm';
+  table.innerHTML = `
+    <thead><tr><th class="text-left">Prompt</th><th>Duration (s)</th><th>Source</th><th>Cost</th><th>Started</th></tr></thead>
+    <tbody></tbody>`;
+  const tbody = table.querySelector('tbody');
+  let totalCost = 0;
+  let totalDuration = 0;
+  logs.forEach((l) => {
+    const dur = l.finished_at ? (new Date(l.finished_at) - new Date(l.started_at)) / 1000 : 0;
+    totalCost += l.cost_cents || 0;
+    totalDuration += dur;
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td class="pr-2">${l.prompt}</td><td class="text-center">${dur.toFixed(1)}</td><td class="text-center">${l.source}</td><td class="text-center">${formatCurrency(l.cost_cents)}</td><td>${new Date(l.started_at).toLocaleString()}</td>`;
+    tbody.appendChild(tr);
+  });
+  const summary = document.createElement('div');
+  summary.className = 'space-y-1';
+  summary.innerHTML = `
+    <p>Total generations: ${logs.length}</p>
+    <p>Average duration: ${(logs.length ? totalDuration / logs.length : 0).toFixed(1)}s</p>
+    <p>Cumulative cost: ${formatCurrency(totalCost)}</p>`;
+  app.innerHTML = '';
+  app.appendChild(summary);
+  app.appendChild(table);
+  if (logs.length) {
+    const canvas = document.createElement('canvas');
+    canvas.id = 'genChart';
+    app.appendChild(canvas);
+    const ctx = canvas.getContext('2d');
+    // eslint-disable-next-line no-undef
+    new Chart(ctx, {
+      type: 'bar',
+      data: {
+        labels: logs.map((l) => new Date(l.started_at).toLocaleTimeString()),
+        datasets: [{ label: 'Cost ($)', data: logs.map((l) => l.cost_cents / 100), backgroundColor: '#30D5C8' }],
+      },
+      options: { scales: { y: { beginAtZero: true } } },
+    });
+  }
+}
+
+document.addEventListener('DOMContentLoaded', load);


### PR DESCRIPTION
## Summary
- track model generations in new DB table
- expose generation logs via `/api/admin/analytics`
- implement admin dashboard page to chart model generation metrics
- test analytics endpoint and dashboard

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_687133ea0c00832d92b3b3c67a522cf3