### PR TITLE
Add HF_TOKEN guidance and tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,7 @@ CLOUDFRONT_MODEL_DOMAIN=d2b5mm5pinpo2y.cloudfront.net
 SPARC3D_ENDPOINT=https://api-inference.huggingface.co/models/print2/Sparc3D
 SPARC3D_TOKEN=your-token-here
 STABILITY_KEY=your-stability-key-here
+HF_TOKEN=your-hf-token
 AWS_ACCESS_KEY_ID=your-aws-access-key-id
 AWS_SECRET_ACCESS_KEY=your-aws-secret-access-key
 S3_BUCKET=your-s3-bucket

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,26 +7,27 @@ These guidelines apply to all automated agents (e.g. the Codex agent) working on
 
 1. **Go to the repository root** – run `cd "$(git rev-parse --show-toplevel)"` after opening a shell to ensure paths resolve correctly.
 2. **Unset proxy variables** – before running any `npm` commands, **and whenever you start a new shell session**, execute `unset npm_config_http_proxy npm_config_https_proxy` to silence `http-proxy` warnings.
-3. **Validate the environment** – run `npm run validate-env` to ensure required variables are set and proxy vars remain unset.
-4. **Check network access** – ensure the environment can reach both
+3. **Set required tokens** – export `HF_TOKEN`, `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` with non-empty values (dummy tokens are fine) before running validation or CI scripts.
+4. **Validate the environment** – run `npm run validate-env` to ensure required variables are set and proxy vars remain unset.
+5. **Check network access** – ensure the environment can reach both
    `https://registry.npmjs.org` and `https://cdn.playwright.dev`. The setup
    script downloads packages and browsers from these domains. If they are
    blocked, adjust your environment or proxy settings.
-5. **Install dependencies** – run `npm run setup` at the repository root **before your first `npm run ci`**. Run it again whenever the container is restarted or if Playwright tests fail with messages like "Test was interrupted" or "page.evaluate: Test ended". This script unsets proxy variables, checks registry connectivity, runs `npm ci` in the root and `backend/`, and installs Playwright browsers.
+6. **Install dependencies** – run `npm run setup` at the repository root **before your first `npm run ci`**. Run it again whenever the container is restarted or if Playwright tests fail with messages like "Test was interrupted" or "page.evaluate: Test ended". This script unsets proxy variables, checks registry connectivity, runs `npm ci` in the root and `backend/`, and installs Playwright browsers.
    - If `npm ci` fails with an `EUSAGE` error complaining that packages are missing from the lock file, run `npm install` in the affected directory and then re-run the setup script.
    - Set `SKIP_PW_DEPS=1` before running the setup script if Playwright dependencies are already installed. This skips the long `apt-get` step and reduces CI time. The `smoke` script also runs the setup script, so use `SKIP_PW_DEPS=1 npm run smoke` to avoid reinstalling Playwright dependencies when they are already present.
