### PR TITLE
Add tests for assert setup

### DIFF
--- a/backend/tests/assertSetup.test.js
+++ b/backend/tests/assertSetup.test.js
@@ -1,0 +1,40 @@
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+const script = path.join(__dirname, "..", "scripts", "assert-setup.js");
+const stub = path.join(__dirname, "stubExecSync.js");
+
+function runAssertSetup(nodeVersion) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pw-"));
+  const browserDir = path.join(tmpDir, "chromium");
+  fs.mkdirSync(browserDir, { recursive: true });
+  const env = {
+    ...process.env,
+    NODE_OPTIONS: `--require ${stub}`,
+    PLAYWRIGHT_BROWSERS_PATH: tmpDir,
+  };
+  const flag = path.join(__dirname, "..", ".setup-complete");
+  fs.writeFileSync(flag, "");
+  const code = `Object.defineProperty(process.versions,'node',{value:'${nodeVersion}'});require('${script.replace(/\\/g, "\\\\")}');`;
+  const result = spawnSync(process.execPath, ["-e", code], {
+    env,
+    encoding: "utf8",
+  });
+  fs.unlinkSync(flag);
+  return result;
+}
+
+describe("assert-setup script", () => {
+  test("fails on Node <20", () => {
+    const res = runAssertSetup("18.0.0");
+    expect(res.status).not.toBe(0);
+    expect(res.stderr).toContain("Node 20 or newer is required");
+  });
+
+  test("succeeds on Node >=20", () => {
+    const res = runAssertSetup("20.0.0");
+    expect(res.status).toBe(0);
+  });
+});

--- a/backend/tests/stubExecSync.js
+++ b/backend/tests/stubExecSync.js
@@ -1,0 +1,7 @@
+const child_process = require("child_process");
+child_process.execSync = function (cmd, _opts) {
+  if (cmd.includes("playwright install")) {
+    return Buffer.from("Playwright host dependencies already satisfied.");
+  }
+  return Buffer.from("");
+};

--- a/tests/pnpm-lock-sync.test.js
+++ b/tests/pnpm-lock-sync.test.js
@@ -2,6 +2,11 @@ const fs = require("fs");
 const path = require("path");
 const YAML = require("yaml");
 
+/**
+ * Verify the pnpm lock file matches dependencies for the given directory.
+ *
+ * @param {string} dir directory to check
+ */
 function verifyPnpmLockSync(dir) {
   const pkgPath = path.join(dir, "package.json");
   const lockPath = path.join(dir, "pnpm-lock.yaml");


### PR DESCRIPTION
## Summary
- improve pnpm lock sync test docs
- add tests covering assert-setup script

## Testing
- `npx prettier --write backend/tests/assertSetup.test.js backend/tests/stubExecSync.js tests/pnpm-lock-sync.test.js`
- `npm test`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68725ae2f78c832d83ac773843d8ad3e