### PR TITLE
Add network check for Playwright deps

### DIFF
--- a/scripts/check-host-deps.js
+++ b/scripts/check-host-deps.js
@@ -1,23 +1,41 @@
 #!/usr/bin/env node
-const { execSync } = require('child_process');
+const { execSync } = require("child_process");
+
+function checkNetwork() {
+  try {
+    execSync("node scripts/network-check.js", { stdio: "ignore" });
+  } catch {
+    console.error(
+      "Network check failed. Ensure access to the npm registry and Playwright CDN.",
+    );
+    process.exit(1);
+  }
+}
 
 function hostDepsInstalled() {
   try {
-    const out = execSync('npx playwright install --with-deps --dry-run', { encoding: 'utf8' });
+    const out = execSync("npx playwright install --with-deps --dry-run", {
+      encoding: "utf8",
+    });
     return !/Missing libraries/i.test(out);
   } catch {
     return false;
   }
 }
 
+checkNetwork();
+
 if (!hostDepsInstalled()) {
-  console.log('Playwright host dependencies missing. Installing...');
+  console.log("Playwright host dependencies missing. Installing...");
   try {
-    execSync('CI=1 npx playwright install --with-deps', { stdio: 'inherit' });
+    execSync("CI=1 npx playwright install --with-deps", { stdio: "inherit" });
   } catch (err) {
-    console.error('Failed to install Playwright host dependencies:', err.message);
+    console.error(
+      "Failed to install Playwright host dependencies:",
+      err.message,
+    );
     process.exit(1);
   }
 } else {
-  console.log('Playwright host dependencies already satisfied.');
+  console.log("Playwright host dependencies already satisfied.");
 }


### PR DESCRIPTION
## Summary
- check registry/CDN connectivity before installing host deps
- test that the network check runs and fails properly

## Testing
- `npx prettier scripts/check-host-deps.js tests/checkHostDeps.test.js --write`
- `node scripts/run-jest.js tests/checkHostDeps.test.js --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_687281d93c34832dac3a92bf3194fba0