### PR TITLE
Ensure build script presence for serve

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "validate-env": "bash scripts/validate-env.sh",
     "setup": "bash scripts/setup.sh",
     "e2e": "playwright test",
-    "serve": "npm run build && npx serve dist",
+    "serve": "npm run build && node scripts/dev-server.js",
     "smoke": "npm run setup && npx -y playwright install --with-deps && npx -y concurrently -k -s first \"npm run serve\" \"wait-on http://localhost:3000 && npx playwright test e2e/smoke.test.js\"",
     "build": "echo 'no build step'",
     "load": "artillery run tests/load/models.yml",

--- a/tests/buildScript.test.js
+++ b/tests/buildScript.test.js
@@ -1,0 +1,5 @@
+const pkg = require("../package.json");
+
+test("build script exists", () => {
+  expect(typeof pkg.scripts?.build).toBe("string");
+});


### PR DESCRIPTION
## Summary
- run dev server in `npm run serve`
- add test to ensure build script exists

## Testing
- `npm test`
- `SKIP_PW_DEPS=1 npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_687238aaada8832d84a23a6b23fdcca2