### PR TITLE
Improve viewer readiness detection

### DIFF
--- a/backend/tests/frontend/viewerReady.test.js
+++ b/backend/tests/frontend/viewerReady.test.js
@@ -1,0 +1,39 @@
+/** @jest-environment node */
+const fs = require("fs");
+const path = require("path");
+const { JSDOM } = require("jsdom");
+
+let html = fs.readFileSync(path.join(__dirname, "../../../index.html"), "utf8");
+html = html
+  .replace(/<script[^>]+src="https?:\/\/[^>]+><\/script>/g, "")
+  .replace(/<link[^>]+href="https?:\/\/[^>]+>/g, "")
+  .replace(
+    /<script[^>]+src="js\/(?:index|theme|subredditLanding|modelViewerTouchFix)\.js"[^>]*><\/script>/g,
+    "",
+  );
+
+function setup() {
+  const dom = new JSDOM(html, {
+    runScripts: "dangerously",
+    resources: "usable",
+    url: "http://localhost/",
+  });
+  global.window = dom.window;
+  global.document = dom.window.document;
+  let script = fs
+    .readFileSync(path.join(__dirname, "../../../js/index.js"), "utf8")
+    .replace(/import { shareOn } from ['"]\.\/share.js['"];?/, "")
+    .replace(/window\.addEventListener\(['"]DOMContentLoaded['"][\s\S]+$/, "")
+    .replace(/let savedProfile = null;\n?/, "");
+  script += "\nwindow._showModel = showModel;\nwindow._hideAll = hideAll;";
+  dom.window.eval(script);
+  return dom;
+}
+
+test("showModel toggles viewerReady dataset", () => {
+  const dom = setup();
+  dom.window._hideAll();
+  expect(dom.window.document.body.dataset.viewerReady).toBeUndefined();
+  dom.window._showModel();
+  expect(dom.window.document.body.dataset.viewerReady).toBe("true");
+});

--- a/e2e/smoke.test.js
+++ b/e2e/smoke.test.js
@@ -65,7 +65,9 @@ test('model generator page', async ({ page }) => {
   await page.waitForFunction(() => window.customElements.get('model-viewer'));
   // Allow extra time for the viewer to load when the CDN script fails and the
   // page falls back to the local copy.
-  await page.waitForSelector('#viewer', { state: 'visible', timeout: 60000 });
+  await page.waitForSelector('body[data-viewer-ready="true"]', {
+    timeout: 60000,
+  });
   await expect(page.locator('#viewer')).toBeVisible();
 });
 

--- a/js/index.js
+++ b/js/index.js
@@ -479,6 +479,9 @@ const hideAll = () => {
   if (typeof refs.viewer.pause === "function") {
     refs.viewer.pause();
   }
+  if (globalThis.document) {
+    delete document.body.dataset.viewerReady;
+  }
 };
 const showLoader = (withProgress = true) => {
   // Keep the viewer visible while showing the loader so the fallback model
@@ -501,6 +504,10 @@ const showModel = () => {
   refs.viewer.style.pointerEvents = "auto";
   if (typeof refs.viewer.play === "function") {
     refs.viewer.play();
+  }
+
+  if (globalThis.document) {
+    document.body.dataset.viewerReady = "true";
   }
 
   stopProgress();


### PR DESCRIPTION
## Summary
- expose viewer readiness via dataset flag in `showModel`
- clear viewer readiness when hiding model
- wait for viewer-ready flag in smoke test
- add unit test for viewerReady behaviour

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6872c16a3848832dae83e851e7ac6dbe