### PR TITLE
Fix textToImage proxy warning noise

### DIFF
--- a/backend/tests/setupGlobals.js
+++ b/backend/tests/setupGlobals.js
@@ -30,6 +30,13 @@ console.warn = (...args) => {
   ) {
     return;
   }
+  if (
+    args[0] &&
+    typeof args[0] === "string" &&
+    args[0].includes("non-retryable streaming request")
+  ) {
+    return;
+  }
   return originalConsoleWarn(...args);
 };
 

--- a/backend/tests/textToImage.proxy.test.ts
+++ b/backend/tests/textToImage.proxy.test.ts
@@ -31,7 +31,7 @@ describe("textToImage proxy cleanup", () => {
   afterEach(() => {
     nock.cleanAll();
     nock.enableNetConnect();
-    jest.restoreAllMocks();
+    jest.clearAllMocks();
   });
 
   test("uses nock endpoint even when proxy env was set", async () => {
@@ -42,6 +42,8 @@ describe("textToImage proxy cleanup", () => {
 
     const url = await textToImage("hello");
     expect(url).toBe("https://cdn.test/image.png");
+    expect(s3.uploadFile).toHaveBeenCalledTimes(1);
+    expect(nock.isDone()).toBe(true);
   });
 
   test("works without AWS credentials when uploadFile is mocked", async () => {
@@ -53,5 +55,7 @@ describe("textToImage proxy cleanup", () => {
       .reply(200, png, { "Content-Type": "image/png" });
     const url = await textToImage("no-creds");
     expect(url).toBe("https://cdn.test/image.png");
+    expect(s3.uploadFile).toHaveBeenCalledTimes(1);
+    expect(nock.isDone()).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- silence AWS streaming warnings in backend tests
- verify mocked uploadFile is used in textToImage proxy tests

## Testing
- `npm test --prefix backend tests/textToImage.proxy.test.ts`
- `npm test --prefix backend` *(fails: large output truncated but shows PASS)*


------
https://chatgpt.com/codex/tasks/task_e_68726782f25c832d8d99026a39a00dc7