### PR TITLE
Improve textToImage tests

### DIFF
--- a/backend/tests/textToImage.proxy.test.ts
+++ b/backend/tests/textToImage.proxy.test.ts
@@ -1,25 +1,28 @@
-const nock = require('nock');
+jest.mock("../src/lib/uploadS3.js", () => ({
+  uploadFile: jest.fn().mockResolvedValue("https://cdn.test/image.png"),
+}));
 
-process.env.http_proxy = 'http://proxy:8080';
-process.env.https_proxy = 'http://proxy:8080';
-process.env.HTTP_PROXY = 'http://proxy:8080';
-process.env.HTTPS_PROXY = 'http://proxy:8080';
+const nock = require("nock");
+
+process.env.http_proxy = "http://proxy:8080";
+process.env.https_proxy = "http://proxy:8080";
+process.env.HTTP_PROXY = "http://proxy:8080";
+process.env.HTTPS_PROXY = "http://proxy:8080";
 
 delete process.env.http_proxy;
 delete process.env.https_proxy;
 delete process.env.HTTP_PROXY;
 delete process.env.HTTPS_PROXY;
 
-const { textToImage } = require('../src/lib/textToImage.js');
-const s3 = require('../src/lib/uploadS3.js');
+const { textToImage } = require("../src/lib/textToImage.js");
+const s3 = require("../src/lib/uploadS3.js");
 
-describe('textToImage proxy cleanup', () => {
+describe("textToImage proxy cleanup", () => {
   beforeEach(() => {
-    process.env.STABILITY_KEY = 'abc';
-    process.env.AWS_REGION = 'us-east-1';
-    process.env.S3_BUCKET = 'bucket';
-    process.env.CLOUDFRONT_DOMAIN = 'cdn.test';
-    jest.spyOn(s3, 'uploadFile').mockResolvedValue('https://cdn.test/image.png');
+    process.env.STABILITY_KEY = "abc";
+    process.env.AWS_REGION = "us-east-1";
+    process.env.S3_BUCKET = "bucket";
+    process.env.CLOUDFRONT_DOMAIN = "cdn.test";
     nock.disableNetConnect();
   });
 
@@ -29,13 +32,24 @@ describe('textToImage proxy cleanup', () => {
     jest.restoreAllMocks();
   });
 
-  test('uses nock endpoint even when proxy env was set', async () => {
-    const png = Buffer.from('png');
-    nock('https://api.stability.ai')
-      .post('/v2beta/stable-image/generate/core')
-      .reply(200, png, { 'Content-Type': 'image/png' });
+  test("uses nock endpoint even when proxy env was set", async () => {
+    const png = Buffer.from("png");
+    nock("https://api.stability.ai")
+      .post("/v2beta/stable-image/generate/core")
+      .reply(200, png, { "Content-Type": "image/png" });
 
-    const url = await textToImage('hello');
-    expect(url).toBe('https://cdn.test/image.png');
+    const url = await textToImage("hello");
+    expect(url).toBe("https://cdn.test/image.png");
+  });
+
+  test("works without AWS credentials when uploadFile is mocked", async () => {
+    delete process.env.AWS_ACCESS_KEY_ID;
+    delete process.env.AWS_SECRET_ACCESS_KEY;
+    const png = Buffer.from("png");
+    nock("https://api.stability.ai")
+      .post("/v2beta/stable-image/generate/core")
+      .reply(200, png, { "Content-Type": "image/png" });
+    const url = await textToImage("no-creds");
+    expect(url).toBe("https://cdn.test/image.png");
   });
 });


### PR DESCRIPTION
## Summary
- ensure `uploadFile` is mocked in textToImage tests
- add test cases for missing AWS credentials

## Testing
- `npx prettier -w backend/tests/textToImage.test.ts backend/tests/textToImage.proxy.test.ts`
- `npm test --prefix backend --silent`

------
https://chatgpt.com/codex/tasks/task_e_687243855e98832d88a9717d22b2aa2d