### PR TITLE
Fix coverage workflow

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "test": "jest",
     "test-ci": "jest --ci --coverage --collectCoverageFrom=\"**/*.{js,jsx,ts,tsx}\" --maxWorkers=2 --forceExit",
-    "coverage": "jest --ci --coverage --maxWorkers=2 --detectOpenHandles --forceExit && npx coverage-badges-cli --source coverage/coverage-summary.json --output coverage/badge.svg",
+    "coverage": "node ../scripts/run-jest.js --ci --coverage --maxWorkers=2 --detectOpenHandles --forceExit && npx coverage-badges-cli --source coverage/coverage-summary.json --output coverage/badge.svg",
     "start": "node server.js",
     "init-db": "node scripts/init-db.js",
     "migrate": "node scripts/run-migrations.js",

--- a/tests/coverageScript.test.js
+++ b/tests/coverageScript.test.js
@@ -1,0 +1,7 @@
+const pkg = require("../backend/package.json");
+
+describe("coverage script", () => {
+  test("uses run-jest helper", () => {
+    expect(pkg.scripts.coverage).toMatch(/run-jest\.js/);
+  });
+});


### PR DESCRIPTION
## Summary
- use run-jest helper in backend coverage script
- add regression test for coverage script to ensure run-jest is used

## Testing
- `npm test`
- `SKIP_ROOT_DEPS_CHECK=1 npm run format`
- `node scripts/run-jest.js tests/coverageScript.test.js`

------
https://chatgpt.com/codex/tasks/task_e_687372cc0b08832d96857bc4d14d1f3e