### PR TITLE
Add checkout module test and fix generateModel mocks

### DIFF
--- a/backend/tests/checkoutModule.test.js
+++ b/backend/tests/checkoutModule.test.js
@@ -1,0 +1,7 @@
+const { orders } = require('../src/routes/checkout.js');
+
+describe('checkout module', () => {
+  test('exports orders map', () => {
+    expect(orders).toBeInstanceOf(Map);
+  });
+});

--- a/backend/tests/generateModel.test.ts
+++ b/backend/tests/generateModel.test.ts
@@ -1,15 +1,15 @@
-jest.mock('../src/lib/textToImage.js', () => ({ textToImage: jest.fn() }));
-jest.mock('../src/lib/imageToText.js', () => ({ imageToText: jest.fn() }));
-jest.mock('../src/lib/prepareImage.js', () => ({ prepareImage: jest.fn() }));
-jest.mock('../src/lib/sparc3dClient.js', () => ({ generateGlb: jest.fn() }));
-jest.mock('../src/lib/storeGlb.js', () => ({ storeGlb: jest.fn() }));
+jest.mock('../src/lib/textToImage', () => ({ textToImage: jest.fn() }));
+jest.mock('../src/lib/imageToText', () => ({ imageToText: jest.fn() }));
+jest.mock('../src/lib/prepareImage', () => ({ prepareImage: jest.fn() }));
+jest.mock('../src/lib/sparc3dClient', () => ({ generateGlb: jest.fn() }));
+jest.mock('../src/lib/storeGlb', () => ({ storeGlb: jest.fn() }));
 
 const { generateModel } = require('../src/pipeline/generateModel.js');
-const text = require('../src/lib/textToImage.js');
-const img2text = require('../src/lib/imageToText.js');
-const prep = require('../src/lib/prepareImage.js');
-const sparc = require('../src/lib/sparc3dClient.js');
-const s3 = require('../src/lib/storeGlb.js');
+const text = require('../src/lib/textToImage');
+const img2text = require('../src/lib/imageToText');
+const prep = require('../src/lib/prepareImage');
+const sparc = require('../src/lib/sparc3dClient');
+const s3 = require('../src/lib/storeGlb');
 const fs = require('fs');
 const path = require('path');
 


### PR DESCRIPTION
## Summary
- ensure test mocks use extensionless paths
- add test verifying the checkout orders map is exported

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68724375e57c832db7055a38f6a29e96