### PR TITLE
Fix pre-commit env loading

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,5 +2,4 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 npm audit --audit-level=high
-npm run validate-env
-npx lint-staged
+bash -c "source scripts/check-env.sh && npx lint-staged"


### PR DESCRIPTION
## Summary
- ensure Husky pre-commit loads environment variables

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_6872d87b1a80832da103b5c7315386a0