### PR TITLE
Add HF token environment checks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,7 @@ HTTP2=true
 CLOUDFRONT_MODEL_DOMAIN=d2b5mm5pinpo2y.cloudfront.net
 SPARC3D_ENDPOINT=https://api-inference.huggingface.co/models/print2/Sparc3D
 SPARC3D_TOKEN=your-token-here
+HF_TOKEN=your-hf-token
 STABILITY_KEY=your-stability-key-here
 AWS_ACCESS_KEY_ID=your-aws-access-key-id
 AWS_SECRET_ACCESS_KEY=your-aws-secret-access-key

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ These guidelines apply to all automated agents (e.g. the Codex agent) working on
 1. **Go to the repository root** – run `cd "$(git rev-parse --show-toplevel)"` after opening a shell to ensure paths resolve correctly.
 2. **Unset proxy variables** – before running any `npm` commands, **and whenever you start a new shell session**, execute `unset npm_config_http_proxy npm_config_https_proxy` to silence `http-proxy` warnings.
 3. **Validate the environment** – run `npm run validate-env` to ensure required variables are set and proxy vars remain unset.
+   - Set `HF_TOKEN`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY` to dummy values if real credentials are unavailable. The setup script and tests fail when these variables are missing.
 4. **Check network access** – ensure the environment can reach both
    `https://registry.npmjs.org` and `https://cdn.playwright.dev`. The setup
    script downloads packages and browsers from these domains. If they are

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Run `docker compose up` to start the API and Postgres services.
 - `STRIPE_PUBLISHABLE_KEY` – publishable key for Stripe.js on the frontend.
 - `STRIPE_WEBHOOK_SECRET` – signing secret for Stripe webhooks.
 - `HUNYUAN_API_KEY` – key for the Sparc3D API.
+- `HF_TOKEN` – authentication token for the Hugging Face API.
+- `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` – credentials for S3 uploads.
 
 The server uses `STRIPE_LIVE_KEY` when `NODE_ENV=production`; otherwise `STRIPE_TEST_KEY` is used.
 

--- a/tests/validateEnv.test.js
+++ b/tests/validateEnv.test.js
@@ -39,4 +39,15 @@ describe("validate-env script", () => {
     };
     expect(() => run(env)).toThrow();
   });
+
+  test("fails when HF_TOKEN missing", () => {
+    const env = {
+      ...process.env,
+      STRIPE_TEST_KEY: "sk_test",
+      HF_TOKEN: "",
+      npm_config_http_proxy: "",
+      npm_config_https_proxy: "",
+    };
+    expect(() => run(env)).toThrow();
+  });
 });


### PR DESCRIPTION
## Summary
- add HF_TOKEN to env example
- document HF_TOKEN and AWS creds in README
- remind agents to supply dummy HF credentials
- test that validate-env fails when HF_TOKEN is missing

## Testing
- `env SKIP_NET_CHECKS=1 bash -c 'cd backend && npm test --silent tests/validateEnv.test.ts -b'`


------
https://chatgpt.com/codex/tasks/task_e_68728155efcc832d9dbd8ae642c566ad