### PR TITLE
Fix textToImage tests

### DIFF
--- a/backend/tests/textToImage.proxy.test.ts
+++ b/backend/tests/textToImage.proxy.test.ts
@@ -1,4 +1,4 @@
-jest.mock("../src/lib/uploadS3.js", () => ({
+jest.mock("../src/lib/uploadS3", () => ({
   uploadFile: jest.fn().mockResolvedValue("https://cdn.test/image.png"),
 }));
 
@@ -14,8 +14,8 @@ delete process.env.https_proxy;
 delete process.env.HTTP_PROXY;
 delete process.env.HTTPS_PROXY;
 
-const { textToImage } = require("../src/lib/textToImage.js");
-const s3 = require("../src/lib/uploadS3.js");
+const { textToImage } = require("../src/lib/textToImage");
+const s3 = require("../src/lib/uploadS3");
 
 describe("textToImage proxy cleanup", () => {
   beforeEach(() => {

--- a/backend/tests/textToImage.test.ts
+++ b/backend/tests/textToImage.test.ts
@@ -15,13 +15,13 @@ delete process.env.https_proxy;
 delete process.env.HTTP_PROXY;
 delete process.env.HTTPS_PROXY;
 
-jest.mock("../src/lib/uploadS3.js", () => ({
+jest.mock("../src/lib/uploadS3", () => ({
   uploadFile: jest.fn().mockResolvedValue("https://cdn.test/image.png"),
 }));
 
 const nock = require("nock");
-const s3 = require("../src/lib/uploadS3.js");
-const { textToImage } = require("../src/lib/textToImage.js");
+const s3 = require("../src/lib/uploadS3");
+const { textToImage } = require("../src/lib/textToImage");
 
 describe("textToImage", () => {
   const endpoint = "https://api.stability.ai";


### PR DESCRIPTION
## Summary
- fix import paths in textToImage tests so mocking works properly

## Testing
- `npx jest backend/tests/textToImage.test.ts backend/tests/textToImage.proxy.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68724d4ff720832db2d4bc541df97317