### PR TITLE
Fix setup automation

### DIFF
--- a/scripts/assert-setup.js
+++ b/scripts/assert-setup.js
@@ -19,7 +19,7 @@ if (!fs.existsSync('.setup-complete') || !browsersInstalled()) {
     "Playwright browsers not installed. Running 'npm run setup' to install them"
   );
   try {
-    require('child_process').execSync('npm run setup', { stdio: 'inherit' });
+    require('child_process').execSync('CI=1 npm run setup', { stdio: 'inherit' });
   } catch (err) {
     console.error('Failed to run setup:', err.message);
     process.exit(1);


### PR DESCRIPTION
## Summary
- set `CI=1` when running `npm run setup` automatically so Playwright can install

## Testing
- `npm run format`
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_687199ec6e88832d948481c1cf73a6d4