### PR TITLE
Fix host dependency check when SKIP_PW_DEPS used

### DIFF
--- a/scripts/check-host-deps.js
+++ b/scripts/check-host-deps.js
@@ -30,18 +30,20 @@ checkNetwork();
 
 if (!hostDepsInstalled()) {
   if (process.env.SKIP_PW_DEPS) {
-    console.log("Skipping Playwright host dependency install");
-  } else {
-    console.log("Playwright host dependencies missing. Installing...");
-    try {
-      execSync("CI=1 npx playwright install --with-deps", { stdio: "inherit" });
-    } catch (err) {
-      console.error(
-        "Failed to install Playwright host dependencies:",
-        err.message,
-      );
-      process.exit(1);
-    }
+    console.error(
+      "Playwright host dependencies are missing. Run 'npx playwright install --with-deps' or remove SKIP_PW_DEPS.",
+    );
+    process.exit(1);
+  }
+  console.log("Playwright host dependencies missing. Installing...");
+  try {
+    execSync("CI=1 npx playwright install --with-deps", { stdio: "inherit" });
+  } catch (err) {
+    console.error(
+      "Failed to install Playwright host dependencies:",
+      err.message,
+    );
+    process.exit(1);
   }
 } else {
   console.log("Playwright host dependencies already satisfied.");

--- a/tests/checkHostDeps.test.js
+++ b/tests/checkHostDeps.test.js
@@ -47,14 +47,18 @@ test("skips network check when SKIP_NET_CHECKS is set", () => {
   delete process.env.SKIP_NET_CHECKS;
 });
 
-test("skips install when SKIP_PW_DEPS is set", () => {
+test("fails when SKIP_PW_DEPS is set and deps are missing", () => {
   process.env.SKIP_PW_DEPS = "1";
   child_process.execSync
     .mockReturnValueOnce("network ok")
     .mockImplementationOnce(() => {
       throw new Error("missing deps");
     });
-  require("../scripts/check-host-deps.js");
+  const exitSpy = jest.spyOn(process, "exit").mockImplementation(() => {
+    throw new Error("exit");
+  });
+  expect(() => require("../scripts/check-host-deps.js")).toThrow("exit");
+  expect(exitSpy).toHaveBeenCalledWith(1);
   expect(child_process.execSync).toHaveBeenNthCalledWith(
     1,
     "node scripts/network-check.js",


### PR DESCRIPTION
## Summary
- fail with a clear message if `SKIP_PW_DEPS` is set but Playwright host deps are missing
- add a regression test for this case

## Testing
- `npm test`
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_6872cd015550832dbab15d6f243ccb84