### PR TITLE
Fix missing Playwright module in backend tests

### DIFF
--- a/backend/scripts/ensure-deps.js
+++ b/backend/scripts/ensure-deps.js
@@ -5,6 +5,7 @@ const { execSync } = require("child_process");
 const jestPath = "node_modules/.bin/jest";
 const repoRoot = path.join(__dirname, "..", "..");
 const expressPath = path.join(repoRoot, "node_modules", "express");
+const pwPath = path.join(repoRoot, "node_modules", "@playwright", "test");
 const setupFlag = path.join(repoRoot, ".setup-complete");
 
 const networkCheck = path.join(
@@ -58,6 +59,18 @@ if (!fs.existsSync(expressPath)) {
   runNetworkCheck();
   if (!canReachRegistry()) process.exit(1);
   console.log("Express not found. Installing root dependencies...");
+  try {
+    execSync("npm ci", { stdio: "inherit", cwd: repoRoot });
+  } catch (err) {
+    console.error("Failed to install root dependencies:", err.message);
+    process.exit(1);
+  }
+}
+
+if (!fs.existsSync(pwPath)) {
+  runNetworkCheck();
+  if (!canReachRegistry()) process.exit(1);
+  console.log("@playwright/test not found. Installing root dependencies...");
   try {
     execSync("npm ci", { stdio: "inherit", cwd: repoRoot });
   } catch (err) {

--- a/tests/ensureDeps.test.js
+++ b/tests/ensureDeps.test.js
@@ -67,4 +67,25 @@ describe("ensure-deps", () => {
     expect(() => require("../backend/scripts/ensure-deps")).toThrow("exit");
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
+
+  test("installs root deps when playwright missing", () => {
+    fs.existsSync.mockImplementation((p) => {
+      if (p.includes(".setup-complete")) return true;
+      if (p.includes("node_modules/express")) return true;
+      if (p.includes("@playwright/test")) return false;
+      return true;
+    });
+    const execMock = jest.fn();
+    child_process.execSync.mockImplementation(execMock);
+    require("../backend/scripts/ensure-deps");
+    expect(execMock).toHaveBeenCalledWith(
+      expect.stringContaining("network-check.js"),
+      expect.any(Object),
+    );
+    expect(execMock).toHaveBeenCalledWith("npm ping", { stdio: "ignore" });
+    expect(execMock).toHaveBeenCalledWith("npm ci", {
+      stdio: "inherit",
+      cwd: expect.any(String),
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- ensure Playwright dependency is installed when running backend tests
- add regression test for missing Playwright in ensure-deps script

## Testing
- `npm test --prefix backend`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6872eb5cc740832d9ff7b2ac60540d6b