### PR TITLE
Fix Playwright imports

### DIFF
--- a/backend/tests/frontend/modelViewerFallback.e2e.test.ts
+++ b/backend/tests/frontend/modelViewerFallback.e2e.test.ts
@@ -1,5 +1,5 @@
 /** @jest-environment node */
-const { chromium } = require("playwright");
+const { chromium } = require("playwright-core");
 const { startDevServer } = require("../../../scripts/dev-server");
 
 test("model-viewer falls back to local copy when CDN fails", async () => {

--- a/backend/tests/noPlaywrightImport.test.js
+++ b/backend/tests/noPlaywrightImport.test.js
@@ -1,0 +1,39 @@
+const fs = require("fs");
+const path = require("path");
+
+function collectFiles(dir) {
+  let results = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === "node_modules") continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results = results.concat(collectFiles(full));
+    } else if (entry.name.endsWith(".js") || entry.name.endsWith(".ts")) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+test("no test imports playwright package directly", () => {
+  const root = path.resolve(__dirname, "..");
+  const dirs = ["tests", "backend/tests"];
+  const offenders = [];
+  for (const dir of dirs) {
+    const absolute = path.join(root, dir);
+    if (!fs.existsSync(absolute)) continue;
+    for (const file of collectFiles(absolute)) {
+      if (file.endsWith("noPlaywrightImport.test.js")) continue;
+      const content = fs.readFileSync(file, "utf8");
+      if (
+        content.includes("require('playwright')") ||
+        content.includes('require("playwright")') ||
+        content.includes("from 'playwright'") ||
+        content.includes('from "playwright"')
+      ) {
+        offenders.push(path.relative(root, file));
+      }
+    }
+  }
+  expect(offenders).toEqual([]);
+});

--- a/tests/browserConnectivity.test.js
+++ b/tests/browserConnectivity.test.js
@@ -1,4 +1,4 @@
-const { chromium } = require("playwright");
+const { chromium } = require("playwright-core");
 
 async function check(url) {
   const browser = await chromium.launch();


### PR DESCRIPTION
## Summary
- use `playwright-core` in frontend tests
- add regression test to ensure `playwright` package isn't imported

## Testing
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_687370eac470832db1a3dfb5b096617f