### PR TITLE
Add AWS credential checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,16 +17,17 @@ These guidelines apply to all automated agents (e.g. the Codex agent) working on
    - Set `SKIP_PW_DEPS=1` before running the setup script if Playwright dependencies are already installed. This skips the long `apt-get` step and reduces CI time. The `smoke` script also runs the setup script, so use `SKIP_PW_DEPS=1 npm run smoke` to avoid reinstalling Playwright dependencies when they are already present.
 5. **Format code** – run `npm run format` in `backend/` to apply Prettier formatting.
 6. **Run tests** – execute `npm test` in `backend/`. If tests cannot run because of environment limitations, mention this in the PR.
-7. **Run full CI locally** – execute `npm run ci` at the repo root before opening a PR. Set `SKIP_PW_DEPS=1` if Playwright dependencies were installed previously to avoid redundant `apt-get` steps.
-8. **Install Playwright browsers** – the setup script installs these automatically. If browsers or host dependencies are missing (e.g. Playwright warns that the host system lacks libraries), run `CI=1 npx playwright install --with-deps` manually.
-9. **Run smoke tests** – execute `npm run smoke` at the repository root. This script starts the dev server and runs the Playwright smoke test. If the browsers are already installed, prepend `SKIP_PW_DEPS=1` to skip reinstalling them. **Do not run `npx playwright test` directly** – that can trigger `"Playwright Test did not expect test() to be called here"` errors when dependencies are missing.
-9. **Limit scope** – only modify files related to the task. Do not change anything under `img/`, `models/`, or `uploads/` unless explicitly requested. Avoid editing `docs/` unless the task specifically involves documentation.
-10. **Use Conventional Commits** – commit messages must follow the `type: description` format enforced by commitlint. Allowed types are `build`, `ci`, `docs`, `feat`, `fix`, `chore`, `refactor`, `test`, `style`, `perf`, and `revert`. Example: `fix: handle missing avatar images`.
-11. **Review your diff** – run `git status --short` and `git diff --stat` to ensure only intended files were modified. Revert any unrelated changes.
-12. **Include logs** – paste the output of `npm test` (or `npm run test-ci`) and `npm run format` in the PR description so maintainers can verify the steps.
-13. **Avoid PRs with failing tests** – if `npm run ci` or the smoke tests fail for reasons other than environment limitations, do not open a pull request. Fix the issues or open an issue summarizing the failure instead.
-14. **Avoid committing binary files** – Codex cannot generate patches for binary changes. Do not modify images, audio, or other binary assets. If adding new ones, update `.gitattributes` so they are treated as binary.
-15. **Pin GitHub Action versions** – use explicit tags instead of broad majors to prevent resolution errors (e.g. `aquasecurity/tfsec-action@v1.0.3`).
+7. **AWS credentials** – when `STABILITY_KEY` is provided (for text-to-image tests), set `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` to placeholder values so environment validation passes.
+8. **Run full CI locally** – execute `npm run ci` at the repo root before opening a PR. Set `SKIP_PW_DEPS=1` if Playwright dependencies were installed previously to avoid redundant `apt-get` steps.
+9. **Install Playwright browsers** – the setup script installs these automatically. If browsers or host dependencies are missing (e.g. Playwright warns that the host system lacks libraries), run `CI=1 npx playwright install --with-deps` manually.
+10. **Run smoke tests** – execute `npm run smoke` at the repository root. This script starts the dev server and runs the Playwright smoke test. If the browsers are already installed, prepend `SKIP_PW_DEPS=1` to skip reinstalling them. **Do not run `npx playwright test` directly** – that can trigger `"Playwright Test did not expect test() to be called here"` errors when dependencies are missing.
+11. **Limit scope** – only modify files related to the task. Do not change anything under `img/`, `models/`, or `uploads/` unless explicitly requested. Avoid editing `docs/` unless the task specifically involves documentation.
+12. **Use Conventional Commits** – commit messages must follow the `type: description` format enforced by commitlint. Allowed types are `build`, `ci`, `docs`, `feat`, `fix`, `chore`, `refactor`, `test`, `style`, `perf`, and `revert`. Example: `fix: handle missing avatar images`.
+13. **Review your diff** – run `git status --short` and `git diff --stat` to ensure only intended files were modified. Revert any unrelated changes.
+14. **Include logs** – paste the output of `npm test` (or `npm run test-ci`) and `npm run format` in the PR description so maintainers can verify the steps.
+15. **Avoid PRs with failing tests** – if `npm run ci` or the smoke tests fail for reasons other than environment limitations, do not open a pull request. Fix the issues or open an issue summarizing the failure instead.
+16. **Avoid committing binary files** – Codex cannot generate patches for binary changes. Do not modify images, audio, or other binary assets. If adding new ones, update `.gitattributes` so they are treated as binary.
+17. **Pin GitHub Action versions** – use explicit tags instead of broad majors to prevent resolution errors (e.g. `aquasecurity/tfsec-action@v1.0.3`).
 
 ## Troubleshooting
 

