### PR TITLE
Ensure mise config trusted

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,2 @@
+[settings]
+idiomatic_version_file_enable_tools = ["node"]

--- a/backend/tests/miseConfig.test.js
+++ b/backend/tests/miseConfig.test.js
@@ -5,4 +5,10 @@ describe('mise config', () => {
     const output = execSync('mise settings get idiomatic_version_file_enable_tools', { encoding: 'utf8' }).trim();
     expect(output).toContain('node');
   });
+
+  test('mise config file is trusted', () => {
+    execSync('mise trust --yes', { stdio: 'ignore' });
+    const status = execSync('mise trust --show', { encoding: 'utf8' }).trim();
+    expect(status).toMatch(/: trusted$/);
+  });
 });


### PR DESCRIPTION
## Summary
- silence `mise` warnings by committing `.mise.toml`
- verify the setting in a new test

## Testing
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_68722c3c442c832db9888759009ee557