### PR TITLE
Add proxy env checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,26 +7,26 @@ These guidelines apply to all automated agents (e.g. the Codex agent) working on
 
 1. **Go to the repository root** – run `cd "$(git rev-parse --show-toplevel)"` after opening a shell to ensure paths resolve correctly.
 2. **Unset proxy variables** – before running any `npm` commands, **and whenever you start a new shell session**, execute `unset npm_config_http_proxy npm_config_https_proxy` to silence `http-proxy` warnings.
-  Run `npm ping` to verify that the registry is reachable before proceeding.
-3. **Check network access** – ensure the environment can reach both
+3. **Validate the environment** – run `npm run validate-env` to ensure required variables are set and proxy vars remain unset.
+4. **Check network access** – ensure the environment can reach both
    `https://registry.npmjs.org` and `https://cdn.playwright.dev`. The setup
    script downloads packages and browsers from these domains. If they are
    blocked, adjust your environment or proxy settings.
-4. **Install dependencies** – run `npm run setup` at the repository root **before your first `npm run ci`**. Run it again whenever the container is restarted or if Playwright tests fail with messages like "Test was interrupted" or "page.evaluate: Test ended". This script unsets proxy variables, checks registry connectivity, runs `npm ci` in the root and `backend/`, and installs Playwright browsers.
+5. **Install dependencies** – run `npm run setup` at the repository root **before your first `npm run ci`**. Run it again whenever the container is restarted or if Playwright tests fail with messages like "Test was interrupted" or "page.evaluate: Test ended". This script unsets proxy variables, checks registry connectivity, runs `npm ci` in the root and `backend/`, and installs Playwright browsers.
    - If `npm ci` fails with an `EUSAGE` error complaining that packages are missing from the lock file, run `npm install` in the affected directory and then re-run the setup script.
    - Set `SKIP_PW_DEPS=1` before running the setup script if Playwright dependencies are already installed. This skips the long `apt-get` step and reduces CI time. The `smoke` script also runs the setup script, so use `SKIP_PW_DEPS=1 npm run smoke` to avoid reinstalling Playwright dependencies when they are already present.
-5. **Format code** – run `npm run format` in `backend/` to apply Prettier formatting.
-6. **Run tests** – execute `npm test` in `backend/`. If tests cannot run because of environment limitations, mention this in the PR.
-7. **Run full CI locally** – execute `npm run ci` at the repo root before opening a PR. Set `SKIP_PW_DEPS=1` if Playwright dependencies were installed previously to avoid redundant `apt-get` steps.
+6. **Format code** – run `npm run format` in `backend/` to apply Prettier formatting.
+7. **Run tests** – execute `npm test` in `backend/`. If tests cannot run because of environment limitations, mention this in the PR.
+8. **Run full CI locally** – execute `npm run ci` at the repo root before opening a PR. Set `SKIP_PW_DEPS=1` if Playwright dependencies were installed previously to avoid redundant `apt-get` steps.
 8. **Install Playwright browsers** – the setup script installs these automatically. If browsers or host dependencies are missing (e.g. Playwright warns that the host system lacks libraries), run `CI=1 npx playwright install --with-deps` manually.
 9. **Run smoke tests** – execute `npm run smoke` at the repository root. This script starts the dev server and runs the Playwright smoke test. If the browsers are already installed, prepend `SKIP_PW_DEPS=1` to skip reinstalling them. **Do not run `npx playwright test` directly** – that can trigger `"Playwright Test did not expect test() to be called here"` errors when dependencies are missing.
-9. **Limit scope** – only modify files related to the task. Do not change anything under `img/`, `models/`, or `uploads/` unless explicitly requested. Avoid editing `docs/` unless the task specifically involves documentation.
-10. **Use Conventional Commits** – commit messages must follow the `type: description` format enforced by commitlint. Allowed types are `build`, `ci`, `docs`, `feat`, `fix`, `chore`, `refactor`, `test`, `style`, `perf`, and `revert`. Example: `fix: handle missing avatar images`.
-11. **Review your diff** – run `git status --short` and `git diff --stat` to ensure only intended files were modified. Revert any unrelated changes.
-12. **Include logs** – paste the output of `npm test` (or `npm run test-ci`) and `npm run format` in the PR description so maintainers can verify the steps.
-13. **Avoid PRs with failing tests** – if `npm run ci` or the smoke tests fail for reasons other than environment limitations, do not open a pull request. Fix the issues or open an issue summarizing the failure instead.
-14. **Avoid committing binary files** – Codex cannot generate patches for binary changes. Do not modify images, audio, or other binary assets. If adding new ones, update `.gitattributes` so they are treated as binary.
-15. **Pin GitHub Action versions** – use explicit tags instead of broad majors to prevent resolution errors (e.g. `aquasecurity/tfsec-action@v1.0.3`).
+10. **Limit scope** – only modify files related to the task. Do not change anything under `img/`, `models/`, or `uploads/` unless explicitly requested. Avoid editing `docs/` unless the task specifically involves documentation.
+11. **Use Conventional Commits** – commit messages must follow the `type: description` format enforced by commitlint. Allowed types are `build`, `ci`, `docs`, `feat`, `fix`, `chore`, `refactor`, `test`, `style`, `perf`, and `revert`. Example: `fix: handle missing avatar images`.
+12. **Review your diff** – run `git status --short` and `git diff --stat` to ensure only intended files were modified. Revert any unrelated changes.
+13. **Include logs** – paste the output of `npm test` (or `npm run test-ci`) and `npm run format` in the PR description so maintainers can verify the steps.
+14. **Avoid PRs with failing tests** – if `npm run ci` or the smoke tests fail for reasons other than environment limitations, do not open a pull request. Fix the issues or open an issue summarizing the failure instead.
+15. **Avoid committing binary files** – Codex cannot generate patches for binary changes. Do not modify images, audio, or other binary assets. If adding new ones, update `.gitattributes` so they are treated as binary.
+16. **Pin GitHub Action versions** – use explicit tags instead of broad majors to prevent resolution errors (e.g. `aquasecurity/tfsec-action@v1.0.3`).
 
 ## Troubleshooting
 

