### PR TITLE
Improve network diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Run `docker compose up` to start the API and Postgres services.
 ## Local Setup
 
 1. Copy `.env.example` to `.env` in the repository root and update the values:
-
    - `DB_URL` – connection string for your PostgreSQL database.
 
 - `STRIPE_TEST_KEY` – test secret key for Stripe.
@@ -67,6 +66,7 @@ The server uses `STRIPE_LIVE_KEY` when `NODE_ENV=production`; otherwise `STRIPE_
    If `npm ci` fails with an `EUSAGE` error complaining about missing lock file entries,
    run `npm install` in the affected directory and re-run this setup step.
    Ensure your environment can reach `https://registry.npmjs.org` and `https://cdn.playwright.dev`. The setup script downloads packages and browsers from these domains, so network restrictions may cause it to fail.
+   Run `npm run net:check` to verify connectivity before running the setup script.
 
 3. Initialize the database:
 

--- a/scripts/network-check.js
+++ b/scripts/network-check.js
@@ -1,14 +1,27 @@
 #!/usr/bin/env node
-const { execSync } = require('child_process');
+const { execSync } = require("child_process");
 
-const targets = [
-  { url: 'https://registry.npmjs.org', name: 'npm registry' },
-  { url: 'https://cdn.playwright.dev', name: 'Playwright CDN' },
+const defaultTargets = [
+  { url: "https://registry.npmjs.org", name: "npm registry" },
+  { url: "https://cdn.playwright.dev", name: "Playwright CDN" },
 ];
+
+let targets;
+try {
+  targets = process.env.NETWORK_CHECK_TARGETS
+    ? JSON.parse(process.env.NETWORK_CHECK_TARGETS)
+    : defaultTargets;
+} catch {
+  console.error("Invalid NETWORK_CHECK_TARGETS value");
+  process.exit(1);
+}
 
 function check(url) {
   try {
-    execSync(`curl -sI --max-time 10 ${url}`, { stdio: 'ignore' });
+    execSync(`curl -sI --max-time 10 ${url}`, {
+      stdio: "ignore",
+      env: { ...process.env, http_proxy: "", https_proxy: "" },
+    });
     return true;
   } catch {
     return false;
@@ -21,4 +34,4 @@ for (const { url, name } of targets) {
     process.exit(1);
   }
 }
-console.log('✅ network OK');
+console.log("✅ network OK");

--- a/tests/networkCheckScript.test.js
+++ b/tests/networkCheckScript.test.js
@@ -1,9 +1,25 @@
-const { execFileSync } = require('child_process');
-const path = require('path');
+const { execFileSync } = require("child_process");
+const path = require("path");
 
-describe('network-check script', () => {
-  test('reports network OK', () => {
-    const out = execFileSync('node', [path.join('scripts', 'network-check.js')], { encoding: 'utf8' });
-    expect(out).toContain('✅ network OK');
+describe("network-check script", () => {
+  test("reports network OK", () => {
+    const out = execFileSync(
+      "node",
+      [path.join("scripts", "network-check.js")],
+      { encoding: "utf8" },
+    );
+    expect(out).toContain("✅ network OK");
+  });
+
+  test("fails when target unreachable", () => {
+    const env = {
+      ...process.env,
+      NETWORK_CHECK_TARGETS: JSON.stringify([
+        { url: "http://invalid.invalid", name: "bad" },
+      ]),
+    };
+    expect(() =>
+      execFileSync("node", [path.join("scripts", "network-check.js")], { env }),
+    ).toThrow();
   });
 });


### PR DESCRIPTION
## Summary
- support custom NETWORK_CHECK_TARGETS in `network-check.js`
- clear proxy vars in the script
- add failing case test for the network check
- mention `npm run net:check` in README

## Testing
- `npx prettier -w scripts/network-check.js tests/networkCheckScript.test.js README.md`
- `SKIP_NET_CHECKS=1 AWS_ACCESS_KEY_ID=dummy AWS_SECRET_ACCESS_KEY=dummy HF_TOKEN=test npm test --silent`
- `SKIP_NET_CHECKS=1 SKIP_PW_DEPS=1 HF_TOKEN=dummy AWS_ACCESS_KEY_ID=dummy AWS_SECRET_ACCESS_KEY=dummy npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_687280cbfa74832db3427ed70b989df9