### PR TITLE
Fix textToImage test variable redeclaration

### DIFF
--- a/backend/tests/textToImage.test.ts
+++ b/backend/tests/textToImage.test.ts
@@ -15,9 +15,9 @@ delete process.env.https_proxy;
 delete process.env.HTTP_PROXY;
 delete process.env.HTTPS_PROXY;
 
-const s3 = require("../src/lib/uploadS3");
 const nock = require("nock");
 const { textToImage } = require("../src/lib/textToImage.js");
+const mockUrl = "https://cdn.test/image.png";
 let s3;
 
 describe("textToImage", () => {
@@ -40,7 +40,9 @@ describe("textToImage", () => {
     delete process.env.HTTP_PROXY;
     delete process.env.HTTPS_PROXY;
     nock.disableNetConnect();
-    jest.spyOn(s3, "uploadFile").mockResolvedValue("https://cdn.test/image.png");
+    jest
+      .spyOn(s3, "uploadFile")
+      .mockResolvedValue("https://cdn.test/image.png");
     expect(jest.isMockFunction(s3.uploadFile)).toBe(true);
   });
 


### PR DESCRIPTION
## Summary
- fix variable redeclaration in textToImage test

## Testing
- `npx prettier backend/tests/textToImage.test.ts -w`
- `npm test --silent` *(fails to provide full logs due to coverage noise but tests pass)*

------
https://chatgpt.com/codex/tasks/task_e_6872720b12ec832dab9c2692edc87247