### PR TITLE
Fix setup Stripe key handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Run `docker compose up` to start the API and Postgres services.
   - `HUNYUAN_API_KEY` – key for the Sparc3D API.
 
 The server uses `STRIPE_LIVE_KEY` when `NODE_ENV=production`; otherwise `STRIPE_TEST_KEY` is used.
+- If `STRIPE_TEST_KEY` isn't set, `npm run setup` generates a temporary dummy key
+  so local installs don't fail.
 - `SENDGRID_API_KEY` – API key for sending email via SendGrid.
 - `SENTRY_DSN` – connection string for sending errors to Sentry.
 - `EMAIL_FROM` – address used for the "from" field in outgoing mail.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -13,7 +13,7 @@ cleanup_npm_cache
 unset npm_config_http_proxy npm_config_https_proxy
 export npm_config_fund=false
 
-if [ -z "$STRIPE_TEST_KEY" ] && [ -n "$CI" ]; then
+if [ -z "$STRIPE_TEST_KEY" ]; then
   export STRIPE_TEST_KEY="sk_test_dummy_$(date +%s)"
 fi
 


### PR DESCRIPTION
## Summary
- create a temporary Stripe key if not provided
- document this behaviour in the readme

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: output truncated)*
- `npm run ci` *(fails: output truncated)*
- `npm run smoke` *(fails: output truncated)*

------
https://chatgpt.com/codex/tasks/task_e_687196deb2a4832da2e1ad7efd2afb48