-6. **Format code** – run `npm run format` in `backend/` to apply Prettier formatting.
-7. **Run tests** – execute `npm test` in `backend/`. If tests cannot run because of environment limitations, mention this in the PR.
-8. **Run full CI locally** – execute `npm run ci` at the repo root before opening a PR. Set `SKIP_PW_DEPS=1` if Playwright dependencies were installed previously to avoid redundant `apt-get` steps.
-8. **Install Playwright browsers** – the setup script installs these automatically. If browsers or host dependencies are missing (e.g. Playwright warns that the host system lacks libraries), run `CI=1 npx playwright install --with-deps` manually.
-9. **Run smoke tests** – execute `npm run smoke` at the repository root. This script starts the dev server and runs the Playwright smoke test. If the browsers are already installed, prepend `SKIP_PW_DEPS=1` to skip reinstalling them. **Do not run `npx playwright test` directly** – that can trigger `"Playwright Test did not expect test() to be called here"` errors when dependencies are missing.
-10. **Limit scope** – only modify files related to the task. Do not change anything under `img/`, `models/`, or `uploads/` unless explicitly requested. Avoid editing `docs/` unless the task specifically involves documentation.
-11. **Use Conventional Commits** – commit messages must follow the `type: description` format enforced by commitlint. Allowed types are `build`, `ci`, `docs`, `feat`, `fix`, `chore`, `refactor`, `test`, `style`, `perf`, and `revert`. Example: `fix: handle missing avatar images`.
-12. **Review your diff** – run `git status --short` and `git diff --stat` to ensure only intended files were modified. Revert any unrelated changes.
-13. **Include logs** – paste the output of `npm test` (or `npm run test-ci`) and `npm run format` in the PR description so maintainers can verify the steps.
-14. **Avoid PRs with failing tests** – if `npm run ci` or the smoke tests fail for reasons other than environment limitations, do not open a pull request. Fix the issues or open an issue summarizing the failure instead.
-15. **Avoid committing binary files** – Codex cannot generate patches for binary changes. Do not modify images, audio, or other binary assets. If adding new ones, update `.gitattributes` so they are treated as binary.
-16. **Pin GitHub Action versions** – use explicit tags instead of broad majors to prevent resolution errors (e.g. `aquasecurity/tfsec-action@v1.0.3`).
+7. **Format code** – run `npm run format` in `backend/` to apply Prettier formatting.
+8. **Run tests** – execute `npm test` in `backend/`. If tests cannot run because of environment limitations, mention this in the PR.
+9. **Run full CI locally** – execute `npm run ci` at the repo root before opening a PR. Set `SKIP_PW_DEPS=1` if Playwright dependencies were installed previously to avoid redundant `apt-get` steps.
+10. **Install Playwright browsers** – the setup script installs these automatically. If browsers or host dependencies are missing (e.g. Playwright warns that the host system lacks libraries), run `CI=1 npx playwright install --with-deps` manually.
+11. **Run smoke tests** – execute `npm run smoke` at the repository root. This script starts the dev server and runs the Playwright smoke test. If the browsers are already installed, prepend `SKIP_PW_DEPS=1` to skip reinstalling them. **Do not run `npx playwright test` directly** – that can trigger `"Playwright Test did not expect test() to be called here"` errors when dependencies are missing.
+12. **Limit scope** – only modify files related to the task. Do not change anything under `img/`, `models/`, or `uploads/` unless explicitly requested. Avoid editing `docs/` unless the task specifically involves documentation.
+13. **Use Conventional Commits** – commit messages must follow the `type: description` format enforced by commitlint. Allowed types are `build`, `ci`, `docs`, `feat`, `fix`, `chore`, `refactor`, `test`, `style`, `perf`, and `revert`. Example: `fix: handle missing avatar images`.
+14. **Review your diff** – run `git status --short` and `git diff --stat` to ensure only intended files were modified. Revert any unrelated changes.
+15. **Include logs** – paste the output of `npm test` (or `npm run test-ci`) and `npm run format` in the PR description so maintainers can verify the steps.
+16. **Avoid PRs with failing tests** – if `npm run ci` or the smoke tests fail for reasons other than environment limitations, do not open a pull request. Fix the issues or open an issue summarizing the failure instead.
+17. **Avoid committing binary files** – Codex cannot generate patches for binary changes. Do not modify images, audio, or other binary assets. If adding new ones, update `.gitattributes` so they are treated as binary.
+18. **Pin GitHub Action versions** – use explicit tags instead of broad majors to prevent resolution errors (e.g. `aquasecurity/tfsec-action@v1.0.3`).
 
 ## Troubleshooting
 

--- a/scripts/validate-env.sh
+++ b/scripts/validate-env.sh
@@ -11,7 +11,8 @@ if [[ -z "${STRIPE_TEST_KEY:-}" && -z "${STRIPE_LIVE_KEY:-}" ]]; then
   echo "Using dummy STRIPE_TEST_KEY" >&2
   export STRIPE_TEST_KEY="sk_test_dummy_$(date +%s)"
 fi
-: "${HF_TOKEN:?HF_TOKEN must be set}"
+: "${HF_TOKEN:=${HF_API_KEY:-}}"
+: "${HF_TOKEN:?HF_TOKEN must be set (HF_API_KEY also accepted)}"
 : "${AWS_ACCESS_KEY_ID:?AWS_ACCESS_KEY_ID must be set}"
 : "${AWS_SECRET_ACCESS_KEY:?AWS_SECRET_ACCESS_KEY must be set}"
 

--- a/tests/envVars.test.js
+++ b/tests/envVars.test.js
@@ -1,4 +1,5 @@
-const requiredVars = ["HF_TOKEN", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"];
+const requiredVars = ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"];
+const tokenVars = ["HF_TOKEN", "HF_API_KEY"];
 
 describe("required environment variables", () => {
   for (const name of requiredVars) {
@@ -7,4 +8,8 @@ describe("required environment variables", () => {
       expect(process.env[name]).not.toBe("");
     });
   }
+  test("HF_TOKEN or HF_API_KEY is defined", () => {
+    const defined = tokenVars.some((v) => process.env[v]);
+    expect(defined).toBe(true);
+  });
 });

--- a/tests/validateEnv.test.js
+++ b/tests/validateEnv.test.js
@@ -39,4 +39,15 @@ describe("validate-env script", () => {
     };
     expect(() => run(env)).toThrow();
   });
+
+  test("fails when HF_TOKEN missing", () => {
+    const env = {
+      ...process.env,
+      STRIPE_TEST_KEY: "sk_test",
+      npm_config_http_proxy: "",
+      npm_config_https_proxy: "",
+    };
+    delete env.HF_TOKEN;
+    expect(() => run(env)).toThrow();
+  });
 });


### PR DESCRIPTION
## Summary
- clarify required environment variables in AGENTS.md
- document HF_TOKEN in `.env.example`
- allow `HF_API_KEY` fallback in `validate-env.sh`
- check for token in `envVars.test.js`
- ensure `validateEnv.test.js` fails when HF_TOKEN missing

## Testing
- `npm run format --prefix backend`
- `SKIP_NET_CHECKS=1 npm test --prefix backend --silent | head -n 20`
- `SKIP_PW_DEPS=1 npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_687281829b30832dae0972a2c63d063c