### PR TITLE
Stabilize smoke test viewer waits

### DIFF
--- a/e2e/smoke.test.js
+++ b/e2e/smoke.test.js
@@ -30,11 +30,18 @@ test('checkout flow', async ({ page }) => {
 
 test('model generator page', async ({ page }) => {
   await page.goto('/index.html');
+  // <model-viewer> loads asynchronously; wait for the custom element
+  // definition and for the model to finish loading before checking visibility.
+  await page.waitForFunction(() => window.customElements.get('model-viewer'));
+  await page.waitForSelector('#viewer', { state: 'visible', timeout: 15000 });
   await expect(page.locator('#viewer')).toBeVisible();
 });
 
 test('generate flow', async ({ page }) => {
   await page.goto('/generate.html');
+  // The form is rendered via React after scripts load, so wait for the prompt
+  // field before interacting with it.
+  await page.waitForSelector('#gen-prompt', { state: 'visible', timeout: 10000 });
   await page.fill('#gen-prompt', 'test');
   await page.click('#gen-submit');
   await expect(page.locator('canvas')).toBeVisible();


### PR DESCRIPTION
## Summary
- wait for model-viewer load in smoke test
- wait for generator prompt to appear before interacting

## Testing
- `npm test` in `backend/`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_6872225d814c832d9636a3a07ec28546