### PR TITLE
Add required env var check

### DIFF
--- a/scripts/check-env.sh
+++ b/scripts/check-env.sh
@@ -37,6 +37,7 @@ fi
 : "${AWS_SECRET_ACCESS_KEY:?AWS_SECRET_ACCESS_KEY must be set}"
 : "${DB_URL:?DB_URL must be set}"
 : "${STRIPE_SECRET_KEY:?STRIPE_SECRET_KEY must be set}"
+: "${CLOUDFRONT_MODEL_DOMAIN:?CLOUDFRONT_MODEL_DOMAIN must be set}"
 
 # Fail fast if npm-specific proxy variables are set. Other proxy variables may be required
 if [[ -n "${npm_config_http_proxy:-}" || -n "${npm_config_https_proxy:-}" ]]; then

--- a/tests/assertSetup.test.js
+++ b/tests/assertSetup.test.js
@@ -17,6 +17,7 @@ describe("assert-setup script", () => {
     process.env.HF_TOKEN = "x";
     process.env.AWS_ACCESS_KEY_ID = "id";
     process.env.AWS_SECRET_ACCESS_KEY = "secret";
+    process.env.CLOUDFRONT_MODEL_DOMAIN = "cdn.test";
   }
 
   test("runs setup when browsers missing", () => {

--- a/tests/envVars.test.js
+++ b/tests/envVars.test.js
@@ -4,6 +4,7 @@ const requiredVars = [
   "AWS_SECRET_ACCESS_KEY",
   "DB_URL",
   "STRIPE_SECRET_KEY",
+  "CLOUDFRONT_MODEL_DOMAIN",
 ];
 
 describe("required environment variables", () => {

--- a/tests/validateEnv.test.js
+++ b/tests/validateEnv.test.js
@@ -24,6 +24,7 @@ describe("validate-env script", () => {
       STRIPE_LIVE_KEY: "",
       DB_URL: "postgres://user:pass@localhost/db",
       STRIPE_SECRET_KEY: "sk_test_dummy",
+      CLOUDFRONT_MODEL_DOMAIN: "cdn.test",
       npm_config_http_proxy: "",
       npm_config_https_proxy: "",
       http_proxy: "http://proxy",
@@ -44,6 +45,7 @@ describe("validate-env script", () => {
       AWS_SECRET_ACCESS_KEY: "secret",
       DB_URL: "postgres://user:pass@localhost/db",
       STRIPE_SECRET_KEY: "sk_test_dummy",
+      CLOUDFRONT_MODEL_DOMAIN: "cdn.test",
     };
     const output = run(env);
     expect(output).toContain("✅ environment OK");
@@ -56,6 +58,7 @@ describe("validate-env script", () => {
       AWS_ACCESS_KEY_ID: "id",
       AWS_SECRET_ACCESS_KEY: "secret",
       STRIPE_SECRET_KEY: "sk_test",
+      CLOUDFRONT_MODEL_DOMAIN: "cdn.test",
     };
     delete env.DB_URL;
     expect(() => run(env)).toThrow();
@@ -68,6 +71,7 @@ describe("validate-env script", () => {
       AWS_ACCESS_KEY_ID: "id",
       AWS_SECRET_ACCESS_KEY: "secret",
       STRIPE_TEST_KEY: "sk_test",
+      CLOUDFRONT_MODEL_DOMAIN: "cdn.test",
       npm_config_http_proxy: "http://proxy",
       SKIP_NET_CHECKS: "1",
     };
@@ -84,6 +88,7 @@ describe("validate-env script", () => {
       npm_config_http_proxy: "",
       npm_config_https_proxy: "",
       NETWORK_CHECK_URL: "http://127.0.0.1:9",
+      CLOUDFRONT_MODEL_DOMAIN: "cdn.test",
       SKIP_NET_CHECKS: "",
     };
     expect(() => run(env)).toThrow(/Network check failed/);


### PR DESCRIPTION
## Summary
- require `CLOUDFRONT_MODEL_DOMAIN` in `check-env.sh`
- assert that the variable is set in tests

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6872cd76022c832da2c7e7b996c8d796