### PR TITLE
Add lockfile sync test

### DIFF
--- a/backend/tests/checkLockfilesScript.test.js
+++ b/backend/tests/checkLockfilesScript.test.js
@@ -1,0 +1,11 @@
+const { execSync } = require('child_process');
+const path = require('path');
+
+describe('check-lockfiles script', () => {
+  test('runs without error', () => {
+    const root = path.resolve(__dirname, '..', '..');
+    expect(() => {
+      execSync('node scripts/check-lockfiles.js', { cwd: root, stdio: 'inherit' });
+    }).not.toThrow();
+  });
+});

--- a/scripts/check-lockfiles.js
+++ b/scripts/check-lockfiles.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+const { execSync } = require('child_process');
+
+const dirs = ['.', 'backend', 'backend/dalle_server'];
+let failed = false;
+
+for (const dir of dirs) {
+  try {
+    execSync('npm ci --dry-run --ignore-scripts', { cwd: dir, stdio: 'inherit' });
+  } catch {
+    console.error(`Lockfile out of sync in ${dir}. Run 'npm install' in that directory.`);
+    failed = true;
+  }
+}
+process.exit(failed ? 1 : 0);

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -72,8 +72,25 @@ if [ -z "$SKIP_PW_DEPS" ]; then
   done
 fi
 
-npm ci --no-audit --no-fund
-npm ci --prefix backend --no-audit --no-fund
+run_ci_with_fix() {
+  local dir="$1"
+  if [ "$dir" = "." ]; then
+    if ! npm ci --no-audit --no-fund; then
+      echo "npm ci failed in $dir, running npm install to update lockfile..." >&2
+      npm install --no-audit --no-fund
+      npm ci --no-audit --no-fund
+    fi
+  else
+    if ! npm ci --prefix "$dir" --no-audit --no-fund; then
+      echo "npm ci failed in $dir, running npm install to update lockfile..." >&2
+      npm install --prefix "$dir" --no-audit --no-fund
+      npm ci --prefix "$dir" --no-audit --no-fund
+    fi
+  fi
+}
+
+run_ci_with_fix "."
+run_ci_with_fix "backend"
 
 cleanup_npm_cache
 


### PR DESCRIPTION
## Summary
- add script to check lockfile integrity
- call script from a new test
- retry `npm ci` in `setup.sh` and auto-run `npm install` if needed

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_687242577d18832db39ebc362d855e2d