### PR TITLE
Add test for apt-get failure in setup script

### DIFF
--- a/tests/bin-apt/apt-get
+++ b/tests/bin-apt/apt-get
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exit 1

--- a/tests/bin-apt/sudo
+++ b/tests/bin-apt/sudo
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# pass through to real command but use PATH to our fake apt-get
+if [[ "$1" == "apt-get" ]]; then
+  shift
+  apt-get "$@"
+else
+  command sudo "$@"
+fi

--- a/tests/setupScriptAptFailure.test.js
+++ b/tests/setupScriptAptFailure.test.js
@@ -1,0 +1,35 @@
+/** @file Tests setup.sh when apt-get fails */
+const { execFileSync } = require("child_process");
+const path = require("path");
+const fs = require("fs");
+
+const script = path.join(__dirname, "..", "scripts", "setup.sh");
+const binDir = path.join(__dirname, "bin-apt");
+
+/** Ensure fake bin exists */
+expect(fs.existsSync(path.join(binDir, "apt-get"))).toBe(true);
+
+/**
+ * Execute the setup script with a modified PATH.
+ * @param {Record<string, string>} env environment variables
+ * @returns {Buffer} script output
+ */
+function run(env) {
+  return execFileSync("bash", [script], {
+    env: { ...process.env, PATH: `${binDir}:${process.env.PATH}`, ...env },
+    encoding: "utf8",
+    stdio: "pipe",
+  });
+}
+
+describe("setup script apt-get failure", () => {
+  test("fails when apt-get is not available and deps not skipped", () => {
+    expect(() => run({})).toThrow();
+  });
+
+  test("succeeds when SKIP_PW_DEPS=1", () => {
+    expect(() =>
+      run({ SKIP_PW_DEPS: "1", SKIP_NET_CHECKS: "1" }),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- add fake `apt-get` and `sudo` stubs for tests
- verify setup script aborts when `apt-get` fails but succeeds with `SKIP_PW_DEPS`

## Testing
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6872ad3b4458832d875c2d40f2140c46