### PR TITLE
Fix gitignore to exclude Playwright results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ infra/.terraform/
 infra/*.tfstate*
 infra/AWSCLIV2.pkg
 infra/awscliv2.zip
+test-results/

--- a/tests/gitignore.test.js
+++ b/tests/gitignore.test.js
@@ -1,0 +1,14 @@
+const fs = require("fs");
+const path = require("path");
+
+const repoRoot = path.resolve(__dirname, "..");
+
+describe(".gitignore", () => {
+  test("ignores Playwright test results", () => {
+    const gitignore = fs.readFileSync(
+      path.join(repoRoot, ".gitignore"),
+      "utf8",
+    );
+    expect(gitignore).toMatch(/test-results\//);
+  });
+});


### PR DESCRIPTION
## Summary
- ignore `test-results` from Playwright runs
- add regression test to ensure `.gitignore` lists this entry

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6872ea2f2214832db0d7e9c187946f96