### PR TITLE
Fix missing deps

### DIFF
--- a/scripts/ensure-root-deps.js
+++ b/scripts/ensure-root-deps.js
@@ -10,8 +10,23 @@ const pluginPath = path.join(
   "plugin-syntax-typescript",
   "package.json",
 );
+const expressPath = path.join(
+  __dirname,
+  "..",
+  "node_modules",
+  "express",
+  "package.json",
+);
+const playwrightPath = path.join(
+  __dirname,
+  "..",
+  "node_modules",
+  "playwright",
+  "package.json",
+);
 
 const networkCheck = path.join(__dirname, "network-check.js");
+const requiredPaths = [pluginPath, expressPath, playwrightPath];
 
 function runNetworkCheck() {
   try {
@@ -36,7 +51,7 @@ function canReachRegistry() {
   }
 }
 
-if (!fs.existsSync(pluginPath)) {
+if (!requiredPaths.every((p) => fs.existsSync(p))) {
   runNetworkCheck();
   if (!canReachRegistry()) process.exit(1);
   console.log("Dependencies missing. Installing root dependencies...");


### PR DESCRIPTION
## Summary
- verify root dependencies include express and playwright before running tests

## Testing
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_6873703c8234832d8a75d6664fb3eefd