### PR TITLE
Fix coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,4 +12,5 @@ jobs:
           node-version: "20"
       - run: npm ci
       - run: npm ci --prefix backend
+      - run: npm run setup
       - run: npm run coverage -- --reporter=text-lcov | npx coveralls

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "jest": "node scripts/run-jest.js",
     "test:structure": "jest --runTestsByPath tests/projectStructure.test.js",
     "test": "npm test --prefix backend",
-    "coverage": "npm run coverage --prefix backend",
+    "coverage": "node scripts/assert-setup.js && npm run coverage --prefix backend",
     "typecheck": "tsc --noEmit",
     "i18n:lint": "node scripts/i18n-lint.js",
     "ci": "node scripts/assert-setup.js && npm run format && npm run lint && npm run typecheck && npm run i18n:lint && npm run test:ci && npm run test:a11y",

--- a/tests/coverageScript.test.js
+++ b/tests/coverageScript.test.js
@@ -1,0 +1,9 @@
+const pkg = require("../package.json");
+
+describe("coverage script", () => {
+  test("invokes assert-setup before running backend coverage", () => {
+    expect(
+      pkg.scripts.coverage.startsWith("node scripts/assert-setup.js &&"),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- run `assert-setup` before generating coverage
- install browsers in `coverage.yml`
- add a regression test for the coverage script

## Testing
- `npm test`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_68737560dad8832d91946c9d8f71e0df