### PR TITLE
Fix host deps install when skipping

### DIFF
--- a/scripts/check-host-deps.js
+++ b/scripts/check-host-deps.js
@@ -32,12 +32,12 @@ checkNetwork();
 
 if (!hostDepsInstalled()) {
   if (process.env.SKIP_PW_DEPS) {
-    console.error(
-      "Playwright host dependencies are missing. Run 'npx playwright install --with-deps' or remove SKIP_PW_DEPS.",
+    console.log(
+      "Playwright host dependencies missing but SKIP_PW_DEPS=1. Installing anyway...",
     );
-    process.exit(1);
+  } else {
+    console.log("Playwright host dependencies missing. Installing...");
   }
-  console.log("Playwright host dependencies missing. Installing...");
   try {
     execSync("CI=1 npx playwright install --with-deps", { stdio: "inherit" });
   } catch (err) {

--- a/tests/checkHostDeps.test.js
+++ b/tests/checkHostDeps.test.js
@@ -47,20 +47,15 @@ test("skips network check when SKIP_NET_CHECKS is set", () => {
   delete process.env.SKIP_NET_CHECKS;
 });
 
-
-test("fails when SKIP_PW_DEPS is set and deps are missing", () => {
+test("installs deps when SKIP_PW_DEPS is set and deps are missing", () => {
   process.env.SKIP_PW_DEPS = "1";
   child_process.execSync
     .mockReturnValueOnce("network ok")
     .mockImplementationOnce(() => {
-
+      throw new Error("deps missing");
     })
     .mockReturnValueOnce("");
-  const exitSpy = jest.spyOn(process, "exit").mockImplementation(() => {
-    throw new Error("exit");
-  });
-  expect(() => require("../scripts/check-host-deps.js")).toThrow("exit");
-  expect(exitSpy).toHaveBeenCalledWith(1);
+  require("../scripts/check-host-deps.js");
   expect(child_process.execSync).toHaveBeenNthCalledWith(
     1,
     "node scripts/network-check.js",
@@ -71,13 +66,16 @@ test("fails when SKIP_PW_DEPS is set and deps are missing", () => {
     "npx playwright install --with-deps --dry-run 2>&1",
     { encoding: "utf8" },
   );
-  expect(child_process.execSync).toHaveBeenCalledTimes(2);
-
-  expect(exitSpy).toHaveBeenCalledWith(1);
+  expect(child_process.execSync).toHaveBeenNthCalledWith(
+    3,
+    "CI=1 npx playwright install --with-deps",
+    { stdio: "inherit" },
+  );
+  expect(child_process.execSync).toHaveBeenCalledTimes(3);
   delete process.env.SKIP_PW_DEPS;
 });
 
-test("fails when SKIP_PW_DEPS is set and warning is printed", () => {
+test("installs deps when SKIP_PW_DEPS is set and warning is printed", () => {
   process.env.SKIP_PW_DEPS = "1";
   child_process.execSync
     .mockReturnValueOnce("network ok")
@@ -85,10 +83,7 @@ test("fails when SKIP_PW_DEPS is set and warning is printed", () => {
       "Playwright Host validation warning: Host system is missing dependencies",
     )
     .mockReturnValueOnce("");
-  const exitSpy = jest.spyOn(process, "exit").mockImplementation(() => {
-    throw new Error("exit");
-  });
-  expect(() => require("../scripts/check-host-deps.js")).toThrow("exit");
+  require("../scripts/check-host-deps.js");
   expect(child_process.execSync).toHaveBeenNthCalledWith(
     1,
     "node scripts/network-check.js",
@@ -99,8 +94,12 @@ test("fails when SKIP_PW_DEPS is set and warning is printed", () => {
     "npx playwright install --with-deps --dry-run 2>&1",
     { encoding: "utf8" },
   );
-  expect(child_process.execSync).toHaveBeenCalledTimes(2);
-  expect(exitSpy).toHaveBeenCalledWith(1);
+  expect(child_process.execSync).toHaveBeenNthCalledWith(
+    3,
+    "CI=1 npx playwright install --with-deps",
+    { stdio: "inherit" },
+  );
+  expect(child_process.execSync).toHaveBeenCalledTimes(3);
   delete process.env.SKIP_PW_DEPS;
 });
 


### PR DESCRIPTION
## Summary
- retry Playwright deps install even if `SKIP_PW_DEPS` is set
- update tests for new behaviour

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_68737dd78c14832d82a8ccc13d26b0ea