### PR TITLE
Add structured logging for textToImage fetch

### DIFF
--- a/backend/src/lib/textToImage.ts
+++ b/backend/src/lib/textToImage.ts
@@ -1,9 +1,9 @@
-import axios from 'axios';
-import fs from 'fs';
-import { pipeline } from 'stream/promises';
-import path from 'path';
-import { uploadFile } from './uploadS3';
-import { capture } from './logger';
+import axios from "axios";
+import fs from "fs";
+import { pipeline } from "stream/promises";
+import path from "path";
+import { uploadFile } from "./uploadS3";
+import { capture } from "./logger";
 
 /**
  * Generate an image from text using Stability AI and upload to S3.
@@ -12,24 +12,43 @@ import { capture } from './logger';
  */
 export async function textToImage(prompt: string): Promise<string> {
   const key = process.env.STABILITY_KEY;
-  if (!key) throw new Error('STABILITY_KEY is not set');
-  const endpoint = 'https://api.stability.ai/v2beta/stable-image/generate/core';
+  if (!key) throw new Error("STABILITY_KEY is not set");
+  const endpoint = "https://api.stability.ai/v2beta/stable-image/generate/core";
   try {
-    const res = await axios.post(
-      endpoint,
-      { text_prompts: [{ text: prompt }], output_format: 'png' },
-      { headers: { Authorization: `Bearer ${key}` }, responseType: 'stream', validateStatus: () => true },
-    );
+    let res;
+    try {
+      res = await axios.post(
+        endpoint,
+        { text_prompts: [{ text: prompt }], output_format: "png" },
+        {
+          headers: { Authorization: `Bearer ${key}` },
+          responseType: "stream",
+          validateStatus: () => true,
+        },
+      );
+    } catch (err: any) {
+      console.error(
+        JSON.stringify({
+          step: "textToImage-fetch",
+          error: err.message,
+          stack: err.stack,
+        }),
+      );
+      throw err;
+    }
 
     if (res.status >= 400) {
       const msg = res.data?.error || `request failed with status ${res.status}`;
       throw new Error(msg);
     }
 
-    const tmpPath = path.join('/tmp', `${Date.now()}-${Math.random().toString(36).slice(2)}.png`);
+    const tmpPath = path.join(
+      "/tmp",
+      `${Date.now()}-${Math.random().toString(36).slice(2)}.png`,
+    );
     await pipeline(res.data, fs.createWriteStream(tmpPath));
     try {
-      return await uploadFile(tmpPath, 'image/png');
+      return await uploadFile(tmpPath, "image/png");
     } finally {
       fs.unlink(tmpPath, () => {});
     }


### PR DESCRIPTION
## Summary
- add nested error handler around axios POST in `textToImage.ts`
- log step, message and stack when fetch fails

## Testing
- `npm test` in `backend/`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6872c3747780832da4b1459125f18056