### PR TITLE
Handle npm tar cleanup failures

### DIFF
--- a/scripts/assert-setup.js
+++ b/scripts/assert-setup.js
@@ -100,6 +100,24 @@ if (!rootDepsInstalled()) {
         console.error("Failed to install dependencies:", err2.message);
         process.exit(1);
       }
+    } else if (/(TAR_ENTRY_ERROR|ENOENT|ENOTEMPTY)/.test(msg)) {
+      console.warn("npm ci encountered tar errors. Retrying after cleanup...");
+      try {
+        child_process.execSync(
+          "npx --yes rimraf node_modules backend/node_modules",
+          { stdio: "inherit" },
+        );
+      } catch {
+        child_process.execSync("rm -rf node_modules backend/node_modules", {
+          stdio: "inherit",
+        });
+      }
+      try {
+        child_process.execSync("npm ci", { stdio: "inherit" });
+      } catch (err2) {
+        console.error("Failed to reinstall dependencies:", err2.message);
+        process.exit(1);
+      }
     } else {
       console.error("Failed to install dependencies:", err.message);
       process.exit(1);

--- a/tests/backendFormatTarError.test.js
+++ b/tests/backendFormatTarError.test.js
@@ -1,0 +1,20 @@
+const { execSync } = require('child_process');
+const path = require('path');
+
+describe('backend format tar error', () => {
+  test('retries when npm ci reports TAR_ENTRY_ERROR', () => {
+    const env = {
+      ...process.env,
+      HF_TOKEN: 'test',
+      AWS_ACCESS_KEY_ID: 'id',
+      AWS_SECRET_ACCESS_KEY: 'secret',
+      DB_URL: 'postgres://user:pass@localhost/db',
+      STRIPE_SECRET_KEY: 'sk_test',
+      SKIP_NET_CHECKS: '1',
+      SKIP_PW_DEPS: '1',
+      REAL_NPM: execSync('command -v npm').toString().trim(),
+      PATH: path.join(__dirname, 'bin-tar') + ':' + process.env.PATH,
+    };
+    execSync('npm run format --prefix backend', { env, stdio: 'inherit' });
+  });
+});


### PR DESCRIPTION
## Summary
- robust cleanup for npm ci failures in assert-setup
- test format command tar error handling

## Testing
- `npm run format`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_6872ea014350832d9663e4858c155c65