### PR TITLE
Add sanity test for spec files

### DIFF
--- a/tests/utils/sanity.test.ts
+++ b/tests/utils/sanity.test.ts
@@ -1,0 +1,20 @@
+const fs = require("fs");
+const path = require("path");
+
+test("all specs contain at least one expect", () => {
+  const backendRoot = "backend";
+  const subdirs = fs
+    .readdirSync(backendRoot)
+    .filter((d) => fs.statSync(path.join(backendRoot, d)).isDirectory());
+  const files = subdirs
+    .flatMap((dir) =>
+      fs
+        .readdirSync(path.join(backendRoot, dir))
+        .map((f) => path.join(backendRoot, dir, f)),
+    )
+    .filter((f) => f.endsWith(".spec.ts"));
+  for (const file of files) {
+    const src = fs.readFileSync(file, "utf8");
+    expect(src).toMatch(/expect\(/, `${file} has no expect()`);
+  }
+});


### PR DESCRIPTION
## Summary
- add test to ensure each `backend/*.spec.ts` contains an `expect()` call

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: waitForSelector timeout)*

------
https://chatgpt.com/codex/tasks/task_e_6872e0d75c70832d8debb620578b09f1