### PR TITLE
Fix smoke test timing and add regression check

### DIFF
--- a/e2e/smoke.test.js
+++ b/e2e/smoke.test.js
@@ -97,6 +97,11 @@ test('generate flow', async ({ page }) => {
   await page.waitForSelector('#gen-prompt', { state: 'visible', timeout: 30000 });
   await page.fill('#gen-prompt', 'test');
   await page.click('#gen-submit');
+  // Wait for the viewer to signal readiness before checking the canvas.
+  // This prevents flaky timeouts when external scripts load slowly.
+  await page.waitForSelector('body[data-viewer-ready="true"]', {
+    timeout: 60000,
+  });
   // Wait longer for the model viewer to load on slow networks
   await page.waitForSelector('canvas', { state: 'visible', timeout: 60000 });
   await expect(page.locator('canvas')).toBeVisible();

--- a/tests/smokeViewerReady.test.js
+++ b/tests/smokeViewerReady.test.js
@@ -1,0 +1,7 @@
+const fs = require("fs");
+const path = require("path");
+
+test("smoke test waits for viewer readiness", () => {
+  const content = fs.readFileSync(path.join("e2e", "smoke.test.js"), "utf8");
+  expect(content).toMatch(/body\[data-viewer-ready="true"\]/);
+});


### PR DESCRIPTION
## Summary
- wait for `data-viewer-ready` before asserting canvas visibility in the smoke test
- add a unit test that verifies the smoke test checks this attribute

## Testing
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_687375a25f38832dafb76bbae6ea9bd9