### PR TITLE
Add env var check test

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,7 @@ CLOUDFRONT_MODEL_DOMAIN=d2b5mm5pinpo2y.cloudfront.net
 SPARC3D_ENDPOINT=https://api-inference.huggingface.co/models/print2/Sparc3D
 SPARC3D_TOKEN=your-token-here
 STABILITY_KEY=your-stability-key-here
+HF_TOKEN=your-huggingface-token
 AWS_ACCESS_KEY_ID=your-aws-access-key-id
 AWS_SECRET_ACCESS_KEY=your-aws-secret-access-key
 S3_BUCKET=your-s3-bucket

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Run `docker compose up` to start the API and Postgres services.
 ## Local Setup
 
 1. Copy `.env.example` to `.env` in the repository root and update the values:
-
    - `DB_URL` – connection string for your PostgreSQL database.
 
 - `STRIPE_TEST_KEY` – test secret key for Stripe.
@@ -34,6 +33,8 @@ Run `docker compose up` to start the API and Postgres services.
 - `STRIPE_PUBLISHABLE_KEY` – publishable key for Stripe.js on the frontend.
 - `STRIPE_WEBHOOK_SECRET` – signing secret for Stripe webhooks.
 - `HUNYUAN_API_KEY` – key for the Sparc3D API.
+- `HF_TOKEN` – Hugging Face access token used by scripts like `setup_space.sh`.
+- `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` – credentials for S3 uploads.
 
 The server uses `STRIPE_LIVE_KEY` when `NODE_ENV=production`; otherwise `STRIPE_TEST_KEY` is used.
 

--- a/backend/tests/validateEnv.test.ts
+++ b/backend/tests/validateEnv.test.ts
@@ -4,7 +4,7 @@ const path = require("path");
 const root = path.resolve(__dirname, "..", "..");
 
 function run(env, clean = true) {
-  const e = { ...process.env, ...env };
+  const e = { ...process.env, SKIP_NET_CHECKS: "1", ...env };
   if (clean) {
     delete e.npm_config_http_proxy;
     delete e.npm_config_https_proxy;
@@ -33,6 +33,18 @@ describe("validate-env script", () => {
           npm_config_http_proxy: "http://proxy",
         },
         false,
+      ),
+    ).toThrow();
+  });
+
+  test("fails when HF_TOKEN is missing", () => {
+    expect(() =>
+      run(
+        {
+          STRIPE_TEST_KEY: "test",
+          HF_TOKEN: "",
+        },
+        true,
       ),
     ).toThrow();
   });

--- a/tests/validateEnv.test.js
+++ b/tests/validateEnv.test.js
@@ -8,7 +8,7 @@ const { execFileSync } = require("child_process");
  */
 function run(env) {
   return execFileSync("bash", ["scripts/validate-env.sh"], {
-    env,
+    env: { SKIP_NET_CHECKS: "1", ...env },
     encoding: "utf8",
   });
 }
@@ -36,6 +36,15 @@ describe("validate-env script", () => {
       HF_TOKEN: "test",
       STRIPE_TEST_KEY: "sk_test",
       npm_config_http_proxy: "http://proxy",
+    };
+    expect(() => run(env)).toThrow();
+  });
+
+  test("fails when HF_TOKEN is missing", () => {
+    const env = {
+      ...process.env,
+      STRIPE_TEST_KEY: "sk_test",
+      HF_TOKEN: "",
     };
     expect(() => run(env)).toThrow();
   });


### PR DESCRIPTION
## Summary
- document HF_TOKEN requirement in README
- include HF_TOKEN in `.env.example`
- add tests verifying the setup script fails when `HF_TOKEN` is missing

## Testing
- `npx prettier --write README.md tests/validateEnv.test.js backend/tests/validateEnv.test.ts`
- `HF_TOKEN=dummy AWS_ACCESS_KEY_ID=dummy AWS_SECRET_ACCESS_KEY=dummy SKIP_NET_CHECKS=1 npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_687282428864832d8c379eac9f348fa7