### PR TITLE
Fix root deps installation

### DIFF
--- a/scripts/assert-setup.js
+++ b/scripts/assert-setup.js
@@ -93,39 +93,12 @@ function rootDepsInstalled() {
 if (!rootDepsInstalled()) {
   console.log("Root dependencies missing. Installing...");
   try {
-    child_process.execSync("npm ci", { stdio: "inherit" });
+    child_process.execSync("node scripts/ensure-root-deps.js", {
+      stdio: "inherit",
+    });
   } catch (err) {
-    const msg = String(err.message || err);
-    if (msg.includes("EUSAGE")) {
-      console.warn("npm ci failed, falling back to 'npm install'");
-      try {
-        child_process.execSync("npm install", { stdio: "inherit" });
-      } catch (err2) {
-        console.error("Failed to install dependencies:", err2.message);
-        process.exit(1);
-      }
-    } else if (/(TAR_ENTRY_ERROR|ENOENT|ENOTEMPTY)/.test(msg)) {
-      console.warn("npm ci encountered tar errors. Retrying after cleanup...");
-      try {
-        child_process.execSync(
-          "npx --yes rimraf node_modules backend/node_modules",
-          { stdio: "inherit" },
-        );
-      } catch {
-        child_process.execSync("rm -rf node_modules backend/node_modules", {
-          stdio: "inherit",
-        });
-      }
-      try {
-        child_process.execSync("npm ci", { stdio: "inherit" });
-      } catch (err2) {
-        console.error("Failed to reinstall dependencies:", err2.message);
-        process.exit(1);
-      }
-    } else {
-      console.error("Failed to install dependencies:", err.message);
-      process.exit(1);
-    }
+    console.error("Failed to install dependencies:", err.message);
+    process.exit(1);
   }
 }
 
@@ -187,20 +160,11 @@ function pluginInstalled() {
 if (!jestInstalled() || !pluginInstalled()) {
   console.log("Dependencies missing. Installing root dependencies...");
   try {
-    require("child_process").execSync("npm ci", { stdio: "inherit" });
+    child_process.execSync("node scripts/ensure-root-deps.js", {
+      stdio: "inherit",
+    });
   } catch (err) {
-    const msg = String(err.message || err);
-    if (msg.includes("EUSAGE")) {
-      console.warn("npm ci failed, falling back to 'npm install'");
-      try {
-        require("child_process").execSync("npm install", { stdio: "inherit" });
-      } catch (err2) {
-        console.error("Failed to install dependencies:", err2.message);
-        process.exit(1);
-      }
-    } else {
-      console.error("Failed to install dependencies:", err.message);
-      process.exit(1);
-    }
+    console.error("Failed to install dependencies:", err.message);
+    process.exit(1);
   }
 }

--- a/tests/assertSetup.test.js
+++ b/tests/assertSetup.test.js
@@ -76,4 +76,20 @@ describe("assert-setup script", () => {
     );
     delete process.env.SKIP_NET_CHECKS;
   });
+
+  test("uses ensure-root-deps when root deps missing", () => {
+    setEnv();
+    fs.existsSync.mockImplementation((p) => {
+      if (p === ".setup-complete") return true;
+      return false;
+    });
+    fs.readdirSync.mockReturnValue(["chromium"]);
+    child_process.execSync.mockImplementation(() => {});
+
+    expect(() => require("../scripts/assert-setup.js")).not.toThrow();
+    expect(child_process.execSync).toHaveBeenCalledWith(
+      "node scripts/ensure-root-deps.js",
+      { stdio: "inherit" },
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- install root deps via `ensure-root-deps.js` in `assert-setup.js`
- verify this path in tests

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68737f7ddb7c832d9af83fcee373446e