### PR TITLE
Add connectivity test file

### DIFF
--- a/backend/tests/npmRegistryConnectivity.test.ts
+++ b/backend/tests/npmRegistryConnectivity.test.ts
@@ -1,0 +1,13 @@
+const { execSync } = require("child_process");
+const nock = require("nock");
+
+describe("npm registry connectivity", () => {
+  test("npm ping succeeds", () => {
+    if (process.env.SKIP_NET_CHECKS) {
+      console.warn("Skipping npm ping due to SKIP_NET_CHECKS");
+      return;
+    }
+    nock.enableNetConnect();
+    expect(() => execSync("npm ping", { stdio: "pipe" })).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- rename npm registry connectivity test so Jest picks it up

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend tests/textToImage.test.ts`
- `npm test --prefix backend tests/npmRegistryConnectivity.test.ts`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: HF_TOKEN must be set)*

------
https://chatgpt.com/codex/tasks/task_e_687272597c1c832dacbdd686ed7e9cfa