### PR TITLE
Fix coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,4 +11,5 @@ jobs:
         with:
           node-version: "20"
       - run: npm ci
-      - run: npm run coverage -- --reporter=text-lcov | coveralls
+      - run: npm ci --prefix backend
+      - run: npm run coverage -- --reporter=text-lcov | npx coveralls

--- a/tests/coverageWorkflow.test.js
+++ b/tests/coverageWorkflow.test.js
@@ -1,0 +1,23 @@
+const fs = require("fs");
+const path = require("path");
+const YAML = require("yaml");
+
+describe("coverage workflow", () => {
+  test("installs backend deps and uses npx coveralls", () => {
+    const file = path.join(
+      __dirname,
+      "..",
+      ".github",
+      "workflows",
+      "coverage.yml",
+    );
+    const yml = YAML.parse(fs.readFileSync(file, "utf8"));
+    const steps = yml.jobs.coverage.steps.map((s) => s.run || "");
+    const hasBackendCi = steps.some((cmd) =>
+      cmd.includes("npm ci --prefix backend"),
+    );
+    const hasCoveralls = steps.some((cmd) => cmd.includes("npx coveralls"));
+    expect(hasBackendCi).toBe(true);
+    expect(hasCoveralls).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- install backend deps before running coverage
- send coverage data via `npx coveralls`
- add test to verify workflow

## Testing
- `npm test --prefix backend`
- `npm run format --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_6872f0993b04832da6a4243ac4ffaa83