### PR TITLE
Add AWS credentials test

### DIFF
--- a/backend/tests/awsCredentials.test.js
+++ b/backend/tests/awsCredentials.test.js
@@ -1,0 +1,9 @@
+describe("aws credentials", () => {
+  test("dummy credentials are set by setupGlobals", () => {
+    if (!process.env.AWS_ACCESS_KEY_ID || !process.env.AWS_SECRET_ACCESS_KEY) {
+      require("./setupGlobals.js");
+    }
+    expect(process.env.AWS_ACCESS_KEY_ID).toBeDefined();
+    expect(process.env.AWS_SECRET_ACCESS_KEY).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add a test ensuring dummy AWS credentials are set

## Testing
- `npm test backend/tests/awsCredentials.test.js`
- `npm run format`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_687243031918832dba38fbac012ac3f3