### PR TITLE
Fix textToImage mocks

### DIFF
--- a/backend/tests/textToImage.proxy.test.ts
+++ b/backend/tests/textToImage.proxy.test.ts
@@ -1,8 +1,5 @@
-jest.mock("../src/lib/uploadS3", () => ({
-  uploadFile: jest.fn().mockResolvedValue("https://cdn.test/image.png"),
-}));
-
 const nock = require("nock");
+let s3;
 
 process.env.http_proxy = "http://proxy:8080";
 process.env.https_proxy = "http://proxy:8080";
@@ -14,12 +11,14 @@ delete process.env.https_proxy;
 delete process.env.HTTP_PROXY;
 delete process.env.HTTPS_PROXY;
 
-
 const { textToImage } = require("../src/lib/textToImage.js");
-const s3 = require("../src/lib/uploadS3");
 
 describe("textToImage proxy cleanup", () => {
   beforeEach(() => {
+    s3 = require("../src/lib/uploadS3");
+    jest
+      .spyOn(s3, "uploadFile")
+      .mockResolvedValue("https://cdn.test/image.png");
     process.env.STABILITY_KEY = "abc";
     process.env.AWS_REGION = "us-east-1";
     process.env.S3_BUCKET = "bucket";

--- a/backend/tests/textToImage.test.ts
+++ b/backend/tests/textToImage.test.ts
@@ -15,19 +15,19 @@ delete process.env.https_proxy;
 delete process.env.HTTP_PROXY;
 delete process.env.HTTPS_PROXY;
 
-jest.mock("../src/lib/uploadS3", () => ({
-  uploadFile: jest.fn().mockResolvedValue("https://cdn.test/image.png"),
-}));
-
 const nock = require("nock");
-const s3 = require("../src/lib/uploadS3");
 const { textToImage } = require("../src/lib/textToImage.js");
+let s3;
 
 describe("textToImage", () => {
   const endpoint = "https://api.stability.ai";
   const token = "abc";
 
   beforeEach(() => {
+    s3 = require("../src/lib/uploadS3");
+    jest
+      .spyOn(s3, "uploadFile")
+      .mockResolvedValue("https://cdn.test/image.png");
     process.env.STABILITY_KEY = token;
     process.env.AWS_REGION = "us-east-1";
     process.env.S3_BUCKET = "bucket";


### PR DESCRIPTION
## Summary
- mock `uploadFile` with `jest.spyOn`
- apply same approach for proxy cleanup tests

## Testing
- `npx jest tests/textToImage.test.ts tests/textToImage.proxy.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_6872663785e4832d9b6c3ed499e0d55a