### PR TITLE
Mock S3 client in textToImage tests

### DIFF
--- a/backend/tests/textToImage.test.ts
+++ b/backend/tests/textToImage.test.ts
@@ -1,3 +1,10 @@
+jest.mock("@aws-sdk/client-s3", () => ({
+  S3Client: jest.fn().mockImplementation(() => ({
+    send: jest.fn().mockResolvedValue({}),
+  })),
+  PutObjectCommand: jest.fn(),
+}));
+
 const nock = require('nock');
 const { textToImage } = require('../src/lib/textToImage.js');
 const s3 = require('../src/lib/uploadS3.js');


### PR DESCRIPTION
## Summary
- mock S3 client for textToImage tests to avoid real AWS calls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68718f76f524832d9b335cf1ed9e0d0b