### PR TITLE
Add run-jest integration test

### DIFF
--- a/backend/tests/runJestScript.test.js
+++ b/backend/tests/runJestScript.test.js
@@ -15,7 +15,7 @@ test("uses backend jest when installed", () => {
   runJest(["--version"]);
   expect(child_process.execSync).toHaveBeenCalledWith(
     expect.stringContaining("backend/node_modules/.bin/jest"),
-    { stdio: "inherit" },
+    expect.objectContaining({ stdio: "inherit" }),
   );
 });
 
@@ -24,6 +24,6 @@ test("falls back to npm test when jest missing", () => {
   runJest(["--help"]);
   expect(child_process.execSync).toHaveBeenCalledWith(
     expect.stringContaining("npm test --prefix backend"),
-    { stdio: "inherit" },
+    expect.objectContaining({ stdio: "inherit" }),
   );
 });

--- a/tests/runJestIntegration.test.js
+++ b/tests/runJestIntegration.test.js
@@ -1,0 +1,22 @@
+const { execFileSync } = require("child_process");
+const path = require("path");
+
+test("run-jest runs root env tests", () => {
+  const script = path.join("scripts", "run-jest.js");
+  const env = {
+    ...process.env,
+    HF_TOKEN: "test",
+    AWS_ACCESS_KEY_ID: "id",
+    AWS_SECRET_ACCESS_KEY: "secret",
+    SKIP_NET_CHECKS: "1",
+  };
+  delete env.npm_config_http_proxy;
+  delete env.npm_config_https_proxy;
+  expect(() =>
+    execFileSync(
+      "node",
+      [script, "tests/validateEnv.test.js", "tests/proxyUnset.test.js"],
+      { stdio: "inherit", env },
+    ),
+  ).not.toThrow();
+});


### PR DESCRIPTION
## Summary
- support running tests from repo root in `run-jest`
- cover `run-jest` with an integration test
- update `runJestScript` test expectations

## Testing
- `SKIP_NET_CHECKS=1 SKIP_PW_DEPS=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_687280d86654832d87200143258075d2