### PR TITLE
Handle apt failures in setup

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -60,14 +60,18 @@ sudo rm -f /var/lib/apt/lists/lock /var/lib/dpkg/lock /var/cache/apt/archives/lo
 
 if [ -z "$SKIP_PW_DEPS" ]; then
   # Retry apt-get update to ensure the proxy is respected and networking is ready
+  set +e
+  success=0
   for i in {1..3}; do
-    if sudo -E apt-get update; then
-      break
-    else
-      echo "apt-get update failed, retrying ($i/3)..." >&2
-      sleep 5
-    fi
+    sudo -E apt-get update && success=1 && break
+    echo "apt-get update failed, retrying ($i/3)..." >&2
+    sleep 5
   done
+  set -e
+  if [ $success -ne 1 ]; then
+    echo "apt-get update failed after retries, proceeding without Playwright system dependencies" >&2
+    SKIP_PW_DEPS=1
+  fi
 fi
 
 run_ci() {

--- a/tests/setupScriptAptFailure.test.js
+++ b/tests/setupScriptAptFailure.test.js
@@ -23,11 +23,12 @@ function run(env) {
 }
 
 describe("setup script apt-get failure", () => {
-  test("fails when apt-get is not available and deps not skipped", () => {
-    expect(() => run({})).toThrow();
+  test("script falls back to skipping deps when apt-get fails", () => {
+    const output = run({ SKIP_NET_CHECKS: "1" });
+    expect(output).toMatch(/apt-get update failed after retries/);
   });
 
-  test("succeeds when SKIP_PW_DEPS=1", () => {
+  test("still succeeds when SKIP_PW_DEPS=1", () => {
     expect(() =>
       run({ SKIP_PW_DEPS: "1", SKIP_NET_CHECKS: "1" }),
     ).not.toThrow();


### PR DESCRIPTION
## Summary
- update `setup.sh` to fall back when `apt-get` fails
- expect automatic fallback in `setupScriptAptFailure` test

## Testing
- `SKIP_PW_DEPS=1 npm run ci`
- `npm --prefix backend run format`


------
https://chatgpt.com/codex/tasks/task_e_6872cdfb730c832d8bc95bac3e401f90