### PR TITLE
Add mise config test

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,2 @@
+[settings]
+idiomatic_version_file_enable_tools = ["node"]

--- a/backend/tests/miseConfig.test.js
+++ b/backend/tests/miseConfig.test.js
@@ -1,8 +1,16 @@
 const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
 
 describe('mise config', () => {
   test('idiomatic_version_file_enable_tools includes node', () => {
     const output = execSync('mise settings get idiomatic_version_file_enable_tools', { encoding: 'utf8' }).trim();
     expect(output).toContain('node');
+  });
+
+  test('.mise.toml sets idiomatic setting', () => {
+    const configPath = path.join(__dirname, '..', '..', '.mise.toml');
+    const config = fs.readFileSync(configPath, 'utf8');
+    expect(config).toMatch(/idiomatic_version_file_enable_tools\s*=\s*\[\s*['\"]node['\"]\s*\]/);
   });
 });


### PR DESCRIPTION
## Summary
- configure mise with a `.mise.toml`
- add test ensuring the idiomatic version file setting is present

## Testing
- `npm test --prefix backend --silent`


------
https://chatgpt.com/codex/tasks/task_e_68722c80a5b8832d8b7e4e9437c464de