### PR TITLE
Fix missing Playwright dependency issue

### DIFF
--- a/backend/scripts/ensure-deps.js
+++ b/backend/scripts/ensure-deps.js
@@ -5,6 +5,12 @@ const { execSync } = require("child_process");
 const jestPath = "node_modules/.bin/jest";
 const repoRoot = path.join(__dirname, "..", "..");
 const expressPath = path.join(repoRoot, "node_modules", "express");
+const playwrightPath = path.join(
+  repoRoot,
+  "node_modules",
+  "@playwright",
+  "test",
+);
 const setupFlag = path.join(repoRoot, ".setup-complete");
 
 const networkCheck = path.join(
@@ -58,6 +64,18 @@ if (!fs.existsSync(expressPath)) {
   runNetworkCheck();
   if (!canReachRegistry()) process.exit(1);
   console.log("Express not found. Installing root dependencies...");
+  try {
+    execSync("npm ci", { stdio: "inherit", cwd: repoRoot });
+  } catch (err) {
+    console.error("Failed to install root dependencies:", err.message);
+    process.exit(1);
+  }
+}
+
+if (!fs.existsSync(playwrightPath)) {
+  runNetworkCheck();
+  if (!canReachRegistry()) process.exit(1);
+  console.log("Playwright not found. Installing root dependencies...");
   try {
     execSync("npm ci", { stdio: "inherit", cwd: repoRoot });
   } catch (err) {

--- a/tests/dependency.test.js
+++ b/tests/dependency.test.js
@@ -83,4 +83,8 @@ describe("environment", () => {
   test("express installed", () => {
     expect(() => require("express")).not.toThrow();
   });
+
+  test("@playwright/test installed", () => {
+    expect(() => require("@playwright/test")).not.toThrow();
+  });
 });


### PR DESCRIPTION
## Summary
- ensure Playwright is installed when running backend tests
- verify `@playwright/test` exists in the dependency tests

## Testing
- `npx prettier --write backend/scripts/ensure-deps.js tests/dependency.test.js`
- `npm test --prefix backend`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_6873703c8234832d8a75d6664fb3eefd