### PR TITLE
Fix smoke script environment setup

### DIFF
--- a/scripts/run-smoke.js
+++ b/scripts/run-smoke.js
@@ -1,6 +1,29 @@
 #!/usr/bin/env node
 const { execSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
 const env = { ...process.env };
+
+function loadEnvFile(file) {
+  if (!fs.existsSync(file)) return;
+  const content = fs.readFileSync(file, "utf8");
+  for (const line of content.split(/\r?\n/)) {
+    const m = line.match(/^\s*([A-Za-z0-9_]+)\s*=\s*(.*)\s*$/);
+    if (m) {
+      const [, key, val] = m;
+      if (!env[key]) {
+        env[key] = val.replace(/^['"]|['"]$/g, "");
+      }
+    }
+  }
+}
+
+if (fs.existsSync(path.join(process.cwd(), ".env"))) {
+  loadEnvFile(path.join(process.cwd(), ".env"));
+} else if (fs.existsSync(path.join(process.cwd(), ".env.example"))) {
+  loadEnvFile(path.join(process.cwd(), ".env.example"));
+}
 
 function ensureDefault(key, value) {
   if (!env[key]) {

--- a/tests/runSmoke.load-env-file.test.ts
+++ b/tests/runSmoke.load-env-file.test.ts
@@ -1,0 +1,28 @@
+const fs = require("fs");
+const path = require("path");
+
+const envFile = path.join(__dirname, "..", ".env");
+
+function withTempEnv(content, fn) {
+  const exists = fs.existsSync(envFile);
+  const backup = exists ? fs.readFileSync(envFile, "utf8") : null;
+  fs.writeFileSync(envFile, content);
+  try {
+    fn();
+  } finally {
+    if (exists) {
+      fs.writeFileSync(envFile, backup);
+    } else {
+      fs.unlinkSync(envFile);
+    }
+  }
+}
+
+test("run-smoke loads variables from .env", () => {
+  withTempEnv("CUSTOM_SMOKE_VAR=hello", () => {
+    jest.isolateModules(() => {
+      const { env } = require("../scripts/run-smoke.js");
+      expect(env.CUSTOM_SMOKE_VAR).toBe("hello");
+    });
+  });
+});

--- a/tests/smokeScript.test.js
+++ b/tests/smokeScript.test.js
@@ -26,13 +26,15 @@ describe("smoke script", () => {
     expect(setupIdx).toBeGreaterThan(validateIdx);
   });
 
-  test("run-smoke.js sets fallback env vars", () => {
+  test("run-smoke.js loads env file values", () => {
     jest.isolateModules(() => {
       const { env } = require("../scripts/run-smoke.js");
-      expect(env.AWS_ACCESS_KEY_ID).toBe("dummy");
-      expect(env.AWS_SECRET_ACCESS_KEY).toBe("dummy");
-      expect(env.DB_URL).toBe("postgres://user:pass@localhost/db");
-      expect(env.STRIPE_SECRET_KEY).toBe("sk_test_dummy");
+      expect(env.AWS_ACCESS_KEY_ID).toBe("your-aws-access-key-id");
+      expect(env.AWS_SECRET_ACCESS_KEY).toBe("your-aws-secret-access-key");
+      expect(env.DB_URL).toBe(
+        "postgres://user:password@localhost:5432/your_database",
+      );
+      expect(env.STRIPE_SECRET_KEY).toBe("sk_test_...");
     });
   });
 });


### PR DESCRIPTION
## Summary
- load env variables from `.env` or `.env.example` when running smoke tests
- test smoke script env file loading
- adjust smokeScript test to reflect new defaults

## Testing
- `npm test`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6872eb29d1ec832dbeaa21df3443cfdd