### PR TITLE
Fix Prettier detection in setup check

### DIFF
--- a/backend/tests/assertSetup.test.js
+++ b/backend/tests/assertSetup.test.js
@@ -3,7 +3,7 @@ const os = require("os");
 const path = require("path");
 const { spawnSync } = require("child_process");
 
-const script = path.join(__dirname, "..", "scripts", "assert-setup.js");
+const script = path.join(__dirname, "..", "..", "scripts", "assert-setup.js");
 const stub = path.join(__dirname, "stubExecSync.js");
 
 function runAssertSetup(nodeVersion) {

--- a/scripts/assert-setup.js
+++ b/scripts/assert-setup.js
@@ -167,9 +167,9 @@ if (!fs.existsSync(".setup-complete") || !browsersInstalled()) {
   }
 }
 
-function jestInstalled() {
+function prettierInstalled() {
   try {
-    return fs.existsSync(path.join("node_modules", ".bin", "jest"));
+    return fs.existsSync(path.join("node_modules", ".bin", "prettier"));
   } catch {
     return false;
   }
@@ -184,7 +184,7 @@ function pluginInstalled() {
   }
 }
 
-if (!jestInstalled() || !pluginInstalled()) {
+if (!prettierInstalled() || !pluginInstalled()) {
   console.log("Dependencies missing. Installing root dependencies...");
   try {
     require("child_process").execSync("npm ci", { stdio: "inherit" });


### PR DESCRIPTION
## Summary
- make `assert-setup` check for Prettier instead of Jest so `npm run format` no longer reinstalls dependencies every time
- update tests for the new logic and ensure backend path points to the root script

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68737e05fcc8832d89b8c1d7939bebec