--- a/backend/tests/envValidation.test.js
+++ b/backend/tests/envValidation.test.js
@@ -1,33 +1,69 @@
-const { execSync } = require('child_process');
-const path = require('path');
+const { execSync } = require("child_process");
+const path = require("path");
 
-const script = path.join(__dirname, '..', '..', 'scripts', 'validate-env.sh');
+const script = path.join(__dirname, "..", "..", "scripts", "validate-env.sh");
 
-describe('validate-env script', () => {
-  test('passes with STRIPE_TEST_KEY set', () => {
+describe("validate-env script", () => {
+  test("passes with STRIPE_TEST_KEY set", () => {
     expect(() =>
       execSync(`bash ${script}`, {
-        env: { ...process.env, STRIPE_TEST_KEY: 'sk_test', HF_TOKEN: 't' },
-        stdio: 'pipe',
-      })
+        env: {
+          ...process.env,
+          STRIPE_TEST_KEY: "sk_test",
+          HF_TOKEN: "t",
+          http_proxy: "",
+          https_proxy: "",
+          npm_config_http_proxy: "",
+          npm_config_https_proxy: "",
+        },
+        stdio: "pipe",
+      }),
     ).not.toThrow();
   });
 
-  test('passes with STRIPE_LIVE_KEY set', () => {
+  test("passes with STRIPE_LIVE_KEY set", () => {
     expect(() =>
       execSync(`bash ${script}`, {
-        env: { ...process.env, STRIPE_LIVE_KEY: 'sk_live', STRIPE_TEST_KEY: '', HF_TOKEN: 't' },
-        stdio: 'pipe',
-      })
+        env: {
+          ...process.env,
+          STRIPE_LIVE_KEY: "sk_live",
+          STRIPE_TEST_KEY: "",
+          HF_TOKEN: "t",
+          http_proxy: "",
+          https_proxy: "",
+          npm_config_http_proxy: "",
+          npm_config_https_proxy: "",
+        },
+        stdio: "pipe",
+      }),
     ).not.toThrow();
   });
 
-  test('fails without stripe keys', () => {
+  test("fails without stripe keys", () => {
     expect(() =>
       execSync(`bash ${script}`, {
-        env: { ...process.env, STRIPE_TEST_KEY: '', STRIPE_LIVE_KEY: '', HF_TOKEN: 't' },
-        stdio: 'pipe',
-      })
+        env: {
+          ...process.env,
+          STRIPE_TEST_KEY: "",
+          STRIPE_LIVE_KEY: "",
+          HF_TOKEN: "t",
+        },
+        stdio: "pipe",
+      }),
+    ).toThrow();
+  });
+
+  test("fails when npm proxy vars are set", () => {
+    expect(() =>
+      execSync(`bash ${script}`, {
+        env: {
+          ...process.env,
+          STRIPE_TEST_KEY: "sk_test",
+          HF_TOKEN: "t",
+          npm_config_http_proxy: "http://proxy",
+        },
+        stdio: "pipe",
+      }),
     ).toThrow();
   });
 });

--- a/scripts/validate-env.sh
+++ b/scripts/validate-env.sh
@@ -5,4 +5,10 @@ if [[ -z "${STRIPE_TEST_KEY:-}" && -z "${STRIPE_LIVE_KEY:-}" ]]; then
   exit 1
 fi
 : "${HF_TOKEN:?HF_TOKEN must be set}"
+
+if [[ -n "${npm_config_http_proxy:-}" || -n "${npm_config_https_proxy:-}" || -n "${http_proxy:-}" || -n "${https_proxy:-}" ]]; then
+  echo "npm proxy variables must be unset" >&2
+  exit 1
+fi
+
 echo "✅ environment OK"


### PR DESCRIPTION
## Summary
- enforce proxy variables are unset in `validate-env.sh`
- check proxy vars in env validation test
- document `validate-env` step for agents

## Testing
- `npm test --prefix backend tests/envValidation.test.js`
- `npm run format --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_687242128be4832d8281b8931bbf84dd