### PR TITLE
Silence test logs

### DIFF
--- a/backend/tests/setup.js
+++ b/backend/tests/setup.js
@@ -34,6 +34,7 @@ beforeEach(() => {
     if (msg.includes("Could not load script")) return;
     throw new Error("console.error called: " + msg);
   });
+  jest.spyOn(console, "log").mockImplementation(() => {});
 });
 
 // Clean up between tests


### PR DESCRIPTION
## Summary
- disable console.log output during backend tests

## Testing
- `npm test --prefix backend`
- `npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_687238beffbc832da9b6930f65a83633