### PR TITLE
Fix Jest coverage path

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -18,12 +18,18 @@ module.exports = {
 module.exports = {
   ...module.exports,
   collectCoverage: true,
-  collectCoverageFrom: ["**/*.{js,jsx,ts,tsx}"],
+  collectCoverageFrom: [
+    "**/*.{js,jsx,ts,tsx}",
+    "!<rootDir>/node_modules/**",
+    "!<rootDir>/tests/**",
+  ],
   coveragePathIgnorePatterns: [
-    "<rootDir>/backend/db.js",
-    "<rootDir>/backend/shipping.js",
-    "<rootDir>/backend/social.js",
-    "<rootDir>/backend/utils/validateStl.js",
+    "<rootDir>/db.js",
+    "<rootDir>/shipping.js",
+    "<rootDir>/social.js",
+    "<rootDir>/utils/validateStl.js",
+    "<rootDir>/node_modules/",
+    "<rootDir>/tests/",
   ],
   coverageThreshold: {
     global: {


### PR DESCRIPTION
## Summary
- exclude `node_modules` and tests from Jest coverage

## Testing
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_687298792e44832da8d03497da030f28