### PR TITLE
Fix test setup detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint:fix": "eslint . --fix",
     "check-conflicts": "! grep -R --include=*.js --include=*.jsx --include=*.ts --include=*.tsx '^(<{7}|={7}|>{7})' .",
     "check-root": "node scripts/check-repo-root.js",
-    "pretest": "node scripts/check-repo-root.js",
+    "pretest": "node scripts/check-repo-root.js && node scripts/assert-setup.js",
     "jest": "node scripts/run-jest.js",
     "test:structure": "jest --runTestsByPath tests/projectStructure.test.js",
     "test": "npm test --prefix backend",

--- a/tests/pretestScript.test.js
+++ b/tests/pretestScript.test.js
@@ -1,0 +1,6 @@
+describe("package.json pretest", () => {
+  test("includes assert-setup script", () => {
+    const pkg = require("../package.json");
+    expect(pkg.scripts.pretest).toMatch(/assert-setup/);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure `assert-setup.js` runs before tests by extending the `pretest` script
- add regression test verifying the pretest script includes the setup check

## Testing
- `npm run format --prefix backend`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_68737e13c1d0832db27bb54055cb7324