### PR TITLE
Improve textToImage mocking tests

### DIFF
--- a/backend/src/lib/uploadS3.js
+++ b/backend/src/lib/uploadS3.js
@@ -25,11 +25,12 @@ async function uploadFile(filePath, contentType) {
   if (!domain) throw new Error("CLOUDFRONT_DOMAIN is not set");
   const client = new client_s3_1.S3Client({ region });
   const key = `images/${Date.now()}-${path_1.default.basename(filePath)}`;
+  const body = fs_1.default.readFileSync(filePath);
   await client.send(
     new client_s3_1.PutObjectCommand({
       Bucket: bucket,
       Key: key,
-      Body: fs_1.default.createReadStream(filePath),
+      Body: body,
       ContentType: contentType,
     }),
   );

--- a/backend/src/lib/uploadS3.ts
+++ b/backend/src/lib/uploadS3.ts
@@ -1,6 +1,6 @@
-import fs from 'fs';
-import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
-import path from 'path';
+import fs from "fs";
+import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
+import path from "path";
 
 /**
  * Upload a file to S3 and return its public CloudFront URL
@@ -8,17 +8,27 @@ import path from 'path';
  * @param {string} contentType MIME type for the object
  * @returns {Promise<string>} public URL of uploaded file
  */
-export async function uploadFile(filePath: string, contentType: string): Promise<string> {
+export async function uploadFile(
+  filePath: string,
+  contentType: string,
+): Promise<string> {
   const region = process.env.AWS_REGION;
   const bucket = process.env.S3_BUCKET;
-  const domain = process.env.CLOUDFRONT_DOMAIN || process.env.CLOUDFRONT_MODEL_DOMAIN;
-  if (!region) throw new Error('AWS_REGION is not set');
-  if (!bucket) throw new Error('S3_BUCKET is not set');
-  if (!domain) throw new Error('CLOUDFRONT_DOMAIN is not set');
+  const domain =
+    process.env.CLOUDFRONT_DOMAIN || process.env.CLOUDFRONT_MODEL_DOMAIN;
+  if (!region) throw new Error("AWS_REGION is not set");
+  if (!bucket) throw new Error("S3_BUCKET is not set");
+  if (!domain) throw new Error("CLOUDFRONT_DOMAIN is not set");
   const client = new S3Client({ region });
   const key = `images/${Date.now()}-${path.basename(filePath)}`;
+  const body = fs.readFileSync(filePath);
   await client.send(
-    new PutObjectCommand({ Bucket: bucket, Key: key, Body: fs.createReadStream(filePath), ContentType: contentType }),
+    new PutObjectCommand({
+      Bucket: bucket,
+      Key: key,
+      Body: body,
+      ContentType: contentType,
+    }),
   );
   return `https://${domain}/${key}`;
 }

--- a/backend/tests/textToImage.test.js
+++ b/backend/tests/textToImage.test.js
@@ -95,4 +95,34 @@ describe("textToImage", () => {
     expect(url).toBe("https://cdn.test/image.png");
     expect(s3.uploadFile).toHaveBeenCalledWith(expect.any(String), "image/png");
   });
+  test("works without AWS credentials when uploadFile is mocked", async () => {
+    delete process.env.AWS_ACCESS_KEY_ID;
+    delete process.env.AWS_SECRET_ACCESS_KEY;
+    const png = Buffer.from("png");
+    (0, nock_1.default)(endpoint)
+      .post("/v2beta/stable-image/generate/core")
+      .reply(200, png, { "Content-Type": "image/png" });
+    const url = await (0, textToImage_1.textToImage)("hello again");
+    expect(url).toBe("https://cdn.test/image.png");
+    expect(s3.uploadFile).toHaveBeenCalledWith(expect.any(String), "image/png");
+  });
+  test("returns unique url with real uploadFile", async () => {
+    jest.resetModules();
+    jest.unmock("../src/lib/uploadS3");
+    const s3Actual = require("../src/lib/uploadS3");
+    jest.spyOn(s3Actual, "uploadFile");
+    const {
+      textToImage: textToImageActual,
+    } = require("../src/lib/textToImage.js");
+    const png = Buffer.from("png");
+    (0, nock_1.default)(endpoint)
+      .post("/v2beta/stable-image/generate/core")
+      .reply(200, png, { "Content-Type": "image/png" });
+    const url = await textToImageActual("unique");
+    expect(url).toMatch(/^https:\/\/cdn\.test\/images\/\d+-.*\.png$/);
+    expect(s3Actual.uploadFile).toHaveBeenCalledWith(
+      expect.any(String),
+      "image/png",
+    );
+  });
 });

--- a/backend/tests/textToImage.test.ts
+++ b/backend/tests/textToImage.test.ts
@@ -15,8 +15,9 @@ delete process.env.https_proxy;
 delete process.env.HTTP_PROXY;
 delete process.env.HTTPS_PROXY;
 
+const mockUrl = "https://cdn.test/image.png";
 jest.mock("../src/lib/uploadS3", () => ({
-  uploadFile: jest.fn().mockResolvedValue("https://cdn.test/image.png"),
+  uploadFile: jest.fn().mockResolvedValue(mockUrl),
 }));
 
 const nock = require("nock");
@@ -56,7 +57,7 @@ describe("textToImage", () => {
       .post("/v2beta/stable-image/generate/core")
       .reply(200, png, { "Content-Type": "image/png" });
     const url = await textToImage("hello");
-    expect(url).toBe("https://cdn.test/image.png");
+    expect(url).toBe(mockUrl);
     expect(s3.uploadFile).toHaveBeenCalledWith(expect.any(String), "image/png");
   });
 
@@ -68,7 +69,27 @@ describe("textToImage", () => {
       .post("/v2beta/stable-image/generate/core")
       .reply(200, png, { "Content-Type": "image/png" });
     const url = await textToImage("hello again");
-    expect(url).toBe("https://cdn.test/image.png");
+    expect(url).toBe(mockUrl);
     expect(s3.uploadFile).toHaveBeenCalledWith(expect.any(String), "image/png");
+  });
+
+  test("returns unique url with real uploadFile", async () => {
+    jest.resetModules();
+    jest.unmock("../src/lib/uploadS3");
+    const s3Actual = require("../src/lib/uploadS3");
+    jest.spyOn(s3Actual, "uploadFile");
+    const {
+      textToImage: textToImageActual,
+    } = require("../src/lib/textToImage.js");
+    const png = Buffer.from("png");
+    nock(endpoint)
+      .post("/v2beta/stable-image/generate/core")
+      .reply(200, png, { "Content-Type": "image/png" });
+    const url = await textToImageActual("unique");
+    expect(url).toMatch(/^https:\/\/cdn\.test\/images\/\d+-.*\.png$/);
+    expect(s3Actual.uploadFile).toHaveBeenCalledWith(
+      expect.any(String),
+      "image/png",
+    );
   });
 });


### PR DESCRIPTION
## Summary
- fix uploadFile to read file before upload
- ensure textToImage tests verify mocked S3 URLs
- add regression test for real uploadFile path

## Testing
- `npx prettier --write backend/src/lib/uploadS3.ts backend/src/lib/uploadS3.js backend/tests/textToImage.test.ts backend/tests/textToImage.test.js`
- `npm test -- -t textToImage`

------
https://chatgpt.com/codex/tasks/task_e_687264becb84832d966b3e762cd0dfe3