### PR TITLE
Increase generate flow timeout

### DIFF
--- a/e2e/smoke.test.js
+++ b/e2e/smoke.test.js
@@ -103,5 +103,7 @@ test('generate flow', async ({ page }) => {
   await page.waitForSelector('#gen-prompt', { state: 'visible', timeout: 30000 });
   await page.fill('#gen-prompt', 'test');
   await page.click('#gen-submit');
-  await expect(page.locator('canvas')).toBeVisible({ timeout: 20000 });
+  // Wait longer for the model viewer to load on slow networks
+  await page.waitForSelector('canvas', { state: 'visible', timeout: 60000 });
+  await expect(page.locator('canvas')).toBeVisible();
 });


### PR DESCRIPTION
## Summary
- extend smoke test wait time for model viewer

## Testing
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6872c17bce4c832d93919d525cd9fd1f