### PR TITLE
Improve env docs and add missing validate-env tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,9 @@ These guidelines apply to all automated agents (e.g. the Codex agent) working on
 1. **Go to the repository root** – run `cd "$(git rev-parse --show-toplevel)"` after opening a shell to ensure paths resolve correctly.
 2. **Unset proxy variables** – before running any `npm` commands, **and whenever you start a new shell session**, execute `unset npm_config_http_proxy npm_config_https_proxy` to silence `http-proxy` warnings.
 3. **Validate the environment** – run `npm run validate-env` to ensure required variables are set and proxy vars remain unset.
+   - `HF_TOKEN`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY` must be defined
+     for the setup script and tests to run correctly. Dummy values are fine for
+     local development.
 4. **Check network access** – ensure the environment can reach both
    `https://registry.npmjs.org` and `https://cdn.playwright.dev`. The setup
    script downloads packages and browsers from these domains. If they are

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ The server uses `STRIPE_LIVE_KEY` when `NODE_ENV=production`; otherwise `STRIPE_
   persists, run that command manually.
 - `SENDGRID_API_KEY` – API key for sending email via SendGrid.
 - `SENTRY_DSN` – connection string for sending errors to Sentry.
+- `HF_TOKEN` – token used to sync the Hugging Face Space.
+- `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` – credentials for S3 access.
 - `EMAIL_FROM` – address used for the "from" field in outgoing mail.
 - Optional: `PORT` and `HUNYUAN_PORT` to override the default ports for the
   Sparc3D service.

--- a/backend/tests/validateEnv.test.ts
+++ b/backend/tests/validateEnv.test.ts
@@ -20,7 +20,11 @@ function run(env, clean = true) {
 
 describe("validate-env script", () => {
   test("succeeds when required vars set and proxies unset", () => {
-    const output = run({ STRIPE_TEST_KEY: "test", HF_TOKEN: "token" });
+    const output = run({
+      STRIPE_TEST_KEY: "test",
+      HF_TOKEN: "token",
+      SKIP_NET_CHECKS: "1",
+    });
     expect(output).toContain("environment OK");
   });
 
@@ -30,6 +34,7 @@ describe("validate-env script", () => {
         {
           STRIPE_TEST_KEY: "test",
           HF_TOKEN: "token",
+          SKIP_NET_CHECKS: "1",
           npm_config_http_proxy: "http://proxy",
         },
         false,

--- a/tests/validateEnv.test.js
+++ b/tests/validateEnv.test.js
@@ -24,6 +24,7 @@ describe("validate-env script", () => {
       npm_config_https_proxy: "",
       http_proxy: "http://proxy",
       https_proxy: "http://proxy",
+      SKIP_NET_CHECKS: "1",
     };
     const output = run(env);
     expect(output).toContain("✅ environment OK");
@@ -36,7 +37,36 @@ describe("validate-env script", () => {
       HF_TOKEN: "test",
       STRIPE_TEST_KEY: "sk_test",
       npm_config_http_proxy: "http://proxy",
+      SKIP_NET_CHECKS: "1",
     };
     expect(() => run(env)).toThrow();
+  });
+
+  test("fails when HF_TOKEN is missing", () => {
+    const env = {
+      ...process.env,
+      STRIPE_TEST_KEY: "sk_test",
+      npm_config_http_proxy: "",
+      npm_config_https_proxy: "",
+      AWS_ACCESS_KEY_ID: "id",
+      AWS_SECRET_ACCESS_KEY: "secret",
+      SKIP_NET_CHECKS: "1",
+    };
+    delete env.HF_TOKEN;
+    expect(() => run(env)).toThrow(/HF_TOKEN must be set/);
+  });
+
+  test("fails when AWS credentials are missing", () => {
+    const env = {
+      ...process.env,
+      HF_TOKEN: "test",
+      STRIPE_TEST_KEY: "sk_test",
+      npm_config_http_proxy: "",
+      npm_config_https_proxy: "",
+      SKIP_NET_CHECKS: "1",
+    };
+    delete env.AWS_ACCESS_KEY_ID;
+    delete env.AWS_SECRET_ACCESS_KEY;
+    expect(() => run(env)).toThrow(/AWS_ACCESS_KEY_ID must be set/);
   });
 });


### PR DESCRIPTION
## Summary
- document HF_TOKEN and AWS credentials in README
- note required env vars in AGENTS guide
- test validate-env script for missing variables and disable network checks in tests

## Testing
- `npm --prefix backend run format`
- `CI=true npm --prefix backend test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6872818f4e80832db4cddc1f70adb2f5