### PR TITLE
fix: rebuild sharp automatically

### DIFF
--- a/backend/scripts/ensure-deps.js
+++ b/backend/scripts/ensure-deps.js
@@ -85,3 +85,24 @@ if (!fs.existsSync(jestPath)) {
     process.exit(1);
   }
 }
+
+function sharpWorks() {
+  try {
+    require("sharp");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+if (!sharpWorks()) {
+  runNetworkCheck();
+  if (!canReachRegistry()) process.exit(1);
+  console.log("Sharp failed to load. Rebuilding...");
+  try {
+    execSync("npm rebuild sharp", { stdio: "inherit" });
+  } catch (err) {
+    console.error("Failed to rebuild sharp:", err.message);
+    process.exit(1);
+  }
+}

--- a/tests/ensureDeps.test.js
+++ b/tests/ensureDeps.test.js
@@ -67,4 +67,18 @@ describe("ensure-deps", () => {
     expect(() => require("../backend/scripts/ensure-deps")).toThrow("exit");
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
+
+  test("rebuilds sharp when require fails", () => {
+    fs.existsSync.mockReturnValue(true);
+    jest.resetModules();
+    jest.doMock(
+      "sharp",
+      () => {
+        throw new Error("load fail");
+      },
+      { virtual: true },
+    );
+    child_process.execSync.mockReturnValue();
+    expect(() => require("../backend/scripts/ensure-deps")).not.toThrow();
+  });
 });


### PR DESCRIPTION
## Summary
- rebuild `sharp` if it fails to load
- add regression test for `ensure-deps`

## Testing
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_68736fb1f870832dbf902028bc547914