### PR TITLE
Fix npm ci tar error handling

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -93,7 +93,7 @@ run_ci() {
       echo "npm ci failed in $dir due to lock mismatch. Running npm install..." >&2
       npm install $extra --no-audit --no-fund
       npm ci $extra --no-audit --no-fund
-    elif grep -E -q "TAR_ENTRY_ERROR|ENOENT" ci.log; then
+    elif grep -E -q "TAR_ENTRY_ERROR|ENOENT|Z_DATA_ERROR|Z_BUF_ERROR" ci.log; then
       echo "npm ci encountered tar errors in $dir. Cleaning cache and retrying..." >&2
       cleanup_npm_cache
       rm -rf ${dir:-.}/node_modules

--- a/tests/bin-zdata/npm
+++ b/tests/bin-zdata/npm
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+if [[ "$1" == "ci" && -z "$ZDATA_ERROR_DONE" ]]; then
+  echo "npm ERR! code Z_BUF_ERROR" >&2
+  echo "npm ERR! errno Z_BUF_ERROR" >&2
+  echo "npm ERR! invalid tar file" >&2
+  export ZDATA_ERROR_DONE=1
+  exit 1
+fi
+exec "$REAL_NPM" "$@"

--- a/tests/setupScriptZDataError.test.js
+++ b/tests/setupScriptZDataError.test.js
@@ -1,0 +1,20 @@
+const { execSync } = require("child_process");
+const path = require("path");
+
+describe("setup script zlib error", () => {
+  test("retries when npm ci reports Z_BUF_ERROR", () => {
+    const env = {
+      ...process.env,
+      HF_TOKEN: "test",
+      AWS_ACCESS_KEY_ID: "id",
+      AWS_SECRET_ACCESS_KEY: "secret",
+      DB_URL: "postgres://user:pass@localhost/db",
+      STRIPE_SECRET_KEY: "sk_test",
+      SKIP_NET_CHECKS: "1",
+      SKIP_PW_DEPS: "1",
+      REAL_NPM: execSync("command -v npm").toString().trim(),
+      PATH: path.join(__dirname, "bin-zdata") + ":" + process.env.PATH,
+    };
+    execSync("bash scripts/setup.sh", { env, stdio: "inherit" });
+  });
+});


### PR DESCRIPTION
## Summary
- retry `npm ci` when zlib errors occur
- add regression test for zlib tar errors

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_6872ea7fb35c832d914ad8b3d45fdecf