### PR TITLE
Add HF_TOKEN checks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,7 @@ HTTP2=true
 CLOUDFRONT_MODEL_DOMAIN=d2b5mm5pinpo2y.cloudfront.net
 SPARC3D_ENDPOINT=https://api-inference.huggingface.co/models/print2/Sparc3D
 SPARC3D_TOKEN=your-token-here
+HF_TOKEN=your-huggingface-token
 STABILITY_KEY=your-stability-key-here
 AWS_ACCESS_KEY_ID=your-aws-access-key-id
 AWS_SECRET_ACCESS_KEY=your-aws-secret-access-key

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Run `docker compose up` to start the API and Postgres services.
 ## Local Setup
 
 1. Copy `.env.example` to `.env` in the repository root and update the values:
-
    - `DB_URL` – connection string for your PostgreSQL database.
 
 - `STRIPE_TEST_KEY` – test secret key for Stripe.
@@ -34,6 +33,7 @@ Run `docker compose up` to start the API and Postgres services.
 - `STRIPE_PUBLISHABLE_KEY` – publishable key for Stripe.js on the frontend.
 - `STRIPE_WEBHOOK_SECRET` – signing secret for Stripe webhooks.
 - `HUNYUAN_API_KEY` – key for the Sparc3D API.
+- `HF_TOKEN` – token for Hugging Face API access used by setup scripts.
 
 The server uses `STRIPE_LIVE_KEY` when `NODE_ENV=production`; otherwise `STRIPE_TEST_KEY` is used.
 

--- a/tests/validateEnv.test.js
+++ b/tests/validateEnv.test.js
@@ -39,4 +39,13 @@ describe("validate-env script", () => {
     };
     expect(() => run(env)).toThrow();
   });
+
+  test("fails when HF_TOKEN missing", () => {
+    const env = {
+      ...process.env,
+      HF_TOKEN: "",
+      STRIPE_TEST_KEY: "sk_test",
+    };
+    expect(() => run(env)).toThrow();
+  });
 });


### PR DESCRIPTION
## Summary
- document HF_TOKEN in README and .env.example
- test for missing HF_TOKEN in validate-env script

## Testing
- `npx prettier -w README.md tests/validateEnv.test.js`
- `SKIP_NET_CHECKS=1 npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_687282319460832d9bea8edb069a171c