### PR TITLE
Improve environment network diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,10 +8,12 @@ These guidelines apply to all automated agents (e.g. the Codex agent) working on
 1. **Go to the repository root** – run `cd "$(git rev-parse --show-toplevel)"` after opening a shell to ensure paths resolve correctly.
 2. **Unset proxy variables** – before running any `npm` commands, **and whenever you start a new shell session**, execute `unset npm_config_http_proxy npm_config_https_proxy` to silence `http-proxy` warnings.
 3. **Validate the environment** – run `npm run validate-env` to ensure required variables are set and proxy vars remain unset.
-4. **Check network access** – ensure the environment can reach both
-   `https://registry.npmjs.org` and `https://cdn.playwright.dev`. The setup
-   script downloads packages and browsers from these domains. If they are
-   blocked, adjust your environment or proxy settings.
+4. **Check network access** – run `node scripts/network-check.js` to verify
+   connectivity to `https://registry.npmjs.org` and
+   `https://cdn.playwright.dev`. The setup script downloads packages and
+   browsers from these domains. If they are blocked, adjust your environment
+   or proxy settings. Override the default URLs by setting `NPM_REGISTRY_URL`,
+   `PLAYWRIGHT_CDN_URL`, or adjust `NETWORK_CHECK_TIMEOUT` for debugging.
 5. **Install dependencies** – run `npm run setup` at the repository root **before your first `npm run ci`**. Run it again whenever the container is restarted or if Playwright tests fail with messages like "Test was interrupted" or "page.evaluate: Test ended". This script unsets proxy variables, checks registry connectivity, runs `npm ci` in the root and `backend/`, and installs Playwright browsers.
    - If `npm ci` fails with an `EUSAGE` error complaining that packages are missing from the lock file, run `npm install` in the affected directory and then re-run the setup script.
    - Set `SKIP_PW_DEPS=1` before running the setup script if Playwright dependencies are already installed. This skips the long `apt-get` step and reduces CI time. The `smoke` script also runs the setup script, so use `SKIP_PW_DEPS=1 npm run smoke` to avoid reinstalling Playwright dependencies when they are already present.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The server uses `STRIPE_LIVE_KEY` when `NODE_ENV=production`; otherwise `STRIPE_
    are missing, run `npx husky install` manually.
    If `npm ci` fails with an `EUSAGE` error complaining about missing lock file entries,
    run `npm install` in the affected directory and re-run this setup step.
-   Ensure your environment can reach `https://registry.npmjs.org` and `https://cdn.playwright.dev`. The setup script downloads packages and browsers from these domains, so network restrictions may cause it to fail.
+  Ensure your environment can reach `https://registry.npmjs.org` and `https://cdn.playwright.dev`. Run `node scripts/network-check.js` to verify connectivity. The setup script downloads packages and browsers from these domains, so network restrictions may cause it to fail.
 
 3. Initialize the database:
 

--- a/backend/tests/validateEnv.test.ts
+++ b/backend/tests/validateEnv.test.ts
@@ -13,7 +13,12 @@ function run(env, clean = true) {
   }
   return execSync("npm run validate-env", {
     cwd: root,
-    env: e,
+    env: {
+      AWS_ACCESS_KEY_ID: "test",
+      AWS_SECRET_ACCESS_KEY: "test",
+      ...e,
+      SKIP_NET_CHECKS: "1",
+    },
     stdio: "pipe",
   }).toString();
 }

--- a/scripts/network-check.js
+++ b/scripts/network-check.js
@@ -1,14 +1,22 @@
 #!/usr/bin/env node
-const { execSync } = require('child_process');
+const { execSync } = require("child_process");
 
 const targets = [
-  { url: 'https://registry.npmjs.org', name: 'npm registry' },
-  { url: 'https://cdn.playwright.dev', name: 'Playwright CDN' },
+  {
+    url: process.env.NPM_REGISTRY_URL || "https://registry.npmjs.org",
+    name: "npm registry",
+  },
+  {
+    url: process.env.PLAYWRIGHT_CDN_URL || "https://cdn.playwright.dev",
+    name: "Playwright CDN",
+  },
 ];
+
+const timeout = parseInt(process.env.NETWORK_CHECK_TIMEOUT, 10) || 10;
 
 function check(url) {
   try {
-    execSync(`curl -sI --max-time 10 ${url}`, { stdio: 'ignore' });
+    execSync(`curl -sI --max-time ${timeout} ${url}`, { stdio: "ignore" });
     return true;
   } catch {
     return false;
@@ -17,8 +25,11 @@ function check(url) {
 
 for (const { url, name } of targets) {
   if (!check(url)) {
-    console.error(`Unable to reach ${name}: ${url}`);
+    console.error(
+      `Unable to reach ${name}: ${url}\n` +
+        "Check proxy and firewall settings or set SKIP_NET_CHECKS=1 if connectivity is intentionally blocked.",
+    );
     process.exit(1);
   }
 }
-console.log('✅ network OK');
+console.log("✅ network OK");

--- a/tests/networkCheckScript.test.js
+++ b/tests/networkCheckScript.test.js
@@ -1,9 +1,27 @@
-const { execFileSync } = require('child_process');
-const path = require('path');
+const { execFileSync } = require("child_process");
+const path = require("path");
 
-describe('network-check script', () => {
-  test('reports network OK', () => {
-    const out = execFileSync('node', [path.join('scripts', 'network-check.js')], { encoding: 'utf8' });
-    expect(out).toContain('✅ network OK');
+describe("network-check script", () => {
+  test("reports network OK", () => {
+    const out = execFileSync(
+      "node",
+      [path.join("scripts", "network-check.js")],
+      { encoding: "utf8" },
+    );
+    expect(out).toContain("✅ network OK");
+  });
+
+  test("fails when a target is unreachable", () => {
+    const env = {
+      ...process.env,
+      PLAYWRIGHT_CDN_URL: "http://192.0.2.1",
+      NETWORK_CHECK_TIMEOUT: "1",
+    };
+    expect(() =>
+      execFileSync("node", [path.join("scripts", "network-check.js")], {
+        env,
+        encoding: "utf8",
+      }),
+    ).toThrow();
   });
 });

--- a/tests/validateEnv.test.js
+++ b/tests/validateEnv.test.js
@@ -8,7 +8,12 @@ const { execFileSync } = require("child_process");
  */
 function run(env) {
   return execFileSync("bash", ["scripts/validate-env.sh"], {
-    env,
+    env: {
+      AWS_ACCESS_KEY_ID: "test",
+      AWS_SECRET_ACCESS_KEY: "test",
+      ...env,
+      SKIP_NET_CHECKS: "1",
+    },
     encoding: "utf8",
   });
 }


### PR DESCRIPTION
## Summary
- add config overrides and better messaging for `network-check.js`
- skip network checks in validate-env tests
- add failing network target test
- document the new network-check workflow

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687280c41984832d8df6255afae6b713