### PR TITLE
Fix smoke env defaults and add tests

### DIFF
--- a/backend/tests/runSmokeFailure.test.ts
+++ b/backend/tests/runSmokeFailure.test.ts
@@ -2,7 +2,7 @@ const child_process = require("child_process");
 
 jest.mock("child_process");
 
-const main = require("../../scripts/run-smoke");
+const { main } = require("../../scripts/run-smoke");
 
 describe("run-smoke failure handling", () => {
   beforeEach(() => {

--- a/scripts/run-smoke.js
+++ b/scripts/run-smoke.js
@@ -2,6 +2,17 @@
 const { execSync } = require("child_process");
 const env = { ...process.env };
 
+function ensureDefault(key, value) {
+  if (!env[key]) {
+    env[key] = value;
+  }
+}
+
+ensureDefault("AWS_ACCESS_KEY_ID", "dummy");
+ensureDefault("AWS_SECRET_ACCESS_KEY", "dummy");
+ensureDefault("DB_URL", "postgres://user:pass@localhost/db");
+ensureDefault("STRIPE_SECRET_KEY", "sk_test_dummy");
+
 function run(cmd) {
   execSync(cmd, { stdio: "inherit", env });
 }
@@ -29,4 +40,4 @@ if (require.main === module) {
   main();
 }
 
-module.exports = main;
+module.exports = { main, env };

--- a/tests/smokeScript.test.js
+++ b/tests/smokeScript.test.js
@@ -25,4 +25,14 @@ describe("smoke script", () => {
     expect(validateIdx).toBeGreaterThan(-1);
     expect(setupIdx).toBeGreaterThan(validateIdx);
   });
+
+  test("run-smoke.js sets fallback env vars", () => {
+    jest.isolateModules(() => {
+      const { env } = require("../scripts/run-smoke.js");
+      expect(env.AWS_ACCESS_KEY_ID).toBe("dummy");
+      expect(env.AWS_SECRET_ACCESS_KEY).toBe("dummy");
+      expect(env.DB_URL).toBe("postgres://user:pass@localhost/db");
+      expect(env.STRIPE_SECRET_KEY).toBe("sk_test_dummy");
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- provide fallback env vars in `run-smoke.js`
- export env for testing and update failure test
- check dummy values in smoke script tests

## Testing
- `npm test`
- `SKIP_PW_DEPS=1 npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_687298642ba0832dad64fd10d577f001