--- a/backend/tests/awsEnvValidation.test.js
+++ b/backend/tests/awsEnvValidation.test.js
@@ -1,0 +1,38 @@
+const { execSync } = require("child_process");
+const path = require("path");
+
+const script = path.join(__dirname, "..", "..", "scripts", "validate-env.sh");
+
+describe("validate-env AWS checks", () => {
+  test("fails when STABILITY_KEY set without AWS creds", () => {
+    expect(() =>
+      execSync(`bash ${script}`, {
+        env: {
+          ...process.env,
+          STABILITY_KEY: "key",
+          AWS_ACCESS_KEY_ID: "",
+          AWS_SECRET_ACCESS_KEY: "",
+          STRIPE_TEST_KEY: "sk",
+          HF_TOKEN: "t",
+        },
+        stdio: "pipe",
+      }),
+    ).toThrow();
+  });
+
+  test("passes with STABILITY_KEY and AWS creds", () => {
+    expect(() =>
+      execSync(`bash ${script}`, {
+        env: {
+          ...process.env,
+          STABILITY_KEY: "key",
+          AWS_ACCESS_KEY_ID: "id",
+          AWS_SECRET_ACCESS_KEY: "secret",
+          STRIPE_TEST_KEY: "sk",
+          HF_TOKEN: "t",
+        },
+        stdio: "pipe",
+      }),
+    ).not.toThrow();
+  });
+});

--- a/backend/tests/textToImage.proxy.test.ts
+++ b/backend/tests/textToImage.proxy.test.ts
@@ -1,25 +1,29 @@
-const nock = require('nock');
+const nock = require("nock");
 
-process.env.http_proxy = 'http://proxy:8080';
-process.env.https_proxy = 'http://proxy:8080';
-process.env.HTTP_PROXY = 'http://proxy:8080';
-process.env.HTTPS_PROXY = 'http://proxy:8080';
+process.env.http_proxy = "http://proxy:8080";
+process.env.https_proxy = "http://proxy:8080";
+process.env.HTTP_PROXY = "http://proxy:8080";
+process.env.HTTPS_PROXY = "http://proxy:8080";
 
 delete process.env.http_proxy;
 delete process.env.https_proxy;
 delete process.env.HTTP_PROXY;
 delete process.env.HTTPS_PROXY;
 
-const { textToImage } = require('../src/lib/textToImage.js');
-const s3 = require('../src/lib/uploadS3.js');
+const { textToImage } = require("../src/lib/textToImage.js");
+const s3 = require("../src/lib/uploadS3.js");
 
-describe('textToImage proxy cleanup', () => {
+describe("textToImage proxy cleanup", () => {
   beforeEach(() => {
-    process.env.STABILITY_KEY = 'abc';
-    process.env.AWS_REGION = 'us-east-1';
-    process.env.S3_BUCKET = 'bucket';
-    process.env.CLOUDFRONT_DOMAIN = 'cdn.test';
-    jest.spyOn(s3, 'uploadFile').mockResolvedValue('https://cdn.test/image.png');
+    process.env.STABILITY_KEY = "abc";
+    process.env.AWS_ACCESS_KEY_ID = "test";
+    process.env.AWS_SECRET_ACCESS_KEY = "secret";
+    process.env.AWS_REGION = "us-east-1";
+    process.env.S3_BUCKET = "bucket";
+    process.env.CLOUDFRONT_DOMAIN = "cdn.test";
+    jest
+      .spyOn(s3, "uploadFile")
+      .mockResolvedValue("https://cdn.test/image.png");
     nock.disableNetConnect();
   });
 
@@ -27,15 +31,17 @@ describe('textToImage proxy cleanup', () => {
     nock.cleanAll();
     nock.enableNetConnect();
     jest.restoreAllMocks();
+    delete process.env.AWS_ACCESS_KEY_ID;
+    delete process.env.AWS_SECRET_ACCESS_KEY;
   });
 
-  test('uses nock endpoint even when proxy env was set', async () => {
-    const png = Buffer.from('png');
-    nock('https://api.stability.ai')
-      .post('/v2beta/stable-image/generate/core')
-      .reply(200, png, { 'Content-Type': 'image/png' });
+  test("uses nock endpoint even when proxy env was set", async () => {
+    const png = Buffer.from("png");
+    nock("https://api.stability.ai")
+      .post("/v2beta/stable-image/generate/core")
+      .reply(200, png, { "Content-Type": "image/png" });
 
-    const url = await textToImage('hello');
-    expect(url).toBe('https://cdn.test/image.png');
+    const url = await textToImage("hello");
+    expect(url).toBe("https://cdn.test/image.png");
   });
 });

--- a/scripts/validate-env.sh
+++ b/scripts/validate-env.sh
@@ -1,8 +1,16 @@
 #!/usr/bin/env bash
 set -e
+
 if [[ -z "${STRIPE_TEST_KEY:-}" && -z "${STRIPE_LIVE_KEY:-}" ]]; then
   echo "STRIPE_TEST_KEY or STRIPE_LIVE_KEY must be set" >&2
   exit 1
 fi
+
 : "${HF_TOKEN:?HF_TOKEN must be set}"
+
+if [[ -n "${STABILITY_KEY:-}" ]]; then
+  : "${AWS_ACCESS_KEY_ID:?AWS_ACCESS_KEY_ID must be set when STABILITY_KEY is set}"
+  : "${AWS_SECRET_ACCESS_KEY:?AWS_SECRET_ACCESS_KEY must be set when STABILITY_KEY is set}"
+fi
+
 echo "✅ environment OK"


### PR DESCRIPTION
## Summary
- validate AWS creds when STABILITY_KEY is set
- mention AWS creds in AGENT guidelines
- ensure text-to-image proxy tests set dummy creds
- add test for validate-env AWS handling

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687243906654832dab211071bc4ff3a7