### PR TITLE
Fix env validation in CI

### DIFF
--- a/scripts/assert-setup.js
+++ b/scripts/assert-setup.js
@@ -26,6 +26,16 @@ if (fs.existsSync(".env")) {
 }
 
 try {
+  child_process.execSync(
+    "SKIP_NET_CHECKS=1 bash scripts/validate-env.sh >/dev/null",
+    { stdio: "inherit" },
+  );
+} catch (err) {
+  console.error("Environment validation failed:", err.message);
+  process.exit(1);
+}
+
+try {
   child_process.execSync("mise trust .mise.toml >/dev/null 2>&1");
   child_process.execSync(
     "mise settings add idiomatic_version_file_enable_tools node --yes >/dev/null 2>&1",

--- a/tests/assertSetup.test.js
+++ b/tests/assertSetup.test.js
@@ -36,4 +36,21 @@ describe("assert-setup script", () => {
 
     expect(() => require("../scripts/assert-setup.js")).not.toThrow();
   });
+
+  test("invokes validate-env when HF_TOKEN missing", () => {
+    delete process.env.HF_TOKEN;
+    process.env.AWS_ACCESS_KEY_ID = "id";
+    process.env.AWS_SECRET_ACCESS_KEY = "secret";
+
+    fs.existsSync.mockReturnValue(true);
+    fs.readdirSync.mockReturnValue(["chromium"]);
+
+    child_process.execSync.mockImplementation(() => {});
+
+    expect(() => require("../scripts/assert-setup.js")).not.toThrow();
+    expect(child_process.execSync).toHaveBeenCalledWith(
+      "SKIP_NET_CHECKS=1 bash scripts/validate-env.sh >/dev/null",
+      { stdio: "inherit" },
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- run `validate-env.sh` automatically from `assert-setup.js`
- test that `assert-setup.js` invokes validation when `HF_TOKEN` is missing

## Testing
- `HUSKY=0 npm test`
- `HUSKY=0 SKIP_PW_DEPS=1 npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_687298566578832dbbf21a5189cec08d