### PR TITLE
Add network diagnostic checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "visual-test": "percy exec -- npm run e2e",
     "test:a11y": "node scripts/assert-setup.js && bash scripts/install-playwright.sh chromium && playwright test e2e/a11y.test.js",
     "a11y": "jest --runTestsByPath tests/a11y",
+    "net:check": "node scripts/network-check.js",
     "netlify:deploy": "scripts/netlify-preflight.sh && netlify deploy",
     "diagnose": "bash scripts/diagnose.sh",
     "test:generate": "node scripts/test-generate.js",

--- a/scripts/network-check.js
+++ b/scripts/network-check.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+const { execSync } = require('child_process');
+
+const targets = [
+  { url: 'https://registry.npmjs.org', name: 'npm registry' },
+  { url: 'https://cdn.playwright.dev', name: 'Playwright CDN' },
+];
+
+function check(url) {
+  try {
+    execSync(`curl -sI --max-time 10 ${url}`, { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+for (const { url, name } of targets) {
+  if (!check(url)) {
+    console.error(`Unable to reach ${name}: ${url}`);
+    process.exit(1);
+  }
+}
+console.log('✅ network OK');

--- a/scripts/validate-env.sh
+++ b/scripts/validate-env.sh
@@ -25,12 +25,8 @@ fi
 
 
 if [[ -z "${SKIP_NET_CHECKS:-}" ]]; then
-  if ! npm ping >/dev/null 2>&1; then
-    echo "Unable to reach the npm registry. Check network connectivity or proxy settings." >&2
-    exit 1
-  fi
-  if ! curl -sfI https://cdn.playwright.dev >/dev/null; then
-    echo "Unable to reach https://cdn.playwright.dev" >&2
+  if ! node scripts/network-check.js >/dev/null 2>&1; then
+    echo "Network check failed. Ensure access to the npm registry and Playwright CDN." >&2
     exit 1
   fi
 fi

--- a/tests/networkCheckScript.test.js
+++ b/tests/networkCheckScript.test.js
@@ -1,0 +1,9 @@
+const { execFileSync } = require('child_process');
+const path = require('path');
+
+describe('network-check script', () => {
+  test('reports network OK', () => {
+    const out = execFileSync('node', [path.join('scripts', 'network-check.js')], { encoding: 'utf8' });
+    expect(out).toContain('✅ network OK');
+  });
+});


### PR DESCRIPTION
## Summary
- add `network-check.js` script to verify npm and Playwright connectivity
- call it from `validate-env.sh`
- expose `net:check` npm script
- add Jest test for the new script

## Testing
- `npm test --prefix backend` *(passed)*
- `node scripts/network-check.js` *(passed)*
- `npm run ci` *(failed: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_687277ec4248832d974aa21a49c72c8c