### PR TITLE
Fix Playwright timeout

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -3,6 +3,7 @@ const baseURL = process.env.PLAYWRIGHT_BASE_URL || "http://localhost:3000";
 
 module.exports = defineConfig({
   testDir: "e2e",
+  timeout: 120 * 1000,
   use: { baseURL, headless: true, ignoreHTTPSErrors: true },
   webServer: process.env.PLAYWRIGHT_BASE_URL
     ? undefined

--- a/tests/playwrightTimeout.test.js
+++ b/tests/playwrightTimeout.test.js
@@ -1,0 +1,5 @@
+const config = require('../playwright.config.js');
+
+test('playwright test timeout is at least 60s', () => {
+  expect(config.timeout).toBeGreaterThanOrEqual(60 * 1000);
+});


### PR DESCRIPTION
## Summary
- extend Playwright test timeout to avoid 30s failures
- add regression test validating the timeout configuration

## Testing
- `npm test` *(fails: Setup script requires packages and apt dependencies)*
- `npm run format` *(fails: Setup script requires packages and apt dependencies)*
- `npm run smoke` *(fails: Setup script requires packages and apt dependencies)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6872dfa10c90832d84589108f4d233e0