### PR TITLE
fix backend dev-server test

### DIFF
--- a/backend/scripts/ensure-deps.js
+++ b/backend/scripts/ensure-deps.js
@@ -3,6 +3,8 @@ const path = require("path");
 const { execSync } = require("child_process");
 
 const jestPath = "node_modules/.bin/jest";
+const repoRoot = path.join(__dirname, "..", "..");
+const expressPath = path.join(repoRoot, "node_modules", "express");
 
 const networkCheck = path.join(
   __dirname,
@@ -32,6 +34,18 @@ function canReachRegistry() {
       "Unable to reach the npm registry. Check network connectivity or proxy settings.",
     );
     return false;
+  }
+}
+
+if (!fs.existsSync(expressPath)) {
+  runNetworkCheck();
+  if (!canReachRegistry()) process.exit(1);
+  console.log("Express not found. Installing root dependencies...");
+  try {
+    execSync("npm ci", { stdio: "inherit", cwd: repoRoot });
+  } catch (err) {
+    console.error("Failed to install root dependencies:", err.message);
+    process.exit(1);
   }
 }
 

--- a/tests/assertSetup.test.js
+++ b/tests/assertSetup.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable jsdoc/require-jsdoc */
 jest.mock("fs");
 jest.mock("child_process");
 
@@ -12,7 +11,6 @@ describe("assert-setup script", () => {
     fs.readdirSync.mockReset();
     child_process.execSync.mockReset();
   });
-
 
   /** Set required environment variables for tests */
   function setEnv() {

--- a/tests/backendSyntax.test.js
+++ b/tests/backendSyntax.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable jsdoc/require-jsdoc */
 const fs = require("fs");
 const path = require("path");
 const parser = require("@babel/parser");

--- a/tests/dev-server.test.ts
+++ b/tests/dev-server.test.ts
@@ -1,34 +1,33 @@
-jest.mock(
-  "express",
-  () => {
-    const mExpress = jest.fn(() => ({
-      use: jest.fn(),
-      get: jest.fn(),
-      listen: jest.fn(),
-    }));
-    mExpress.static = jest.fn();
-    return mExpress;
-  },
-  { virtual: true },
-);
-const express = require("express");
-
 describe("startDevServer", () => {
   test("builds middleware chain without real server", () => {
-    const use = jest.fn();
-    const get = jest.fn();
-    const post = jest.fn();
-    const listen = jest.fn();
-    express.mockReturnValue({ use, get, post, listen });
-
     jest.isolateModules(() => {
+      jest.doMock(
+        "express",
+        () => {
+          const mExpress = jest.fn(() => ({
+            use: jest.fn(),
+            get: jest.fn(),
+            post: jest.fn(),
+            listen: jest.fn(),
+          }));
+          mExpress.static = jest.fn();
+          mExpress.json = jest.fn(() => "json");
+          return mExpress;
+        },
+        { virtual: true },
+      );
+      const express = require("express");
+      const use = jest.fn();
+      const get = jest.fn();
+      const post = jest.fn();
+      const listen = jest.fn();
+      express.mockReturnValue({ use, get, post, listen });
       const { startDevServer } = require("../scripts/dev-server");
       expect(() => startDevServer()).not.toThrow();
+      expect(use).toHaveBeenCalled();
+      expect(get).toHaveBeenCalledWith("/healthz", expect.any(Function));
+      expect(post).toHaveBeenCalledWith("/api/generate", expect.any(Function));
+      expect(listen).toHaveBeenCalledWith(3000, expect.any(Function));
     });
-
-    expect(use).toHaveBeenCalled();
-    expect(get).toHaveBeenCalledWith("/healthz", expect.any(Function));
-    expect(post).toHaveBeenCalledWith("/api/generate", expect.any(Function));
-    expect(listen).toHaveBeenCalledWith(3000, expect.any(Function));
   });
 });

--- a/tests/ensureDeps.test.js
+++ b/tests/ensureDeps.test.js
@@ -23,7 +23,19 @@ describe("ensure-deps", () => {
     expect(execMock).toHaveBeenNthCalledWith(2, "npm ping", {
       stdio: "ignore",
     });
-    expect(execMock).toHaveBeenNthCalledWith(4, "npm ci", { stdio: "inherit" });
+    expect(execMock).toHaveBeenNthCalledWith(3, "npm ci", {
+      stdio: "inherit",
+      cwd: expect.any(String),
+    });
+    expect(execMock).toHaveBeenNthCalledWith(
+      4,
+      expect.stringContaining("network-check.js"),
+      expect.any(Object),
+    );
+    expect(execMock).toHaveBeenNthCalledWith(5, "npm ping", {
+      stdio: "ignore",
+    });
+    expect(execMock).toHaveBeenNthCalledWith(7, "npm ci", { stdio: "inherit" });
   });
 
   test("exits when npm ping fails", () => {
@@ -40,11 +52,11 @@ describe("ensure-deps", () => {
 
   test("exits when npm ci fails", () => {
     fs.existsSync.mockReturnValue(false);
-    child_process.execSync
-      .mockImplementationOnce(() => {})
-      .mockImplementationOnce(() => {
+    child_process.execSync.mockImplementation((cmd, opts) => {
+      if (cmd === "npm ci" && !opts.cwd) {
         throw new Error("ci fail");
-      });
+      }
+    });
     const exitSpy = jest.spyOn(process, "exit").mockImplementation(() => {
       throw new Error("exit");
     });


### PR DESCRIPTION
## Summary
- install root dependencies when missing
- mock `express.json` for dev-server unit test
- update ensure-deps tests for new dependency check
- remove unused eslint directives

## Testing
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_6872b0a84c7c832dbb82f8ebf02e1d3b