### PR TITLE
Fix validateEnv test network dependency

### DIFF
--- a/backend/tests/validateEnv.test.ts
+++ b/backend/tests/validateEnv.test.ts
@@ -4,7 +4,7 @@ const path = require("path");
 const root = path.resolve(__dirname, "..", "..");
 
 function run(env, clean = true) {
-  const e = { ...process.env, ...env };
+  const e = { ...process.env, SKIP_NET_CHECKS: "1", ...env };
   if (clean) {
     delete e.npm_config_http_proxy;
     delete e.npm_config_https_proxy;


### PR DESCRIPTION
## Summary
- skip network connectivity check in validateEnv test

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6872824de7a4832db5d9faab934f5ddd