### PR TITLE
Add global network guard tests

### DIFF
--- a/backend/tests/globalTeardown.js
+++ b/backend/tests/globalTeardown.js
@@ -1,4 +1,7 @@
+const nock = require("nock");
+
 module.exports = async () => {
+  nock.enableNetConnect();
   const leaks = global.__LEAKS__ || [];
   for (const leak of leaks) {
     if (typeof leak.close === "function") {

--- a/backend/tests/networkBlock.test.js
+++ b/backend/tests/networkBlock.test.js
@@ -1,0 +1,9 @@
+const axios = require("axios");
+
+describe("network guard", () => {
+  test("external requests are blocked", async () => {
+    await expect(axios.get("https://example.com")).rejects.toThrow(
+      "Nock: Disallowed net connect",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- block external network connections in test setup
- ensure network is re-enabled on teardown
- add test verifying network restrictions

## Testing
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_68722d907360832da84290835b2a3c4d