### PR TITLE
fix: extend smoke test timeout

### DIFF
--- a/e2e/smoke.test.js
+++ b/e2e/smoke.test.js
@@ -85,5 +85,5 @@ test('generate flow', async ({ page }) => {
   await page.waitForSelector('#gen-prompt', { state: 'visible', timeout: 30000 });
   await page.fill('#gen-prompt', 'test');
   await page.click('#gen-submit');
-  await expect(page.locator('canvas')).toBeVisible({ timeout: 10000 });
+  await expect(page.locator('canvas')).toBeVisible({ timeout: 30000 });
 });


### PR DESCRIPTION
## Summary
- extend the canvas wait timeout in the smoke test

## Testing
- `npm test`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6872b9e9d57c832da6bbc027ccb01285