### PR TITLE
Fix test lockfile mismatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,8 +67,6 @@
     "@percy/playwright": "^1.0.8",
     "@playwright/test": "^1.53.1",
     "@size-limit/file": "^11.2.0",
-    "@types/jest": "^30.0.0",
-    "jest": "^30.0.4",
     "@types/node": "^24.0.10",
     "@typescript-eslint/eslint-plugin": "^8.34.1",
     "@typescript-eslint/parser": "^8.36.0",


### PR DESCRIPTION
## Summary
- drop root jest devDependency to keep lockfile in sync

## Testing
- `npm run format` in `backend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_6872423c3d54832d88a01e73b58e1ec2