### PR TITLE
Add ensure-deps skip test

### DIFF
--- a/tests/ensureDeps.test.js
+++ b/tests/ensureDeps.test.js
@@ -75,7 +75,6 @@ describe("ensure-deps", () => {
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
 
-
   test("falls back to SKIP_PW_DEPS when apt check fails", () => {
     fs.existsSync.mockReturnValue(false);
     const execMock = jest
@@ -97,5 +96,12 @@ describe("ensure-deps", () => {
         env: expect.objectContaining({ SKIP_PW_DEPS: "1" }),
       }),
     );
+  });
+
+  test("skips setup when flag and deps exist", () => {
+    fs.existsSync.mockReturnValue(true);
+    const execMock = jest.spyOn(child_process, "execSync");
+    require("../backend/scripts/ensure-deps");
+    expect(execMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- verify ensure-deps does nothing when setup flag and dependencies exist

## Testing
- `SKIP_PW_DEPS=1 npm test --prefix backend`
- `npm run format --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_68737ded2a28832da53c6dbc0bba3cf1