### PR TITLE
Fix smoke test server path

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "validate-env": "bash scripts/validate-env.sh",
     "setup": "scripts/setup.sh",
     "e2e": "playwright test",
-    "serve": "npm run build && npx serve dist",
+    "serve": "npm run build && npx serve -s .",
     "smoke": "npm run setup && npx playwright install --with-deps && concurrently -k -s first \"npm run serve\" \"wait-on http://localhost:3000 && npx playwright test e2e/smoke.test.js\"",
     "build": "echo 'no build step'",
     "load": "artillery run tests/load/models.yml",


### PR DESCRIPTION
## Summary
- serve the project root instead of a non-existent `dist` folder

## Testing
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68722cfb4144832db3dd74939efc38d1