### PR TITLE
Fix setup proxy handling

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -10,7 +10,7 @@ cleanup_npm_cache() {
 trap cleanup_npm_cache EXIT
 cleanup_npm_cache
 
-unset npm_config_http_proxy npm_config_https_proxy http_proxy https_proxy
+unset npm_config_http_proxy npm_config_https_proxy
 export npm_config_fund=false
 
 # Provide a temporary Stripe key if none is configured so validation succeeds

--- a/tests/setupScriptProxy.test.js
+++ b/tests/setupScriptProxy.test.js
@@ -1,0 +1,14 @@
+const fs = require("fs");
+const path = require("path");
+
+describe("setup script proxy handling", () => {
+  test("does not unset system proxy vars", () => {
+    const file = fs.readFileSync(
+      path.join(__dirname, "..", "scripts", "setup.sh"),
+      "utf8",
+    );
+    expect(file).toMatch(/unset npm_config_http_proxy npm_config_https_proxy/);
+    expect(file).not.toMatch(/\bhttp_proxy\b/);
+    expect(file).not.toMatch(/\bhttps_proxy\b/);
+  });
+});


### PR DESCRIPTION
## Summary
- keep system proxy variables intact during setup
- add regression test ensuring setup.sh only unsets npm proxy variables

## Testing
- `npm test`
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_6872ccefc30c832daa9174557c2ef976