### PR TITLE
Add assert setup test

### DIFF
--- a/.github/workflows/pipeline-smoke.yml
+++ b/.github/workflows/pipeline-smoke.yml
@@ -40,7 +40,7 @@ jobs:
         run: pnpm install
 
       - name: Run smoke tests
-        run: pnpm run smoke
+        run: SKIP_PW_DEPS=1 pnpm run smoke
 
       - name: Start backend
         run: pnpm dev &

--- a/backend/tests/assertSetup.test.js
+++ b/backend/tests/assertSetup.test.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const path = require('path');
+const child_process = require('child_process');
+
+test('assert-setup skips playwright deps when browsers exist', () => {
+  const tmp = fs.mkdtempSync(path.join(__dirname, 'tmp-'));
+  const browserDir = path.join(tmp, 'browsers');
+  fs.mkdirSync(browserDir);
+  fs.writeFileSync(path.join(browserDir, 'browser'), '');
+
+  const script = path.resolve(__dirname, '../../scripts/assert-setup.js');
+  const output = child_process.execSync(`node ${script}`, {
+    cwd: tmp,
+    env: {
+      ...process.env,
+      PLAYWRIGHT_BROWSERS_PATH: browserDir,
+      ASSERT_SETUP_DRY_RUN: '1',
+    },
+  }).toString();
+
+  expect(output).toContain('SKIP_PW_DEPS=1');
+});


### PR DESCRIPTION
## Summary
- skip playwright dependencies if browsers already installed
- run smoke tests without reinstalling Playwright on CI
- test assert-setup logic

## Testing
- `npm test --prefix backend --silent -- --coverage=false backend/tests/assertSetup.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68722bb098e4832db290365abd5916a1