### PR TITLE
Improve smoke setup diagnostics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,7 @@ HTTP2=true
 CLOUDFRONT_MODEL_DOMAIN=d2b5mm5pinpo2y.cloudfront.net
 SPARC3D_ENDPOINT=https://api-inference.huggingface.co/models/print2/Sparc3D
 SPARC3D_TOKEN=your-token-here
+HF_TOKEN=your-hf-token
 STABILITY_KEY=your-stability-key-here
 AWS_ACCESS_KEY_ID=your-aws-access-key-id
 AWS_SECRET_ACCESS_KEY=your-aws-secret-access-key

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Run `docker compose up` to start the API and Postgres services.
 - `STRIPE_PUBLISHABLE_KEY` – publishable key for Stripe.js on the frontend.
 - `STRIPE_WEBHOOK_SECRET` – signing secret for Stripe webhooks.
 - `HUNYUAN_API_KEY` – key for the Sparc3D API.
+- `HF_TOKEN` – token for Hugging Face API access.
+- `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` – credentials for S3 uploads.
 
 The server uses `STRIPE_LIVE_KEY` when `NODE_ENV=production`; otherwise `STRIPE_TEST_KEY` is used.
 

--- a/scripts/run-smoke.js
+++ b/scripts/run-smoke.js
@@ -2,6 +2,16 @@
 const { execSync } = require("child_process");
 const env = { ...process.env };
 
+const required = ["HF_TOKEN", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"];
+for (const name of required) {
+  if (!env[name]) {
+    console.error(
+      `Environment variable ${name} must be set. Run 'npm run validate-env' to verify your configuration.`,
+    );
+    process.exit(1);
+  }
+}
+
 function run(cmd) {
   execSync(cmd, { stdio: "inherit", env });
 }

--- a/tests/smokeScript.test.js
+++ b/tests/smokeScript.test.js
@@ -13,5 +13,7 @@ describe("smoke script", () => {
       "utf8",
     );
     expect(/SKIP_PW_DEPS/.test(content)).toBe(true);
+    expect(content).toMatch(/HF_TOKEN/);
+    expect(content).toMatch(/validate-env/);
   });
 });


### PR DESCRIPTION
## Summary
- verify required env vars in `run-smoke.js`
- document additional env vars in README
- show `HF_TOKEN` example in `.env.example`
- test for new checks in smoke script

## Testing
- `npm run format --prefix backend`
- `CI=1 SKIP_NET_CHECKS=1 SKIP_PW_DEPS=1 npm run test:ci --silent`
- `SKIP_PW_DEPS=1 npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_6872810d21d0832d803eba7abe25597d