### PR TITLE
Add retry loop around HF sync

### DIFF
--- a/scripts/sync-hf-space.sh
+++ b/scripts/sync-hf-space.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HF_TOKEN="${HF_TOKEN:-${HF_API_KEY:-}}"
+if [[ -z "$HF_TOKEN" ]]; then
+  echo "HF_TOKEN or HF_API_KEY must be set" >&2
+  exit 1
+fi
+
+SPACE="${SPACE:-print2/Sparc3D}"
+RETRIES=3
+for i in $(seq 1 $RETRIES); do
+  huggingface-cli sync "$SPACE" && exit 0
+  echo "Sync failed, retry #$i..." >&2
+  sleep $((i * 2))
+done
+
+exit 1


### PR DESCRIPTION
## Summary
- add new script `scripts/sync-hf-space.sh` with retry/backoff logic for `huggingface-cli sync`

## Testing
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: npm install attempts causing environment issues)*
- `SKIP_PW_DEPS=1 npm run format --prefix backend` *(fails: Playwright dependencies need network access)*

------
https://chatgpt.com/codex/tasks/task_e_6872e0cdaa68832d82d54c7a65cdd805