### PR TITLE
Fix env loading for smoke script

### DIFF
--- a/backend/tests/validateEnv.test.ts
+++ b/backend/tests/validateEnv.test.ts
@@ -1,5 +1,6 @@
 const { execSync } = require("child_process");
 const path = require("path");
+const fs = require("fs");
 
 const root = path.resolve(__dirname, "..", "..");
 
@@ -48,6 +49,9 @@ describe("validate-env script", () => {
   });
 
   test("fails when HF_TOKEN is missing", () => {
+    const example = path.resolve(root, ".env.example");
+    const backup = `${example}.bak`;
+    fs.renameSync(example, backup);
     expect(() =>
       run(
         {
@@ -57,5 +61,6 @@ describe("validate-env script", () => {
         true,
       ),
     ).toThrow();
+    fs.renameSync(backup, example);
   });
 });

--- a/scripts/assert-setup.js
+++ b/scripts/assert-setup.js
@@ -4,6 +4,27 @@ const os = require("os");
 const path = require("path");
 const child_process = require("child_process");
 
+function loadEnvFile(file) {
+  if (!fs.existsSync(file)) return;
+  const lines = fs.readFileSync(file, "utf8").split(/\r?\n/);
+  for (const line of lines) {
+    if (!line || line.startsWith("#")) continue;
+    const idx = line.indexOf("=");
+    if (idx === -1) continue;
+    const key = line.slice(0, idx);
+    const value = line.slice(idx + 1);
+    if (!process.env[key]) {
+      process.env[key] = value;
+    }
+  }
+}
+
+if (fs.existsSync(".env")) {
+  loadEnvFile(".env");
+} else if (fs.existsSync(".env.example")) {
+  loadEnvFile(".env.example");
+}
+
 try {
   child_process.execSync("mise trust .mise.toml >/dev/null 2>&1");
   child_process.execSync(

--- a/scripts/validate-env.sh
+++ b/scripts/validate-env.sh
@@ -7,6 +7,22 @@ mise settings add idiomatic_version_file_enable_tools node --yes >/dev/null 2>&1
 if [ -f .mise.toml ]; then
   mise trust .mise.toml >/dev/null 2>&1 || true
 fi
+load_env_file() {
+  local file="$1"
+  while IFS='=' read -r key value; do
+    [[ "$key" =~ ^\s*# || -z "$key" ]] && continue
+    if [ -z "${!key:-}" ]; then
+      export "$key"="$value"
+    fi
+  done < "$file"
+}
+
+if [ -f .env ]; then
+  load_env_file .env
+elif [ -f .env.example ]; then
+  load_env_file .env.example
+fi
+
 if [[ -z "${STRIPE_TEST_KEY:-}" && -z "${STRIPE_LIVE_KEY:-}" ]]; then
   echo "Using dummy STRIPE_TEST_KEY" >&2
   export STRIPE_TEST_KEY="sk_test_dummy_$(date +%s)"

--- a/tests/assertSetup.test.js
+++ b/tests/assertSetup.test.js
@@ -1,3 +1,4 @@
+/** @file Tests for the assert-setup script */
 jest.mock("fs");
 jest.mock("child_process");
 
@@ -12,6 +13,7 @@ describe("assert-setup script", () => {
     child_process.execSync.mockReset();
   });
 
+  /** Set required env vars for the script */
   function setEnv() {
     process.env.HF_TOKEN = "x";
     process.env.AWS_ACCESS_KEY_ID = "id";

--- a/tests/backendSyntax.test.js
+++ b/tests/backendSyntax.test.js
@@ -1,7 +1,13 @@
+/** @file Ensures backend test files parse correctly */
 const fs = require("fs");
 const path = require("path");
 const parser = require("@babel/parser");
 
+/**
+ * Recursively gather .ts files
+ * @param {string} dir directory to search
+ * @returns {string[]} list of TypeScript files
+ */
 function getTsFiles(dir) {
   let files = [];
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {


### PR DESCRIPTION
## Summary
- load env vars from `.env` or `.env.example` in `validate-env.sh`
- mirror the same logic in `assert-setup.js`
- update env validation tests for new behavior
- document intent in related unit tests

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68728ba87e94832d8bed68e47177bee6