### PR TITLE
Fix Jest deps fallback and add test

### DIFF
--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -3,7 +3,19 @@ const fs = require("fs");
 const { execSync } = require("child_process");
 const path = require("path");
 
+const rootPlugin = path.join(
+  __dirname,
+  "..",
+  "node_modules",
+  "@babel",
+  "plugin-syntax-typescript",
+  "package.json",
+);
+
 if (!process.env.SKIP_ROOT_DEPS_CHECK) {
+  require("./ensure-root-deps.js");
+} else if (!fs.existsSync(rootPlugin)) {
+  console.warn("Root dependencies missing. Running ensure-root-deps...");
   require("./ensure-root-deps.js");
 }
 

--- a/tests/runJestRootDeps.test.js
+++ b/tests/runJestRootDeps.test.js
@@ -1,0 +1,34 @@
+const fs = require("fs");
+const child_process = require("child_process");
+
+jest.mock("fs");
+jest.mock("../scripts/ensure-root-deps.js", () => ({}));
+
+beforeEach(() => {
+  jest.resetModules();
+  fs.existsSync.mockReset();
+  child_process.execSync = jest.fn();
+  jest.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  delete process.env.SKIP_ROOT_DEPS_CHECK;
+  console.warn.mockRestore();
+});
+
+test("run-jest invokes ensure-root-deps when SKIP_ROOT_DEPS_CHECK=1 but deps missing", () => {
+  process.env.SKIP_ROOT_DEPS_CHECK = "1";
+  fs.existsSync.mockImplementation((p) => {
+    if (p.includes("@babel/plugin-syntax-typescript")) return false;
+    if (p.includes("backend/node_modules/.bin/jest")) return true;
+    return true;
+  });
+
+  const runJest = require("../scripts/run-jest.js");
+  runJest(["tests/validateEnv.test.js"]);
+
+  expect(console.warn).toHaveBeenCalledWith(
+    "Root dependencies missing. Running ensure-root-deps...",
+  );
+  expect(child_process.execSync).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- ensure `run-jest.js` installs root dependencies when they are missing even if `SKIP_ROOT_DEPS_CHECK` is set
- add integration test covering the fallback logic

## Testing
- `npm run format`
- `npm test` in `backend/`
- `node scripts/run-jest.js tests/runJestRootDeps.test.js`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_68737f6c12a8832d9abe70e04b355603