### PR TITLE
Add test for network-check failure case

### DIFF
--- a/tests/bin/curl
+++ b/tests/bin/curl
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exit 1

--- a/tests/networkCheckFailure.test.js
+++ b/tests/networkCheckFailure.test.js
@@ -1,0 +1,17 @@
+const { execFileSync } = require("child_process");
+const path = require("path");
+
+const fakeBin = path.join(__dirname, "bin");
+const env = { ...process.env, PATH: `${fakeBin}:${process.env.PATH}` };
+
+describe("network-check failure", () => {
+  test("reports useful error when unreachable", () => {
+    expect(() => {
+      execFileSync("node", [path.join("scripts", "network-check.js")], {
+        env,
+        encoding: "utf8",
+        stdio: "pipe",
+      });
+    }).toThrow(/Unable to reach npm registry/);
+  });
+});


### PR DESCRIPTION
## Summary
- add failing curl script for tests
- verify network-check prints helpful error when registry is unreachable

## Testing
- `npm --prefix backend run format`
- `SKIP_NET_CHECKS=1 npm --prefix backend test --silent -- -i | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_687281c5e5f8832dbe04751834e240da