### PR TITLE
Improve smoke script reliability

### DIFF
--- a/backend/tests/concurrentlyInstalled.test.js
+++ b/backend/tests/concurrentlyInstalled.test.js
@@ -1,0 +1,16 @@
+const fs = require("fs");
+const path = require("path");
+
+describe("dependencies", () => {
+  test("concurrently installed", () => {
+    const pkg = path.join(
+      __dirname,
+      "..",
+      "..",
+      "node_modules",
+      "concurrently",
+      "package.json",
+    );
+    expect(fs.existsSync(pkg)).toBe(true);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "setup": "scripts/setup.sh",
     "e2e": "playwright test",
     "serve": "npm run build && npx serve dist",
-    "smoke": "npm run setup && npx playwright install --with-deps && concurrently -k -s first \"npm run serve\" \"wait-on http://localhost:3000 && npx playwright test e2e/smoke.test.js\"",
+    "smoke": "npm run setup && npx -y playwright install --with-deps && npx -y concurrently -k -s first \"npm run serve\" \"wait-on http://localhost:3000 && npx playwright test e2e/smoke.test.js\"",
     "build": "echo 'no build step'",
     "load": "artillery run tests/load/models.yml",
     "visual-test": "percy exec -- npm run e2e",


### PR DESCRIPTION
## Summary
- check for `concurrently` dependency in tests
- run smoke script with noninteractive `npx` flags

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_68722d63ee8c832d8fec172e5c1bfdb9