### PR TITLE
Ensure run-jest checks full setup

### DIFF
--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -16,6 +16,12 @@ if (!process.env.SKIP_ROOT_DEPS_CHECK) {
   }
 }
 
+// Ensure Playwright browsers and host dependencies are present so running tests
+// via this helper works in clean environments.
+if (!process.env.SKIP_ASSERT_SETUP) {
+  require("./assert-setup.js");
+}
+
 function runJest(args) {
   const repoRoot = path.resolve(__dirname, "..");
   const backendDir = path.join(repoRoot, "backend");

--- a/tests/runJestSetup.test.js
+++ b/tests/runJestSetup.test.js
@@ -1,0 +1,18 @@
+jest.mock("../scripts/assert-setup.js");
+jest.mock("../scripts/ensure-root-deps.js");
+const child_process = require("child_process");
+const fs = require("fs");
+
+describe("run-jest setup", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    child_process.execSync = jest.fn();
+    fs.existsSync = jest.fn().mockReturnValue(true);
+  });
+
+  test("invokes assert-setup before running", () => {
+    const runJest = require("../scripts/run-jest");
+    runJest(["tests/validateEnv.test.js"]);
+    expect(require("../scripts/assert-setup.js")).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- verify Playwright setup when invoking `run-jest`
- add regression test for `run-jest`

## Testing
- `SKIP_ROOT_DEPS_CHECK=1 npm test`
- `SKIP_ROOT_DEPS_CHECK=1 SKIP_PW_DEPS=1 npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_68737ec2bcbc832db1a80e59340f5556