### PR TITLE
Add Node version check to validate script

### DIFF
--- a/backend/tests/nodeVersion.test.js
+++ b/backend/tests/nodeVersion.test.js
@@ -1,0 +1,26 @@
+const fs = require("fs");
+const path = require("path");
+
+const root = path.resolve(__dirname, "..", "..");
+
+describe("node version", () => {
+  test("runtime is >=20", () => {
+    const major = parseInt(process.versions.node.split(".")[0], 10);
+    expect(major).toBeGreaterThanOrEqual(20);
+  });
+
+  test("root package.json engines field is >=20", () => {
+    const pkg = require(path.join(root, "package.json"));
+    expect(pkg.engines.node).toBe(">=20");
+  });
+
+  test("backend package.json engines field is >=20", () => {
+    const pkg = require(path.join(root, "backend", "package.json"));
+    expect(pkg.engines.node).toBe(">=20");
+  });
+
+  test(".nvmrc specifies Node 20", () => {
+    const version = fs.readFileSync(path.join(root, ".nvmrc"), "utf8").trim();
+    expect(version.replace(/^v/, "")).toMatch(/^20/);
+  });
+});

--- a/backend/tests/validateEnv.test.ts
+++ b/backend/tests/validateEnv.test.ts
@@ -20,7 +20,13 @@ function run(env, clean = true) {
 
 describe("validate-env script", () => {
   test("succeeds when required vars set and proxies unset", () => {
-    const output = run({ STRIPE_TEST_KEY: "test", HF_TOKEN: "token" });
+    const output = run({
+      STRIPE_TEST_KEY: "test",
+      HF_TOKEN: "token",
+      AWS_ACCESS_KEY_ID: "id",
+      AWS_SECRET_ACCESS_KEY: "secret",
+      SKIP_NET_CHECKS: "1",
+    });
     expect(output).toContain("environment OK");
   });
 
@@ -30,6 +36,9 @@ describe("validate-env script", () => {
         {
           STRIPE_TEST_KEY: "test",
           HF_TOKEN: "token",
+          AWS_ACCESS_KEY_ID: "id",
+          AWS_SECRET_ACCESS_KEY: "secret",
+          SKIP_NET_CHECKS: "1",
           npm_config_http_proxy: "http://proxy",
         },
         false,

--- a/scripts/validate-env.sh
+++ b/scripts/validate-env.sh
@@ -7,6 +7,14 @@ mise settings add idiomatic_version_file_enable_tools node --yes >/dev/null 2>&1
 if [ -f .mise.toml ]; then
   mise trust .mise.toml >/dev/null 2>&1 || true
 fi
+
+# Enforce Node.js version 20 or newer
+required_major=20
+current_major=$(node -v | sed 's/^v//' | cut -d. -f1)
+if [ "$current_major" -lt "$required_major" ]; then
+  echo "Node $required_major or newer is required. Current version: $(node -v)" >&2
+  exit 1
+fi
 if [[ -z "${STRIPE_TEST_KEY:-}" && -z "${STRIPE_LIVE_KEY:-}" ]]; then
   echo "Using dummy STRIPE_TEST_KEY" >&2
   export STRIPE_TEST_KEY="sk_test_dummy_$(date +%s)"

--- a/tests/validateEnv.test.js
+++ b/tests/validateEnv.test.js
@@ -18,6 +18,9 @@ describe("validate-env script", () => {
     const env = {
       ...process.env,
       HF_TOKEN: "test",
+      AWS_ACCESS_KEY_ID: "id",
+      AWS_SECRET_ACCESS_KEY: "secret",
+      SKIP_NET_CHECKS: "1",
       STRIPE_TEST_KEY: "",
       STRIPE_LIVE_KEY: "",
       npm_config_http_proxy: "",
@@ -34,6 +37,9 @@ describe("validate-env script", () => {
     const env = {
       ...process.env,
       HF_TOKEN: "test",
+      AWS_ACCESS_KEY_ID: "id",
+      AWS_SECRET_ACCESS_KEY: "secret",
+      SKIP_NET_CHECKS: "1",
       STRIPE_TEST_KEY: "sk_test",
       npm_config_http_proxy: "http://proxy",
     };


### PR DESCRIPTION
## Summary
- enforce Node 20+ in `validate-env.sh`
- skip network checks in environment tests
- add backend test to verify Node version requirements

## Testing
- `npm test --prefix backend --silent -- --runTestsByPath tests/validateEnv.test.ts tests/nodeVersion.test.js --json --outputFile=/tmp/jest.json`


------
https://chatgpt.com/codex/tasks/task_e_6872810285d8832db7c7cea9c621aab1