### PR TITLE
Add AWS credential checks for tests

### DIFF
--- a/backend/tests/awsCredentials.test.ts
+++ b/backend/tests/awsCredentials.test.ts
@@ -1,0 +1,8 @@
+import { describe, test, expect } from "@jest/globals";
+
+describe("test environment", () => {
+  test("provides dummy AWS credentials", () => {
+    expect(process.env.AWS_ACCESS_KEY_ID).toBeDefined();
+    expect(process.env.AWS_SECRET_ACCESS_KEY).toBeDefined();
+  });
+});

--- a/scripts/validate-env.sh
+++ b/scripts/validate-env.sh
@@ -5,6 +5,8 @@ if [[ -z "${STRIPE_TEST_KEY:-}" && -z "${STRIPE_LIVE_KEY:-}" ]]; then
   exit 1
 fi
 : "${HF_TOKEN:?HF_TOKEN must be set}"
+: "${AWS_ACCESS_KEY_ID:?AWS_ACCESS_KEY_ID must be set}"
+: "${AWS_SECRET_ACCESS_KEY:?AWS_SECRET_ACCESS_KEY must be set}"
 
 if [[ -n "${npm_config_http_proxy:-}" || -n "${npm_config_https_proxy:-}" || -n "${http_proxy:-}" || -n "${https_proxy:-}" ]]; then
   echo "npm proxy variables must be unset" >&2


### PR DESCRIPTION
## Summary
- check for AWS credentials in `validate-env.sh`
- add regression test verifying AWS credentials are available in the test environment

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_68726759c574832dae1817a9b837e4d9