### PR TITLE
Improve setup validation checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ## 🤖 Codex Integration
 
 Before you run any Codex-driven prompts, always sync your code and Hugging Face Space:
+
 ```bash
 bash scripts/sync-space.sh
 ```
@@ -28,13 +29,14 @@ Run `docker compose up` to start the API and Postgres services.
 
    - `DB_URL` – connection string for your PostgreSQL database.
 
-  - `STRIPE_TEST_KEY` – test secret key for Stripe.
-  - `STRIPE_LIVE_KEY` – live secret key for Stripe.
-  - `STRIPE_PUBLISHABLE_KEY` – publishable key for Stripe.js on the frontend.
-  - `STRIPE_WEBHOOK_SECRET` – signing secret for Stripe webhooks.
-  - `HUNYUAN_API_KEY` – key for the Sparc3D API.
+- `STRIPE_TEST_KEY` – test secret key for Stripe.
+- `STRIPE_LIVE_KEY` – live secret key for Stripe.
+- `STRIPE_PUBLISHABLE_KEY` – publishable key for Stripe.js on the frontend.
+- `STRIPE_WEBHOOK_SECRET` – signing secret for Stripe webhooks.
+- `HUNYUAN_API_KEY` – key for the Sparc3D API.
 
 The server uses `STRIPE_LIVE_KEY` when `NODE_ENV=production`; otherwise `STRIPE_TEST_KEY` is used.
+
 - If `STRIPE_TEST_KEY` isn't set, `npm run setup` generates a temporary dummy key
   so local installs don't fail.
 - The repository uses `mise` for toolchain management. The included `.mise.toml` enables
@@ -54,13 +56,14 @@ The server uses `STRIPE_LIVE_KEY` when `NODE_ENV=production`; otherwise `STRIPE_
    npm run setup
    ```
 
-
    This script runs `npm ci` in the root and `backend/`, then downloads the browsers
    required for the end-to-end tests. Set `SKIP_PW_DEPS=1` to skip the
    Playwright dependency installation when the browsers are already available.
    It also installs the Husky git hooks used for pre-commit checks. If the hooks
    are missing, run `npx husky install` manually.
-Ensure your environment can reach `https://registry.npmjs.org` and `https://cdn.playwright.dev`. The setup script downloads packages and browsers from these domains, so network restrictions may cause it to fail.
+   If `npm ci` fails with an `EUSAGE` error complaining about missing lock file entries,
+   run `npm install` in the affected directory and re-run this setup step.
+   Ensure your environment can reach `https://registry.npmjs.org` and `https://cdn.playwright.dev`. The setup script downloads packages and browsers from these domains, so network restrictions may cause it to fail.
 
 3. Initialize the database:
 

--- a/backend/tests/setupValidation.test.js
+++ b/backend/tests/setupValidation.test.js
@@ -15,4 +15,9 @@ describe("environment setup", () => {
     expect(fs.existsSync(browserPath)).toBe(true);
     expect(fs.readdirSync(browserPath).length).toBeGreaterThan(0);
   });
+
+  test("jest installed", () => {
+    const jestBin = path.resolve(__dirname, "../../node_modules/.bin/jest");
+    expect(fs.existsSync(jestBin)).toBe(true);
+  });
 });

--- a/scripts/assert-setup.js
+++ b/scripts/assert-setup.js
@@ -14,29 +14,27 @@ function browsersInstalled() {
   }
 }
 
-
 try {
-  require('child_process').execSync('node scripts/check-host-deps.js', {
-    stdio: 'inherit',
+  require("child_process").execSync("node scripts/check-host-deps.js", {
+    stdio: "inherit",
   });
 } catch (err) {
-  console.error('Failed to verify Playwright host dependencies:', err.message);
+  console.error("Failed to verify Playwright host dependencies:", err.message);
   process.exit(1);
 }
 
-if (!fs.existsSync('.setup-complete') || !browsersInstalled()) {
+if (!fs.existsSync(".setup-complete") || !browsersInstalled()) {
   console.log(
-    "Playwright browsers not installed. Running 'bash scripts/setup.sh' to install them"
+    "Playwright browsers not installed. Running 'bash scripts/setup.sh' to install them",
   );
   try {
-
-  const env = { ...process.env };
-  delete env.npm_config_http_proxy;
-  delete env.npm_config_https_proxy;
-  require('child_process').execSync('CI=1 npm run setup', {
-    stdio: 'inherit',
-    env,
-  });
+    const env = { ...process.env };
+    delete env.npm_config_http_proxy;
+    delete env.npm_config_https_proxy;
+    require("child_process").execSync("CI=1 npm run setup", {
+      stdio: "inherit",
+      env,
+    });
   } catch (err) {
     console.error("Failed to run setup:", err.message);
     process.exit(1);
@@ -56,7 +54,18 @@ if (!jestInstalled()) {
   try {
     require("child_process").execSync("npm ci", { stdio: "inherit" });
   } catch (err) {
-    console.error("Failed to install dependencies:", err.message);
-    process.exit(1);
+    const msg = String(err.message || err);
+    if (msg.includes("EUSAGE")) {
+      console.warn("npm ci failed, falling back to 'npm install'");
+      try {
+        require("child_process").execSync("npm install", { stdio: "inherit" });
+      } catch (err2) {
+        console.error("Failed to install dependencies:", err2.message);
+        process.exit(1);
+      }
+    } else {
+      console.error("Failed to install dependencies:", err.message);
+      process.exit(1);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- make `assert-setup.js` recover from lockfile desync by falling back to `npm install`
- verify Jest binary exists in setup validation test
- document `npm ci` fallback in README

## Testing
- `npm test --prefix backend tests/setupValidation.test.js`

------
https://chatgpt.com/codex/tasks/task_e_687241f2f620832da60058d868c21831