### PR TITLE
Fix smoke test flake on network failure

### DIFF
--- a/e2e/smoke.test.js
+++ b/e2e/smoke.test.js
@@ -33,6 +33,16 @@ test('checkout flow', async ({ page }) => {
 });
 
 test('model generator page', async ({ page }) => {
+  // Skip if esm.sh is unreachable since the React bundle won't load.
+  try {
+    const resp = await page.request.get('https://esm.sh');
+    if (resp.status() >= 400) {
+      test.skip(true, 'esm.sh unreachable');
+    }
+  } catch {
+    test.skip(true, 'esm.sh unreachable');
+  }
+
   // Skip if the CDN hosting <model-viewer> is unreachable.
   try {
     const resp = await page.request.get(

--- a/scripts/network-check.js
+++ b/scripts/network-check.js
@@ -5,6 +5,10 @@ const { execSync } = require("child_process");
 const targets = [
   { url: "https://registry.npmjs.org/-/ping", name: "npm registry" },
   { url: "https://cdn.playwright.dev", name: "Playwright CDN" },
+  { url: "https://esm.sh", name: "esm.sh" },
+  {
+    url: "https://cdn.jsdelivr.net/npm/@google/model-viewer@1.12.0/dist/model-viewer.min.js",
+    name: "jsdelivr" },
 ];
 
 // Allow tests to override the first target URL so failure scenarios can be

--- a/tests/network.test.js
+++ b/tests/network.test.js
@@ -36,4 +36,20 @@ describe("network connectivity", () => {
     });
     expect(ok).toBe(true);
   });
+
+  test("esm.sh reachable", async () => {
+    const ok = await check("https://esm.sh").catch((err) => {
+      throw new Error(`esm.sh unreachable: ${err.message}`);
+    });
+    expect(ok).toBe(true);
+  });
+
+  test("jsdelivr reachable", async () => {
+    const ok = await check(
+      "https://cdn.jsdelivr.net/npm/@google/model-viewer@1.12.0/dist/model-viewer.min.js",
+    ).catch((err) => {
+      throw new Error(`jsdelivr unreachable: ${err.message}`);
+    });
+    expect(ok).toBe(true);
+  });
 });

--- a/tests/networkConnectivity.test.js
+++ b/tests/networkConnectivity.test.js
@@ -38,4 +38,28 @@ describe("network connectivity", () => {
     }
     expect(status).toBeLessThan(500);
   });
+
+  test("esm.sh reachable", async () => {
+    let status;
+    try {
+      status = await head("https://esm.sh");
+    } catch (err) {
+      console.warn("Skipping esm.sh connectivity test:", err.message);
+      return;
+    }
+    expect(status).toBeLessThan(500);
+  });
+
+  test("jsdelivr reachable", async () => {
+    let status;
+    try {
+      status = await head(
+        "https://cdn.jsdelivr.net/npm/@google/model-viewer@1.12.0/dist/model-viewer.min.js",
+      );
+    } catch (err) {
+      console.warn("Skipping jsdelivr connectivity test:", err.message);
+      return;
+    }
+    expect(status).toBeLessThan(500);
+  });
 });


### PR DESCRIPTION
## Summary
- skip model generator smoke test if esm.sh is unreachable
- extend network-check script to verify access to esm.sh and jsDelivr
- add connectivity checks for esm.sh and jsDelivr

## Testing
- `npm test`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6872ba27920c832d97f1ce093701c68e