### PR TITLE
Fix Playwright setup test

### DIFF
--- a/tests/assertSetup.test.js
+++ b/tests/assertSetup.test.js
@@ -24,8 +24,13 @@ describe("assert-setup script", () => {
     setEnv();
     fs.existsSync.mockReturnValue(false);
     fs.readdirSync.mockReturnValue([]);
+    child_process.execSync.mockImplementation(() => {});
 
     expect(() => require("../scripts/assert-setup.js")).not.toThrow();
+    expect(child_process.execSync).toHaveBeenCalledWith(
+      "CI=1 npm run setup",
+      { stdio: "inherit", env: expect.any(Object) },
+    );
   });
 
   test("skips setup when browsers installed", () => {


### PR DESCRIPTION
## Summary
- ensure assert-setup triggers npm run setup when browsers missing

## Testing
- `npm test`
- `npm run format --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_6872ea6fbd28832db2277b480d521420