### PR TITLE
Add network checks for backend setup

### DIFF
--- a/backend/scripts/ensure-deps.js
+++ b/backend/scripts/ensure-deps.js
@@ -1,7 +1,27 @@
 const fs = require("fs");
+const path = require("path");
 const { execSync } = require("child_process");
 
 const jestPath = "node_modules/.bin/jest";
+
+const networkCheck = path.join(
+  __dirname,
+  "..",
+  "..",
+  "scripts",
+  "network-check.js",
+);
+
+function runNetworkCheck() {
+  try {
+    execSync(`node ${networkCheck}`, { stdio: "inherit" });
+  } catch {
+    console.error(
+      "Network check failed. Ensure access to the npm registry and Playwright CDN.",
+    );
+    process.exit(1);
+  }
+}
 
 function canReachRegistry() {
   try {
@@ -16,6 +36,7 @@ function canReachRegistry() {
 }
 
 if (!fs.existsSync(jestPath)) {
+  runNetworkCheck();
   if (!canReachRegistry()) process.exit(1);
   console.log("Jest not found. Installing backend dependencies...");
   try {

--- a/scripts/assert-setup.js
+++ b/scripts/assert-setup.js
@@ -20,6 +20,15 @@ for (const name of requiredEnv) {
   }
 }
 
+try {
+  require("child_process").execSync("node scripts/network-check.js", {
+    stdio: "inherit",
+  });
+} catch (err) {
+  console.error("Network check failed:", err.message);
+  process.exit(1);
+}
+
 function browsersInstalled() {
   const envPath = process.env.PLAYWRIGHT_BROWSERS_PATH;
   const defaultPath = path.join(os.homedir(), ".cache", "ms-playwright");

--- a/tests/ensureDeps.test.js
+++ b/tests/ensureDeps.test.js
@@ -10,13 +10,20 @@ describe("ensure-deps", () => {
     fs.existsSync.mockReset();
     child_process.execSync.mockReset();
   });
-  test("pings npm registry before installing", () => {
+  test("checks network then installs", () => {
     fs.existsSync.mockReturnValue(false);
     const execMock = jest.fn();
     child_process.execSync.mockImplementation(execMock);
     require("../backend/scripts/ensure-deps");
-    expect(execMock).toHaveBeenCalledWith("npm ping", { stdio: "ignore" });
-    expect(execMock).toHaveBeenCalledWith("npm ci", { stdio: "inherit" });
+    expect(execMock).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining("network-check.js"),
+      expect.any(Object),
+    );
+    expect(execMock).toHaveBeenNthCalledWith(2, "npm ping", {
+      stdio: "ignore",
+    });
+    expect(execMock).toHaveBeenNthCalledWith(4, "npm ci", { stdio: "inherit" });
   });
 
   test("exits when npm ping fails", () => {

--- a/tests/networkCheckScriptFailure.test.js
+++ b/tests/networkCheckScriptFailure.test.js
@@ -1,0 +1,19 @@
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+describe("network-check failure", () => {
+  test("exits when curl fails", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "curl-"));
+    const fakeCurl = path.join(tmp, "curl");
+    fs.writeFileSync(fakeCurl, "#!/bin/sh\nexit 1");
+    fs.chmodSync(fakeCurl, 0o755);
+    expect(() => {
+      execFileSync("node", [path.join("scripts", "network-check.js")], {
+        env: { ...process.env, PATH: `${tmp}:${process.env.PATH}` },
+        encoding: "utf8",
+      });
+    }).toThrow(/Unable to reach/);
+  });
+});


### PR DESCRIPTION
## Summary
- run a network check before installing backend dependencies
- verify connectivity in assert-setup
- update ensure-deps tests
- add failure test for network-check script

## Testing
- `SKIP_NET_CHECKS=1 npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_687280f7da54832dafdfb55efd89453b