### PR TITLE
Add script to detect dependency cycles

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "deps:check": "npx -y lockfile-diff HEAD package-lock.json && npx -y lockfile-diff HEAD backend/package-lock.json && npx -y lockfile-diff HEAD backend/hunyuan_server/package-lock.json",
     "deps:dedupe": "npm dedupe",
     "deps:dedupe-check": "npm dedupe --dry-run",
+    "check-cycles": "node scripts/check-cycles.js",
     "bundle:size": "size-limit",
     "dev": "node backend/server.js",
     "validate-env": "bash scripts/validate-env.sh",

--- a/scripts/check-cycles.js
+++ b/scripts/check-cycles.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+import madge from "madge";
+
+madge("src")
+  .then((res) => {
+    const cycles = res.circular();
+    if (cycles.length) {
+      console.error("Dependency cycles detected:", cycles);
+      process.exit(1);
+    }
+    console.log("No cycles found.");
+  })
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary
- add a `check-cycles` script using `madge`
- wire the script into `package.json`

## Testing
- `npm test` in `backend/`
- `SKIP_PW_DEPS=1 npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_6872e165bbec832d9b9fecbef8b7dcb1