### PR TITLE
Fix npm ci tarball retry

### DIFF
--- a/tests/bin-tarball/npm
+++ b/tests/bin-tarball/npm
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-if [[ "$1" == "ci" && -z "$TARBALL_WARN_DONE" ]]; then
+flag=/tmp/tarball_warn_done
+if [[ "$1" == "ci" && ! -f "$flag" ]]; then
   echo "npm WARN tarball tarball data for foo@https://registry.npmjs.org/foo/-/foo-1.0.0.tgz (sha512-deadbeef) seems to be corrupted. Trying again." >&2
-  export TARBALL_WARN_DONE=1
+  touch "$flag"
   exit 1
 fi
 exec "$REAL_NPM" "$@"


### PR DESCRIPTION
## Summary
- handle corrupted tarball warnings in `assert-setup.js`
- simulate one-time tarball failure for tests using `/tmp/tarball_warn_done`

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_68737fa35f50832d8bb63cd4d6a06163