### PR TITLE
Add Playwright install check

### DIFF
--- a/scripts/install-playwright.sh
+++ b/scripts/install-playwright.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 set -e
+
+# Abort if Playwright packages are not installed. Running `npx playwright install`
+# without them triggers warnings and fetches the CLI from the network.
+if [ ! -x node_modules/.bin/playwright ]; then
+  echo "Playwright package missing. Run 'npm install' first." >&2
+  exit 1
+fi
+
 if [ -z "$SKIP_PW_DEPS" ]; then
   npx playwright install "$@" --with-deps
 else

--- a/tests/installPlaywright.test.js
+++ b/tests/installPlaywright.test.js
@@ -1,0 +1,45 @@
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const { execFileSync } = require("child_process");
+/**
+ * Run the install-playwright script in the provided directory using a stub npx binary that records whether it was called.
+ * @param {string} dir temporary working directory
+ * @returns {boolean} true if the stub npx executed
+ */
+function run(dir) {
+  const stubDir = fs.mkdtempSync(path.join(os.tmpdir(), "npx-"));
+  const log = path.join(dir, "npx.log");
+  const stub = path.join(stubDir, "npx");
+  fs.writeFileSync(stub, '#!/bin/sh\necho called >> "$NPX_LOG"\n');
+  fs.chmodSync(stub, 0o755);
+  const env = {
+    ...process.env,
+    PATH: `${stubDir}:${process.env.PATH}`,
+    NPX_LOG: log,
+    SKIP_PW_DEPS: "1",
+  };
+  execFileSync(
+    "bash",
+    [path.resolve(__dirname, "..", "scripts", "install-playwright.sh")],
+    { cwd: dir, env },
+  );
+  return fs.existsSync(log);
+}
+
+describe("install-playwright script", () => {
+  test("fails without dependencies", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pwtest-"));
+    expect(() => run(dir)).toThrow();
+    expect(fs.existsSync(path.join(dir, "npx.log"))).toBe(false);
+  });
+
+  test("runs when playwright installed", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pwtest-"));
+    const binDir = path.join(dir, "node_modules", ".bin");
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.writeFileSync(path.join(binDir, "playwright"), "");
+    fs.chmodSync(path.join(binDir, "playwright"), 0o755);
+    expect(run(dir)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- guard install-playwright script against missing dependencies
- add Jest test covering this script

## Testing
- `npm test --prefix backend`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_68727a5aeba4832dbd2cf263f2058d48