### PR TITLE
Improve docs for npm cache errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,6 +338,10 @@ Install dependencies and Playwright browsers:
 npm run setup
 ```
 
+If `npm run ci` fails with messages like `TAR_ENTRY_ERROR` or missing files in
+`node_modules`, rerun `npm run setup`. The setup script cleans the npm cache and
+reinstalls packages to recover from corrupted installs.
+
 If the browsers are missing, the CI scripts will automatically invoke this
 command for you. Running it manually first speeds up subsequent test runs.
 


### PR DESCRIPTION
## Summary
- document how to recover from TAR_ENTRY_ERROR by rerunning the setup script

## Testing
- `npm test`
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_68737fcf86cc832d94a8c18be72b0959