### PR TITLE
Improve model generation UX

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -465,7 +465,7 @@ app.post(
         });
       } catch (err) {
         console.error("🚨 generateModel() failed:", err);
-        return res.status(500).json({ error: "Model generation error" });
+        return res.status(500).json({ error: err.message });
       }
       const finishTime = new Date();
       const cost =
@@ -494,7 +494,7 @@ app.post(
     } catch (err) {
       logError(err);
       console.log("🔹 Exiting /api/generate with error");
-      res.status(500).json({ error: "Failed to generate model" });
+      res.status(500).json({ error: err.message });
     }
   },
 );

--- a/e2e/generate.test.js
+++ b/e2e/generate.test.js
@@ -1,0 +1,32 @@
+const { test, expect } = require('@playwright/test');
+
+test('generate success shows confirmation', async ({ page }) => {
+  await page.route('/api/generate', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ glb_url: '/models/test.glb' }),
+    });
+  });
+
+  await page.goto('/generate.html');
+  await page.fill('#gen-prompt', 'test');
+  await page.click('#gen-submit');
+  await expect(page.locator('#gen-success')).toHaveText(/Model generated!/);
+  await expect(page.locator('canvas')).toBeVisible();
+});
+
+test('generate failure shows error message', async ({ page }) => {
+  await page.route('/api/generate', async (route) => {
+    await route.fulfill({
+      status: 500,
+      contentType: 'application/json',
+      body: JSON.stringify({ error: 'SPARC3D_TOKEN is not set' }),
+    });
+  });
+
+  await page.goto('/generate.html');
+  await page.fill('#gen-prompt', 'test');
+  await page.click('#gen-submit');
+  await expect(page.locator('.text-red-500')).toHaveText(/SPARC3D_TOKEN is not set/);
+});

--- a/js/modelGenerator.js
+++ b/js/modelGenerator.js
@@ -44,6 +44,8 @@ function GeneratorApp() {
           'animate-spin h-8 w-8 border-4 border-blue-500 border-t-transparent rounded-full',
       }),
     error && React.createElement('p', { className: 'text-red-500' }, error),
+    modelUrl &&
+      React.createElement('p', { id: 'gen-success', className: 'text-green-500' }, 'Model generated!'),
     modelUrl && React.createElement(ModelViewer, { url: modelUrl })
   );
 }


### PR DESCRIPTION
## Summary
- display success/error messages on the model generator page
- surface backend errors from `/api/generate`
- add e2e tests for generation success and failure

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_68722264f248832d85aeaccd270c9187