### PR TITLE
Fix textToImage mock paths

### DIFF
--- a/backend/tests/textToImage.proxy.test.ts
+++ b/backend/tests/textToImage.proxy.test.ts
@@ -1,4 +1,4 @@
-jest.mock("../src/lib/uploadS3.js", () => ({
+jest.mock("../src/lib/uploadS3", () => ({
   uploadFile: jest.fn().mockResolvedValue("https://cdn.test/image.png"),
 }));
 
@@ -15,7 +15,7 @@ delete process.env.HTTP_PROXY;
 delete process.env.HTTPS_PROXY;
 
 const { textToImage } = require("../src/lib/textToImage.js");
-const s3 = require("../src/lib/uploadS3.js");
+const s3 = require("../src/lib/uploadS3");
 
 describe("textToImage proxy cleanup", () => {
   beforeEach(() => {

--- a/backend/tests/textToImage.test.ts
+++ b/backend/tests/textToImage.test.ts
@@ -15,12 +15,12 @@ delete process.env.https_proxy;
 delete process.env.HTTP_PROXY;
 delete process.env.HTTPS_PROXY;
 
-jest.mock("../src/lib/uploadS3.js", () => ({
+jest.mock("../src/lib/uploadS3", () => ({
   uploadFile: jest.fn().mockResolvedValue("https://cdn.test/image.png"),
 }));
 
 const nock = require("nock");
-const s3 = require("../src/lib/uploadS3.js");
+const s3 = require("../src/lib/uploadS3");
 const { textToImage } = require("../src/lib/textToImage.js");
 
 describe("textToImage", () => {


### PR DESCRIPTION
## Summary
- correct uploadS3 mock paths in textToImage tests

## Testing
- `npm test -- -t textToImage`


------
https://chatgpt.com/codex/tasks/task_e_68725a3876bc832d8c4c4e948f4cafb5