### PR TITLE
Fix coverage script for Coveralls

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,4 +12,5 @@ jobs:
           node-version: "20"
       - run: npm ci
       - run: npm ci --prefix backend
-      - run: npm run coverage -- --reporter=text-lcov | npx coveralls
+      - run: npm run setup
+      - run: npm run coverage-lcov | npx coveralls

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,6 +6,7 @@
     "test": "jest",
     "test-ci": "jest --ci --coverage --collectCoverageFrom=\"**/*.{js,jsx,ts,tsx}\" --maxWorkers=2 --forceExit",
     "coverage": "jest --ci --coverage --maxWorkers=2 --detectOpenHandles --forceExit && npx coverage-badges-cli --source coverage/coverage-summary.json --output coverage/badge.svg",
+    "coverage-lcov": "jest --ci --coverage --maxWorkers=2 --detectOpenHandles --forceExit --coverageReporters=text-lcov",
     "start": "node server.js",
     "init-db": "node scripts/init-db.js",
     "migrate": "node scripts/run-migrations.js",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test:structure": "jest --runTestsByPath tests/projectStructure.test.js",
     "test": "npm test --prefix backend",
     "coverage": "npm run coverage --prefix backend",
+    "coverage-lcov": "npm --prefix backend run coverage-lcov",
     "typecheck": "tsc --noEmit",
     "i18n:lint": "node scripts/i18n-lint.js",
     "ci": "node scripts/assert-setup.js && npm run format && npm run lint && npm run typecheck && npm run i18n:lint && npm run test:ci && npm run test:a11y",

--- a/tests/coverageLcovScript.test.ts
+++ b/tests/coverageLcovScript.test.ts
@@ -1,0 +1,10 @@
+const fs = require("fs");
+const pkg = JSON.parse(fs.readFileSync("backend/package.json", "utf8"));
+
+describe("coverage-lcov script", () => {
+  test("outputs lcov reporter", () => {
+    const script = pkg.scripts["coverage-lcov"];
+    expect(script).toBeDefined();
+    expect(script).toContain("--coverageReporters=text-lcov");
+  });
+});

--- a/tests/coverageWorkflow.test.ts
+++ b/tests/coverageWorkflow.test.ts
@@ -9,6 +9,16 @@ test("coverage workflow uses setup script", () => {
   expect(hasSetup).toBe(true);
 });
 
+test("coverage workflow pipes lcov output to coveralls", () => {
+  const content = fs.readFileSync(".github/workflows/coverage.yml", "utf8");
+  const workflow = YAML.parse(content);
+  const steps = workflow.jobs.coverage.steps || [];
+  const coverallsStep = steps.find((s) => s.run && s.run.includes("coveralls"));
+  expect(coverallsStep && coverallsStep.run).toBe(
+    "npm run coverage-lcov | npx coveralls",
+  );
+});
+
 test("coveralls listed in devDependencies", () => {
   const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
   expect(pkg.devDependencies && pkg.devDependencies.coveralls).toBeDefined();


### PR DESCRIPTION
## Summary
- add `coverage-lcov` script to emit LCOV format
- run the new script in the coverage workflow
- document the new script in `package.json`
- check that the workflow and script are set up via tests

## Testing
- `npm --prefix backend run format`
- `node scripts/run-jest.js`


------
https://chatgpt.com/codex/tasks/task_e_6873756cda70832d8895a1e33ef8209e