### PR TITLE
Improve setup checks

### DIFF
--- a/backend/scripts/ensure-deps.js
+++ b/backend/scripts/ensure-deps.js
@@ -5,5 +5,13 @@ const jestPath = "node_modules/.bin/jest";
 
 if (!fs.existsSync(jestPath)) {
   console.log("Jest not found. Installing backend dependencies...");
+  try {
+    execSync("npm ping", { stdio: "ignore" });
+  } catch {
+    console.error(
+      "Unable to reach the npm registry. Check network connectivity or proxy settings.",
+    );
+    process.exit(1);
+  }
   execSync("npm ci", { stdio: "inherit" });
 }

--- a/backend/tests/textToImage.proxy.test.ts
+++ b/backend/tests/textToImage.proxy.test.ts
@@ -1,4 +1,4 @@
-jest.mock("../src/lib/uploadS3.js", () => ({
+jest.mock("../src/lib/uploadS3", () => ({
   uploadFile: jest.fn().mockResolvedValue("https://cdn.test/image.png"),
 }));
 
@@ -15,7 +15,7 @@ delete process.env.HTTP_PROXY;
 delete process.env.HTTPS_PROXY;
 
 const { textToImage } = require("../src/lib/textToImage.js");
-const s3 = require("../src/lib/uploadS3.js");
+const s3 = require("../src/lib/uploadS3");
 
 describe("textToImage proxy cleanup", () => {
   beforeEach(() => {

--- a/backend/tests/textToImage.test.ts
+++ b/backend/tests/textToImage.test.ts
@@ -15,12 +15,12 @@ delete process.env.https_proxy;
 delete process.env.HTTP_PROXY;
 delete process.env.HTTPS_PROXY;
 
-jest.mock("../src/lib/uploadS3.js", () => ({
+jest.mock("../src/lib/uploadS3", () => ({
   uploadFile: jest.fn().mockResolvedValue("https://cdn.test/image.png"),
 }));
 
 const nock = require("nock");
-const s3 = require("../src/lib/uploadS3.js");
+const s3 = require("../src/lib/uploadS3");
 const { textToImage } = require("../src/lib/textToImage.js");
 
 describe("textToImage", () => {

--- a/tests/ensureDeps.test.js
+++ b/tests/ensureDeps.test.js
@@ -1,0 +1,16 @@
+const fs = require("fs");
+const child_process = require("child_process");
+
+jest.mock("fs");
+jest.mock("child_process");
+
+describe("ensure-deps", () => {
+  test("pings npm registry before installing", () => {
+    fs.existsSync.mockReturnValue(false);
+    const execMock = jest.fn();
+    child_process.execSync.mockImplementation(execMock);
+    require("../backend/scripts/ensure-deps");
+    expect(execMock).toHaveBeenCalledWith("npm ping", { stdio: "ignore" });
+    expect(execMock).toHaveBeenCalledWith("npm ci", { stdio: "inherit" });
+  });
+});


### PR DESCRIPTION
## Summary
- fail fast when npm registry is unreachable
- ensure we ping npm before installing backend deps
- add regression test for ensure-deps
- fix uploadS3 mocks in textToImage tests

## Testing
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68725b5bcf80832d8b69c6e30c9c6e85