### PR TITLE
Add test for checkout router singleton

### DIFF
--- a/backend/tests/checkout.shared.test.ts
+++ b/backend/tests/checkout.shared.test.ts
@@ -1,0 +1,27 @@
+const { expect, test } = require("@jest/globals");
+
+beforeEach(() => {
+  process.env.STRIPE_TEST_KEY = "sk_test";
+  process.env.STRIPE_LIVE_KEY = "sk_live";
+  process.env.STRIPE_WEBHOOK_SECRET = "whsec";
+  jest.resetModules();
+});
+
+afterEach(() => {
+  delete process.env.STRIPE_TEST_KEY;
+  delete process.env.STRIPE_LIVE_KEY;
+  delete process.env.STRIPE_WEBHOOK_SECRET;
+});
+
+test("app uses the checkout router instance", () => {
+  const { default: router, orders } = require("../src/routes/checkout");
+  const app = require("../src/app");
+
+  // Router should expose the same orders map exported from the module
+  expect(router.orders).toBe(orders);
+
+  // Express layers list the router handle
+  const stack = app._router?.stack || app.router?.stack;
+  const found = stack?.some((layer) => layer.handle === router);
+  expect(found).toBe(true);
+});

--- a/backend/tests/checkout.test.ts
+++ b/backend/tests/checkout.test.ts
@@ -21,7 +21,7 @@ Stripe.mockImplementation(() => stripeMock);
 
 const request = require("supertest");
 const app = require("../src/app");
-const { orders } = require("../src/routes/checkout.js");
+const { orders } = require("../src/routes/checkout");
 
 afterEach(() => {
   orders.clear();


### PR DESCRIPTION
## Summary
- ensure tests import the router consistently
- check that the Express app and module share the same `orders` map

## Testing
- `npm test`
- `npx jest backend/tests/checkout.shared.test.ts --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_6872432e46a0832da6ba4d3b2bd7e48e