### PR TITLE
Add mock assertion for textToImage tests

### DIFF
--- a/backend/tests/textToImage.proxy.test.ts
+++ b/backend/tests/textToImage.proxy.test.ts
@@ -1,4 +1,4 @@
-jest.mock("../src/lib/uploadS3.js", () => ({
+jest.mock("../src/lib/uploadS3", () => ({
   uploadFile: jest.fn().mockResolvedValue("https://cdn.test/image.png"),
 }));
 
@@ -15,7 +15,7 @@ delete process.env.HTTP_PROXY;
 delete process.env.HTTPS_PROXY;
 
 const { textToImage } = require("../src/lib/textToImage.js");
-const s3 = require("../src/lib/uploadS3.js");
+const s3 = require("../src/lib/uploadS3");
 
 describe("textToImage proxy cleanup", () => {
   beforeEach(() => {
@@ -30,6 +30,10 @@ describe("textToImage proxy cleanup", () => {
     nock.cleanAll();
     nock.enableNetConnect();
     jest.restoreAllMocks();
+  });
+
+  test("uploadFile is mocked", () => {
+    expect(jest.isMockFunction(s3.uploadFile)).toBe(true);
   });
 
   test("uses nock endpoint even when proxy env was set", async () => {

--- a/backend/tests/textToImage.test.ts
+++ b/backend/tests/textToImage.test.ts
@@ -15,12 +15,12 @@ delete process.env.https_proxy;
 delete process.env.HTTP_PROXY;
 delete process.env.HTTPS_PROXY;
 
-jest.mock("../src/lib/uploadS3.js", () => ({
+jest.mock("../src/lib/uploadS3", () => ({
   uploadFile: jest.fn().mockResolvedValue("https://cdn.test/image.png"),
 }));
 
 const nock = require("nock");
-const s3 = require("../src/lib/uploadS3.js");
+const s3 = require("../src/lib/uploadS3");
 const { textToImage } = require("../src/lib/textToImage.js");
 
 describe("textToImage", () => {
@@ -47,6 +47,10 @@ describe("textToImage", () => {
     jest.restoreAllMocks();
     delete process.env.AWS_ACCESS_KEY_ID;
     delete process.env.AWS_SECRET_ACCESS_KEY;
+  });
+
+  test("uploadFile is mocked", () => {
+    expect(jest.isMockFunction(s3.uploadFile)).toBe(true);
   });
 
   test("uploads generated image and returns url", async () => {


### PR DESCRIPTION
## Summary
- update `textToImage` tests to mock `uploadS3` consistently
- verify the mock is applied so network calls are not attempted

## Testing
- `npm test` in `backend/`
- `SKIP_PW_DEPS=1 npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_68725af943a4832da96130fa64d79d8a