### PR TITLE
Improve npm cache cleanup resilience

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -6,7 +6,14 @@ set -e
 
 cleanup_npm_cache() {
   npm cache clean --force >/dev/null 2>&1 || true
-  rm -rf "$(npm config get cache)/_cacache" "$HOME/.npm/_cacache" 2>/dev/null || true
+  for dir in "$(npm config get cache)/_cacache" "$HOME/.npm/_cacache"; do
+    if [ -d "$dir" ]; then
+      for i in {1..5}; do
+        rm -rf "$dir" 2>/dev/null && break
+        sleep 1
+      done
+    fi
+  done
   rm -rf "$(npm config get cache)/_cacache/tmp" "$HOME/.npm/_cacache/tmp" 2>/dev/null || true
   npm cache verify >/dev/null 2>&1 || true
 }

--- a/tests/bin-cacache/rm
+++ b/tests/bin-cacache/rm
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+if [[ "$*" == *"_cacache"* && -z "$CACACHE_FAIL_DONE" ]]; then
+  echo "rm: cannot remove '$2': Directory not empty" >&2
+  export CACACHE_FAIL_DONE=1
+  exit 1
+fi
+exec "$REAL_RM" "$@"

--- a/tests/setupScriptCacheRetry.test.js
+++ b/tests/setupScriptCacheRetry.test.js
@@ -1,0 +1,20 @@
+const { execSync } = require("child_process");
+const path = require("path");
+
+describe("setup script npm cache cleanup", () => {
+  test("retries when rm fails to remove _cacache", () => {
+    const env = {
+      ...process.env,
+      HF_TOKEN: "test",
+      AWS_ACCESS_KEY_ID: "id",
+      AWS_SECRET_ACCESS_KEY: "secret",
+      DB_URL: "postgres://user:pass@localhost/db",
+      STRIPE_SECRET_KEY: "sk_test",
+      SKIP_NET_CHECKS: "1",
+      SKIP_PW_DEPS: "1",
+      REAL_RM: execSync("command -v rm").toString().trim(),
+      PATH: path.join(__dirname, "bin-cacache") + ":" + process.env.PATH,
+    };
+    execSync("bash scripts/setup.sh", { env, stdio: "inherit" });
+  });
+});


### PR DESCRIPTION
## Summary
- retry deleting npm cache directories if removal fails
- test setup script's cacache cleanup

## Testing
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `npm run ci` (with `SKIP_PW_DEPS=1`)
- `npm run smoke` (with `SKIP_PW_DEPS=1`)


------
https://chatgpt.com/codex/tasks/task_e_68737e52bd04832d955a84eb7248f17e