### PR TITLE
Add invalid GLB upload test

### DIFF
--- a/backend/src/lib/storeGlb.js
+++ b/backend/src/lib/storeGlb.js
@@ -1,6 +1,9 @@
 const { S3Client, PutObjectCommand } = require("@aws-sdk/client-s3");
 
 async function storeGlb(data) {
+  if (data.length < 12 || data.toString("utf8", 0, 4) !== "glTF") {
+    throw new Error("Invalid GLB");
+  }
   const region = process.env.AWS_REGION;
   const bucket = process.env.S3_BUCKET;
   const accessKeyId = process.env.AWS_ACCESS_KEY_ID;

--- a/backend/src/lib/storeGlb.ts
+++ b/backend/src/lib/storeGlb.ts
@@ -1,4 +1,4 @@
-import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
 
 /**
  * Upload GLB data to S3 and return its public URL
@@ -6,14 +6,17 @@ import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
  * @returns {Promise<string>} public URL of uploaded model
  */
 export async function storeGlb(data: Buffer): Promise<string> {
+  if (data.length < 12 || data.toString("utf8", 0, 4) !== "glTF") {
+    throw new Error("Invalid GLB");
+  }
   const region = process.env.AWS_REGION;
   const bucket = process.env.S3_BUCKET;
   const accessKeyId = process.env.AWS_ACCESS_KEY_ID;
   const secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
-  if (!region) throw new Error('AWS_REGION is not set');
-  if (!bucket) throw new Error('S3_BUCKET is not set');
-  if (!accessKeyId) throw new Error('AWS_ACCESS_KEY_ID is not set');
-  if (!secretAccessKey) throw new Error('AWS_SECRET_ACCESS_KEY is not set');
+  if (!region) throw new Error("AWS_REGION is not set");
+  if (!bucket) throw new Error("S3_BUCKET is not set");
+  if (!accessKeyId) throw new Error("AWS_ACCESS_KEY_ID is not set");
+  if (!secretAccessKey) throw new Error("AWS_SECRET_ACCESS_KEY is not set");
   const client = new S3Client({
     region,
     credentials: { accessKeyId, secretAccessKey },
@@ -24,8 +27,8 @@ export async function storeGlb(data: Buffer): Promise<string> {
       Bucket: bucket,
       Key: key,
       Body: data,
-      ContentType: 'model/gltf-binary',
-      ACL: 'public-read',
+      ContentType: "model/gltf-binary",
+      ACL: "public-read",
     }),
   );
   return `https://${bucket}.s3.${region}.amazonaws.com/${key}`;

--- a/backend/tests/storeGlb.test.ts
+++ b/backend/tests/storeGlb.test.ts
@@ -1,40 +1,48 @@
-const { storeGlb } = require('../src/lib/storeGlb.js');
-const aws = require('@aws-sdk/client-s3');
+const { storeGlb } = require("../src/lib/storeGlb.js");
+const aws = require("@aws-sdk/client-s3");
 
-jest.mock('@aws-sdk/client-s3', () => ({
+jest.mock("@aws-sdk/client-s3", () => ({
   S3Client: jest.fn(),
   PutObjectCommand: jest.fn(),
 }));
 
-describe('storeGlb', () => {
+describe("storeGlb", () => {
   beforeEach(() => {
-    process.env.AWS_REGION = 'us-east-1';
-    process.env.S3_BUCKET = 'bucket';
-    process.env.AWS_ACCESS_KEY_ID = 'id';
-    process.env.AWS_SECRET_ACCESS_KEY = 'secret';
+    process.env.AWS_REGION = "us-east-1";
+    process.env.S3_BUCKET = "bucket";
+    process.env.AWS_ACCESS_KEY_ID = "id";
+    process.env.AWS_SECRET_ACCESS_KEY = "secret";
   });
 
   afterEach(() => {
     jest.resetAllMocks();
   });
 
-  test('uploads buffer to s3 and returns url', async () => {
+  test("uploads buffer to s3 and returns url", async () => {
     const send = jest.fn().mockResolvedValue({});
     aws.S3Client.mockImplementation(() => ({ send }));
-    const data = Buffer.from('glb');
+    const data = Buffer.alloc(12);
+    data.write("glTF", 0);
+    data.writeUInt32LE(2, 4);
+    data.writeUInt32LE(12, 8);
 
     const url = await storeGlb(data);
 
     expect(aws.PutObjectCommand).toHaveBeenCalledWith({
-      Bucket: 'bucket',
+      Bucket: "bucket",
       Key: expect.stringMatching(/^models\/\d+-[a-z0-9]+\.glb$/),
       Body: data,
-      ContentType: 'model/gltf-binary',
-      ACL: 'public-read',
+      ContentType: "model/gltf-binary",
+      ACL: "public-read",
     });
     expect(url).toMatch(
       /^https:\/\/bucket\.s3\.us-east-1\.amazonaws\.com\/models\/\d+-[a-z0-9]+\.glb$/,
     );
     expect(send).toHaveBeenCalled();
+  });
+
+  test("rejects invalid glb buffer", async () => {
+    await expect(storeGlb(Buffer.alloc(0))).rejects.toThrow("Invalid GLB");
+    expect(aws.S3Client).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- validate buffer data in `storeGlb`
- test rejection when uploading invalid GLB data

## Testing
- `npx prettier -w backend/src/lib/storeGlb.ts backend/src/lib/storeGlb.js backend/tests/storeGlb.test.ts`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6872c379e1a8832dbef5c86f44c5dd7d