### PR TITLE
Add env script checks

### DIFF
--- a/backend/tests/checkEnvProxy.test.ts
+++ b/backend/tests/checkEnvProxy.test.ts
@@ -1,0 +1,26 @@
+const { execFileSync } = require("child_process");
+const path = require("path");
+
+describe("check-env proxy vars", () => {
+  test("fails when npm proxy variables set", () => {
+    const env = {
+      ...process.env,
+      npm_config_http_proxy: "http://proxy",
+      npm_config_https_proxy: "http://proxy",
+      HF_TOKEN: "x",
+      AWS_ACCESS_KEY_ID: "id",
+      AWS_SECRET_ACCESS_KEY: "secret",
+      DB_URL: "db",
+      STRIPE_SECRET_KEY: "sk",
+      CLOUDFRONT_MODEL_DOMAIN: "cdn",
+      SKIP_NET_CHECKS: "1",
+    };
+    expect(() => {
+      execFileSync(
+        "bash",
+        [path.join(__dirname, "..", "..", "scripts", "check-env.sh")],
+        { env, encoding: "utf8" },
+      );
+    }).toThrow(/npm proxy variables must be unset/);
+  });
+});

--- a/backend/tests/validateEnvNodeVersion.test.ts
+++ b/backend/tests/validateEnvNodeVersion.test.ts
@@ -1,0 +1,26 @@
+const { execFileSync } = require("child_process");
+const path = require("path");
+
+describe("validate-env node version check", () => {
+  test("fails when node version too low", () => {
+    const major = parseInt(process.versions.node.split(".")[0], 10);
+    const env = {
+      ...process.env,
+      REQUIRED_NODE_MAJOR: String(major + 5),
+      HF_TOKEN: "x",
+      AWS_ACCESS_KEY_ID: "id",
+      AWS_SECRET_ACCESS_KEY: "secret",
+      DB_URL: "db",
+      STRIPE_SECRET_KEY: "sk",
+      SKIP_NET_CHECKS: "1",
+      SKIP_PW_DEPS: "1",
+    };
+    expect(() => {
+      execFileSync(
+        "bash",
+        [path.join(__dirname, "..", "..", "scripts", "validate-env.sh")],
+        { env, encoding: "utf8" },
+      );
+    }).toThrow(new RegExp(`Node ${major + 5}`));
+  });
+});

--- a/scripts/check-env.sh
+++ b/scripts/check-env.sh
@@ -38,6 +38,12 @@ fi
 : "${DB_URL:?DB_URL must be set}"
 : "${STRIPE_SECRET_KEY:?STRIPE_SECRET_KEY must be set}"
 : "${CLOUDFRONT_MODEL_DOMAIN:?CLOUDFRONT_MODEL_DOMAIN must be set}"
+required_node_major="${REQUIRED_NODE_MAJOR:-20}"
+current_major=$(node -v | sed -E "s/^v([0-9]+).*/\1/")
+if [ "$current_major" -lt "$required_node_major" ]; then
+  echo "Node $required_node_major or newer is required. Current version: $current_major" >&2
+  exit 1
+fi
 
 # Fail fast if npm-specific proxy variables are set. Other proxy variables may be required
 if [[ -n "${npm_config_http_proxy:-}" || -n "${npm_config_https_proxy:-}" ]]; then

--- a/scripts/validate-env.sh
+++ b/scripts/validate-env.sh
@@ -35,6 +35,12 @@ fi
 : "${AWS_SECRET_ACCESS_KEY:?AWS_SECRET_ACCESS_KEY must be set}"
 : "${DB_URL:?DB_URL must be set}"
 : "${STRIPE_SECRET_KEY:?STRIPE_SECRET_KEY must be set}"
+required_node_major="${REQUIRED_NODE_MAJOR:-20}"
+current_major=$(node -v | sed -E "s/^v([0-9]+).*/\1/")
+if [ "$current_major" -lt "$required_node_major" ]; then
+  echo "Node $required_node_major or newer is required. Current version: $current_major" >&2
+  exit 1
+fi
 
 
 # Fail fast if npm-specific proxy variables are set. Other proxy variables may


### PR DESCRIPTION
## Summary
- enforce Node 20 in `validate-env.sh` and `check-env.sh`
- add regression tests for env scripts

## Testing
- `npm run format` in backend
- `npm test` in backend

------
https://chatgpt.com/codex/tasks/task_e_68737f18cc18832d86c25f97d32ea123