### PR TITLE
Improve host dependency checks

### DIFF
--- a/tests/assertSetup.test.js
+++ b/tests/assertSetup.test.js
@@ -52,4 +52,22 @@ describe("assert-setup script", () => {
       { stdio: "inherit" },
     );
   });
+
+  test("fails when host deps missing and SKIP_PW_DEPS is set", () => {
+    setEnv();
+    process.env.SKIP_PW_DEPS = "1";
+    fs.existsSync.mockReturnValue(true);
+    fs.readdirSync.mockReturnValue(["chromium"]);
+    child_process.execSync
+      .mockImplementationOnce(() => {})
+      .mockImplementationOnce(() => {
+        throw new Error("missing deps");
+      });
+    const exitSpy = jest.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("exit");
+    });
+    expect(() => require("../scripts/assert-setup.js")).toThrow("exit");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    delete process.env.SKIP_PW_DEPS;
+  });
 });

--- a/tests/checkHostDeps.test.js
+++ b/tests/checkHostDeps.test.js
@@ -47,17 +47,18 @@ test("skips network check when SKIP_NET_CHECKS is set", () => {
   delete process.env.SKIP_NET_CHECKS;
 });
 
-
-test("installs deps even when SKIP_PW_DEPS is set", () => {
+test("exits when deps missing and SKIP_PW_DEPS is set", () => {
   process.env.SKIP_PW_DEPS = "1";
   child_process.execSync
     .mockReturnValueOnce("network ok")
     .mockImplementationOnce(() => {
       throw new Error("missing deps");
-    })
-
-    .mockReturnValueOnce("");
-  require("../scripts/check-host-deps.js");
+    });
+  const exitSpy = jest.spyOn(process, "exit").mockImplementation(() => {
+    throw new Error("exit");
+  });
+  expect(() => require("../scripts/check-host-deps.js")).toThrow("exit");
+  expect(exitSpy).toHaveBeenCalledWith(1);
   expect(child_process.execSync).toHaveBeenNthCalledWith(
     1,
     "node scripts/network-check.js",
@@ -68,11 +69,7 @@ test("installs deps even when SKIP_PW_DEPS is set", () => {
     "npx playwright install --with-deps --dry-run",
     { encoding: "utf8" },
   );
-  expect(child_process.execSync).toHaveBeenNthCalledWith(
-    3,
-    "CI=1 npx playwright install --with-deps",
-    { stdio: "inherit" },
-  );
+  expect(child_process.execSync).toHaveBeenCalledTimes(2);
   delete process.env.SKIP_PW_DEPS;
 });
 
@@ -92,10 +89,6 @@ test("skips install when deps satisfied even if SKIP_PW_DEPS is set", () => {
     "npx playwright install --with-deps --dry-run",
     { encoding: "utf8" },
   );
-  expect(child_process.execSync).toHaveBeenNthCalledWith(
-    3,
-    "CI=1 npx playwright install --with-deps",
-    { stdio: "inherit" },
-  );
+  expect(child_process.execSync).toHaveBeenCalledTimes(2);
   delete process.env.SKIP_PW_DEPS;
 });


### PR DESCRIPTION
## Summary
- update check-host-deps tests for skip mode
- verify assert-setup fails when Playwright deps missing

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_6872daa8cb20832d9d339916fe498b45