### PR TITLE
Fix coverage script invocation

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "test": "jest",
     "test-ci": "jest --ci --coverage --collectCoverageFrom=\"**/*.{js,jsx,ts,tsx}\" --maxWorkers=2 --forceExit",
-    "coverage": "jest --ci --coverage --maxWorkers=2 --detectOpenHandles --forceExit && npx coverage-badges-cli --source coverage/coverage-summary.json --output coverage/badge.svg",
+    "coverage": "npx jest --ci --coverage --maxWorkers=2 --detectOpenHandles --forceExit && npx coverage-badges-cli --source coverage/coverage-summary.json --output coverage/badge.svg",
     "start": "node server.js",
     "init-db": "node scripts/init-db.js",
     "migrate": "node scripts/run-migrations.js",

--- a/tests/coverageScript.test.js
+++ b/tests/coverageScript.test.js
@@ -1,0 +1,8 @@
+const fs = require("fs");
+const path = require("path");
+
+test("uses npx jest in the coverage script", () => {
+  const pkgPath = path.join(__dirname, "..", "backend", "package.json");
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+  expect(pkg.scripts.coverage).toMatch(/npx jest/);
+});


### PR DESCRIPTION
## Summary
- invoke Jest via `npx` in backend coverage script
- add a regression test ensuring the coverage script uses `npx`

## Testing
- `npm test --prefix backend`
- `node scripts/run-jest.js tests/coverageWorkflow.test.js tests/coverageScript.test.js`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_687372e256f0832da4bb818d318aa7c6