### PR TITLE
Add credential validation to uploadS3

### DIFF
--- a/backend/src/lib/uploadS3.js
+++ b/backend/src/lib/uploadS3.js
@@ -20,9 +20,12 @@ async function uploadFile(filePath, contentType) {
   const bucket = process.env.S3_BUCKET;
   const domain =
     process.env.CLOUDFRONT_DOMAIN || process.env.CLOUDFRONT_MODEL_DOMAIN;
+  const accessKey = process.env.AWS_ACCESS_KEY_ID;
+  const secretKey = process.env.AWS_SECRET_ACCESS_KEY;
   if (!region) throw new Error("AWS_REGION is not set");
   if (!bucket) throw new Error("S3_BUCKET is not set");
   if (!domain) throw new Error("CLOUDFRONT_DOMAIN is not set");
+  if (!accessKey || !secretKey) throw new Error("AWS credentials are not set");
   const client = new client_s3_1.S3Client({ region });
   const key = `images/${Date.now()}-${path_1.default.basename(filePath)}`;
   await client.send(

--- a/backend/src/lib/uploadS3.ts
+++ b/backend/src/lib/uploadS3.ts
@@ -1,6 +1,6 @@
-import fs from 'fs';
-import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
-import path from 'path';
+import fs from "fs";
+import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
+import path from "path";
 
 /**
  * Upload a file to S3 and return its public CloudFront URL
@@ -8,17 +8,29 @@ import path from 'path';
  * @param {string} contentType MIME type for the object
  * @returns {Promise<string>} public URL of uploaded file
  */
-export async function uploadFile(filePath: string, contentType: string): Promise<string> {
+export async function uploadFile(
+  filePath: string,
+  contentType: string,
+): Promise<string> {
   const region = process.env.AWS_REGION;
   const bucket = process.env.S3_BUCKET;
-  const domain = process.env.CLOUDFRONT_DOMAIN || process.env.CLOUDFRONT_MODEL_DOMAIN;
-  if (!region) throw new Error('AWS_REGION is not set');
-  if (!bucket) throw new Error('S3_BUCKET is not set');
-  if (!domain) throw new Error('CLOUDFRONT_DOMAIN is not set');
+  const domain =
+    process.env.CLOUDFRONT_DOMAIN || process.env.CLOUDFRONT_MODEL_DOMAIN;
+  const accessKey = process.env.AWS_ACCESS_KEY_ID;
+  const secretKey = process.env.AWS_SECRET_ACCESS_KEY;
+  if (!region) throw new Error("AWS_REGION is not set");
+  if (!bucket) throw new Error("S3_BUCKET is not set");
+  if (!domain) throw new Error("CLOUDFRONT_DOMAIN is not set");
+  if (!accessKey || !secretKey) throw new Error("AWS credentials are not set");
   const client = new S3Client({ region });
   const key = `images/${Date.now()}-${path.basename(filePath)}`;
   await client.send(
-    new PutObjectCommand({ Bucket: bucket, Key: key, Body: fs.createReadStream(filePath), ContentType: contentType }),
+    new PutObjectCommand({
+      Bucket: bucket,
+      Key: key,
+      Body: fs.createReadStream(filePath),
+      ContentType: contentType,
+    }),
   );
   return `https://${domain}/${key}`;
 }

--- a/backend/tests/uploadS3.test.ts
+++ b/backend/tests/uploadS3.test.ts
@@ -1,0 +1,36 @@
+import fs from "fs";
+import path from "path";
+import { uploadFile } from "../src/lib/uploadS3";
+
+describe("uploadFile env validation", () => {
+  const tmp = path.join("/tmp", "test-upload");
+  beforeAll(() => {
+    fs.writeFileSync(tmp, "data");
+  });
+
+  afterAll(() => {
+    fs.unlinkSync(tmp);
+  });
+
+  beforeEach(() => {
+    process.env.AWS_REGION = "us-east-1";
+    process.env.S3_BUCKET = "bucket";
+    process.env.CLOUDFRONT_DOMAIN = "cdn.test";
+    delete process.env.AWS_ACCESS_KEY_ID;
+    delete process.env.AWS_SECRET_ACCESS_KEY;
+  });
+
+  afterEach(() => {
+    delete process.env.AWS_REGION;
+    delete process.env.S3_BUCKET;
+    delete process.env.CLOUDFRONT_DOMAIN;
+    delete process.env.AWS_ACCESS_KEY_ID;
+    delete process.env.AWS_SECRET_ACCESS_KEY;
+  });
+
+  test("throws when AWS credentials are missing", async () => {
+    await expect(uploadFile(tmp, "image/png")).rejects.toThrow(
+      "AWS credentials",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- throw an explicit error if AWS credentials are missing when uploading to S3
- add regression test for `uploadFile`

## Testing
- `npm test --silent -- backend/tests/uploadS3.test.ts`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68726729c33c832d901c9ee1bcc392fe