### PR TITLE
Fix Node runtime check and tests

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -97,6 +97,6 @@
     "babel-jest": "^30.0.4"
   },
   "engines": {
-    "node": ">=20"
+    "node": "20.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "author": "",
   "license": "ISC",
   "engines": {
-    "node": ">=20"
+    "node": "20.x"
   },
   "type": "commonjs",
   "prettier": {},

--- a/scripts/check-node-version.js
+++ b/scripts/check-node-version.js
@@ -1,15 +1,19 @@
 const child_process = require("child_process");
 const requiredMajor = parseInt(process.env.REQUIRED_NODE_MAJOR || "20", 10);
 const major = parseInt(process.versions.node.split(".")[0], 10);
-if (major < requiredMajor) {
+if (major !== requiredMajor) {
   console.error(
-    `Node ${requiredMajor}+ is required, current version is ${process.versions.node}`,
+    `Node ${requiredMajor} is required, current version is ${process.versions.node}`,
   );
   try {
-    child_process.execSync(`mise use -g node@${requiredMajor}`, { stdio: "inherit" });
+    child_process.execSync(`mise use -g node@${requiredMajor}`, {
+      stdio: "inherit",
+    });
     console.error("Node updated. Restart your shell and rerun the command.");
   } catch {
-    console.error(`Run 'mise use -g node@${requiredMajor}' to install the correct version.`);
+    console.error(
+      `Run 'mise use -g node@${requiredMajor}' to install the correct version.`,
+    );
   }
   process.exit(1);
 }

--- a/tests/checkNodeVersionScript.test.js
+++ b/tests/checkNodeVersionScript.test.js
@@ -1,18 +1,18 @@
-const { execFileSync } = require('child_process');
-const path = require('path');
+const { execFileSync } = require("child_process");
+const path = require("path");
 
-describe('check-node-version script', () => {
-  test('prints helpful message when version too low', () => {
+describe("check-node-version script", () => {
+  test("prints helpful message when version too low", () => {
     try {
-      execFileSync('node', [path.join('scripts', 'check-node-version.js')], {
-        env: { ...process.env, REQUIRED_NODE_MAJOR: '25' },
-        encoding: 'utf8',
-        stdio: 'pipe',
+      execFileSync("node", [path.join("scripts", "check-node-version.js")], {
+        env: { ...process.env, REQUIRED_NODE_MAJOR: "25" },
+        encoding: "utf8",
+        stdio: "pipe",
       });
-      throw new Error('script did not exit');
+      throw new Error("script did not exit");
     } catch (err) {
-      const output = (err.stdout || '') + (err.stderr || '');
-      expect(output).toMatch(/Node 25\+ is required/);
+      const output = (err.stdout || "") + (err.stderr || "");
+      expect(output).toMatch(/Node 25 is required/);
       expect(output).toMatch(/mise use -g node@25/);
     }
   });

--- a/tests/nodeVersion.test.js
+++ b/tests/nodeVersion.test.js
@@ -2,19 +2,19 @@ const fs = require("fs");
 const path = require("path");
 
 describe("node version", () => {
-  test("runtime is >=20", () => {
+  test("runtime is exactly 20", () => {
     const major = parseInt(process.versions.node.split(".")[0], 10);
-    expect(major).toBeGreaterThanOrEqual(20);
+    expect(major).toBe(20);
   });
 
-  test("root package.json engines field is >=20", () => {
+  test("root package.json engines field is 20.x", () => {
     const pkg = require("../package.json");
-    expect(pkg.engines.node).toBe(">=20");
+    expect(pkg.engines.node).toBe("20.x");
   });
 
-  test("backend package.json engines field is >=20", () => {
+  test("backend package.json engines field is 20.x", () => {
     const pkg = require("../backend/package.json");
-    expect(pkg.engines.node).toBe(">=20");
+    expect(pkg.engines.node).toBe("20.x");
   });
 
   test(".nvmrc specifies Node 20", () => {


### PR DESCRIPTION
## Summary
- require Node 20.x in package files
- enforce exact Node 20 in `check-node-version.js`
- update tests for new Node version requirement

## Testing
- `npm test`
- `npx prettier -w package.json backend/package.json scripts/check-node-version.js tests/nodeVersion.test.js tests/checkNodeVersionScript.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6872ea414194832da9014e32718ac2c5