### PR TITLE
Fix ensure-deps test mock reset

### DIFF
--- a/tests/ensureDeps.test.js
+++ b/tests/ensureDeps.test.js
@@ -1,5 +1,5 @@
-const fs = require("fs");
-const child_process = require("child_process");
+let fs;
+let child_process;
 
 jest.mock("fs");
 jest.mock("child_process");
@@ -7,6 +7,8 @@ jest.mock("child_process");
 describe("ensure-deps", () => {
   beforeEach(() => {
     jest.resetModules();
+    fs = require("fs");
+    child_process = require("child_process");
     fs.existsSync.mockReset();
     child_process.execSync.mockReset();
   });


### PR DESCRIPTION
## Summary
- ensure the ensure-deps tests reload `fs` and `child_process` after resetting modules

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6872d8eec9d0832d89c8de1380ae6cb7