### PR TITLE
Silence mise warnings and check in tests

### DIFF
--- a/scripts/validate-env.sh
+++ b/scripts/validate-env.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 set -e
+
+# Silence mise warnings about untrusted config files
+mise trust . >/dev/null 2>&1 || true
+mise settings add idiomatic_version_file_enable_tools node --yes >/dev/null 2>&1 || true
+if [ -f .mise.toml ]; then
+  mise trust .mise.toml >/dev/null 2>&1 || true
+fi
 if [[ -z "${STRIPE_TEST_KEY:-}" && -z "${STRIPE_LIVE_KEY:-}" ]]; then
   echo "Using dummy STRIPE_TEST_KEY" >&2
   export STRIPE_TEST_KEY="sk_test_dummy_$(date +%s)"

--- a/tests/validateEnv.test.js
+++ b/tests/validateEnv.test.js
@@ -27,6 +27,7 @@ describe("validate-env script", () => {
     };
     const output = run(env);
     expect(output).toContain("✅ environment OK");
+    expect(output).not.toMatch(/mise WARN/);
   });
 
   test("fails when proxy variables set", () => {


### PR DESCRIPTION
## Summary
- silence mise warnings in `validate-env.sh`
- ensure warnings don't appear in `validateEnv.test.js`

## Testing
- `npx prettier tests/validateEnv.test.js --write`
- `CI=1 npm test --silent 2>&1 | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6872715b94a0832d9a0353df3f5fcf23