### PR TITLE
Add events performance benchmark

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "doc": "docs"
   },
   "scripts": {
+    "perf-events": "node scripts/perf-events.js",
     "preinstall": "node scripts/check-node-version.js",
     "lhci": "lhci autorun",
     "prepare": "husky install && tsc -p scripts/tsconfig.json",

--- a/scripts/perf-events.js
+++ b/scripts/perf-events.js
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+import autocannon from 'autocannon';
+
+const url = process.env.BASE_URL || 'http://localhost:3000/v2/events';
+const instance = autocannon({
+  url,
+  connections: 50,
+  duration: 20,
+  amount: 1000,
+});
+
+autocannon.track(instance, {
+  renderProgressBar: true,
+});
+
+instance.on('done', () => process.exit(0));
+


### PR DESCRIPTION
## Summary
- create `perf-events.js` load test script
- expose `npm run perf-events`

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_6872e11fadd4832dbcbe7c6c17bee8ee