### PR TITLE
Fix apt detection and add regression test

### DIFF
--- a/scripts/check-apt.js
+++ b/scripts/check-apt.js
@@ -1,8 +1,23 @@
 #!/usr/bin/env node
 const { spawnSync } = require("child_process");
 
+function commandExists(cmd) {
+  const res = spawnSync("which", [cmd], { encoding: "utf8" });
+  return res.status === 0;
+}
+
 if (process.env.SKIP_PW_DEPS) {
   console.log("Skipping apt check due to SKIP_PW_DEPS");
+  process.exit(0);
+}
+
+if (!commandExists("apt-get")) {
+  console.log("apt-get not found, skipping apt check");
+  process.exit(0);
+}
+
+if (!commandExists("sudo")) {
+  console.log("sudo not found, skipping apt check");
   process.exit(0);
 }
 

--- a/tests/aptCheckScriptMissing.test.js
+++ b/tests/aptCheckScriptMissing.test.js
@@ -1,0 +1,22 @@
+const { execFileSync } = require("child_process");
+const path = require("path");
+
+const binDir = path.join(__dirname, "bin-noapt");
+
+/** Simulate missing apt-get by overriding PATH */
+
+describe("apt-check script missing apt-get", () => {
+  test("skips gracefully when apt-get is missing", () => {
+    const nodeDir = path.dirname(process.execPath);
+    const env = { ...process.env, PATH: `${binDir}:${nodeDir}` };
+    const output = execFileSync(
+      "node",
+      [path.join("scripts", "check-apt.js")],
+      {
+        env,
+        encoding: "utf8",
+      },
+    );
+    expect(output).toMatch(/apt-get not found/);
+  });
+});

--- a/tests/bin-noapt/sudo
+++ b/tests/bin-noapt/sudo
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# simulate sudo when apt-get is missing
+if [[ "$1" == "apt-get" ]]; then
+  echo "sudo: apt-get: command not found" >&2
+  exit 127
+else
+  command sudo "$@"
+fi


### PR DESCRIPTION
## Summary
- skip apt checks when apt-get or sudo aren't available
- add a regression test covering missing apt-get

## Testing
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_68737e8c096c832db8326a758a3a2065