### PR TITLE
Improve smoke test reliability

### DIFF
--- a/backend/tests/runSmokeFailure.test.ts
+++ b/backend/tests/runSmokeFailure.test.ts
@@ -1,0 +1,26 @@
+const child_process = require("child_process");
+
+jest.mock("child_process");
+
+const main = require("../../scripts/run-smoke");
+
+describe("run-smoke failure handling", () => {
+  beforeEach(() => {
+    child_process.execSync.mockReset();
+  });
+
+  test("exits with message when setup fails", () => {
+    child_process.execSync.mockImplementation(() => {
+      throw Object.assign(new Error("setup failed"), { status: 1 });
+    });
+    const exitSpy = jest.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("exit");
+    });
+    const errSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => main()).toThrow("exit");
+    expect(errSpy.mock.calls[0][0]).toMatch(/Smoke test failed/);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    errSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+});

--- a/scripts/run-smoke.js
+++ b/scripts/run-smoke.js
@@ -6,10 +6,27 @@ function run(cmd) {
   execSync(cmd, { stdio: "inherit", env });
 }
 
-run("npm run setup");
-if (!process.env.SKIP_PW_DEPS) {
-  run("npx -y playwright install --with-deps");
+function main() {
+  try {
+    run("npm run validate-env");
+    run("npm run setup");
+    if (!process.env.SKIP_PW_DEPS) {
+      run("npx -y playwright install --with-deps");
+    }
+    run(
+      'npx -y concurrently -k -s first "npm run serve" "wait-on http://localhost:3000 && npx playwright test e2e/smoke.test.js"',
+    );
+  } catch (err) {
+    console.error("Smoke test failed:", err.message);
+    console.error(
+      "Ensure required environment variables are set and run 'npm run setup' manually.",
+    );
+    process.exit(err.status ?? 1);
+  }
 }
-run(
-  'npx -y concurrently -k -s first "npm run serve" "wait-on http://localhost:3000 && npx playwright test e2e/smoke.test.js"',
-);
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = main;

--- a/tests/smokeScript.test.js
+++ b/tests/smokeScript.test.js
@@ -14,4 +14,15 @@ describe("smoke script", () => {
     );
     expect(/SKIP_PW_DEPS/.test(content)).toBe(true);
   });
+
+  test("run-smoke.js validates env before setup", () => {
+    const content = fs.readFileSync(
+      path.join(__dirname, "..", "scripts", "run-smoke.js"),
+      "utf8",
+    );
+    const validateIdx = content.indexOf("npm run validate-env");
+    const setupIdx = content.indexOf("npm run setup");
+    expect(validateIdx).toBeGreaterThan(-1);
+    expect(setupIdx).toBeGreaterThan(validateIdx);
+  });
 });


### PR DESCRIPTION
## Summary
- run environment validation before setup in the smoke script
- handle setup errors gracefully
- test for new failure handling and validation step

## Testing
- `npm test`
- `npm run format --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_68728203cda4832d9a9fa6d3a091bc59