### PR TITLE
Add jest helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ Run `docker compose up` to start the API and Postgres services.
 - `HF_TOKEN` – Hugging Face access token used by scripts like `setup_space.sh`.
 - `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` – credentials for S3 uploads.
 
-
 The server uses `STRIPE_LIVE_KEY` when `NODE_ENV=production`; otherwise `STRIPE_TEST_KEY` is used.
 
 - If `STRIPE_TEST_KEY` isn't set, `npm run setup` generates a temporary dummy key
@@ -123,9 +122,9 @@ The server uses `STRIPE_LIVE_KEY` when `NODE_ENV=production`; otherwise `STRIPE_
 
 10. (Optional) Clean up expired password reset tokens periodically:
 
-   ```bash
-   npm run cleanup-tokens  # inside backend/
-   ```
+```bash
+npm run cleanup-tokens  # inside backend/
+```
 
 ## Development Container
 
@@ -347,6 +346,14 @@ For a quick end-to-end sanity check, run:
 ```bash
 npm run smoke
 ```
+
+To run Jest directly from the repository root, use:
+
+```bash
+npm run jest -- --runInBand --silent
+```
+
+This script automatically runs Jest in `backend/`, so passing `--prefix` is unnecessary.
 
 ### Pre-commit Hook
 

--- a/backend/tests/rootJestScript.test.js
+++ b/backend/tests/rootJestScript.test.js
@@ -1,0 +1,5 @@
+const rootPkg = require("../../package.json");
+
+test("root package defines jest script", () => {
+  expect(rootPkg.scripts.jest).toBe("node scripts/run-jest.js");
+});

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "check-conflicts": "! grep -R --include=*.js --include=*.jsx --include=*.ts --include=*.tsx '^(<{7}|={7}|>{7})' .",
     "check-root": "node scripts/check-repo-root.js",
     "pretest": "node scripts/check-repo-root.js",
+    "jest": "node scripts/run-jest.js",
     "test:structure": "jest --runTestsByPath tests/projectStructure.test.js",
     "test": "npm test --prefix backend",
     "coverage": "npm run coverage --prefix backend",


### PR DESCRIPTION
## Summary
- expose `npm run jest` to wrap backend Jest
- document the new script
- verify script via new test

## Testing
- `npx prettier --write README.md backend/tests/rootJestScript.test.js package.json`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6872ad97cc90832dbe952a9b34e512ef