### PR TITLE
Fix Playwright host dependency check

### DIFF
--- a/scripts/check-host-deps.js
+++ b/scripts/check-host-deps.js
@@ -2,6 +2,9 @@
 const { execSync } = require("child_process");
 
 function checkNetwork() {
+  if (process.env.SKIP_NET_CHECKS) {
+    return;
+  }
   try {
     execSync("node scripts/network-check.js", { stdio: "ignore" });
   } catch {
@@ -26,15 +29,19 @@ function hostDepsInstalled() {
 checkNetwork();
 
 if (!hostDepsInstalled()) {
-  console.log("Playwright host dependencies missing. Installing...");
-  try {
-    execSync("CI=1 npx playwright install --with-deps", { stdio: "inherit" });
-  } catch (err) {
-    console.error(
-      "Failed to install Playwright host dependencies:",
-      err.message,
-    );
-    process.exit(1);
+  if (process.env.SKIP_PW_DEPS) {
+    console.log("Skipping Playwright host dependency install");
+  } else {
+    console.log("Playwright host dependencies missing. Installing...");
+    try {
+      execSync("CI=1 npx playwright install --with-deps", { stdio: "inherit" });
+    } catch (err) {
+      console.error(
+        "Failed to install Playwright host dependencies:",
+        err.message,
+      );
+      process.exit(1);
+    }
   }
 } else {
   console.log("Playwright host dependencies already satisfied.");

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -110,4 +110,8 @@ if [ -z "$SKIP_PW_DEPS" ]; then
 else
   CI=1 npx playwright install
 fi
+
+# Verify Playwright host dependencies
+node scripts/check-host-deps.js
+
 touch .setup-complete

--- a/tests/checkHostDeps.test.js
+++ b/tests/checkHostDeps.test.js
@@ -34,3 +34,37 @@ test("exits when network check fails", () => {
   expect(() => require("../scripts/check-host-deps.js")).toThrow("exit");
   expect(exitSpy).toHaveBeenCalledWith(1);
 });
+
+test("skips network check when SKIP_NET_CHECKS is set", () => {
+  process.env.SKIP_NET_CHECKS = "1";
+  child_process.execSync.mockReturnValueOnce("deps ok");
+  require("../scripts/check-host-deps.js");
+  expect(child_process.execSync).toHaveBeenCalledTimes(1);
+  expect(child_process.execSync).toHaveBeenCalledWith(
+    "npx playwright install --with-deps --dry-run",
+    { encoding: "utf8" },
+  );
+  delete process.env.SKIP_NET_CHECKS;
+});
+
+test("skips install when SKIP_PW_DEPS is set", () => {
+  process.env.SKIP_PW_DEPS = "1";
+  child_process.execSync
+    .mockReturnValueOnce("network ok")
+    .mockImplementationOnce(() => {
+      throw new Error("missing deps");
+    });
+  require("../scripts/check-host-deps.js");
+  expect(child_process.execSync).toHaveBeenNthCalledWith(
+    1,
+    "node scripts/network-check.js",
+    { stdio: "ignore" },
+  );
+  expect(child_process.execSync).toHaveBeenNthCalledWith(
+    2,
+    "npx playwright install --with-deps --dry-run",
+    { encoding: "utf8" },
+  );
+  expect(child_process.execSync).toHaveBeenCalledTimes(2);
+  delete process.env.SKIP_PW_DEPS;
+});

--- a/tests/setupScript.test.js
+++ b/tests/setupScript.test.js
@@ -12,4 +12,12 @@ describe("setup script", () => {
     expect(fs.existsSync(flag)).toBe(true);
     expect(fs.existsSync(jestBin)).toBe(true);
   });
+
+  test("setup.sh invokes check-host-deps script", () => {
+    const content = fs.readFileSync(
+      path.join(__dirname, "..", "scripts", "setup.sh"),
+      "utf8",
+    );
+    expect(content).toMatch(/check-host-deps\.js/);
+  });
 });


### PR DESCRIPTION
## Summary
- ensure `check-host-deps.js` supports SKIP flags
- verify host deps from `setup.sh`
- cover new logic with tests

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6872988fb228832db511150b49374940