### PR TITLE
Fix ESLint jsdoc rule for tests

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,7 +2,9 @@
 try {
   require.resolve("@eslint/js");
 } catch {
-  console.error("Dependencies not installed. Run 'npm run setup' at the repository root.");
+  console.error(
+    "Dependencies not installed. Run 'npm run setup' at the repository root.",
+  );
   process.exit(1);
 }
 
@@ -58,6 +60,10 @@ module.exports = [
   },
   {
     files: ["scripts/**/*"],
+    rules: { "jsdoc/require-jsdoc": "off" },
+  },
+  {
+    files: ["tests/**/*"],
     rules: { "jsdoc/require-jsdoc": "off" },
   },
 ];

--- a/tests/eslintConfig.test.js
+++ b/tests/eslintConfig.test.js
@@ -1,0 +1,10 @@
+const eslintConfig = require("../eslint.config.js");
+
+/** Ensure jsdoc requirement is disabled for tests directory */
+test("jsdoc rule disabled for tests", () => {
+  const override = eslintConfig.find(
+    (cfg) => Array.isArray(cfg.files) && cfg.files.includes("tests/**/*"),
+  );
+  expect(override).toBeDefined();
+  expect(override.rules["jsdoc/require-jsdoc"]).toBe("off");
+});


### PR DESCRIPTION
## Summary
- disable `jsdoc/require-jsdoc` for test files in ESLint config
- ensure rule stays disabled with a Jest test

## Testing
- `npm test --prefix backend`
- `npm run lint`
- `SKIP_PW_DEPS=1 npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_68729883866c832db6e0ae5ed1ee3127