### PR TITLE
Fix dependency installation in assert-setup

### DIFF
--- a/scripts/assert-setup.js
+++ b/scripts/assert-setup.js
@@ -76,6 +76,9 @@ try {
   process.exit(1);
 }
 
+// Ensure required root dependencies are installed with retry logic
+require("./ensure-root-deps.js");
+
 function rootDepsInstalled() {
   try {
     const pw = fs.existsSync(path.join("node_modules", ".bin", "playwright"));

--- a/tests/assertSetup.test.js
+++ b/tests/assertSetup.test.js
@@ -1,8 +1,10 @@
 jest.mock("fs");
 jest.mock("child_process");
+jest.mock("../scripts/ensure-root-deps.js", () => jest.fn());
 
 const fs = require("fs");
 const child_process = require("child_process");
+const ensureRootDeps = require("../scripts/ensure-root-deps.js");
 
 describe("assert-setup script", () => {
   beforeEach(() => {
@@ -69,5 +71,17 @@ describe("assert-setup script", () => {
     expect(() => require("../scripts/assert-setup.js")).toThrow("exit");
     expect(exitSpy).toHaveBeenCalledWith(1);
     delete process.env.SKIP_PW_DEPS;
+  });
+
+  test("invokes ensure-root-deps", () => {
+    setEnv();
+    fs.existsSync.mockReturnValue(true);
+    fs.readdirSync.mockReturnValue(["chromium"]);
+
+    jest.isolateModules(() => {
+      require("../scripts/assert-setup.js");
+    });
+
+    expect(ensureRootDeps).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- ensure `assert-setup.js` installs root dependencies using existing helper
- test that the new logic calls `ensure-root-deps`

## Testing
- `npm test --prefix backend`
- `node scripts/run-jest.js`


------
https://chatgpt.com/codex/tasks/task_e_68736ff65f9c832da29db19e74529003