### PR TITLE
Fix coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,6 +10,5 @@ jobs:
       - uses: actions/setup-node@v4.4.0
         with:
           node-version: "20"
-      - run: npm ci
-      - run: npm ci --prefix backend
+      - run: SKIP_PW_DEPS=1 npm run setup
       - run: npm run coverage -- --reporter=text-lcov | npx coveralls

--- a/tests/coverageWorkflow.test.js
+++ b/tests/coverageWorkflow.test.js
@@ -5,7 +5,12 @@ test("coverage workflow uses setup script", () => {
   const content = fs.readFileSync(".github/workflows/coverage.yml", "utf8");
   const workflow = YAML.parse(content);
   const steps = workflow.jobs.coverage.steps || [];
-  const hasSetup = steps.some((s) => s.run && s.run.includes("npm run setup"));
+  const hasSetup = steps.some(
+    (s) =>
+      s.run &&
+      s.run.includes("npm run setup") &&
+      s.run.includes("SKIP_PW_DEPS=1"),
+  );
   expect(hasSetup).toBe(true);
 });
 


### PR DESCRIPTION
## Summary
- run setup in coverage workflow so Playwright browsers are available
- verify workflow uses `SKIP_PW_DEPS=1 npm run setup`

## Testing
- `npm test --prefix backend`
- `node scripts/run-jest.js tests/coverageWorkflow.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6873738ace8c832d9091aea6bf5ae3a6