### PR TITLE
Add Prettier dependency checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ column of the `jobs` table.
 ## Contributing
 
 We welcome pull requests! Please fork the repo and create a topic branch. Run
-`npm ci` inside `backend/` to install dependencies, then ensure `npm test` runs
+`npm run setup` in the repository root to install all dependencies, then ensure `npm test` runs
 clean before submitting.
 Run `npm run test-ci` for the same tests using a single process, which matches the CI configuration.
 Run `npm run format` in `backend/` to apply Prettier formatting before committing.
@@ -302,7 +302,7 @@ We sometimes rely on automated agents (such as the Codex agent) to make small
 changes. Agents must follow the steps in [AGENTS.md](AGENTS.md) before opening a
 pull request:
 
-1. Install dependencies with `npm ci` inside `backend/`.
+1. Install dependencies with `npm run setup` in the repository root.
 2. Run `npm run format` in `backend/`.
 3. Run `npm test` in `backend/` and include the results in the PR description.
 

--- a/tests/dependency.test.js
+++ b/tests/dependency.test.js
@@ -20,6 +20,23 @@ describe("environment", () => {
     expect(fs.existsSync(bin)).toBe(true);
   });
 
+  test("prettier binary installed", () => {
+    const bin = path.join(__dirname, "..", "node_modules", ".bin", "prettier");
+    expect(fs.existsSync(bin)).toBe(true);
+  });
+
+  test("backend prettier binary installed", () => {
+    const bin = path.join(
+      __dirname,
+      "..",
+      "backend",
+      "node_modules",
+      ".bin",
+      "prettier",
+    );
+    expect(fs.existsSync(bin)).toBe(true);
+  });
+
   test("setup script has been run", () => {
     const flag = path.join(__dirname, "..", ".setup-complete");
     expect(fs.existsSync(flag)).toBe(true);


### PR DESCRIPTION
## Summary
- document using `npm run setup` before contributing
- ensure Prettier binaries exist for both root and backend

## Testing
- `npm run format` in `backend`
- `node scripts/run-jest.js tests/dependency.test.js`

------
https://chatgpt.com/codex/tasks/task_e_687280ed3590832d9eb87611fa012e02