### PR TITLE
Fix setup script missing Stripe key

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,8 @@ These guidelines apply to all automated agents (e.g. the Codex agent) working on
    blocked, adjust your environment or proxy settings.
 
 3. **Install dependencies** – run `npm run setup` at the repository root **before your first `npm run ci`**. Run it again whenever the container is restarted or if Playwright tests fail with messages like "Test was interrupted" or "page.evaluate: Test ended". This script unsets proxy variables, checks registry connectivity, runs `npm ci` in the root and `backend/`, and installs Playwright browsers.
+   - If neither `STRIPE_TEST_KEY` nor `STRIPE_LIVE_KEY` is set, export a dummy key first:
+     `export STRIPE_TEST_KEY=sk_test_dummy`.
    - Set `SKIP_PW_DEPS=1` before running the setup script if Playwright dependencies are already installed. This skips the long `apt-get` step and reduces CI time. The `smoke` script automatically exports this variable.
 4. **Format code** – run `npm run format` in `backend/` to apply Prettier formatting.
 5. **Run tests** – execute `npm test` in `backend/`. If tests cannot run because of environment limitations, mention this in the PR.

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -13,14 +13,10 @@ cleanup_npm_cache
 unset npm_config_http_proxy npm_config_https_proxy
 export npm_config_fund=false
 
-if [ -z "$STRIPE_TEST_KEY" ] && [ -n "$CI" ]; then
-  export STRIPE_TEST_KEY="sk_test_dummy_$(date +%s)"
-fi
-
-# Validate required Stripe env vars
+# Provide a dummy Stripe key when none is configured
 if [[ -z "$STRIPE_TEST_KEY" && -z "$STRIPE_LIVE_KEY" ]]; then
-  echo "STRIPE_TEST_KEY or STRIPE_LIVE_KEY must be set" >&2
-  exit 1
+  echo "Using dummy STRIPE_TEST_KEY" >&2
+  export STRIPE_TEST_KEY="sk_test_dummy_$(date +%s)"
 fi
 
 # Persist proxy removal so new shells start clean


### PR DESCRIPTION
## Summary
- set dummy Stripe key in scripts/setup.sh when none provided
- note dummy key step in AGENTS instructions

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68719a184d04832d9bbfce08f20d3753