### PR TITLE
Add meta-test for ensure-deps

### DIFF
--- a/scripts/__tests__/ensure-deps.test.ts
+++ b/scripts/__tests__/ensure-deps.test.ts
@@ -1,0 +1,6 @@
+const { execSync } = require('child_process');
+
+test('ensure-deps runs cleanly', () => {
+  const out = execSync('node scripts/ensure-deps.js', { encoding: 'utf8' });
+  expect(out).toMatch(/✅ environment OK/);
+});


### PR DESCRIPTION
## Summary
- add regression test calling `scripts/ensure-deps.js`

## Testing
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: npm run format cannot reach Playwright CDN)*

------
https://chatgpt.com/codex/tasks/task_e_6872e0d1d2a4832d90658d755fb67271