### PR TITLE
Improve smoke test resilience

### DIFF
--- a/e2e/smoke.test.js
+++ b/e2e/smoke.test.js
@@ -33,7 +33,7 @@ test('checkout flow', async ({ page }) => {
 });
 
 test('model generator page', async ({ page }) => {
-  // Skip if the CDN hosting <model-viewer> is unreachable.
+  // Skip if external assets required by <model-viewer> are unreachable.
   try {
     const resp = await page.request.get(
       'https://cdn.jsdelivr.net/npm/@google/model-viewer@1.12.0/dist/model-viewer.min.js',
@@ -41,8 +41,12 @@ test('model generator page', async ({ page }) => {
     if (resp.status() >= 400) {
       test.skip(true, 'cdn.jsdelivr.net unreachable');
     }
+    const mv = await page.request.get('https://modelviewer.dev');
+    if (mv.status() >= 400) {
+      test.skip(true, 'modelviewer.dev unreachable');
+    }
   } catch {
-    test.skip(true, 'cdn.jsdelivr.net unreachable');
+    test.skip(true, 'viewer assets unreachable');
   }
 
   await page.goto('/index.html');
@@ -51,7 +55,7 @@ test('model generator page', async ({ page }) => {
   await page.waitForFunction(() => window.customElements.get('model-viewer'));
   // Allow extra time for the viewer to load when the CDN script fails and the
   // page falls back to the local copy.
-  await page.waitForSelector('#viewer', { state: 'visible', timeout: 30000 });
+  await page.waitForSelector('#viewer', { state: 'visible', timeout: 60000 });
   await expect(page.locator('#viewer')).toBeVisible();
 });
 
@@ -66,7 +70,7 @@ test('generate flow', async ({ page }) => {
     test.skip(true, 'esm.sh unreachable');
   }
 
-  // Skip if the CDN hosting <model-viewer> is unreachable.
+  // Skip if the CDN hosting <model-viewer> or its assets are unreachable.
   try {
     const resp = await page.request.get(
       'https://cdn.jsdelivr.net/npm/@google/model-viewer@1.12.0/dist/model-viewer.min.js',
@@ -74,8 +78,12 @@ test('generate flow', async ({ page }) => {
     if (resp.status() >= 400) {
       test.skip(true, 'cdn.jsdelivr.net unreachable');
     }
+    const mv = await page.request.get('https://modelviewer.dev');
+    if (mv.status() >= 400) {
+      test.skip(true, 'modelviewer.dev unreachable');
+    }
   } catch {
-    test.skip(true, 'cdn.jsdelivr.net unreachable');
+    test.skip(true, 'viewer assets unreachable');
   }
 
   await page.goto('/generate.html');
@@ -85,5 +93,5 @@ test('generate flow', async ({ page }) => {
   await page.waitForSelector('#gen-prompt', { state: 'visible', timeout: 30000 });
   await page.fill('#gen-prompt', 'test');
   await page.click('#gen-submit');
-  await expect(page.locator('canvas')).toBeVisible({ timeout: 10000 });
+  await expect(page.locator('canvas')).toBeVisible({ timeout: 20000 });
 });

--- a/tests/networkConnectivity.test.js
+++ b/tests/networkConnectivity.test.js
@@ -38,4 +38,39 @@ describe("network connectivity", () => {
     }
     expect(status).toBeLessThan(500);
   });
+
+  test("jsdelivr reachable", async () => {
+    let status;
+    try {
+      status = await head(
+        "https://cdn.jsdelivr.net/npm/@google/model-viewer@1.12.0/dist/model-viewer.min.js",
+      );
+    } catch (err) {
+      console.warn("Skipping jsdelivr connectivity test:", err.message);
+      return;
+    }
+    expect(status).toBeLessThan(500);
+  });
+
+  test("esm.sh reachable", async () => {
+    let status;
+    try {
+      status = await head("https://esm.sh");
+    } catch (err) {
+      console.warn("Skipping esm.sh connectivity test:", err.message);
+      return;
+    }
+    expect(status).toBeLessThan(500);
+  });
+
+  test("modelviewer.dev reachable", async () => {
+    let status;
+    try {
+      status = await head("https://modelviewer.dev");
+    } catch (err) {
+      console.warn("Skipping modelviewer.dev connectivity test:", err.message);
+      return;
+    }
+    expect(status).toBeLessThan(500);
+  });
 });


### PR DESCRIPTION
## Summary
- skip smoke test scenarios when model viewer assets are unreachable
- check CDN connectivity for jsdelivr, esm.sh and modelviewer.dev

## Testing
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6872ba018c5c832da3ddbdce6e783704