### PR TITLE
Silence mise warnings in setup

### DIFF
--- a/backend/tests/miseConfig.test.js
+++ b/backend/tests/miseConfig.test.js
@@ -1,0 +1,8 @@
+const { execSync } = require('child_process');
+
+describe('mise config', () => {
+  test('idiomatic_version_file_enable_tools includes node', () => {
+    const output = execSync('mise settings get idiomatic_version_file_enable_tools', { encoding: 'utf8' }).trim();
+    expect(output).toContain('node');
+  });
+});

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -28,6 +28,9 @@ if ! grep -q "unset npm_config_http_proxy" ~/.bashrc 2>/dev/null; then
   echo "unset npm_config_http_proxy npm_config_https_proxy" >> ~/.bashrc
 fi
 
+# Silence mise warnings about idiomatic version files
+mise settings add idiomatic_version_file_enable_tools node --yes >/dev/null 2>&1 || true
+
 # Abort early if the npm registry is unreachable
 if ! npm ping >/dev/null 2>&1; then
   echo "Unable to reach the npm registry. Check network connectivity or proxy settings." >&2


### PR DESCRIPTION
## Summary
- silence mise's idiomatic version file warning in setup script
- add test ensuring the mise config persists

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_68722021ecd0832da75a0fc5774755fe