### PR TITLE
Fix ENOTEMPTY in ensure-root-deps

### DIFF
--- a/scripts/ensure-root-deps.js
+++ b/scripts/ensure-root-deps.js
@@ -59,6 +59,18 @@ if (!fs.existsSync(pluginPath)) {
         execSync("npm install", { stdio: "inherit" });
         return true;
       }
+      if (/TAR_ENTRY_ERROR|ENOENT|ENOTEMPTY|tarball .*corrupted/.test(msg)) {
+        console.warn(
+          "npm ci encountered tar or ENOTEMPTY errors. Cleaning cache and retrying...",
+        );
+        try {
+          execSync("npx --yes rimraf node_modules", { stdio: "inherit" });
+        } catch {
+          execSync("rm -rf node_modules", { stdio: "inherit" });
+        }
+        execSync("npm ci", { stdio: "inherit" });
+        return true;
+      }
       if (/ECONNRESET|ENOTFOUND|network|ETIMEDOUT/i.test(msg)) {
         return false;
       }

--- a/tests/backendFormatEnotempty.test.js
+++ b/tests/backendFormatEnotempty.test.js
@@ -1,0 +1,20 @@
+const { execSync } = require("child_process");
+const path = require("path");
+
+describe("backend format ENOTEMPTY error", () => {
+  test("retries when npm ci reports ENOTEMPTY", () => {
+    const env = {
+      ...process.env,
+      HF_TOKEN: "test",
+      AWS_ACCESS_KEY_ID: "id",
+      AWS_SECRET_ACCESS_KEY: "secret",
+      DB_URL: "postgres://user:pass@localhost/db",
+      STRIPE_SECRET_KEY: "sk_test",
+      SKIP_NET_CHECKS: "1",
+      SKIP_PW_DEPS: "1",
+      REAL_NPM: execSync("command -v npm").toString().trim(),
+      PATH: path.join(__dirname, "bin-enotempty") + ":" + process.env.PATH,
+    };
+    execSync("npm run format --prefix backend", { env, stdio: "inherit" });
+  });
+});


### PR DESCRIPTION
## Summary
- handle ENOTEMPTY errors in `ensure-root-deps.js`
- add regression test for backend format ENOTEMPTY case
- make `ensureRootDeps.test.js` mock `child_process` properly

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68737da47e58832da5ece08e6bad15ff