### PR TITLE
Add admin analytics dashboard

### DIFF
--- a/admin/analytics.html
+++ b/admin/analytics.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Analytics Dashboard</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  </head>
+  <body class="bg-[#1A1A1D] text-white font-sans flex flex-col min-h-screen">
+    <header class="relative flex items-center justify-between py-4 px-6">
+      <a
+        href="../index.html"
+        class="bg-[#2A2A2E] border border-white/10 rounded-3xl px-4 py-2 hover:bg-[#3A3A3E] transition-shape"
+        >Back</a
+      >
+      <h1
+        class="absolute inset-x-0 top-1/2 -translate-y-1/2 text-center text-2xl font-semibold"
+      >
+        Analytics Dashboard
+      </h1>
+      <span class="w-16"></span>
+    </header>
+    <main id="app" class="flex-1 p-4 space-y-4"></main>
+    <script type="module" src="../js/adminAnalytics.js"></script>
+  </body>
+</html>

--- a/backend/migrations/060_create_generation_logs.sql
+++ b/backend/migrations/060_create_generation_logs.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS generation_logs (
+  id SERIAL PRIMARY KEY,
+  prompt TEXT NOT NULL,
+  source TEXT NOT NULL,
+  start_time TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  finish_time TIMESTAMPTZ,
+  cost_cents INTEGER DEFAULT 0
+);

--- a/backend/tests/adminAnalytics.test.js
+++ b/backend/tests/adminAnalytics.test.js
@@ -1,0 +1,46 @@
+process.env.STRIPE_SECRET_KEY = "test";
+process.env.STRIPE_WEBHOOK_SECRET = "whsec";
+process.env.DB_URL = "postgres://user:pass@localhost/db";
+
+jest.mock("../db", () => ({
+  listGenerationLogs: jest.fn(),
+  getGenerationStats: jest.fn(),
+}));
+const db = require("../db");
+const request = require("supertest");
+const app = require("../server");
+
+describe("analytics endpoint", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("requires admin token", async () => {
+    const res = await request(app).get("/api/admin/analytics");
+    expect(res.status).toBe(401);
+  });
+
+  test("returns logs and stats", async () => {
+    db.listGenerationLogs.mockResolvedValueOnce([
+      {
+        id: 1,
+        prompt: "p",
+        start_time: "2024-01-01T00:00:00Z",
+        finish_time: "2024-01-01T00:00:10Z",
+        source: "sparc3d",
+        cost_cents: 50,
+      },
+    ]);
+    db.getGenerationStats.mockResolvedValueOnce({
+      total: 1,
+      avg_duration: 10,
+      total_cost: 50,
+    });
+    const res = await request(app)
+      .get("/api/admin/analytics")
+      .set("x-admin-token", "admin");
+    expect(res.status).toBe(200);
+    expect(res.body.logs.length).toBe(1);
+    expect(res.body.stats.total).toBe(1);
+  });
+});

--- a/backend/tests/api.test.js
+++ b/backend/tests/api.test.js
@@ -23,6 +23,7 @@ jest.mock("../db", () => ({
   getOrCreateOrderReferralLink: jest.fn(),
   insertReferredOrder: jest.fn(),
   updateWeeklyOrderStreak: jest.fn(),
+  insertGenerationLog: jest.fn(),
 }));
 const db = require("../db");
 

--- a/js/adminAnalytics.js
+++ b/js/adminAnalytics.js
@@ -1,0 +1,97 @@
+import { API_BASE, authHeaders } from "./api.js";
+
+function groupByDay(logs) {
+  const map = {};
+  logs.forEach((l) => {
+    const day = new Date(l.start_time).toISOString().slice(0, 10);
+    if (!map[day]) map[day] = { count: 0, cost: 0 };
+    map[day].count += 1;
+    map[day].cost += l.cost_cents || 0;
+  });
+  return map;
+}
+
+async function load() {
+  const app = document.getElementById("app");
+  app.textContent = "Loading...";
+  const res = await fetch(`${API_BASE}/admin/analytics`, {
+    headers: authHeaders(),
+  });
+  if (!res.ok) {
+    app.textContent = "Failed to load analytics";
+    return;
+  }
+  const { logs, stats } = await res.json();
+  app.innerHTML = "";
+
+  const summary = document.createElement("div");
+  summary.className = "space-y-1";
+  summary.innerHTML = `
+    <div>Total generations: ${stats.total}</div>
+    <div>Average duration: ${stats.avg_duration ? stats.avg_duration.toFixed(2) : "n/a"}s</div>
+    <div>Cumulative cost: $${((stats.total_cost || 0) / 100).toFixed(2)}</div>
+  `;
+  app.appendChild(summary);
+
+  const table = document.createElement("table");
+  table.className = "w-full text-sm text-left border-collapse";
+  table.innerHTML = `
+    <thead><tr>
+      <th class="border-b px-2 py-1">Prompt</th>
+      <th class="border-b px-2 py-1">Duration (s)</th>
+      <th class="border-b px-2 py-1">Source</th>
+      <th class="border-b px-2 py-1">Cost</th>
+      <th class="border-b px-2 py-1">Timestamp</th>
+    </tr></thead>
+    <tbody></tbody>`;
+  const tbody = table.querySelector("tbody");
+  logs.forEach((l) => {
+    const tr = document.createElement("tr");
+    const dur = l.finish_time
+      ? (new Date(l.finish_time) - new Date(l.start_time)) / 1000
+      : 0;
+    tr.innerHTML = `
+      <td class="border-b px-2 py-1">${l.prompt}</td>
+      <td class="border-b px-2 py-1">${dur.toFixed(2)}</td>
+      <td class="border-b px-2 py-1">${l.source}</td>
+      <td class="border-b px-2 py-1">$${(l.cost_cents / 100).toFixed(2)}</td>
+      <td class="border-b px-2 py-1">${new Date(l.start_time).toLocaleString()}</td>
+    `;
+    tbody.appendChild(tr);
+  });
+  app.appendChild(table);
+
+  const groups = groupByDay(logs);
+  const labels = Object.keys(groups).sort();
+  const counts = labels.map((d) => groups[d].count);
+  const costs = labels.map((d) => groups[d].cost / 100);
+  if (labels.length) {
+    const canvas = document.createElement("canvas");
+    app.appendChild(canvas);
+    const ctx = canvas.getContext("2d");
+    // eslint-disable-next-line no-undef
+    new Chart(ctx, {
+      type: "bar",
+      data: {
+        labels,
+        datasets: [
+          {
+            label: "Generations",
+            data: counts,
+            borderColor: "#30D5C8",
+            backgroundColor: "#30D5C8",
+          },
+          {
+            label: "Cost ($)",
+            data: costs,
+            borderColor: "#f87171",
+            backgroundColor: "#f87171",
+          },
+        ],
+      },
+      options: { scales: { y: { beginAtZero: true } } },
+    });
+  }
+}
+
+document.addEventListener("DOMContentLoaded", load);


### PR DESCRIPTION
## Summary
- track model generation in a new `generation_logs` table
- expose `/api/admin/analytics` for admins
- log generation metrics from `/api/generate`
- add frontend dashboard to visualize history
- test analytics endpoint

## Testing
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_68719382a388832da04b75eb2ba2bab0