### PR TITLE
Fix preserveColors and validate-env tests

### DIFF
--- a/backend/src/lib/preserveColors.js
+++ b/backend/src/lib/preserveColors.js
@@ -1,19 +1,19 @@
-const { NodeIO } = require('@gltf-transform/core');
+const { NodeIO } = require("@gltf-transform/core");
 
 async function preserveColors(glb) {
   const io = new NodeIO();
-  const doc = io.readBinary(glb);
+  const doc = await io.readBinary(glb);
   const root = doc.getRoot();
   for (const mesh of root.listMeshes()) {
     for (const prim of mesh.listPrimitives()) {
       const extras = prim.getExtras() || {};
-      if (!prim.getAttribute('COLOR_0')) {
+      if (!prim.getAttribute("COLOR_0")) {
         if (Array.isArray(extras.vertexColors)) {
           const accessor = doc
             .createAccessor()
-            .setType('VEC4')
+            .setType("VEC4")
             .setArray(new Float32Array(extras.vertexColors));
-          prim.setAttribute('COLOR_0', accessor);
+          prim.setAttribute("COLOR_0", accessor);
         } else if (Array.isArray(extras.flatColor)) {
           const mat = prim.getMaterial() || doc.createMaterial();
           mat.setBaseColorFactor(extras.flatColor);

--- a/backend/tests/preserveColors.test.ts
+++ b/backend/tests/preserveColors.test.ts
@@ -1,31 +1,33 @@
-const { preserveColors } = require('../src/lib/preserveColors.js');
-const { NodeIO, Document } = require('@gltf-transform/core');
+const { preserveColors } = require("../src/lib/preserveColors.js");
+const { NodeIO, Document } = require("@gltf-transform/core");
 
-describe('preserveColors', () => {
-  function makeGlb() {
+describe("preserveColors", () => {
+  async function makeGlb() {
     const doc = new Document();
-    const position = doc.createAccessor().setType('VEC3').setArray(new Float32Array([0,0,0,1,0,0,0,1,0]));
+    const buffer = doc.createBuffer();
+    const position = doc
+      .createAccessor()
+      .setType("VEC3")
+      .setArray(new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]));
     const prim = doc.createPrimitive();
-    prim.setAttribute('POSITION', position);
-    prim.setExtras({ vertexColors: [1,0,0,1,0,1,0,1,0,0,1,1] });
+    prim.setAttribute("POSITION", position);
+    prim.setExtras({ vertexColors: [1, 0, 0, 1, 0, 1, 0, 1, 0, 0, 1, 1] });
     const mesh = doc.createMesh().addPrimitive(prim);
-    doc.createNode('n').setMesh(mesh);
+    doc.createNode("n").setMesh(mesh);
     const io = new NodeIO();
-    return io.writeBinary(doc);
+    return await io.writeBinary(doc);
   }
 
-  test('promotes vertexColors extras to COLOR_0 attribute', async () => {
-    const buf = makeGlb();
+  test("promotes vertexColors extras to COLOR_0 attribute", async () => {
+    const buf = await makeGlb();
     const out = await preserveColors(buf);
     const io = new NodeIO();
-    const doc = io.readBinary(out);
+    const doc = await io.readBinary(out);
     const prim = doc.getRoot().listMeshes()[0].listPrimitives()[0];
-    const attr = prim.getAttribute('COLOR_0');
+    const attr = prim.getAttribute("COLOR_0");
     expect(attr).toBeDefined();
     expect(Array.from(attr.getArray())).toEqual([
-      1,0,0,1,
-      0,1,0,1,
-      0,0,1,1,
+      1, 0, 0, 1, 0, 1, 0, 1, 0, 0, 1, 1,
     ]);
   });
 });

--- a/backend/tests/validateEnv.test.ts
+++ b/backend/tests/validateEnv.test.ts
@@ -26,6 +26,8 @@ describe("validate-env script", () => {
       HF_TOKEN: "token",
       AWS_ACCESS_KEY_ID: "id",
       AWS_SECRET_ACCESS_KEY: "secret",
+      DB_URL: "postgres://user:pass@localhost/db",
+      STRIPE_SECRET_KEY: "sk_test_dummy",
       SKIP_NET_CHECKS: "1",
     });
     expect(output).toContain("environment OK");

--- a/tests/assertSetup.test.js
+++ b/tests/assertSetup.test.js
@@ -1,3 +1,4 @@
+/** @file Tests for assert-setup script */
 jest.mock("fs");
 jest.mock("child_process");
 
@@ -12,6 +13,7 @@ describe("assert-setup script", () => {
     child_process.execSync.mockReset();
   });
 
+  /** Set required environment variables for tests */
   function setEnv() {
     process.env.HF_TOKEN = "x";
     process.env.AWS_ACCESS_KEY_ID = "id";

--- a/tests/backendSyntax.test.js
+++ b/tests/backendSyntax.test.js
@@ -1,7 +1,13 @@
+/** @file Ensure backend JS files compile */
 const fs = require("fs");
 const path = require("path");
 const parser = require("@babel/parser");
 
+/**
+ * Recursively collect TypeScript test files
+ * @param {string} dir directory to scan
+ * @returns {string[]} list of file paths
+ */
 function getTsFiles(dir) {
   let files = [];
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
@@ -21,7 +27,7 @@ describe("backend test syntax", () => {
     test(`${file} parses`, () => {
       const code = fs.readFileSync(file, "utf8");
       expect(() =>
-        parser.parse(code, { sourceType: "script", plugins: ["typescript"] }),
+        parser.parse(code, { sourceType: "module", plugins: ["typescript"] }),
       ).not.toThrow();
     });
   }


### PR DESCRIPTION
## Summary
- update preserveColors helper to await readBinary
- fix preserveColors tests with async helper and buffer
- include DB_URL and STRIPE_SECRET_KEY in validate-env test
- document test helpers with JSDoc
- parse TypeScript tests as modules

## Testing
- `npm test --prefix backend -- --runInBand`
- `HF_TOKEN=test AWS_ACCESS_KEY_ID=id AWS_SECRET_ACCESS_KEY=secret DB_URL=postgres://u:p@localhost/db STRIPE_SECRET_KEY=sk_dummy SKIP_PW_DEPS=1 npm run ci`
- `HF_TOKEN=test AWS_ACCESS_KEY_ID=id AWS_SECRET_ACCESS_KEY=secret DB_URL=postgres://u:p@localhost/db STRIPE_SECRET_KEY=sk_dummy SKIP_PW_DEPS=1 npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_68728bf70794832da4af844a020560f0