### PR TITLE
Fix dev server path

### DIFF
--- a/backend/tests/dev-server.test.js
+++ b/backend/tests/dev-server.test.js
@@ -1,0 +1,8 @@
+const request = require('supertest');
+const app = require('../../scripts/dev-server');
+
+describe('dev server', () => {
+  test('HEAD / responds with 200', async () => {
+    await request(app).head('/').expect(200);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "validate-env": "bash scripts/validate-env.sh",
     "setup": "scripts/setup.sh",
     "e2e": "playwright test",
-    "serve": "npm run build && npx serve dist",
+    "serve": "npm run build && node scripts/dev-server.js",
     "smoke": "npm run setup && npx playwright install --with-deps && concurrently -k -s first \"npm run serve\" \"wait-on http://localhost:3000 && npx playwright test e2e/smoke.test.js\"",
     "build": "echo 'no build step'",
     "load": "artillery run tests/load/models.yml",

--- a/scripts/dev-server.js
+++ b/scripts/dev-server.js
@@ -13,7 +13,11 @@ app.use(
   }),
 );
 
-const port = process.env.PORT || 3000;
-app.listen(port, () => {
-  console.log(`Dev server listening on http://localhost:${port}`);
-});
+if (require.main === module) {
+  const port = process.env.PORT || 3000;
+  app.listen(port, () => {
+    console.log(`Dev server listening on http://localhost:${port}`);
+  });
+}
+
+module.exports = app;

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -31,6 +31,11 @@ fi
 # Silence mise warnings about idiomatic version files
 mise settings add idiomatic_version_file_enable_tools node --yes >/dev/null 2>&1 || true
 
+# Persist the setting so new shells don't emit warnings
+if ! grep -q "idiomatic_version_file_enable_tools" ~/.bashrc 2>/dev/null; then
+  echo "mise settings add idiomatic_version_file_enable_tools node >/dev/null 2>&1 || true" >> ~/.bashrc
+fi
+
 # Abort early if the npm registry is unreachable
 if ! npm ping >/dev/null 2>&1; then
   echo "Unable to reach the npm registry. Check network connectivity or proxy settings." >&2


### PR DESCRIPTION
## Summary
- start dev server from repository root and export app for tests
- update serve script to use custom dev server
- persist mise setting in setup script
- add regression test for HEAD /

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_68722d2232a4832d936dcd18f0f6278b