### PR TITLE
Persist mise trust and add test

### DIFF
--- a/backend/tests/miseTrustPersist.test.js
+++ b/backend/tests/miseTrustPersist.test.js
@@ -1,0 +1,36 @@
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { execFileSync } = require("child_process");
+
+const repoRoot = path.resolve(__dirname, "..", "..");
+const script = path.join(repoRoot, "scripts", "setup.sh");
+
+function runSetup() {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), "home-"));
+  fs.writeFileSync(path.join(home, ".bashrc"), "");
+  execFileSync("bash", [script], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      HOME: home,
+      STRIPE_TEST_KEY: "sk_test",
+      HF_TOKEN: "t",
+      AWS_ACCESS_KEY_ID: "t",
+      AWS_SECRET_ACCESS_KEY: "t",
+      SKIP_PW_DEPS: "1",
+      SKIP_NET_CHECKS: "1",
+    },
+    stdio: "ignore",
+  });
+  return fs.readFileSync(path.join(home, ".bashrc"), "utf8");
+}
+
+describe("setup script", () => {
+  test("persists mise trust command", () => {
+    const bashrc = runSetup();
+    const escaped = repoRoot.replace(/[-/\\]/g, "\\$&");
+    const regex = new RegExp(`mise trust ${escaped}`);
+    expect(bashrc).toMatch(regex);
+  });
+});

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -34,6 +34,11 @@ if [ -f .mise.toml ]; then
   mise trust .mise.toml >/dev/null 2>&1 || true
 fi
 
+# Persist trust so new shells don't emit warnings
+if ! grep -q "mise trust $(pwd)" ~/.bashrc 2>/dev/null; then
+  echo "mise trust $(pwd) >/dev/null 2>&1 || true" >> ~/.bashrc
+fi
+
 # Persist the setting so new shells don't emit warnings
 if ! grep -q "idiomatic_version_file_enable_tools" ~/.bashrc 2>/dev/null; then
   echo "mise settings add idiomatic_version_file_enable_tools node >/dev/null 2>&1 || true" >> ~/.bashrc


### PR DESCRIPTION
## Summary
- persist `mise trust` invocation in setup script so new shells won't warn
- test that the setup script adds a trust command to `.bashrc`

## Testing
- `npm run format --prefix backend`
- `SKIP_NET_CHECKS=1 npm test --prefix backend --silent`

------
https://chatgpt.com/codex/tasks/task_e_6872819ed204832d89171e3c138b0352