### PR TITLE
Add environment variable helper

### DIFF
--- a/backend/config.js
+++ b/backend/config.js
@@ -1,22 +1,21 @@
 "use strict";
-const required = ["DB_URL", "STRIPE_SECRET_KEY", "STRIPE_WEBHOOK_SECRET"];
+const { getEnv } = require("./utils/getEnv");
+
 const optionalGlb = [
   "CLOUDFRONT_MODEL_DOMAIN",
   "SPARC3D_ENDPOINT",
   "SPARC3D_TOKEN",
 ];
-const missing = required.filter((key) => !process.env[key]);
-if (missing.length) {
-  console.warn(`Missing required env vars: ${missing.join(', ')}`);
-}
+
 const missingGlb = optionalGlb.filter((key) => !process.env[key]);
 if (missingGlb.length) {
-  console.warn(`Missing optional GLB env vars: ${missingGlb.join(', ')}`);
+  console.warn(`Missing optional GLB env vars: ${missingGlb.join(", ")}`);
 }
+
 module.exports = {
-  dbUrl: process.env.DB_URL,
-  stripeKey: process.env.STRIPE_SECRET_KEY,
-  stripeWebhook: process.env.STRIPE_WEBHOOK_SECRET,
+  dbUrl: getEnv("DB_URL"),
+  stripeKey: getEnv("STRIPE_SECRET_KEY"),
+  stripeWebhook: getEnv("STRIPE_WEBHOOK_SECRET"),
   stripePublishable: process.env.STRIPE_PUBLISHABLE_KEY || "",
   dalleServerUrl: process.env.DALLE_SERVER_URL || "http://localhost:5002",
   port: process.env.PORT || 3000,

--- a/backend/utils/getEnv.js
+++ b/backend/utils/getEnv.js
@@ -1,0 +1,12 @@
+function getEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    const message = `Missing required environment variable ${name}`;
+    if (process.env.NODE_ENV !== "test") {
+      console.error(message);
+    }
+  }
+  return value;
+}
+
+module.exports = { getEnv };


### PR DESCRIPTION
## Summary
- create `getEnv` helper for environment variables
- use it in backend config to surface missing env vars

## Testing
- `npm run format`
- `npm test`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6872cd945658832d8c6926d6e76a15e0