### PR TITLE
Fix generate viewer

### DIFF
--- a/backend/tests/frontend/generateModel.static.test.js
+++ b/backend/tests/frontend/generateModel.static.test.js
@@ -1,0 +1,13 @@
+/** @jest-environment node */
+const fs = require('fs');
+const path = require('path');
+
+test('useGenerateModel posts to generate endpoint', () => {
+  const src = fs.readFileSync(path.join(__dirname, '../../../js/useGenerateModel.js'), 'utf8');
+  expect(src).toMatch(/fetch\("\/api\/generate"/);
+});
+
+test('ModelViewer references src prop', () => {
+  const src = fs.readFileSync(path.join(__dirname, '../../../js/ModelViewer.js'), 'utf8');
+  expect(src).toMatch(/Gltf, { src: url/);
+});

--- a/js/useGenerateModel.js
+++ b/js/useGenerateModel.js
@@ -10,7 +10,11 @@ export default function useGenerateModel() {
     setError(null);
     setModelUrl(null);
     try {
-      const res = await fetch(`/api/generate?prompt=${encodeURIComponent(prompt)}`);
+      const res = await fetch("/api/generate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ prompt }),
+      });
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || 'Request failed');
       setModelUrl(data.glb_url);


### PR DESCRIPTION
## Summary
- POST to /api/generate in model generator hook
- add static test verifying viewer uses generated URL

## Testing
- `npm test --prefix backend`
- `npm run format --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_6872225b57ec832d90c7dac21bad8d4d