### PR TITLE
Add EEXIST handling to setup

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -94,7 +94,7 @@ run_ci() {
       echo "npm ci failed in $dir due to lock mismatch. Running npm install..." >&2
       npm install $extra --no-audit --no-fund
       npm ci $extra --no-audit --no-fund
-    elif grep -E -q "TAR_ENTRY_ERROR|ENOENT|ENOTEMPTY|tarball .*corrupted" ci.log; then
+    elif grep -E -q "TAR_ENTRY_ERROR|ENOENT|ENOTEMPTY|EEXIST|rename|tarball .*corrupted" ci.log; then
       echo "npm ci encountered tar or filesystem errors in $dir. Cleaning cache and retrying..." >&2
       cleanup_npm_cache
       rm -rf ${dir:-.}/node_modules

--- a/tests/bin-eexist/npm
+++ b/tests/bin-eexist/npm
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+if [[ "$1" == "ci" && -z "$EEXIST_ERROR_DONE" ]]; then
+  echo "npm ERR! code EEXIST" >&2
+  echo "npm ERR! syscall rename" >&2
+  echo "npm ERR! path /fake/cache/tmp123" >&2
+  echo "npm ERR! dest /fake/cache/content123" >&2
+  echo "npm ERR! errno -2" >&2
+  echo "npm ERR! ENOENT: no such file or directory, rename '/fake/cache/tmp123' -> '/fake/cache/content123'" >&2
+  export EEXIST_ERROR_DONE=1
+  exit 1
+fi
+exec "$REAL_NPM" "$@"

--- a/tests/setupScriptEexist.test.js
+++ b/tests/setupScriptEexist.test.js
@@ -1,0 +1,20 @@
+const { execSync } = require('child_process');
+const path = require('path');
+
+describe('setup script EEXIST rename error', () => {
+  test('retries when npm ci reports EEXIST rename', () => {
+    const env = {
+      ...process.env,
+      HF_TOKEN: 'test',
+      AWS_ACCESS_KEY_ID: 'id',
+      AWS_SECRET_ACCESS_KEY: 'secret',
+      DB_URL: 'postgres://user:pass@localhost/db',
+      STRIPE_SECRET_KEY: 'sk_test',
+      SKIP_NET_CHECKS: '1',
+      SKIP_PW_DEPS: '1',
+      REAL_NPM: execSync('command -v npm').toString().trim(),
+      PATH: path.join(__dirname, 'bin-eexist') + ':' + process.env.PATH,
+    };
+    execSync('bash scripts/setup.sh', { env, stdio: 'inherit' });
+  });
+});


### PR DESCRIPTION
## Summary
- handle EEXIST rename errors during npm ci
- add regression test and fixture for EEXIST failure

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_68737e710da4832dbf864377ae6e5531