### PR TITLE
Handle missing HF_TOKEN in validate-env

### DIFF
--- a/backend/tests/validateEnv.test.ts
+++ b/backend/tests/validateEnv.test.ts
@@ -47,15 +47,14 @@ describe("validate-env script", () => {
     ).toThrow();
   });
 
-  test("fails when HF_TOKEN is missing", () => {
-    expect(() =>
-      run(
-        {
-          STRIPE_TEST_KEY: "test",
-          HF_TOKEN: "",
-        },
-        true,
-      ),
-    ).toThrow();
+  test("succeeds when HF_TOKEN is missing", () => {
+    const output = run({
+      STRIPE_TEST_KEY: "test",
+      HF_TOKEN: "",
+      HF_API_KEY: "",
+      AWS_ACCESS_KEY_ID: "id",
+      AWS_SECRET_ACCESS_KEY: "secret",
+    });
+    expect(output).toContain("environment OK");
   });
 });

--- a/scripts/validate-env.sh
+++ b/scripts/validate-env.sh
@@ -11,7 +11,10 @@ if [[ -z "${STRIPE_TEST_KEY:-}" && -z "${STRIPE_LIVE_KEY:-}" ]]; then
   echo "Using dummy STRIPE_TEST_KEY" >&2
   export STRIPE_TEST_KEY="sk_test_dummy_$(date +%s)"
 fi
-: "${HF_TOKEN:?HF_TOKEN must be set}"
+if [[ -z "${HF_TOKEN:-}" && -z "${HF_API_KEY:-}" ]]; then
+  echo "Using dummy HF_TOKEN" >&2
+  export HF_TOKEN="hf_dummy_$(date +%s)"
+fi
 : "${AWS_ACCESS_KEY_ID:?AWS_ACCESS_KEY_ID must be set}"
 : "${AWS_SECRET_ACCESS_KEY:?AWS_SECRET_ACCESS_KEY must be set}"
 : "${DB_URL:?DB_URL must be set}"

--- a/tests/assertSetup.test.js
+++ b/tests/assertSetup.test.js
@@ -12,6 +12,7 @@ describe("assert-setup script", () => {
     child_process.execSync.mockReset();
   });
 
+  /** Set up dummy environment variables */
   function setEnv() {
     process.env.HF_TOKEN = "x";
     process.env.AWS_ACCESS_KEY_ID = "id";

--- a/tests/backendSyntax.test.js
+++ b/tests/backendSyntax.test.js
@@ -2,6 +2,11 @@ const fs = require("fs");
 const path = require("path");
 const parser = require("@babel/parser");
 
+/**
+ * Recursively gather TypeScript test files
+ * @param {string} dir directory to search
+ * @returns {string[]} list of file paths
+ */
 function getTsFiles(dir) {
   let files = [];
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {

--- a/tests/validateEnv.test.js
+++ b/tests/validateEnv.test.js
@@ -35,6 +35,20 @@ describe("validate-env script", () => {
     expect(output).not.toMatch(/mise WARN/);
   });
 
+  test("succeeds when HF_TOKEN is missing", () => {
+    const env = {
+      ...process.env,
+      HF_TOKEN: "",
+      HF_API_KEY: "",
+      AWS_ACCESS_KEY_ID: "id",
+      AWS_SECRET_ACCESS_KEY: "secret",
+      DB_URL: "postgres://user:pass@localhost/db",
+      STRIPE_SECRET_KEY: "sk_test_dummy",
+    };
+    const output = run(env);
+    expect(output).toContain("✅ environment OK");
+  });
+
   test("fails when DB_URL is missing", () => {
     const env = {
       ...process.env,
@@ -58,7 +72,6 @@ describe("validate-env script", () => {
     };
     expect(() => run(env)).toThrow();
   });
-
 
   test("fails when network unreachable", () => {
     const env = {


### PR DESCRIPTION
## Summary
- allow running `validate-env` without HF_TOKEN by generating a dummy token
- adjust tests for new behavior
- document environment setup in tests

## Testing
- `npm test`
- `npm run lint`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68728bb28518832d92f7192f13675a67