### PR TITLE
Fix formatting script error and ensure upload mocks

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,6 +5,7 @@ competitions.html
 addons.html
 e2e/smoke.test.js
 index.html
+package-lock.json
 
 # Build artifacts
 dist

--- a/backend/tests/textToImage.mock.test.ts
+++ b/backend/tests/textToImage.mock.test.ts
@@ -1,0 +1,10 @@
+jest.mock("../src/lib/uploadS3", () => ({
+  uploadFile: jest.fn(),
+}));
+
+describe("textToImage setup", () => {
+  it("uses mocked uploadFile to avoid real AWS calls", () => {
+    const s3 = require("../src/lib/uploadS3");
+    expect(jest.isMockFunction(s3.uploadFile)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- ignore `package-lock.json` for prettier
- add a small test verifying `uploadFile` is mocked

## Testing
- `npx prettier --write backend/tests/textToImage.test.ts backend/tests/textToImage.proxy.test.ts`
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_6872673c5058832d8ed286744afe3a80