### PR TITLE
Add checks for backend jest dependencies

### DIFF
--- a/backend/tests/setupValidation.test.js
+++ b/backend/tests/setupValidation.test.js
@@ -20,4 +20,9 @@ describe("environment setup", () => {
     const jestBin = path.resolve(__dirname, "../../node_modules/.bin/jest");
     expect(fs.existsSync(jestBin)).toBe(true);
   });
+
+  test("backend jest installed", () => {
+    const jestBin = path.resolve(__dirname, "../node_modules/.bin/jest");
+    expect(fs.existsSync(jestBin)).toBe(true);
+  });
 });

--- a/backend/tests/textToImage.proxy.test.ts
+++ b/backend/tests/textToImage.proxy.test.ts
@@ -1,4 +1,4 @@
-jest.mock("../src/lib/uploadS3.js", () => ({
+jest.mock("../src/lib/uploadS3", () => ({
   uploadFile: jest.fn().mockResolvedValue("https://cdn.test/image.png"),
 }));
 
@@ -15,7 +15,7 @@ delete process.env.HTTP_PROXY;
 delete process.env.HTTPS_PROXY;
 
 const { textToImage } = require("../src/lib/textToImage.js");
-const s3 = require("../src/lib/uploadS3.js");
+const s3 = require("../src/lib/uploadS3");
 
 describe("textToImage proxy cleanup", () => {
   beforeEach(() => {

--- a/backend/tests/textToImage.test.ts
+++ b/backend/tests/textToImage.test.ts
@@ -15,12 +15,12 @@ delete process.env.https_proxy;
 delete process.env.HTTP_PROXY;
 delete process.env.HTTPS_PROXY;
 
-jest.mock("../src/lib/uploadS3.js", () => ({
+jest.mock("../src/lib/uploadS3", () => ({
   uploadFile: jest.fn().mockResolvedValue("https://cdn.test/image.png"),
 }));
 
 const nock = require("nock");
-const s3 = require("../src/lib/uploadS3.js");
+const s3 = require("../src/lib/uploadS3");
 const { textToImage } = require("../src/lib/textToImage.js");
 
 describe("textToImage", () => {

--- a/tests/dependency.test.js
+++ b/tests/dependency.test.js
@@ -8,6 +8,18 @@ describe("environment", () => {
     expect(fs.existsSync(bin)).toBe(true);
   });
 
+  test("backend jest binary installed", () => {
+    const bin = path.join(
+      __dirname,
+      "..",
+      "backend",
+      "node_modules",
+      ".bin",
+      "jest",
+    );
+    expect(fs.existsSync(bin)).toBe(true);
+  });
+
   test("setup script has been run", () => {
     const flag = path.join(__dirname, "..", ".setup-complete");
     expect(fs.existsSync(flag)).toBe(true);


### PR DESCRIPTION
## Summary
- ensure Jest binary is installed in backend
- fix textToImage tests to use the correct mock path

## Testing
- `npx prettier --write tests/dependency.test.js backend/tests/setupValidation.test.js backend/tests/textToImage.test.ts backend/tests/textToImage.proxy.test.ts`
- `npm test --prefix backend -- --runInBand`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68725a6acf3c832d90be539f8b7e02d7