### PR TITLE
Fix validate-env proxy check

### DIFF
--- a/backend/tests/textToImage.test.ts
+++ b/backend/tests/textToImage.test.ts
@@ -15,7 +15,7 @@ delete process.env.https_proxy;
 delete process.env.HTTP_PROXY;
 delete process.env.HTTPS_PROXY;
 
-const s3 = require("../src/lib/uploadS3");
+const mockUrl = "https://cdn.test/image.png";
 const nock = require("nock");
 const { textToImage } = require("../src/lib/textToImage.js");
 let s3;
@@ -28,7 +28,7 @@ describe("textToImage", () => {
     s3 = require("../src/lib/uploadS3");
     jest
       .spyOn(s3, "uploadFile")
-      .mockResolvedValue("https://cdn.test/image.png");
+      .mockResolvedValue(mockUrl);
     process.env.STABILITY_KEY = token;
     process.env.AWS_REGION = "us-east-1";
     process.env.S3_BUCKET = "bucket";
@@ -40,7 +40,7 @@ describe("textToImage", () => {
     delete process.env.HTTP_PROXY;
     delete process.env.HTTPS_PROXY;
     nock.disableNetConnect();
-    jest.spyOn(s3, "uploadFile").mockResolvedValue("https://cdn.test/image.png");
+    jest.spyOn(s3, "uploadFile").mockResolvedValue(mockUrl);
     expect(jest.isMockFunction(s3.uploadFile)).toBe(true);
   });
 

--- a/scripts/validate-env.sh
+++ b/scripts/validate-env.sh
@@ -9,11 +9,9 @@ fi
 : "${AWS_SECRET_ACCESS_KEY:?AWS_SECRET_ACCESS_KEY must be set}"
 
 
-# Fail fast if any proxy variables are set. This includes both lowercase and
-# uppercase variants because different shells export them differently.
-if [[ -n "${npm_config_http_proxy:-}" || -n "${npm_config_https_proxy:-}" || \
-      -n "${http_proxy:-}" || -n "${https_proxy:-}" || \
-      -n "${HTTP_PROXY:-}" || -n "${HTTPS_PROXY:-}" ]]; then
+# Fail fast if npm-specific proxy variables are set. Other proxy variables may
+# be required for connectivity in some environments and are tolerated.
+if [[ -n "${npm_config_http_proxy:-}" || -n "${npm_config_https_proxy:-}" ]]; then
   echo "npm proxy variables must be unset" >&2
   exit 1
 fi

--- a/tests/validateEnv.test.js
+++ b/tests/validateEnv.test.js
@@ -22,8 +22,8 @@ describe("validate-env script", () => {
       STRIPE_LIVE_KEY: "",
       npm_config_http_proxy: "",
       npm_config_https_proxy: "",
-      http_proxy: "",
-      https_proxy: "",
+      http_proxy: "http://proxy",
+      https_proxy: "http://proxy",
     };
     const output = run(env);
     expect(output).toContain("✅ environment OK");
@@ -34,7 +34,7 @@ describe("validate-env script", () => {
       ...process.env,
       HF_TOKEN: "test",
       STRIPE_TEST_KEY: "sk_test",
-      http_proxy: "http://proxy",
+      npm_config_http_proxy: "http://proxy",
     };
     expect(() => run(env)).toThrow();
   });


### PR DESCRIPTION
## Summary
- allow system proxy variables in `validate-env.sh`
- adjust tests for proxy handling
- fix `textToImage` test mock constant

## Testing
- `npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_687271be73e8832d84874e4c874e11e8