### PR TITLE
Fix playwright host dependency check

### DIFF
--- a/scripts/check-host-deps.js
+++ b/scripts/check-host-deps.js
@@ -40,6 +40,12 @@ if (!hostDepsInstalled()) {
   console.log("Playwright host dependencies missing. Installing...");
   try {
     execSync("CI=1 npx playwright install --with-deps", { stdio: "inherit" });
+    if (!hostDepsInstalled()) {
+      console.error(
+        "Playwright host dependencies remain missing after installation.",
+      );
+      process.exit(1);
+    }
   } catch (err) {
     console.error(
       "Failed to install Playwright host dependencies:",

--- a/tests/checkHostDeps.test.js
+++ b/tests/checkHostDeps.test.js
@@ -47,14 +47,11 @@ test("skips network check when SKIP_NET_CHECKS is set", () => {
   delete process.env.SKIP_NET_CHECKS;
 });
 
-
 test("fails when SKIP_PW_DEPS is set and deps are missing", () => {
   process.env.SKIP_PW_DEPS = "1";
   child_process.execSync
     .mockReturnValueOnce("network ok")
-    .mockImplementationOnce(() => {
-
-    })
+    .mockReturnValueOnce("Host system is missing dependencies")
     .mockReturnValueOnce("");
   const exitSpy = jest.spyOn(process, "exit").mockImplementation(() => {
     throw new Error("exit");
@@ -122,4 +119,37 @@ test("skips install when deps satisfied even if SKIP_PW_DEPS is set", () => {
   );
   expect(child_process.execSync).toHaveBeenCalledTimes(2);
   delete process.env.SKIP_PW_DEPS;
+});
+
+test("fails when deps remain missing after install", () => {
+  child_process.execSync
+    .mockReturnValueOnce("network ok")
+    .mockReturnValueOnce("Host system is missing dependencies")
+    .mockReturnValueOnce("")
+    .mockReturnValueOnce("Host system is missing dependencies");
+  const exitSpy = jest.spyOn(process, "exit").mockImplementation(() => {
+    throw new Error("exit");
+  });
+  expect(() => require("../scripts/check-host-deps.js")).toThrow("exit");
+  expect(child_process.execSync).toHaveBeenNthCalledWith(
+    1,
+    "node scripts/network-check.js",
+    { stdio: "ignore" },
+  );
+  expect(child_process.execSync).toHaveBeenNthCalledWith(
+    2,
+    "npx playwright install --with-deps --dry-run 2>&1",
+    { encoding: "utf8" },
+  );
+  expect(child_process.execSync).toHaveBeenNthCalledWith(
+    3,
+    "CI=1 npx playwright install --with-deps",
+    { stdio: "inherit" },
+  );
+  expect(child_process.execSync).toHaveBeenNthCalledWith(
+    4,
+    "npx playwright install --with-deps --dry-run 2>&1",
+    { encoding: "utf8" },
+  );
+  expect(exitSpy).toHaveBeenCalledWith(1);
 });


### PR DESCRIPTION
## Summary
- verify host dependencies after installing Playwright
- test failure when dependencies remain missing

## Testing
- `npm test`
- `npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68737fba63a0832db044160b21dfba22