### PR TITLE
Use Node 20 for smoke tests

### DIFF
--- a/.github/workflows/pipeline-smoke.yml
+++ b/.github/workflows/pipeline-smoke.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Install pnpm
         run: npm install -g pnpm

--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
       - run: npm install -g pnpm
       - run: pnpm install
       - run: pnpm run smoke


### PR DESCRIPTION
## Summary
- upgrade Node to 20 for smoke_test.yml and pipeline-smoke.yml

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`
- `npm run smoke` *(fails: page.fill timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68715b744424832d9fb9334696eebab2