### PR TITLE
Improve ensure-deps script error handling

### DIFF
--- a/backend/scripts/ensure-deps.js
+++ b/backend/scripts/ensure-deps.js
@@ -26,5 +26,10 @@ if (!fs.existsSync(jestPath)) {
     );
     process.exit(1);
   }
-  execSync("npm ci", { stdio: "inherit" });
+  try {
+    execSync("npm ci", { stdio: "inherit" });
+  } catch (err) {
+    console.error("Failed to install dependencies:", err.message);
+    process.exit(1);
+  }
 }

--- a/tests/ensureDeps.test.js
+++ b/tests/ensureDeps.test.js
@@ -5,6 +5,11 @@ jest.mock("fs");
 jest.mock("child_process");
 
 describe("ensure-deps", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    fs.existsSync.mockReset();
+    child_process.execSync.mockReset();
+  });
   test("pings npm registry before installing", () => {
     fs.existsSync.mockReturnValue(false);
     const execMock = jest.fn();
@@ -12,5 +17,31 @@ describe("ensure-deps", () => {
     require("../backend/scripts/ensure-deps");
     expect(execMock).toHaveBeenCalledWith("npm ping", { stdio: "ignore" });
     expect(execMock).toHaveBeenCalledWith("npm ci", { stdio: "inherit" });
+  });
+
+  test("exits when npm ping fails", () => {
+    fs.existsSync.mockReturnValue(false);
+    child_process.execSync.mockImplementation(() => {
+      throw new Error("ping fail");
+    });
+    const exitSpy = jest.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("exit");
+    });
+    expect(() => require("../backend/scripts/ensure-deps")).toThrow("exit");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  test("exits when npm ci fails", () => {
+    fs.existsSync.mockReturnValue(false);
+    child_process.execSync
+      .mockImplementationOnce(() => {})
+      .mockImplementationOnce(() => {
+        throw new Error("ci fail");
+      });
+    const exitSpy = jest.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("exit");
+    });
+    expect(() => require("../backend/scripts/ensure-deps")).toThrow("exit");
+    expect(exitSpy).toHaveBeenCalledWith(1);
   });
 });


### PR DESCRIPTION
## Summary
- catch `npm ci` errors in `ensure-deps.js`
- add tests for failure cases in `ensureDeps.test.js`

## Testing
- `npx prettier backend/scripts/ensure-deps.js tests/ensureDeps.test.js -w`
- `npm test --silent --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_6872689d063c832d80e3d0d03d070a20