### PR TITLE
Fix test network interference

### DIFF
--- a/backend/tests/sparc3dClient.test.js
+++ b/backend/tests/sparc3dClient.test.js
@@ -9,6 +9,7 @@ const nock_1 = __importDefault(require("nock"));
 const sparc3dClient_1 = require("../src/lib/sparc3dClient");
 describe("generateGlb", () => {
   const endpoint = "https://api.example.com/generate";
+nock_1.default.disableNetConnect();
   const token = "t0k";
   beforeEach(() => {
     process.env.SPARC3D_ENDPOINT = endpoint;

--- a/backend/tests/sparc3dClient.test.ts
+++ b/backend/tests/sparc3dClient.test.ts
@@ -1,5 +1,6 @@
 const nock = require('nock');
 const { generateGlb } = require('../src/lib/sparc3dClient.js');
+nock.disableNetConnect();
 
 describe('generateGlb', () => {
   const endpoint = 'https://api.example.com/generate';


### PR DESCRIPTION
## Summary
- prevent outbound requests in sparc3d client tests

## Testing
- `npm test --prefix backend tests/sparc3dClient.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_687196beb1d0832dbda280a9846402b8