### PR TITLE
Add check for TS support in Jest

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -6,7 +6,7 @@ module.exports = {
   globalTeardown: "<rootDir>/tests/globalTeardown.js",
   testEnvironment: "node",
   transform: {
-    "^.+\\.tsx?$": "babel-jest",
+    "^.+\\.[tj]s$": "babel-jest",
   },
   testMatch: ["**/?(*.)+(spec|test).ts?(x)"],
   moduleFileExtensions: ["ts", "js", "json"],

--- a/tests/jestTransform.test.js
+++ b/tests/jestTransform.test.js
@@ -1,0 +1,9 @@
+const backendPkg = require("../backend/package.json");
+const jestConfig = require("../backend/jest.config.js");
+
+describe("jest setup", () => {
+  test("babel-jest installed and ts transform configured", () => {
+    expect(backendPkg.devDependencies["babel-jest"]).toBeDefined();
+    expect(jestConfig.transform["^.+\\.[tj]s$"]).toBe("babel-jest");
+  });
+});


### PR DESCRIPTION
## Summary
- configure Jest to transform both `.js` and `.ts` files
- add regression test verifying `babel-jest` is installed and transform rule is present

## Testing
- `npm run format`
- `SKIP_NET_CHECKS=1 npm test`

------
https://chatgpt.com/codex/tasks/task_e_68728227b974832dbc1d9e4d04d91130