### PR TITLE
Fix textToImage tests mocking S3

### DIFF
--- a/backend/tests/textToImage.proxy.test.ts
+++ b/backend/tests/textToImage.proxy.test.ts
@@ -1,41 +1,45 @@
-const nock = require('nock');
+jest.mock("../src/lib/uploadS3.js", () => ({
+  uploadFile: jest.fn(),
+}));
 
-process.env.http_proxy = 'http://proxy:8080';
-process.env.https_proxy = 'http://proxy:8080';
-process.env.HTTP_PROXY = 'http://proxy:8080';
-process.env.HTTPS_PROXY = 'http://proxy:8080';
+const nock = require("nock");
+
+process.env.http_proxy = "http://proxy:8080";
+process.env.https_proxy = "http://proxy:8080";
+process.env.HTTP_PROXY = "http://proxy:8080";
+process.env.HTTPS_PROXY = "http://proxy:8080";
 
 delete process.env.http_proxy;
 delete process.env.https_proxy;
 delete process.env.HTTP_PROXY;
 delete process.env.HTTPS_PROXY;
 
-const { textToImage } = require('../src/lib/textToImage.js');
-const s3 = require('../src/lib/uploadS3.js');
+const { textToImage } = require("../src/lib/textToImage.js");
+const s3 = require("../src/lib/uploadS3.js");
 
-describe('textToImage proxy cleanup', () => {
+describe("textToImage proxy cleanup", () => {
   beforeEach(() => {
-    process.env.STABILITY_KEY = 'abc';
-    process.env.AWS_REGION = 'us-east-1';
-    process.env.S3_BUCKET = 'bucket';
-    process.env.CLOUDFRONT_DOMAIN = 'cdn.test';
-    jest.spyOn(s3, 'uploadFile').mockResolvedValue('https://cdn.test/image.png');
+    process.env.STABILITY_KEY = "abc";
+    process.env.AWS_REGION = "us-east-1";
+    process.env.S3_BUCKET = "bucket";
+    process.env.CLOUDFRONT_DOMAIN = "cdn.test";
+    s3.uploadFile.mockResolvedValue("https://cdn.test/image.png");
     nock.disableNetConnect();
   });
 
   afterEach(() => {
     nock.cleanAll();
     nock.enableNetConnect();
-    jest.restoreAllMocks();
+    jest.resetAllMocks();
   });
 
-  test('uses nock endpoint even when proxy env was set', async () => {
-    const png = Buffer.from('png');
-    nock('https://api.stability.ai')
-      .post('/v2beta/stable-image/generate/core')
-      .reply(200, png, { 'Content-Type': 'image/png' });
+  test("uses nock endpoint even when proxy env was set", async () => {
+    const png = Buffer.from("png");
+    nock("https://api.stability.ai")
+      .post("/v2beta/stable-image/generate/core")
+      .reply(200, png, { "Content-Type": "image/png" });
 
-    const url = await textToImage('hello');
-    expect(url).toBe('https://cdn.test/image.png');
+    const url = await textToImage("hello");
+    expect(url).toBe("https://cdn.test/image.png");
   });
 });

--- a/backend/tests/textToImage.test.ts
+++ b/backend/tests/textToImage.test.ts
@@ -5,10 +5,14 @@ jest.mock("@aws-sdk/client-s3", () => ({
   PutObjectCommand: jest.fn(),
 }));
 
-process.env.http_proxy = 'http://proxy:8080';
-process.env.https_proxy = 'http://proxy:8080';
-process.env.HTTP_PROXY = 'http://proxy:8080';
-process.env.HTTPS_PROXY = 'http://proxy:8080';
+jest.mock("../src/lib/uploadS3.js", () => ({
+  uploadFile: jest.fn(),
+}));
+
+process.env.http_proxy = "http://proxy:8080";
+process.env.https_proxy = "http://proxy:8080";
+process.env.HTTP_PROXY = "http://proxy:8080";
+process.env.HTTPS_PROXY = "http://proxy:8080";
 
 delete process.env.http_proxy;
 delete process.env.https_proxy;
@@ -35,15 +39,13 @@ describe("textToImage", () => {
     delete process.env.HTTP_PROXY;
     delete process.env.HTTPS_PROXY;
     nock.disableNetConnect();
-    jest
-      .spyOn(s3, "uploadFile")
-      .mockResolvedValue("https://cdn.test/image.png");
+    s3.uploadFile.mockResolvedValue("https://cdn.test/image.png");
   });
 
   afterEach(() => {
     nock.cleanAll();
     nock.enableNetConnect();
-    jest.restoreAllMocks();
+    jest.resetAllMocks();
     delete process.env.AWS_ACCESS_KEY_ID;
     delete process.env.AWS_SECRET_ACCESS_KEY;
   });


### PR DESCRIPTION
## Summary
- mock `uploadS3` in textToImage tests so AWS credentials aren't required

## Testing
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68724369c1dc832d912d19d7a286ed2c