### PR TITLE
Fix prettier path and add format script test

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -11,7 +11,7 @@
     "migrate": "node scripts/run-migrations.js",
     "seed": "node scripts/seed-db.js",
     "create-admin": "node scripts/create-admin.js",
-    "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
+    "format": "node -e \"const path=require('path');process.chdir('..');require(path.join(process.cwd(),'scripts/assert-setup.js'))\" && prettier --write \"**/*.{js,jsx,json,md}\"",
     "send-reminders": "node scripts/send-purchase-reminders.js",
     "send-abandoned-offers": "node scripts/send-abandoned-offers.js",
     "send-followups": "node scripts/send-post-purchase-followups.js",

--- a/backend/tests/formatScript.test.js
+++ b/backend/tests/formatScript.test.js
@@ -1,0 +1,9 @@
+const { execSync } = require("child_process");
+
+describe("format script", () => {
+  test("runs prettier successfully", () => {
+    expect(() => {
+      execSync("npm run format --silent", { cwd: __dirname + "/.." });
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- ensure backend `format` script runs setup steps
- add Jest test exercising backend format script

## Testing
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6872cd3f105c832dab2f6c00141d4413