### PR TITLE
Update smoke script to skip Playwright install

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "setup": "bash scripts/setup.sh",
     "e2e": "playwright test",
     "serve": "npm run build && node scripts/dev-server.js",
-    "smoke": "npm run setup && npx -y playwright install --with-deps && npx -y concurrently -k -s first \"npm run serve\" \"wait-on http://localhost:3000 && npx playwright test e2e/smoke.test.js\"",
+    "smoke": "node scripts/run-smoke.js",
     "build": "echo 'no build step'",
     "load": "artillery run tests/load/models.yml",
     "visual-test": "percy exec -- npm run e2e",

--- a/scripts/run-smoke.js
+++ b/scripts/run-smoke.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+const { execSync } = require("child_process");
+const env = { ...process.env };
+
+function run(cmd) {
+  execSync(cmd, { stdio: "inherit", env });
+}
+
+run("npm run setup");
+if (!process.env.SKIP_PW_DEPS) {
+  run("npx -y playwright install --with-deps");
+}
+run(
+  'npx -y concurrently -k -s first "npm run serve" "wait-on http://localhost:3000 && npx playwright test e2e/smoke.test.js"',
+);

--- a/tests/smokeScript.test.js
+++ b/tests/smokeScript.test.js
@@ -1,0 +1,17 @@
+const fs = require("fs");
+const path = require("path");
+const pkg = require("../package.json");
+
+describe("smoke script", () => {
+  test("uses run-smoke.js", () => {
+    expect(pkg.scripts.smoke).toBe("node scripts/run-smoke.js");
+  });
+
+  test("run-smoke.js checks SKIP_PW_DEPS", () => {
+    const content = fs.readFileSync(
+      path.join(__dirname, "..", "scripts", "run-smoke.js"),
+      "utf8",
+    );
+    expect(/SKIP_PW_DEPS/.test(content)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- use a helper script for smoke tests
- respect `SKIP_PW_DEPS` and skip installing Playwright deps
- add test checking the smoke script

## Testing
- `npx prettier --write scripts/run-smoke.js tests/smokeScript.test.js`
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_687267130a30832dafedaa97795e57f1