### PR TITLE
Fix env validation and add tests

### DIFF
--- a/backend/tests/envValidation.test.js
+++ b/backend/tests/envValidation.test.js
@@ -1,0 +1,33 @@
+const { execSync } = require('child_process');
+const path = require('path');
+
+const script = path.join(__dirname, '..', '..', 'scripts', 'validate-env.sh');
+
+describe('validate-env script', () => {
+  test('passes with STRIPE_TEST_KEY set', () => {
+    expect(() =>
+      execSync(`bash ${script}`, {
+        env: { ...process.env, STRIPE_TEST_KEY: 'sk_test', HF_TOKEN: 't' },
+        stdio: 'pipe',
+      })
+    ).not.toThrow();
+  });
+
+  test('passes with STRIPE_LIVE_KEY set', () => {
+    expect(() =>
+      execSync(`bash ${script}`, {
+        env: { ...process.env, STRIPE_LIVE_KEY: 'sk_live', STRIPE_TEST_KEY: '', HF_TOKEN: 't' },
+        stdio: 'pipe',
+      })
+    ).not.toThrow();
+  });
+
+  test('fails without stripe keys', () => {
+    expect(() =>
+      execSync(`bash ${script}`, {
+        env: { ...process.env, STRIPE_TEST_KEY: '', STRIPE_LIVE_KEY: '', HF_TOKEN: 't' },
+        stdio: 'pipe',
+      })
+    ).toThrow();
+  });
+});

--- a/scripts/assert-setup.js
+++ b/scripts/assert-setup.js
@@ -19,7 +19,13 @@ if (!fs.existsSync('.setup-complete') || !browsersInstalled()) {
     "Playwright browsers not installed. Running 'npm run setup' to install them"
   );
   try {
-    require('child_process').execSync('CI=1 npm run setup', { stdio: 'inherit' });
+  const env = { ...process.env };
+  delete env.npm_config_http_proxy;
+  delete env.npm_config_https_proxy;
+  require('child_process').execSync('CI=1 npm run setup', {
+    stdio: 'inherit',
+    env,
+  });
   } catch (err) {
     console.error('Failed to run setup:', err.message);
     process.exit(1);

--- a/scripts/validate-env.sh
+++ b/scripts/validate-env.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 set -e
-: "${STRIPE_TEST_KEY:?STRIPE_TEST_KEY must be set}"
+if [[ -z "${STRIPE_TEST_KEY:-}" && -z "${STRIPE_LIVE_KEY:-}" ]]; then
+  echo "STRIPE_TEST_KEY or STRIPE_LIVE_KEY must be set" >&2
+  exit 1
+fi
 : "${HF_TOKEN:?HF_TOKEN must be set}"
 echo "✅ environment OK"


### PR DESCRIPTION
## Summary
- skip proxy vars when running setup from assert-setup.js
- check for STRIPE_LIVE_KEY in validate-env.sh
- add tests covering validate-env behavior

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Returned 404)*

------
https://chatgpt.com/codex/tasks/task_e_68722bc05f08832d96183098ba74197b