### PR TITLE
test: verify root deps with run-jest

### DIFF
--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -5,6 +5,15 @@ const path = require("path");
 
 if (!process.env.SKIP_ROOT_DEPS_CHECK) {
   require("./ensure-root-deps.js");
+} else {
+  try {
+    require.resolve("@babel/plugin-syntax-typescript");
+  } catch {
+    console.error(
+      "Missing root dependencies. Run 'npm run setup' before running tests.",
+    );
+    process.exit(1);
+  }
 }
 
 function runJest(args) {

--- a/tests/dummy.test.js
+++ b/tests/dummy.test.js
@@ -1,0 +1,3 @@
+test("dummy", () => {
+  expect(true).toBe(true);
+});

--- a/tests/runJestMissingDeps.test.js
+++ b/tests/runJestMissingDeps.test.js
@@ -1,0 +1,34 @@
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+const pluginDir = path.join(
+  __dirname,
+  "..",
+  "node_modules",
+  "@babel",
+  "plugin-syntax-typescript",
+);
+const backupDir = pluginDir + ".bak";
+
+function run(cmd, args, env = {}) {
+  try {
+    execFileSync(cmd, args, { stdio: "pipe", env: { ...process.env, ...env } });
+    return 0;
+  } catch (err) {
+    return err.status || 1;
+  }
+}
+
+test("run-jest exits when plugin missing and check skipped", () => {
+  if (!fs.existsSync(pluginDir)) return; // skip if dependencies not installed
+  fs.renameSync(pluginDir, backupDir);
+  try {
+    const code = run("node", ["scripts/run-jest.js", "tests/dummy.test.js"], {
+      SKIP_ROOT_DEPS_CHECK: "1",
+    });
+    expect(code).not.toBe(0);
+  } finally {
+    fs.renameSync(backupDir, pluginDir);
+  }
+});


### PR DESCRIPTION
## Summary
- ensure `run-jest` throws when root deps are skipped and missing
- add regression tests for missing plugin logic

## Testing
- `npm run format --silent --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68737ef24360832d8ef75cb4536689e4