### PR TITLE
Add smoke script regression test

### DIFF
--- a/tests/runSmokeScriptRun.test.js
+++ b/tests/runSmokeScriptRun.test.js
@@ -1,0 +1,19 @@
+const { execFileSync } = require('child_process');
+const path = require('path');
+
+test('run-smoke succeeds with SKIP_PW_DEPS=1', () => {
+  const script = path.join('scripts', 'run-smoke.js');
+  const env = {
+    ...process.env,
+    HF_TOKEN: 'test',
+    AWS_ACCESS_KEY_ID: 'id',
+    AWS_SECRET_ACCESS_KEY: 'secret',
+    DB_URL: 'postgres://user:pass@localhost/db',
+    STRIPE_SECRET_KEY: 'sk_test',
+    SKIP_PW_DEPS: '1',
+    SKIP_NET_CHECKS: '1',
+  };
+  delete env.npm_config_http_proxy;
+  delete env.npm_config_https_proxy;
+  expect(() => execFileSync('node', [script], { stdio: 'inherit', env })).not.toThrow();
+});


### PR DESCRIPTION
## Summary
- add test to ensure run-smoke.js succeeds when Playwright deps are skipped

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails due to tar errors)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: huge tar errors)*

------
https://chatgpt.com/codex/tasks/task_e_6872ead06bc4832d84d3e0e6827ea555