### PR TITLE
Fix SKIP_PW_DEPS handling

### DIFF
--- a/scripts/assert-setup.js
+++ b/scripts/assert-setup.js
@@ -150,20 +150,26 @@ try {
 }
 
 if (!fs.existsSync(".setup-complete") || !browsersInstalled()) {
-  console.log(
-    "Playwright browsers not installed. Running 'bash scripts/setup.sh' to install them",
-  );
-  try {
-    const env = { ...process.env };
-    delete env.npm_config_http_proxy;
-    delete env.npm_config_https_proxy;
-    require("child_process").execSync("CI=1 npm run setup", {
-      stdio: "inherit",
-      env,
-    });
-  } catch (err) {
-    console.error("Failed to run setup:", err.message);
-    process.exit(1);
+  if (process.env.SKIP_PW_DEPS) {
+    console.log(
+      "Playwright browsers not installed. Skipping setup due to SKIP_PW_DEPS",
+    );
+  } else {
+    console.log(
+      "Playwright browsers not installed. Running 'bash scripts/setup.sh' to install them",
+    );
+    try {
+      const env = { ...process.env };
+      delete env.npm_config_http_proxy;
+      delete env.npm_config_https_proxy;
+      require("child_process").execSync("CI=1 npm run setup", {
+        stdio: "inherit",
+        env,
+      });
+    } catch (err) {
+      console.error("Failed to run setup:", err.message);
+      process.exit(1);
+    }
   }
 }
 

--- a/tests/assertSetup.test.js
+++ b/tests/assertSetup.test.js
@@ -27,10 +27,10 @@ describe("assert-setup script", () => {
     child_process.execSync.mockImplementation(() => {});
 
     expect(() => require("../scripts/assert-setup.js")).not.toThrow();
-    expect(child_process.execSync).toHaveBeenCalledWith(
-      "CI=1 npm run setup",
-      { stdio: "inherit", env: expect.any(Object) },
-    );
+    expect(child_process.execSync).toHaveBeenCalledWith("CI=1 npm run setup", {
+      stdio: "inherit",
+      env: expect.any(Object),
+    });
   });
 
   test("skips setup when browsers installed", () => {
@@ -58,7 +58,6 @@ describe("assert-setup script", () => {
     );
   });
 
-
   test("skips network check when SKIP_NET_CHECKS is set", () => {
     setEnv();
     process.env.SKIP_NET_CHECKS = "1";
@@ -75,5 +74,19 @@ describe("assert-setup script", () => {
       expect.any(Object),
     );
     delete process.env.SKIP_NET_CHECKS;
+  });
+
+  test("skips setup when SKIP_PW_DEPS is set", () => {
+    setEnv();
+    process.env.SKIP_PW_DEPS = "1";
+    fs.existsSync.mockReturnValue(false);
+    fs.readdirSync.mockReturnValue([]);
+    child_process.execSync.mockImplementation(() => {});
+    expect(() => require("../scripts/assert-setup.js")).not.toThrow();
+    expect(child_process.execSync).not.toHaveBeenCalledWith(
+      "CI=1 npm run setup",
+      expect.any(Object),
+    );
+    delete process.env.SKIP_PW_DEPS;
   });
 });


### PR DESCRIPTION
## Summary
- prevent `assert-setup.js` from running the heavy setup step when `SKIP_PW_DEPS` is set
- test `assert-setup.js` respects `SKIP_PW_DEPS`

## Testing
- `npm run format --prefix backend`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687371925964832d93490262529a937b