### PR TITLE
Add setup script regression test

### DIFF
--- a/tests/setupScript.test.js
+++ b/tests/setupScript.test.js
@@ -1,0 +1,15 @@
+const fs = require("fs");
+const path = require("path");
+const { execSync } = require("child_process");
+
+describe("setup script", () => {
+  test("completes with SKIP_PW_DEPS=1", () => {
+    execSync("SKIP_PW_DEPS=1 SKIP_NET_CHECKS=1 bash scripts/setup.sh", {
+      stdio: "inherit",
+    });
+    const flag = path.join(__dirname, "..", ".setup-complete");
+    const jestBin = path.join(__dirname, "..", "node_modules", ".bin", "jest");
+    expect(fs.existsSync(flag)).toBe(true);
+    expect(fs.existsSync(jestBin)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add a regression test that runs the setup script with SKIP_PW_DEPS

## Testing
- `npm run format`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_687280aa567c832d92e6831187252d2e