### PR TITLE
Improve generate smoke test reliability

### DIFF
--- a/e2e/smoke.test.js
+++ b/e2e/smoke.test.js
@@ -38,10 +38,12 @@ test('model generator page', async ({ page }) => {
 });
 
 test('generate flow', async ({ page }) => {
-  await page.goto('/generate.html');
+  const response = await page.goto('/generate.html');
+  expect(response?.status()).toBe(200);
   // The form is rendered via React after scripts load, so wait for the prompt
-  // field before interacting with it.
-  await page.waitForSelector('#gen-prompt', { state: 'visible', timeout: 10000 });
+  // field before interacting with it. Give the page up to 30s to load the
+  // component to avoid flaky timeouts on slow systems.
+  await page.waitForSelector('#gen-prompt', { state: 'visible', timeout: 30000 });
   await page.fill('#gen-prompt', 'test');
   await page.click('#gen-submit');
   await expect(page.locator('canvas')).toBeVisible();

--- a/e2e/status.test.js
+++ b/e2e/status.test.js
@@ -1,0 +1,16 @@
+const { test, expect } = require('@playwright/test');
+
+const pages = [
+  '/',
+  '/generate.html',
+  '/login.html',
+];
+
+test.describe('static pages respond', () => {
+  for (const path of pages) {
+    test(`GET ${path} returns 200`, async ({ page }) => {
+      const response = await page.goto(path);
+      expect(response?.status()).toBe(200);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- extend wait time in `generate flow` smoke test and verify HTTP response
- add test checking static page availability

## Testing
- `npm test` in `backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: lines truncated)*


------
https://chatgpt.com/codex/tasks/task_e_68722c94166c832d92a4c6db92540002