### PR TITLE
Fix AWS credential errors in text-to-image tests

### DIFF
--- a/backend/tests/awsCredentials.test.ts
+++ b/backend/tests/awsCredentials.test.ts
@@ -1,0 +1,8 @@
+require("../src/lib/uploadS3.js");
+
+describe("AWS credentials", () => {
+  test("dummy credentials are set", () => {
+    expect(process.env.AWS_ACCESS_KEY_ID).toBeTruthy();
+    expect(process.env.AWS_SECRET_ACCESS_KEY).toBeTruthy();
+  });
+});

--- a/backend/tests/textToImage.proxy.test.ts
+++ b/backend/tests/textToImage.proxy.test.ts
@@ -1,25 +1,29 @@
-const nock = require('nock');
+const nock = require("nock");
 
-process.env.http_proxy = 'http://proxy:8080';
-process.env.https_proxy = 'http://proxy:8080';
-process.env.HTTP_PROXY = 'http://proxy:8080';
-process.env.HTTPS_PROXY = 'http://proxy:8080';
+process.env.http_proxy = "http://proxy:8080";
+process.env.https_proxy = "http://proxy:8080";
+process.env.HTTP_PROXY = "http://proxy:8080";
+process.env.HTTPS_PROXY = "http://proxy:8080";
 
 delete process.env.http_proxy;
 delete process.env.https_proxy;
 delete process.env.HTTP_PROXY;
 delete process.env.HTTPS_PROXY;
 
-const { textToImage } = require('../src/lib/textToImage.js');
-const s3 = require('../src/lib/uploadS3.js');
+const { textToImage } = require("../src/lib/textToImage.js");
+const s3 = require("../src/lib/uploadS3.js");
 
-describe('textToImage proxy cleanup', () => {
+describe("textToImage proxy cleanup", () => {
   beforeEach(() => {
-    process.env.STABILITY_KEY = 'abc';
-    process.env.AWS_REGION = 'us-east-1';
-    process.env.S3_BUCKET = 'bucket';
-    process.env.CLOUDFRONT_DOMAIN = 'cdn.test';
-    jest.spyOn(s3, 'uploadFile').mockResolvedValue('https://cdn.test/image.png');
+    process.env.STABILITY_KEY = "abc";
+    process.env.AWS_REGION = "us-east-1";
+    process.env.S3_BUCKET = "bucket";
+    process.env.CLOUDFRONT_DOMAIN = "cdn.test";
+    process.env.AWS_ACCESS_KEY_ID = "test";
+    process.env.AWS_SECRET_ACCESS_KEY = "secret";
+    jest
+      .spyOn(s3, "uploadFile")
+      .mockResolvedValue("https://cdn.test/image.png");
     nock.disableNetConnect();
   });
 
@@ -27,15 +31,17 @@ describe('textToImage proxy cleanup', () => {
     nock.cleanAll();
     nock.enableNetConnect();
     jest.restoreAllMocks();
+    delete process.env.AWS_ACCESS_KEY_ID;
+    delete process.env.AWS_SECRET_ACCESS_KEY;
   });
 
-  test('uses nock endpoint even when proxy env was set', async () => {
-    const png = Buffer.from('png');
-    nock('https://api.stability.ai')
-      .post('/v2beta/stable-image/generate/core')
-      .reply(200, png, { 'Content-Type': 'image/png' });
+  test("uses nock endpoint even when proxy env was set", async () => {
+    const png = Buffer.from("png");
+    nock("https://api.stability.ai")
+      .post("/v2beta/stable-image/generate/core")
+      .reply(200, png, { "Content-Type": "image/png" });
 
-    const url = await textToImage('hello');
-    expect(url).toBe('https://cdn.test/image.png');
+    const url = await textToImage("hello");
+    expect(url).toBe("https://cdn.test/image.png");
   });
 });


### PR DESCRIPTION
## Summary
- ensure textToImage proxy test provides dummy AWS credentials
- add regression test verifying AWS credentials from setup

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_68724358afcc832dbfae7922bef338fd