### PR TITLE
Add extra checkout edge case tests

### DIFF
--- a/backend/tests/checkout.test.ts
+++ b/backend/tests/checkout.test.ts
@@ -1,44 +1,77 @@
-process.env.STRIPE_TEST_KEY = 'sk_test';
-process.env.STRIPE_LIVE_KEY = 'sk_live';
-process.env.STRIPE_WEBHOOK_SECRET = 'whsec';
+process.env.STRIPE_TEST_KEY = "sk_test";
+process.env.STRIPE_LIVE_KEY = "sk_live";
+process.env.STRIPE_WEBHOOK_SECRET = "whsec";
 
-jest.mock('../mail', () => ({ sendMail: jest.fn() }));
-const { sendMail } = require('../mail');
+jest.mock("../mail", () => ({ sendMail: jest.fn() }));
+const { sendMail } = require("../mail");
 
-jest.mock('stripe');
-const Stripe = require('stripe');
+jest.mock("stripe");
+const Stripe = require("stripe");
 const stripeMock = {
-  checkout: { sessions: { create: jest.fn().mockResolvedValue({ id: 'cs_test', url: 'http://checkout' }) } },
+  checkout: {
+    sessions: {
+      create: jest
+        .fn()
+        .mockResolvedValue({ id: "cs_test", url: "http://checkout" }),
+    },
+  },
   webhooks: { constructEvent: jest.fn() },
 };
 Stripe.mockImplementation(() => stripeMock);
 
-const request = require('supertest');
-const app = require('../src/app');
-const { orders } = require('../src/routes/checkout.js');
+const request = require("supertest");
+const app = require("../src/app");
+const { orders } = require("../src/routes/checkout.js");
 
 afterEach(() => {
   orders.clear();
   jest.clearAllMocks();
 });
 
-test('POST /api/checkout creates session', async () => {
-  const res = await request(app).post('/api/checkout').send({ slug: 'm1', email: 'a@a.com' });
+test("POST /api/checkout creates session", async () => {
+  const res = await request(app)
+    .post("/api/checkout")
+    .send({ slug: "m1", email: "a@a.com" });
   expect(res.status).toBe(200);
   expect(stripeMock.checkout.sessions.create).toHaveBeenCalled();
-  expect(orders.get('cs_test')).toBeDefined();
-  expect(res.body.checkoutUrl).toBe('http://checkout');
+  expect(orders.get("cs_test")).toBeDefined();
+  expect(res.body.checkoutUrl).toBe("http://checkout");
 });
 
-test('POST /api/stripe/webhook marks paid and emails', async () => {
-  orders.set('cs_test', { slug: 'm1', email: 'a@a.com' });
-  const payload = JSON.stringify({ id: 'evt', type: 'checkout.session.completed', data: { object: { id: 'cs_test' } } });
+test("POST /api/stripe/webhook marks paid and emails", async () => {
+  orders.set("cs_test", { slug: "m1", email: "a@a.com" });
+  const payload = JSON.stringify({
+    id: "evt",
+    type: "checkout.session.completed",
+    data: { object: { id: "cs_test" } },
+  });
   stripeMock.webhooks.constructEvent.mockReturnValueOnce(JSON.parse(payload));
   const res = await request(app)
-    .post('/api/stripe/webhook')
-    .set('stripe-signature', 'sig')
+    .post("/api/stripe/webhook")
+    .set("stripe-signature", "sig")
     .send(payload);
   expect(res.status).toBe(200);
-  expect(orders.get('cs_test')?.paid).toBe(true);
+  expect(orders.get("cs_test")?.paid).toBe(true);
   expect(sendMail).toHaveBeenCalled();
+});
+
+test("POST /api/checkout validates required fields", async () => {
+  const res = await request(app).post("/api/checkout").send({ slug: "m1" });
+  expect(res.status).toBe(400);
+  expect(orders.size).toBe(0);
+});
+
+test("POST /api/stripe/webhook ignores unknown sessions", async () => {
+  const payload = JSON.stringify({
+    id: "evt",
+    type: "checkout.session.completed",
+    data: { object: { id: "missing" } },
+  });
+  stripeMock.webhooks.constructEvent.mockReturnValueOnce(JSON.parse(payload));
+  const res = await request(app)
+    .post("/api/stripe/webhook")
+    .set("stripe-signature", "sig")
+    .send(payload);
+  expect(res.status).toBe(200);
+  expect(sendMail).not.toHaveBeenCalled();
 });


### PR DESCRIPTION
## Summary
- expand Stripe checkout tests to cover bad inputs and unknown sessions

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_68722091b398832d893aec71f9a6ed71