### PR TITLE
Add network-check before Playwright install

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -100,6 +100,12 @@ cleanup_npm_cache
 # Ensure dpkg is fully configured before Playwright installs dependencies
 sudo dpkg --configure -a || true
 
+# Verify network connectivity again before downloading Playwright browsers
+if ! node scripts/network-check.js >/dev/null 2>&1; then
+  echo "Network check failed. Ensure access to the npm registry and Playwright CDN." >&2
+  exit 1
+fi
+
 if [ -z "$SKIP_PW_DEPS" ]; then
   CI=1 npx playwright install --with-deps
 else

--- a/tests/setupScript.test.js
+++ b/tests/setupScript.test.js
@@ -1,0 +1,15 @@
+const fs = require("fs");
+const path = require("path");
+
+describe("setup script", () => {
+  test("calls network-check before installing Playwright", () => {
+    const content = fs.readFileSync(
+      path.join(__dirname, "..", "scripts", "setup.sh"),
+      "utf8",
+    );
+    const networkIdx = content.indexOf("node scripts/network-check.js");
+    const installIdx = content.indexOf("npx playwright install");
+    expect(networkIdx).toBeGreaterThanOrEqual(0);
+    expect(installIdx).toBeGreaterThan(networkIdx);
+  });
+});


### PR DESCRIPTION
## Summary
- verify external connectivity again in `scripts/setup.sh`
- test that the setup script runs the network check before installing Playwright

## Testing
- `SKIP_NET_CHECKS=1 HF_TOKEN=test AWS_ACCESS_KEY_ID=id AWS_SECRET_ACCESS_KEY=secret npm test`
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_687280cd6470832db0276aafde9cd9dd