### PR TITLE
Add ensure-deps missing dependency tests

### DIFF
--- a/tests/ensureDepsMissingDeps.test.js
+++ b/tests/ensureDepsMissingDeps.test.js
@@ -1,0 +1,49 @@
+const fs = require("fs");
+const child_process = require("child_process");
+
+jest.mock("fs");
+jest.mock("child_process", () => ({ execSync: jest.fn() }));
+
+describe("ensure-deps missing dependency handling", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    fs.existsSync.mockReset();
+    child_process.execSync.mockReset();
+  });
+
+  function run() {
+    require("../backend/scripts/ensure-deps");
+  }
+
+  test("installs root deps when express missing", () => {
+    fs.existsSync.mockImplementation((p) =>
+      p.includes("express") ? false : true,
+    );
+    run();
+    expect(child_process.execSync).toHaveBeenCalledWith("npm ci", {
+      stdio: "inherit",
+      cwd: expect.any(String),
+    });
+  });
+
+  test("installs root deps when @playwright/test missing", () => {
+    fs.existsSync.mockImplementation((p) =>
+      p.includes("@playwright") ? false : true,
+    );
+    run();
+    expect(child_process.execSync).toHaveBeenCalledWith("npm ci", {
+      stdio: "inherit",
+      cwd: expect.any(String),
+    });
+  });
+
+  test("installs backend deps when jest missing", () => {
+    fs.existsSync.mockImplementation((p) =>
+      p.endsWith(".bin/jest") ? false : true,
+    );
+    run();
+    expect(child_process.execSync).toHaveBeenCalledWith("npm ci", {
+      stdio: "inherit",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add test to ensure `ensure-deps.js` reinstalls deps when key modules are missing

## Testing
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_687370736ca8832dbb46c81c13cfefb5