### PR TITLE
Add smoke failure diagnostic test

### DIFF
--- a/backend/tests/runSmokeConnectFailure.test.ts
+++ b/backend/tests/runSmokeConnectFailure.test.ts
@@ -1,0 +1,27 @@
+const child_process = require("child_process");
+
+jest.mock("child_process");
+
+const { main } = require("../../scripts/run-smoke");
+
+/** Simulate failure when the smoke script runs the wait-on step. */
+test("run-smoke reports diagnostics when wait-on fails", () => {
+  child_process.execSync.mockImplementation((cmd) => {
+    if (cmd.includes("wait-on")) {
+      const err = new Error("wait-on failed");
+      err.status = 1;
+      throw err;
+    }
+  });
+  const errSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  const exitSpy = jest.spyOn(process, "exit").mockImplementation(() => {
+    throw new Error("exit");
+  });
+  expect(() => main()).toThrow("exit");
+  const messages = errSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+  expect(messages).toMatch(/Smoke test failed/);
+  expect(messages).toMatch(/wait-on/);
+  expect(exitSpy).toHaveBeenCalledWith(1);
+  errSpy.mockRestore();
+  exitSpy.mockRestore();
+});

--- a/scripts/run-smoke.js
+++ b/scripts/run-smoke.js
@@ -62,8 +62,11 @@ function main() {
     if (!process.env.SKIP_PW_DEPS) {
       run("npx -y playwright install --with-deps");
     }
+    const waitArgs = process.env.WAIT_ON_TIMEOUT
+      ? `-t ${process.env.WAIT_ON_TIMEOUT} `
+      : "";
     run(
-      'npx -y concurrently -k -s first "npm run serve" "wait-on http://localhost:3000 && npx playwright test e2e/smoke.test.js"',
+      `npx -y concurrently -k -s first "npm run serve" "wait-on ${waitArgs}http://localhost:3000 && npx playwright test e2e/smoke.test.js"`,
     );
   } catch (err) {
     dumpDiagnostics(err);


### PR DESCRIPTION
## Summary
- allow configuring wait-on timeout in `run-smoke.js`
- add unit test ensuring diagnostics are printed when the wait-on step fails

## Testing
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6873716ac4dc832d84c220008aa881db