### PR TITLE
Set default AWS credentials for tests

### DIFF
--- a/backend/tests/setupGlobals.js
+++ b/backend/tests/setupGlobals.js
@@ -43,6 +43,14 @@ if (!process.env.SPARC3D_TOKEN) {
   process.env.SPARC3D_TOKEN = "token";
 }
 
+// Provide dummy AWS credentials so tests don't need real ones
+if (!process.env.AWS_ACCESS_KEY_ID) {
+  process.env.AWS_ACCESS_KEY_ID = "test";
+}
+if (!process.env.AWS_SECRET_ACCESS_KEY) {
+  process.env.AWS_SECRET_ACCESS_KEY = "test";
+}
+
 // Ensure any proxy environment variables do not interfere with HTTP mocking
 for (const key of [
   "http_proxy",


### PR DESCRIPTION
## Summary
- add dummy AWS credentials to test setup so AWS SDK doesn't try to resolve real credentials

## Testing
- `npm test --prefix backend tests/textToImage.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_687238ae71ec832d87d6a8e4fcab3066