### PR TITLE
Fix validate-env node path issue

### DIFF
--- a/scripts/validate-env.sh
+++ b/scripts/validate-env.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -e
 
+# Ensure mise activates the configured Node version so npm commands work even
+# when the shell hasn't sourced mise's hook. This prevents "node: command not
+# found" errors in fresh environments.
+eval "$(mise activate bash)"
+
 # Silence mise warnings about untrusted config files
 mise trust . >/dev/null 2>&1 || true
 mise settings add idiomatic_version_file_enable_tools node --yes >/dev/null 2>&1 || true

--- a/tests/validateEnvNodePath.test.js
+++ b/tests/validateEnvNodePath.test.js
@@ -1,0 +1,21 @@
+const { execFileSync } = require("child_process");
+const path = require("path");
+
+describe("validate-env node path", () => {
+  test("script succeeds when node not on PATH", () => {
+    const env = {
+      ...process.env,
+      PATH: "/usr/bin:/bin",
+      AWS_ACCESS_KEY_ID: "id",
+      AWS_SECRET_ACCESS_KEY: "secret",
+      DB_URL: "postgres://u:p@h/db",
+      STRIPE_SECRET_KEY: "sk_test",
+      SKIP_NET_CHECKS: "1",
+      SKIP_PW_DEPS: "1",
+    };
+    execFileSync("bash", [path.join("scripts", "validate-env.sh")], {
+      env,
+      stdio: "inherit",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- make `validate-env` activate Node via mise so scripts work when PATH lacks node
- test that `validate-env` succeeds even when node isn't on PATH

## Testing
- `npm test`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68737e361d60832d995cbc208002f0ab