### PR TITLE
Fix Playwright setup

### DIFF
--- a/scripts/assert-setup.js
+++ b/scripts/assert-setup.js
@@ -160,6 +160,7 @@ if (!fs.existsSync(".setup-complete") || !browsersInstalled()) {
     const env = { ...process.env };
     delete env.npm_config_http_proxy;
     delete env.npm_config_https_proxy;
+    delete env.PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD;
     require("child_process").execSync("CI=1 npm run setup", {
       stdio: "inherit",
       env,
@@ -172,7 +173,10 @@ if (!fs.existsSync(".setup-complete") || !browsersInstalled()) {
 
 function jestInstalled() {
   try {
-    return fs.existsSync(path.join("node_modules", ".bin", "jest"));
+    return (
+      fs.existsSync(path.join("node_modules", ".bin", "jest")) ||
+      fs.existsSync(path.join("backend", "node_modules", ".bin", "jest"))
+    );
   } catch {
     return false;
   }


### PR DESCRIPTION
## Summary
- update `scripts/assert-setup.js` to ignore `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD`
- detect Jest from backend directory too

## Testing
- `npm test`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_68736fcfbd9c832db6b1ab19340320e3