### PR TITLE
Add lockfile sync test

### DIFF
--- a/backend/tests/lockfileSync.test.js
+++ b/backend/tests/lockfileSync.test.js
@@ -1,0 +1,19 @@
+const fs = require('fs');
+const { execSync } = require('child_process');
+
+describe('lockfile sync', () => {
+  const lockFiles = [
+    'package-lock.json',
+    'backend/package-lock.json',
+    'backend/hunyuan_server/package-lock.json',
+  ];
+
+  lockFiles.forEach((file) => {
+    if (!fs.existsSync(file)) return;
+    test(`${file} matches git`, () => {
+      expect(() => {
+        execSync(`git diff --quiet HEAD -- ${file}`);
+      }).not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a new jest test to check that package-lock files are committed

## Testing
- `npm test --prefix backend`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_6872219e3490832d8748fd650233e7a2