### PR TITLE
Add backend test helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,14 @@ To run Jest directly from the repository root, use:
 npm run jest -- --runInBand --silent
 ```
 
+If you encounter environment issues running backend tests, use the helper script
+below. It sets Node 20, validates the environment and saves output to
+`/tmp/test.log`:
+
+```bash
+./scripts/test-backend.sh
+```
+
 This script automatically runs Jest in `backend/`, so passing `--prefix` is unnecessary.
 
 ### Pre-commit Hook

--- a/scripts/test-backend.sh
+++ b/scripts/test-backend.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+cd "$(git rev-parse --show-toplevel)"
+unset npm_config_http_proxy npm_config_https_proxy
+mise use -g node@20 >/dev/null
+npm run validate-env >/dev/null
+npm test --prefix backend "$@" | tee /tmp/test.log

--- a/tests/testBackendScript.test.js
+++ b/tests/testBackendScript.test.js
@@ -1,0 +1,8 @@
+const fs = require("fs");
+const path = require("path");
+
+test("test-backend script exists and runs backend tests", () => {
+  const script = path.join(__dirname, "..", "scripts", "test-backend.sh");
+  const content = fs.readFileSync(script, "utf8");
+  expect(content).toMatch(/npm test --prefix backend/);
+});


### PR DESCRIPTION
## Summary
- add `scripts/test-backend.sh` to run backend tests with the correct Node version
- document the helper script in README
- add test ensuring the script exists

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_6872ea127c54832d8791375e6d764252