### PR TITLE
Improve smoke setup and add test

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "setup": "scripts/setup.sh",
     "e2e": "playwright test",
     "serve": "npm run build && npx serve dist",
-    "smoke": "npm run setup && npx playwright install --with-deps && concurrently -k -s first \"npm run serve\" \"wait-on http://localhost:3000 && npx playwright test e2e/smoke.test.js\"",
+    "smoke": "node scripts/assert-setup.js && npx playwright install --with-deps && concurrently -k -s first \"npm run serve\" \"wait-on http://localhost:3000 && npx playwright test e2e/smoke.test.js\"",
     "build": "echo 'no build step'",
     "load": "artillery run tests/load/models.yml",
     "visual-test": "percy exec -- npm run e2e",
@@ -88,7 +88,7 @@
   "lint-staged": {
     "*.{js,ts,json}": "prettier --write",
     "backend/**/*.js": "eslint --fix",
-    "*.{js,ts}": "jest --bail --findRelatedTests"
+    "*.{js,ts}": "npx jest --bail --findRelatedTests"
   },
   "dependencies": {
     "axios": "^1.10.0",

--- a/scripts/assert-setup.js
+++ b/scripts/assert-setup.js
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
 
 function browsersInstalled() {
   const envPath = process.env.PLAYWRIGHT_BROWSERS_PATH;
-  const defaultPath = path.join(os.homedir(), '.cache', 'ms-playwright');
+  const defaultPath = path.join(os.homedir(), ".cache", "ms-playwright");
   const browserPath = envPath || defaultPath;
   try {
     return fs.existsSync(browserPath) && fs.readdirSync(browserPath).length > 0;
@@ -14,14 +14,20 @@ function browsersInstalled() {
   }
 }
 
-if (!fs.existsSync('.setup-complete') || !browsersInstalled()) {
+if (!fs.existsSync(".setup-complete") || !browsersInstalled()) {
   console.log(
-    "Playwright browsers not installed. Running 'npm run setup' to install them"
+    "Playwright browsers not installed. Running 'npm run setup' to install them",
   );
-  try {
-    require('child_process').execSync('CI=1 npm run setup', { stdio: 'inherit' });
-  } catch (err) {
-    console.error('Failed to run setup:', err.message);
-    process.exit(1);
+  if (process.env.MOCK_SETUP === "1") {
+    console.log("MOCK_SETUP enabled - skipping install");
+  } else {
+    try {
+      require("child_process").execSync("CI=1 npm run setup", {
+        stdio: "inherit",
+      });
+    } catch (err) {
+      console.error("Failed to run setup:", err.message);
+      process.exit(1);
+    }
   }
 }

--- a/tests/assertSetup.test.js
+++ b/tests/assertSetup.test.js
@@ -1,0 +1,37 @@
+const fs = require("fs");
+const path = require("path");
+const { execFileSync } = require("child_process");
+
+describe("assert-setup", () => {
+  const script = path.join("scripts", "assert-setup.js");
+  const browsersPath = path.join(__dirname, "tmp-browsers");
+  beforeAll(() => {
+    fs.mkdirSync(browsersPath, { recursive: true });
+    fs.writeFileSync(path.join(browsersPath, "dummy"), "");
+  });
+  afterAll(() => {
+    fs.rmSync(browsersPath, { recursive: true, force: true });
+  });
+  test("exits without running setup when .setup-complete exists", () => {
+    fs.writeFileSync(".setup-complete", "");
+    const out = execFileSync("node", [script], {
+      env: {
+        ...process.env,
+        PLAYWRIGHT_BROWSERS_PATH: browsersPath,
+        MOCK_SETUP: "1",
+      },
+    }).toString();
+    expect(out).toBe("");
+    fs.unlinkSync(".setup-complete");
+  });
+  test("runs setup when markers missing", () => {
+    const out = execFileSync("node", [script], {
+      env: {
+        ...process.env,
+        PLAYWRIGHT_BROWSERS_PATH: "/nonexistent",
+        MOCK_SETUP: "1",
+      },
+    }).toString();
+    expect(out).toContain("MOCK_SETUP enabled");
+  });
+});


### PR DESCRIPTION
## Summary
- skip redundant install by using assert-setup in `npm run smoke`
- allow skipping setup in `assert-setup.js`
- test `assert-setup.js`

## Testing
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_68722dd7d5c0832da93879a5d532df7a