### PR TITLE
Add error boundaries to API routes

### DIFF
--- a/backend/routes/models.js
+++ b/backend/routes/models.js
@@ -13,18 +13,18 @@ const createModelSchema = z.object({
   fileKey: z.string().regex(/^[A-Za-z0-9._-]+$/, "invalid fileKey"),
 });
 
-router.post("/", validate(createModelSchema), async (req, res) => {
-  const { prompt, fileKey } = req.body;
-  const domain = process.env.CLOUDFRONT_MODEL_DOMAIN;
-  const url = `https://${domain}/${fileKey}`;
+router.post("/", validate(createModelSchema), async (req, res, next) => {
   try {
+    const { prompt, fileKey } = req.body;
+    const domain = process.env.CLOUDFRONT_MODEL_DOMAIN;
+    const url = `https://${domain}/${fileKey}`;
     const { rows } = await db.query(
       "INSERT INTO models(prompt, fileKey, url) VALUES($1,$2,$3) RETURNING id, prompt, fileKey, url, created_at",
       [prompt, fileKey, url],
     );
     res.status(201).json(rows[0]);
-  } catch (_err) {
-    res.status(500).json({ error: "Failed to create model" });
+  } catch (err) {
+    next(err);
   }
 });
 

--- a/backend/src/__tests__/models.test.js
+++ b/backend/src/__tests__/models.test.js
@@ -43,5 +43,5 @@ test("POST /api/models returns 500 on db error", async () => {
     .post("/api/models")
     .send({ prompt: "p", fileKey: "file.glb" });
   expect(res.status).toBe(500);
-  expect(res.body.error).toBe("Failed to insert model");
+  expect(res.body.error).toBe("Internal Server Error");
 });

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -1,10 +1,22 @@
 const express = require("express");
 const modelsRouter = require("./routes/models");
 const checkoutRouter = require("./routes/checkout").default;
+const { capture } = require("./lib/logger");
 
 const app = express();
 app.use(express.json());
 app.use(modelsRouter);
 app.use(checkoutRouter);
+
+app.use((err, req, res, _next) => {
+  const context = {
+    method: req.method,
+    url: req.originalUrl,
+    body: req.body,
+  };
+  console.error("Error handling request", context, err);
+  capture(err);
+  res.status(500).json({ error: "Internal Server Error" });
+});
 
 module.exports = app;

--- a/backend/src/routes/checkout.js
+++ b/backend/src/routes/checkout.js
@@ -18,10 +18,12 @@ const secretKey =
 const stripe = new stripe_1.default(secretKey);
 const router = express_1.default.Router();
 router.orders = exports.orders;
-router.post("/api/checkout", async (req, res) => {
-  const { slug, email } = req.body;
-  if (!slug || !email) return res.status(400).json({ error: "missing fields" });
+router.post("/api/checkout", async (req, res, next) => {
   try {
+    const { slug, email } = req.body;
+    if (!slug || !email) {
+      return res.status(400).json({ error: "missing fields" });
+    }
     const session = await stripe.checkout.sessions.create({
       mode: "payment",
       line_items: [
@@ -40,35 +42,37 @@ router.post("/api/checkout", async (req, res) => {
     });
     exports.orders.set(session.id, { slug, email, paid: false });
     res.json({ checkoutUrl: session.url });
-  } catch (_err) {
-    res.status(500).json({ error: "Failed to create session" });
+  } catch (err) {
+    next(err);
   }
 });
 router.post(
   "/api/stripe/webhook",
   express_1.default.raw({ type: "application/json" }),
-  async (req, res) => {
-    const sig = req.headers["stripe-signature"];
-    let event;
+  async (req, res, next) => {
     try {
-      event = stripe.webhooks.constructEvent(
+      const sig = req.headers["stripe-signature"];
+      const event = stripe.webhooks.constructEvent(
         req.body,
         sig,
         process.env.STRIPE_WEBHOOK_SECRET || "",
       );
-    } catch (_err) {
-      return res.sendStatus(400);
-    }
-    if (event.type === "checkout.session.completed") {
-      const session = event.data.object;
-      const order = exports.orders.get(session.id);
-      if (order && !order.paid) {
-        order.paid = true;
-        const link = `https://huggingface.co/spaces/print2/Sparc3D/resolve/main/output/${order.slug}.glb`;
-        await (0, mail_1.sendMail)(order.email, "Your model is ready", link);
+      if (event.type === "checkout.session.completed") {
+        const session = event.data.object;
+        const order = exports.orders.get(session.id);
+        if (order && !order.paid) {
+          order.paid = true;
+          const link = `https://huggingface.co/spaces/print2/Sparc3D/resolve/main/output/${order.slug}.glb`;
+          await (0, mail_1.sendMail)(order.email, "Your model is ready", link);
+        }
       }
+      res.sendStatus(200);
+    } catch (err) {
+      if (err && err.message && err.message.includes("Webhook Error")) {
+        return res.sendStatus(400);
+      }
+      next(err);
     }
-    res.sendStatus(200);
   },
 );
 exports.default = router;

--- a/backend/src/routes/checkout.ts
+++ b/backend/src/routes/checkout.ts
@@ -22,10 +22,12 @@ const stripe = new Stripe(secretKey);
 const router = express.Router();
 (router as any).orders = orders;
 
-router.post('/api/checkout', async (req, res) => {
-  const { slug, email } = req.body as Order;
-  if (!slug || !email) return res.status(400).json({ error: 'missing fields' });
+router.post('/api/checkout', async (req, res, next) => {
   try {
+    const { slug, email } = req.body as Order;
+    if (!slug || !email) {
+      return res.status(400).json({ error: 'missing fields' });
+    }
     const session = await stripe.checkout.sessions.create({
       mode: 'payment',
       line_items: [
@@ -44,29 +46,40 @@ router.post('/api/checkout', async (req, res) => {
     });
     orders.set(session.id, { slug, email, paid: false });
     res.json({ checkoutUrl: session.url });
-  } catch (_err) {
-    res.status(500).json({ error: 'Failed to create session' });
+  } catch (err) {
+    next(err);
   }
 });
 
-router.post('/api/stripe/webhook', express.raw({ type: 'application/json' }), async (req, res) => {
-  const sig = req.headers['stripe-signature'] as string;
-  let event: Stripe.Event;
-  try {
-    event = stripe.webhooks.constructEvent(req.body, sig, process.env.STRIPE_WEBHOOK_SECRET || '');
-  } catch (_err) {
-    return res.sendStatus(400);
-  }
-  if (event.type === 'checkout.session.completed') {
-    const session = event.data.object as Stripe.Checkout.Session;
-    const order = orders.get(session.id);
-    if (order && !order.paid) {
-      order.paid = true;
-      const link = `https://huggingface.co/spaces/print2/Sparc3D/resolve/main/output/${order.slug}.glb`;
-      await sendMail(order.email, 'Your model is ready', link);
+router.post(
+  '/api/stripe/webhook',
+  express.raw({ type: 'application/json' }),
+  async (req, res, next) => {
+    try {
+      const sig = req.headers['stripe-signature'] as string;
+      const event = stripe.webhooks.constructEvent(
+        req.body,
+        sig,
+        process.env.STRIPE_WEBHOOK_SECRET || '',
+      );
+      if (event.type === 'checkout.session.completed') {
+        const session = event.data.object as Stripe.Checkout.Session;
+        const order = orders.get(session.id);
+        if (order && !order.paid) {
+          order.paid = true;
+          const link = `https://huggingface.co/spaces/print2/Sparc3D/resolve/main/output/${order.slug}.glb`;
+          await sendMail(order.email, 'Your model is ready', link);
+        }
+      }
+      res.sendStatus(200);
+    } catch (err) {
+      // signature errors should return 400
+      if (err instanceof Error && err.message.includes('Webhook Error')) {
+        return res.sendStatus(400);
+      }
+      next(err);
     }
-  }
-  res.sendStatus(200);
-});
+  },
+);
 
 export default router;

--- a/backend/src/routes/stripe/create-checkout-session.ts
+++ b/backend/src/routes/stripe/create-checkout-session.ts
@@ -5,9 +5,9 @@ import db from '../../db';
 const router = Router();
 const stripe = new Stripe(process.env.STRIPE_KEY as string, { apiVersion: '2022-11-15' });
 
-router.post('/api/create-checkout-session', async (req, res) => {
-  const { price, qty = 1, metadata = {} } = req.body;
+router.post('/api/create-checkout-session', async (req, res, next) => {
   try {
+    const { price, qty = 1, metadata = {} } = req.body;
     const session = await stripe.checkout.sessions.create({
       mode: 'payment',
       payment_method_types: ['card'],
@@ -21,7 +21,7 @@ router.post('/api/create-checkout-session', async (req, res) => {
     await db.query('INSERT INTO orders(session_id,status) VALUES($1,$2)', [session.id, 'created']);
     res.json({ id: session.id, url: session.url });
   } catch (err: any) {
-    res.status(500).json({ error: err.message });
+    next(err);
   }
 });
 

--- a/backend/src/routes/stripe/webhook.ts
+++ b/backend/src/routes/stripe/webhook.ts
@@ -7,23 +7,36 @@ import { enqueuePrint as enqueueDbPrint } from '../../queue/dbPrintQueue';
 const router = Router();
 const stripe = new Stripe(process.env.STRIPE_KEY as string, { apiVersion: '2022-11-15' });
 
-router.post('/api/webhook/stripe', express.raw({ type: 'application/json' }), async (req, res) => {
-  const sig = req.headers['stripe-signature'] as string;
-  let event: Stripe.Event;
-  try {
-    event = stripe.webhooks.constructEvent(req.body, sig, process.env.STRIPE_WEBHOOK_SECRET as string);
-  } catch (err: any) {
-    return res.status(400).send(`Webhook Error: ${err.message}`);
-  }
-  if (event.type === 'checkout.session.completed') {
-    const session = event.data.object as Stripe.Checkout.Session;
-    await db.query('UPDATE orders SET status=$1 WHERE session_id=$2', ['paid', session.id]);
-    if (session.metadata?.jobId) {
-      await enqueueDbPrint(session.metadata.jobId, session.id, {}, null, null);
-      enqueuePrint(session.metadata.jobId);
+router.post(
+  '/api/webhook/stripe',
+  express.raw({ type: 'application/json' }),
+  async (req, res, next) => {
+    try {
+      const sig = req.headers['stripe-signature'] as string;
+      const event = stripe.webhooks.constructEvent(
+        req.body,
+        sig,
+        process.env.STRIPE_WEBHOOK_SECRET as string,
+      );
+      if (event.type === 'checkout.session.completed') {
+        const session = event.data.object as Stripe.Checkout.Session;
+        await db.query('UPDATE orders SET status=$1 WHERE session_id=$2', [
+          'paid',
+          session.id,
+        ]);
+        if (session.metadata?.jobId) {
+          await enqueueDbPrint(session.metadata.jobId, session.id, {}, null, null);
+          enqueuePrint(session.metadata.jobId);
+        }
+      }
+      res.sendStatus(200);
+    } catch (err: any) {
+      if (err.message) {
+        return res.status(400).send(`Webhook Error: ${err.message}`);
+      }
+      next(err);
     }
-  }
-  res.sendStatus(200);
-});
+  },
+);
 
 export default router;


### PR DESCRIPTION
## Summary
- wrap API route handlers in try/catch and forward to error middleware
- log request context in global error handler
- update failing test expectation

## Testing
- `npm test`
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_6872c3858b6c832da59ea453a7fbcd56