### PR TITLE
Add network diagnostics tests

### DIFF
--- a/scripts/network-check.js
+++ b/scripts/network-check.js
@@ -1,14 +1,20 @@
 #!/usr/bin/env node
-const { execSync } = require('child_process');
+const { execSync } = require("child_process");
 
 const targets = [
-  { url: 'https://registry.npmjs.org', name: 'npm registry' },
-  { url: 'https://cdn.playwright.dev', name: 'Playwright CDN' },
+  { url: "https://registry.npmjs.org", name: "npm registry" },
+  { url: "https://cdn.playwright.dev", name: "Playwright CDN" },
 ];
+
+// Allow tests to override the first target URL so failure scenarios can be
+// simulated without manipulating the real network environment.
+if (process.env.NETWORK_CHECK_URL) {
+  targets[0] = { url: process.env.NETWORK_CHECK_URL, name: "test url" };
+}
 
 function check(url) {
   try {
-    execSync(`curl -sI --max-time 10 ${url}`, { stdio: 'ignore' });
+    execSync(`curl -sI --max-time 10 ${url}`, { stdio: "ignore" });
     return true;
   } catch {
     return false;
@@ -21,4 +27,4 @@ for (const { url, name } of targets) {
     process.exit(1);
   }
 }
-console.log('✅ network OK');
+console.log("✅ network OK");

--- a/tests/networkCheckScript.test.js
+++ b/tests/networkCheckScript.test.js
@@ -1,9 +1,22 @@
-const { execFileSync } = require('child_process');
-const path = require('path');
+const { execFileSync } = require("child_process");
+const path = require("path");
 
-describe('network-check script', () => {
-  test('reports network OK', () => {
-    const out = execFileSync('node', [path.join('scripts', 'network-check.js')], { encoding: 'utf8' });
-    expect(out).toContain('✅ network OK');
+describe("network-check script", () => {
+  test("reports network OK", () => {
+    const out = execFileSync(
+      "node",
+      [path.join("scripts", "network-check.js")],
+      { encoding: "utf8" },
+    );
+    expect(out).toContain("✅ network OK");
+  });
+
+  test("fails when target unreachable", () => {
+    expect(() => {
+      execFileSync("node", [path.join("scripts", "network-check.js")], {
+        encoding: "utf8",
+        env: { ...process.env, NETWORK_CHECK_URL: "http://127.0.0.1:9" },
+      });
+    }).toThrow(/Unable to reach/);
   });
 });

--- a/tests/validateEnv.test.js
+++ b/tests/validateEnv.test.js
@@ -34,9 +34,25 @@ describe("validate-env script", () => {
     const env = {
       ...process.env,
       HF_TOKEN: "test",
+      AWS_ACCESS_KEY_ID: "id",
+      AWS_SECRET_ACCESS_KEY: "secret",
       STRIPE_TEST_KEY: "sk_test",
       npm_config_http_proxy: "http://proxy",
     };
     expect(() => run(env)).toThrow();
+  });
+
+  test("fails when network unreachable", () => {
+    const env = {
+      ...process.env,
+      HF_TOKEN: "test",
+      AWS_ACCESS_KEY_ID: "id",
+      AWS_SECRET_ACCESS_KEY: "secret",
+      STRIPE_TEST_KEY: "sk_test",
+      npm_config_http_proxy: "",
+      npm_config_https_proxy: "",
+      NETWORK_CHECK_URL: "http://127.0.0.1:9",
+    };
+    expect(() => run(env)).toThrow(/Network check failed/);
   });
 });


### PR DESCRIPTION
## Summary
- allow setting a custom URL for network check
- test failure path in network-check
- verify validate-env script fails when connectivity is lost

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_687281bcabbc832dbb85f790c747ad6e