### PR TITLE
fix: allow setup without env vars

### DIFF
--- a/backend/tests/envValidation.test.js
+++ b/backend/tests/envValidation.test.js
@@ -69,4 +69,24 @@ describe("validate-env script", () => {
       }),
     ).toThrow();
   });
+
+  test("passes without HF_TOKEN or AWS creds", () => {
+    expect(() =>
+      execSync(`bash ${script}`, {
+        env: {
+          ...process.env,
+          STRIPE_TEST_KEY: "sk_test",
+          HF_TOKEN: "",
+          AWS_ACCESS_KEY_ID: "",
+          AWS_SECRET_ACCESS_KEY: "",
+          SKIP_NET_CHECKS: "1",
+          http_proxy: "",
+          https_proxy: "",
+          npm_config_http_proxy: "",
+          npm_config_https_proxy: "",
+        },
+        stdio: "pipe",
+      }),
+    ).not.toThrow();
+  });
 });

--- a/scripts/assert-setup.js
+++ b/scripts/assert-setup.js
@@ -15,8 +15,9 @@ if (currentMajor < requiredMajor) {
 const requiredEnv = ["HF_TOKEN", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"];
 for (const name of requiredEnv) {
   if (!process.env[name]) {
-    console.error(`Environment variable ${name} must be set`);
-    process.exit(1);
+    console.warn(`Using dummy ${name}`);
+    const value = `${name.toLowerCase()}_dummy_${Date.now()}`;
+    process.env[name] = value;
   }
 }
 

--- a/scripts/validate-env.sh
+++ b/scripts/validate-env.sh
@@ -11,9 +11,21 @@ if [[ -z "${STRIPE_TEST_KEY:-}" && -z "${STRIPE_LIVE_KEY:-}" ]]; then
   echo "Using dummy STRIPE_TEST_KEY" >&2
   export STRIPE_TEST_KEY="sk_test_dummy_$(date +%s)"
 fi
-: "${HF_TOKEN:?HF_TOKEN must be set}"
-: "${AWS_ACCESS_KEY_ID:?AWS_ACCESS_KEY_ID must be set}"
-: "${AWS_SECRET_ACCESS_KEY:?AWS_SECRET_ACCESS_KEY must be set}"
+
+if [[ -z "${HF_TOKEN:-}" ]]; then
+  echo "Using dummy HF_TOKEN" >&2
+  export HF_TOKEN="hf_dummy_$(date +%s)"
+fi
+
+if [[ -z "${AWS_ACCESS_KEY_ID:-}" ]]; then
+  echo "Using dummy AWS_ACCESS_KEY_ID" >&2
+  export AWS_ACCESS_KEY_ID="dummy_id"
+fi
+
+if [[ -z "${AWS_SECRET_ACCESS_KEY:-}" ]]; then
+  echo "Using dummy AWS_SECRET_ACCESS_KEY" >&2
+  export AWS_SECRET_ACCESS_KEY="dummy_secret"
+fi
 
 
 # Fail fast if npm-specific proxy variables are set. Other proxy variables may


### PR DESCRIPTION
## Summary
- provide dummy env vars for HF_TOKEN and AWS creds
- fall back to dummy vars in assert-setup.js
- test validate-env works without creds

## Testing
- `npx prettier -w scripts/assert-setup.js backend/tests/envValidation.test.js`
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_68728148c518832d900f10e668953263