### PR TITLE
Fix ensure-deps to run setup automatically

### DIFF
--- a/backend/scripts/ensure-deps.js
+++ b/backend/scripts/ensure-deps.js
@@ -5,6 +5,7 @@ const { execSync } = require("child_process");
 const jestPath = "node_modules/.bin/jest";
 const repoRoot = path.join(__dirname, "..", "..");
 const expressPath = path.join(repoRoot, "node_modules", "express");
+const setupFlag = path.join(repoRoot, ".setup-complete");
 
 const networkCheck = path.join(
   __dirname,
@@ -35,6 +36,22 @@ function canReachRegistry() {
     );
     return false;
   }
+}
+
+function runSetup() {
+  console.log("Setup flag missing. Running 'npm run setup'...");
+  try {
+    execSync("npm run setup", { stdio: "inherit", cwd: repoRoot });
+  } catch (err) {
+    console.error("Failed to run setup:", err.message);
+    process.exit(1);
+  }
+}
+
+if (!fs.existsSync(setupFlag)) {
+  runNetworkCheck();
+  if (!canReachRegistry()) process.exit(1);
+  runSetup();
 }
 
 if (!fs.existsSync(expressPath)) {

--- a/tests/ensureDeps.test.js
+++ b/tests/ensureDeps.test.js
@@ -23,19 +23,21 @@ describe("ensure-deps", () => {
     expect(execMock).toHaveBeenNthCalledWith(2, "npm ping", {
       stdio: "ignore",
     });
-    expect(execMock).toHaveBeenNthCalledWith(3, "npm ci", {
+    expect(execMock).toHaveBeenNthCalledWith(3, "npm run setup", {
       stdio: "inherit",
       cwd: expect.any(String),
     });
-    expect(execMock).toHaveBeenNthCalledWith(
-      4,
-      expect.stringContaining("network-check.js"),
-      expect.any(Object),
+  });
+
+  test("runs setup when flag missing", () => {
+    fs.existsSync.mockReturnValue(false);
+    const execMock = jest.fn();
+    child_process.execSync.mockImplementation(execMock);
+    require("../backend/scripts/ensure-deps");
+    expect(execMock).toHaveBeenCalledWith(
+      "npm run setup",
+      expect.objectContaining({ cwd: expect.any(String) }),
     );
-    expect(execMock).toHaveBeenNthCalledWith(5, "npm ping", {
-      stdio: "ignore",
-    });
-    expect(execMock).toHaveBeenNthCalledWith(7, "npm ci", { stdio: "inherit" });
   });
 
   test("exits when npm ping fails", () => {


### PR DESCRIPTION
## Summary
- ensure backend pretest triggers root setup when `.setup-complete` is missing
- verify new behaviour in ensureDeps test

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_6872cd1c44ac832db6e201ce315ade2e