### PR TITLE
Fix diagnose script test usage

### DIFF
--- a/scripts/diagnose.sh
+++ b/scripts/diagnose.sh
@@ -29,7 +29,7 @@ set +e
 node scripts/test-full-pipeline.js
 PIPELINE_STATUS=$?
 
-npx jest tests/**/*.js tests/**/*.ts --runInBand
+node scripts/run-jest.js tests/**/*.js tests/**/*.ts --runInBand
 TEST_STATUS=$?
 set -e
 

--- a/tests/diagnoseScript.test.js
+++ b/tests/diagnoseScript.test.js
@@ -15,5 +15,6 @@ describe("diagnose script", () => {
     expect(content).toMatch(/validate-env\.sh/);
     expect(content).toMatch(/test-full-pipeline\.js/);
     expect(content).toMatch(/DIAGNOSTICS PASSED/);
+    expect(content).toMatch(/run-jest\.js/);
   });
 });


### PR DESCRIPTION
## Summary
- ensure the diagnose script uses run-jest instead of npx
- check for run-jest usage in diagnoseScript.test

## Testing
- `npx prettier tests/diagnoseScript.test.js -w`
- `node scripts/run-jest.js tests/diagnoseScript.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6872eb3ec268832dacf4f97b55bded92