### PR TITLE
Add repo root test

### DIFF
--- a/scripts/check-repo-root.js
+++ b/scripts/check-repo-root.js
@@ -1,17 +1,28 @@
 #!/usr/bin/env node
-const fs = require('fs');
-const path = require('path');
+const fs = require("fs");
+const path = require("path");
 
-const repoRoot = path.resolve(__dirname, '..');
-const backendPackage = path.join(repoRoot, 'backend', 'package.json');
-const rootPackage = path.join(repoRoot, 'package.json');
+const repoRoot = path.resolve(__dirname, "..");
+const backendPackage = path.join(repoRoot, "backend", "package.json");
+const rootPackage = path.join(repoRoot, "package.json");
+
+if (process.cwd() !== repoRoot) {
+  console.error(
+    `Error: run npm commands from the repository root at ${repoRoot}`,
+  );
+  process.exit(1);
+}
 
 if (!fs.existsSync(rootPackage)) {
-  console.error('Error: package.json not found. Ensure you are in the repository root.');
+  console.error(
+    "Error: package.json not found. Ensure you are in the repository root.",
+  );
   process.exit(1);
 }
 
 if (!fs.existsSync(backendPackage)) {
-  console.error('Error: backend/package.json not found. Check that the repository is cloned correctly');
+  console.error(
+    "Error: backend/package.json not found. Check that the repository is cloned correctly",
+  );
   process.exit(1);
 }

--- a/tests/checkRepoRoot.test.ts
+++ b/tests/checkRepoRoot.test.ts
@@ -1,0 +1,18 @@
+const { execFileSync } = require("child_process");
+const path = require("path");
+
+const root = path.resolve(__dirname, "..");
+const script = path.join(root, "scripts", "check-repo-root.js");
+
+describe("check-repo-root", () => {
+  test("passes when run from repo root", () => {
+    execFileSync("node", [script], { cwd: root, stdio: "pipe" });
+  });
+
+  test("fails outside repo root", () => {
+    const cwd = path.join(root, "backend");
+    expect(() =>
+      execFileSync("node", [script], { cwd, stdio: "pipe" }),
+    ).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- enforce running npm commands from repo root
- add tests for check-repo-root.js

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend` with `SKIP_NET_CHECKS=1`


------
https://chatgpt.com/codex/tasks/task_e_68728218f000832d96de83766e37cc34