### PR TITLE
Fix run-jest missing file handling

### DIFF
--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -16,7 +16,26 @@ if (!process.env.SKIP_ROOT_DEPS_CHECK) {
   }
 }
 
+function verifyFiles(args) {
+  const repoRoot = path.resolve(__dirname, "..");
+  let checking = false;
+  for (const arg of args) {
+    if (arg === "--runTestsByPath") {
+      checking = true;
+      continue;
+    }
+    if (checking || /\.test\.(js|ts)$/.test(arg)) {
+      const file = path.resolve(repoRoot, arg);
+      if (!fs.existsSync(file)) {
+        console.error(`Test file not found: ${arg}`);
+        process.exit(1);
+      }
+    }
+  }
+}
+
 function runJest(args) {
+  verifyFiles(args);
   const repoRoot = path.resolve(__dirname, "..");
   const backendDir = path.join(repoRoot, "backend");
   const jestBin = path.join(backendDir, "node_modules", ".bin", "jest");

--- a/tests/runJestMissingFile.test.js
+++ b/tests/runJestMissingFile.test.js
@@ -1,0 +1,24 @@
+const { execFileSync } = require("child_process");
+const path = require("path");
+
+describe("run-jest missing file", () => {
+  test("exits with helpful error", () => {
+    const script = path.join("scripts", "run-jest.js");
+    const env = {
+      ...process.env,
+      HF_TOKEN: "test",
+      AWS_ACCESS_KEY_ID: "id",
+      AWS_SECRET_ACCESS_KEY: "secret",
+      SKIP_NET_CHECKS: "1",
+    };
+    delete env.npm_config_http_proxy;
+    delete env.npm_config_https_proxy;
+    expect(() =>
+      execFileSync("node", [script, "tests/does-not-exist.test.js"], {
+        encoding: "utf8",
+        env,
+        stdio: "pipe",
+      }),
+    ).toThrow(/Test file not found/);
+  });
+});


### PR DESCRIPTION
## Summary
- validate test paths in `scripts/run-jest.js`
- add regression test for missing test files

## Testing
- `npx prettier -w scripts/run-jest.js tests/runJestMissingFile.test.js`
- `SKIP_PW_DEPS=1 SKIP_ROOT_DEPS_CHECK=1 node scripts/run-jest.js tests/runJestMissingFile.test.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68737f29ac90832d95d4504532e53fe0