### PR TITLE
Fix Prettier missing in format scripts

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -11,6 +11,7 @@
     "migrate": "node scripts/run-migrations.js",
     "seed": "node scripts/seed-db.js",
     "create-admin": "node scripts/create-admin.js",
+    "preformat": "node ../scripts/assert-setup.js",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "send-reminders": "node scripts/send-purchase-reminders.js",
     "send-abandoned-offers": "node scripts/send-abandoned-offers.js",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "preinstall": "node scripts/check-node-version.js",
     "lhci": "lhci autorun",
     "prepare": "husky install && tsc -p scripts/tsconfig.json",
+    "preformat": "node scripts/assert-setup.js",
+    "preformat:check": "node scripts/assert-setup.js",
     "format": "prettier --write \"**/*.{js,jsx,json,md,html}\"",
     "format:check": "prettier --check \"**/*.{js,jsx,json,md,html}\"",
     "lint": "npm run check-conflicts && eslint . --max-warnings=0 && npm run lint --prefix backend",

--- a/scripts/assert-setup.js
+++ b/scripts/assert-setup.js
@@ -4,6 +4,12 @@ const os = require("os");
 const path = require("path");
 const child_process = require("child_process");
 
+// Ensure this script runs from the repo root so relative paths work
+const repoRoot = path.resolve(__dirname, "..");
+if (process.cwd() !== repoRoot) {
+  process.chdir(repoRoot);
+}
+
 function loadEnvFile(file) {
   if (!fs.existsSync(file)) return;
   const lines = fs.readFileSync(file, "utf8").split(/\r?\n/);

--- a/tests/formatScript.test.js
+++ b/tests/formatScript.test.js
@@ -1,0 +1,14 @@
+const rootPkg = require("../package.json");
+const backendPkg = require("../backend/package.json");
+
+describe("format scripts", () => {
+  test("preformat hooks assert-setup", () => {
+    expect(rootPkg.scripts.preformat).toBe("node scripts/assert-setup.js");
+    expect(rootPkg.scripts["preformat:check"]).toBe(
+      "node scripts/assert-setup.js",
+    );
+    expect(backendPkg.scripts.preformat).toBe(
+      "node ../scripts/assert-setup.js",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- ensure the repo root and backend format scripts run the setup checker
- make assert-setup.js work when called from subdirectories
- test that the format scripts use the setup checker

## Testing
- `npx prettier --write package.json backend/package.json scripts/assert-setup.js tests/formatScript.test.js`
- `node scripts/run-jest.js tests/formatScript.test.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6872cd3f105c832dab2f6c00141d4413