### PR TITLE
Improve network diagnostic tests

### DIFF
--- a/scripts/network-check.js
+++ b/scripts/network-check.js
@@ -1,14 +1,20 @@
 #!/usr/bin/env node
-const { execSync } = require('child_process');
+const { execSync } = require("child_process");
 
-const targets = [
-  { url: 'https://registry.npmjs.org', name: 'npm registry' },
-  { url: 'https://cdn.playwright.dev', name: 'Playwright CDN' },
+const defaultTargets = [
+  { url: "https://registry.npmjs.org", name: "npm registry" },
+  { url: "https://cdn.playwright.dev", name: "Playwright CDN" },
 ];
+
+const envTargets = process.env.NET_CHECK_URLS
+  ? process.env.NET_CHECK_URLS.split(",").map((url) => ({ url, name: url }))
+  : null;
+
+const targets = envTargets || defaultTargets;
 
 function check(url) {
   try {
-    execSync(`curl -sI --max-time 10 ${url}`, { stdio: 'ignore' });
+    execSync(`curl -sI --max-time 10 ${url}`, { stdio: "ignore" });
     return true;
   } catch {
     return false;
@@ -21,4 +27,4 @@ for (const { url, name } of targets) {
     process.exit(1);
   }
 }
-console.log('✅ network OK');
+console.log("✅ network OK");

--- a/scripts/run-smoke.js
+++ b/scripts/run-smoke.js
@@ -3,7 +3,16 @@ const { execSync } = require("child_process");
 const env = { ...process.env };
 
 function run(cmd) {
-  execSync(cmd, { stdio: "inherit", env });
+  try {
+    execSync(cmd, { stdio: "inherit", env });
+  } catch (err) {
+    if (cmd === "npm run setup") {
+      console.error(
+        'setup failed. Run "npm run net:check" to verify network connectivity.',
+      );
+    }
+    process.exit(err.status || 1);
+  }
 }
 
 run("npm run setup");

--- a/tests/networkCheckScriptFail.test.js
+++ b/tests/networkCheckScriptFail.test.js
@@ -1,0 +1,23 @@
+const { execFileSync } = require("child_process");
+const path = require("path");
+
+describe("network-check script failure", () => {
+  test("exits when target unreachable", () => {
+    expect(() => {
+      execFileSync("node", [path.join("scripts", "network-check.js")], {
+        env: {
+          ...process.env,
+          NET_CHECK_URLS: "http://127.0.0.1:9",
+          http_proxy: "",
+          https_proxy: "",
+          HTTP_PROXY: "",
+          HTTPS_PROXY: "",
+          npm_config_http_proxy: "",
+          npm_config_https_proxy: "",
+        },
+        encoding: "utf8",
+        stdio: "pipe",
+      });
+    }).toThrow(/Unable to reach/);
+  });
+});

--- a/tests/smokeScript.test.js
+++ b/tests/smokeScript.test.js
@@ -14,4 +14,12 @@ describe("smoke script", () => {
     );
     expect(/SKIP_PW_DEPS/.test(content)).toBe(true);
   });
+
+  test("run-smoke.js hints when setup fails", () => {
+    const content = fs.readFileSync(
+      path.join(__dirname, "..", "scripts", "run-smoke.js"),
+      "utf8",
+    );
+    expect(content).toMatch(/net:check/);
+  });
 });

--- a/tests/validateEnv.test.js
+++ b/tests/validateEnv.test.js
@@ -18,12 +18,15 @@ describe("validate-env script", () => {
     const env = {
       ...process.env,
       HF_TOKEN: "test",
+      AWS_ACCESS_KEY_ID: "id",
+      AWS_SECRET_ACCESS_KEY: "secret",
       STRIPE_TEST_KEY: "",
       STRIPE_LIVE_KEY: "",
       npm_config_http_proxy: "",
       npm_config_https_proxy: "",
       http_proxy: "http://proxy",
       https_proxy: "http://proxy",
+      SKIP_NET_CHECKS: "1",
     };
     const output = run(env);
     expect(output).toContain("✅ environment OK");
@@ -38,5 +41,22 @@ describe("validate-env script", () => {
       npm_config_http_proxy: "http://proxy",
     };
     expect(() => run(env)).toThrow();
+  });
+
+  test("fails when network unreachable", () => {
+    const env = {
+      ...process.env,
+      HF_TOKEN: "test",
+      AWS_ACCESS_KEY_ID: "id",
+      AWS_SECRET_ACCESS_KEY: "secret",
+      npm_config_http_proxy: "",
+      npm_config_https_proxy: "",
+      http_proxy: "",
+      https_proxy: "",
+      HTTP_PROXY: "",
+      HTTPS_PROXY: "",
+      NET_CHECK_URLS: "http://127.0.0.1:9",
+    };
+    expect(() => run(env)).toThrow(/Network check failed/);
   });
 });


### PR DESCRIPTION
## Summary
- expose `NET_CHECK_URLS` override in `network-check.js`
- surface a helpful hint when `npm run setup` fails
- test failure path for network checks
- ensure `validate-env` works when network is unreachable
- verify smoke script includes troubleshooting hint

## Testing
- `SKIP_NET_CHECKS=1 npm test` in `backend/`
- `AWS_ACCESS_KEY_ID=dummy AWS_SECRET_ACCESS_KEY=dummy node scripts/run-jest.js tests/networkCheckScriptFail.test.js tests/validateEnv.test.js tests/smokeScript.test.js`

------
https://chatgpt.com/codex/tasks/task_e_687280b54678832db40784717b1a7b32