### PR TITLE
Fix duplicate Playwright test title

### DIFF
--- a/e2e/smoke.test.js
+++ b/e2e/smoke.test.js
@@ -39,7 +39,7 @@ test('generate flow', async ({ page }) => {
 });
 
 
-test("model generator page", async ({ page }) => {
+test("model generator page shows viewer", async ({ page }) => {
   await page.goto("/index.html");
   await expect(page.locator("#viewer")).toBeVisible();
 });


### PR DESCRIPTION
## Summary
- rename the second "model generator page" test in `e2e/smoke.test.js`

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend` (partial output shown)
- `SKIP_PW_DEPS=1 npm run ci` (partial output shown)
- `STRIPE_TEST_KEY=1 npm run smoke` *(fails: timeout waiting for #gen-prompt)*

------
https://chatgpt.com/codex/tasks/task_e_687144f6f4a4832d9e7351d01dd43821