### PR TITLE
Add setup assertion tests

### DIFF
--- a/backend/tests/validateEnv.test.ts
+++ b/backend/tests/validateEnv.test.ts
@@ -20,7 +20,13 @@ function run(env, clean = true) {
 
 describe("validate-env script", () => {
   test("succeeds when required vars set and proxies unset", () => {
-    const output = run({ STRIPE_TEST_KEY: "test", HF_TOKEN: "token" });
+    const output = run({
+      STRIPE_TEST_KEY: "test",
+      HF_TOKEN: "token",
+      AWS_ACCESS_KEY_ID: "id",
+      AWS_SECRET_ACCESS_KEY: "secret",
+      SKIP_NET_CHECKS: "1",
+    });
     expect(output).toContain("environment OK");
   });
 
@@ -30,6 +36,9 @@ describe("validate-env script", () => {
         {
           STRIPE_TEST_KEY: "test",
           HF_TOKEN: "token",
+          AWS_ACCESS_KEY_ID: "id",
+          AWS_SECRET_ACCESS_KEY: "secret",
+          SKIP_NET_CHECKS: "1",
           npm_config_http_proxy: "http://proxy",
         },
         false,

--- a/tests/assertSetup.test.js
+++ b/tests/assertSetup.test.js
@@ -1,0 +1,36 @@
+jest.mock("fs");
+jest.mock("child_process");
+
+const fs = require("fs");
+const child_process = require("child_process");
+
+describe("assert-setup script", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    fs.existsSync.mockReset();
+    fs.readdirSync.mockReset();
+    child_process.execSync.mockReset();
+  });
+
+  function setEnv() {
+    process.env.HF_TOKEN = "x";
+    process.env.AWS_ACCESS_KEY_ID = "id";
+    process.env.AWS_SECRET_ACCESS_KEY = "secret";
+  }
+
+  test("runs setup when browsers missing", () => {
+    setEnv();
+    fs.existsSync.mockReturnValue(false);
+    fs.readdirSync.mockReturnValue([]);
+
+    expect(() => require("../scripts/assert-setup.js")).not.toThrow();
+  });
+
+  test("skips setup when browsers installed", () => {
+    setEnv();
+    fs.existsSync.mockReturnValue(true);
+    fs.readdirSync.mockReturnValue(["chromium"]);
+
+    expect(() => require("../scripts/assert-setup.js")).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- ensure validate-env unit test sets AWS keys
- add tests for assert-setup script

## Testing
- `npm test`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_687281e819ec832d803be071d422713e