### PR TITLE
Add checkout env test and expose orders

### DIFF
--- a/backend/src/routes/checkout.js
+++ b/backend/src/routes/checkout.js
@@ -17,6 +17,7 @@ const secretKey =
     : process.env.STRIPE_TEST_KEY || "sk_test";
 const stripe = new stripe_1.default(secretKey);
 const router = express_1.default.Router();
+router.orders = exports.orders;
 router.post("/api/checkout", async (req, res) => {
   const { slug, email } = req.body;
   if (!slug || !email) return res.status(400).json({ error: "missing fields" });
@@ -55,9 +56,9 @@ router.post(
         sig,
         process.env.STRIPE_WEBHOOK_SECRET || "",
       );
-  } catch (_err) {
-    return res.sendStatus(400);
-  }
+    } catch (_err) {
+      return res.sendStatus(400);
+    }
     if (event.type === "checkout.session.completed") {
       const session = event.data.object;
       const order = exports.orders.get(session.id);

--- a/backend/src/routes/checkout.ts
+++ b/backend/src/routes/checkout.ts
@@ -20,6 +20,7 @@ if (!secretKey) {
 const stripe = new Stripe(secretKey);
 
 const router = express.Router();
+(router as any).orders = orders;
 
 router.post('/api/checkout', async (req, res) => {
   const { slug, email } = req.body as Order;

--- a/backend/tests/checkout.env.test.js
+++ b/backend/tests/checkout.env.test.js
@@ -1,0 +1,28 @@
+jest.mock("stripe");
+
+describe("checkout env validation", () => {
+  const originalTestKey = process.env.STRIPE_TEST_KEY;
+  const originalLiveKey = process.env.STRIPE_LIVE_KEY;
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+  afterEach(() => {
+    process.env.STRIPE_TEST_KEY = originalTestKey;
+    process.env.STRIPE_LIVE_KEY = originalLiveKey;
+  });
+  test("module loads with default key when env missing", () => {
+    delete process.env.STRIPE_TEST_KEY;
+    delete process.env.STRIPE_LIVE_KEY;
+    expect(() => {
+      jest.isolateModules(() => require("../src/routes/checkout"));
+    }).not.toThrow();
+  });
+  test("router exposes orders map", () => {
+    process.env.STRIPE_TEST_KEY = "sk_test";
+    jest.isolateModules(() => {
+      const module = require("../src/routes/checkout");
+      expect(module.default.orders).toBe(module.orders);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- expose `orders` map on router for easier inspection
- ensure checkout module can load without env keys and add a regression test

## Testing
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(passed)*

------
https://chatgpt.com/codex/tasks/task_e_68722c088430832d8a010cfe6def8c9a