### PR TITLE
Fix apt check fallback and add validation test

### DIFF
--- a/scripts/validate-env.sh
+++ b/scripts/validate-env.sh
@@ -54,8 +54,8 @@ fi
 
 if [[ -z "${SKIP_PW_DEPS:-}" ]]; then
   if ! node scripts/check-apt.js >/dev/null 2>&1; then
-    echo "APT repository check failed. Set SKIP_PW_DEPS=1 to skip Playwright dependencies." >&2
-    exit 1
+    echo "APT repository check failed. Falling back to SKIP_PW_DEPS=1." >&2
+    export SKIP_PW_DEPS=1
   fi
 fi
 

--- a/tests/validateEnv.test.js
+++ b/tests/validateEnv.test.js
@@ -1,5 +1,6 @@
 /** @file Tests for validate-env script */
 const { execFileSync } = require("child_process");
+const path = require("path");
 
 /**
  * Run the validate-env script with the provided environment variables.
@@ -92,5 +93,21 @@ describe("validate-env script", () => {
       SKIP_NET_CHECKS: "",
     };
     expect(() => run(env)).toThrow(/Network check failed/);
+  });
+
+  test("falls back to SKIP_PW_DEPS when apt check fails", () => {
+    const env = {
+      ...process.env,
+      HF_TOKEN: "test",
+      AWS_ACCESS_KEY_ID: "id",
+      AWS_SECRET_ACCESS_KEY: "secret",
+      DB_URL: "postgres://user:pass@localhost/db",
+      STRIPE_SECRET_KEY: "sk_test",
+      CLOUDFRONT_MODEL_DOMAIN: "cdn.test",
+      PATH: path.join(__dirname, "bin-apt") + ":" + process.env.PATH,
+    };
+    const output = run(env);
+    expect(output).toContain("APT repository check failed");
+    expect(output).toContain("✅ environment OK");
   });
 });


### PR DESCRIPTION
## Summary
- automatically set `SKIP_PW_DEPS` when `check-apt.js` fails
- add regression test ensuring validate-env falls back to skipping Playwright deps

## Testing
- `npm run format` in `backend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_68736fe71cb4832d930a0f0a5242f6df