### PR TITLE
Add EUSAGE fallback test

### DIFF
--- a/tests/bin-eusage/npm
+++ b/tests/bin-eusage/npm
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+if [[ "$1" == "ci" && -z "$EUSAGE_DONE" ]]; then
+  echo "npm ERR! code EUSAGE" >&2
+  echo "npm ERR! This command requires additional dependency resolution" >&2
+  export EUSAGE_DONE=1
+  exit 1
+fi
+exec "$REAL_NPM" "$@"

--- a/tests/setupScriptEusageFailure.test.js
+++ b/tests/setupScriptEusageFailure.test.js
@@ -1,0 +1,20 @@
+const { execSync } = require("child_process");
+const path = require("path");
+
+describe("setup script EUSAGE failure", () => {
+  test("falls back to npm install when npm ci exits with EUSAGE", () => {
+    const env = {
+      ...process.env,
+      HF_TOKEN: "test",
+      AWS_ACCESS_KEY_ID: "id",
+      AWS_SECRET_ACCESS_KEY: "secret",
+      DB_URL: "postgres://user:pass@localhost/db",
+      STRIPE_SECRET_KEY: "sk_test",
+      SKIP_NET_CHECKS: "1",
+      SKIP_PW_DEPS: "1",
+      REAL_NPM: execSync("command -v npm").toString().trim(),
+      PATH: path.join(__dirname, "bin-eusage") + ":" + process.env.PATH,
+    };
+    execSync("bash scripts/setup.sh", { env, stdio: "inherit" });
+  });
+});


### PR DESCRIPTION
## Summary
- add test directory for mocking npm `EUSAGE` error
- ensure setup script falls back to `npm install` when `npm ci` exits with EUSAGE

## Testing
- `npm run format`
- `npm test`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_687371494710832dbe6dd1ee8ca244d2