### PR TITLE
Fix Playwright HTTPS errors

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -3,7 +3,7 @@ const baseURL = process.env.PLAYWRIGHT_BASE_URL || "http://localhost:3000";
 
 module.exports = defineConfig({
   testDir: "e2e",
-  use: { baseURL, headless: true },
+  use: { baseURL, headless: true, ignoreHTTPSErrors: true },
   webServer: process.env.PLAYWRIGHT_BASE_URL
     ? undefined
     : {


### PR DESCRIPTION
## Summary
- ignore HTTPS errors during Playwright runs

## Testing
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_6872d49d93bc832d91cc92d0d9953957