### PR TITLE
Fix textToImage mocks

### DIFF
--- a/backend/tests/textToImage.proxy.test.ts
+++ b/backend/tests/textToImage.proxy.test.ts
@@ -1,4 +1,4 @@
-jest.mock("../src/lib/uploadS3.js", () => ({
+jest.mock("../src/lib/uploadS3", () => ({
   uploadFile: jest.fn().mockResolvedValue("https://cdn.test/image.png"),
 }));
 
@@ -15,7 +15,7 @@ delete process.env.HTTP_PROXY;
 delete process.env.HTTPS_PROXY;
 
 const { textToImage } = require("../src/lib/textToImage.js");
-const s3 = require("../src/lib/uploadS3.js");
+const s3 = require("../src/lib/uploadS3");
 
 describe("textToImage proxy cleanup", () => {
   beforeEach(() => {
@@ -24,6 +24,7 @@ describe("textToImage proxy cleanup", () => {
     process.env.S3_BUCKET = "bucket";
     process.env.CLOUDFRONT_DOMAIN = "cdn.test";
     nock.disableNetConnect();
+    expect(jest.isMockFunction(s3.uploadFile)).toBe(true);
   });
 
   afterEach(() => {

--- a/backend/tests/textToImage.test.ts
+++ b/backend/tests/textToImage.test.ts
@@ -15,12 +15,12 @@ delete process.env.https_proxy;
 delete process.env.HTTP_PROXY;
 delete process.env.HTTPS_PROXY;
 
-jest.mock("../src/lib/uploadS3.js", () => ({
+jest.mock("../src/lib/uploadS3", () => ({
   uploadFile: jest.fn().mockResolvedValue("https://cdn.test/image.png"),
 }));
 
 const nock = require("nock");
-const s3 = require("../src/lib/uploadS3.js");
+const s3 = require("../src/lib/uploadS3");
 const { textToImage } = require("../src/lib/textToImage.js");
 
 describe("textToImage", () => {
@@ -39,6 +39,7 @@ describe("textToImage", () => {
     delete process.env.HTTP_PROXY;
     delete process.env.HTTPS_PROXY;
     nock.disableNetConnect();
+    expect(jest.isMockFunction(s3.uploadFile)).toBe(true);
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary
- correct mock module paths for textToImage tests
- ensure uploadFile is mocked before each test

## Testing
- `npx prettier -w backend/tests/textToImage.test.ts backend/tests/textToImage.proxy.test.ts`
- `npm test -- textToImage.test.ts`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68725a5bf9ac832d87e9dd2a3826299f