### PR TITLE
Fix npm tar errors during setup

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -87,6 +87,11 @@ run_ci() {
       echo "npm ci failed in $dir due to lock mismatch. Running npm install..." >&2
       npm install $extra --no-audit --no-fund
       npm ci $extra --no-audit --no-fund
+    elif grep -E -q "TAR_ENTRY_ERROR|ENOENT" ci.log; then
+      echo "npm ci encountered tar errors in $dir. Cleaning cache and retrying..." >&2
+      cleanup_npm_cache
+      rm -rf ${dir:-.}/node_modules
+      npm ci $extra --no-audit --no-fund
     else
       cat ci.log >&2
       rm ci.log

--- a/tests/bin-tar/npm
+++ b/tests/bin-tar/npm
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+if [[ "$1" == "ci" && -z "$TAR_ERROR_DONE" ]]; then
+  echo "npm WARN tar TAR_ENTRY_ERROR ENOENT: no such file or directory, open '/fake/file.js'" >&2
+  export TAR_ERROR_DONE=1
+  exit 1
+fi
+exec "$REAL_NPM" "$@"

--- a/tests/setupScriptTarError.test.js
+++ b/tests/setupScriptTarError.test.js
@@ -1,0 +1,20 @@
+const { execSync } = require("child_process");
+const path = require("path");
+
+describe("setup script tar error", () => {
+  test("retries when npm ci reports TAR_ENTRY_ERROR", () => {
+    const env = {
+      ...process.env,
+      HF_TOKEN: "test",
+      AWS_ACCESS_KEY_ID: "id",
+      AWS_SECRET_ACCESS_KEY: "secret",
+      DB_URL: "postgres://user:pass@localhost/db",
+      STRIPE_SECRET_KEY: "sk_test",
+      SKIP_NET_CHECKS: "1",
+      SKIP_PW_DEPS: "1",
+      REAL_NPM: execSync("command -v npm").toString().trim(),
+      PATH: path.join(__dirname, "bin-tar") + ":" + process.env.PATH,
+    };
+    execSync("bash scripts/setup.sh", { env, stdio: "inherit" });
+  });
+});


### PR DESCRIPTION
## Summary
- retry npm ci when tar extraction errors appear
- add regression test simulating TAR_ENTRY_ERROR
- remove unused ESLint disable comments in tests

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_6872b86a0a0c832d9cd08f463c64978d