### PR TITLE
Add coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,14 @@
+name: Coverage
+
+on: [push, pull_request]
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version: "20"
+      - run: npm ci
+      - run: npm run coverage -- --reporter=text-lcov | coveralls


### PR DESCRIPTION
## Summary
- add Coverage job to CI

## Testing
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: process terminated by SIGINT)*

------
https://chatgpt.com/codex/tasks/task_e_6872e15d77b0832d9808dd1c35cea0d1