### PR TITLE
Fix coverage summary generation

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -12,7 +12,7 @@ module.exports = {
   moduleFileExtensions: ["ts", "js", "json"],
   testTimeout: 10000,
   coverageDirectory: "coverage",
-  coverageReporters: ["text", "lcov"],
+  coverageReporters: ["text", "lcov", "json-summary"],
 };
 
 module.exports = {

--- a/tests/coverageSummary.test.js
+++ b/tests/coverageSummary.test.js
@@ -1,0 +1,7 @@
+const jestConfig = require("../backend/jest.config.js");
+
+describe("coverage reporters", () => {
+  test("includes json-summary for coverage-badges", () => {
+    expect(jestConfig.coverageReporters).toContain("json-summary");
+  });
+});


### PR DESCRIPTION
## Summary
- output a `json-summary` coverage report
- verify that Jest is configured for `json-summary`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687295c38830832da8abae06d318e160