### PR TITLE
Fix formatting setup when node_modules corrupt

### DIFF
--- a/scripts/ensure-root-deps.js
+++ b/scripts/ensure-root-deps.js
@@ -40,6 +40,14 @@ if (!fs.existsSync(pluginPath)) {
   runNetworkCheck();
   if (!canReachRegistry()) process.exit(1);
   console.log("Dependencies missing. Installing root dependencies...");
+  const nodeModules = path.join(__dirname, "..", "node_modules");
+  if (fs.existsSync(nodeModules)) {
+    try {
+      fs.rmSync(nodeModules, { recursive: true, force: true });
+    } catch (err) {
+      console.warn("Failed to clean node_modules:", err.message);
+    }
+  }
   try {
     execSync("npm ping", { stdio: "ignore" });
   } catch {

--- a/tests/backendFormatEnotempty.test.js
+++ b/tests/backendFormatEnotempty.test.js
@@ -1,0 +1,20 @@
+const { execSync } = require("child_process");
+const path = require("path");
+
+describe("backend format ENOTEMPTY error", () => {
+  test("retries when npm ci reports ENOTEMPTY", () => {
+    const env = {
+      ...process.env,
+      HF_TOKEN: "test",
+      AWS_ACCESS_KEY_ID: "id",
+      AWS_SECRET_ACCESS_KEY: "secret",
+      DB_URL: "postgres://user:pass@localhost/db",
+      STRIPE_SECRET_KEY: "sk_test",
+      SKIP_NET_CHECKS: "1",
+      SKIP_PW_DEPS: "1",
+      REAL_NPM: execSync("command -v npm").toString().trim(),
+      PATH: path.join(__dirname, "bin-enotempty") + ":" + process.env.PATH,
+    };
+    execSync("npm run format --prefix backend", { env, stdio: "inherit" });
+  });
+});


### PR DESCRIPTION
## Summary
- remove existing `node_modules` before running root install
- test retry logic for ENOTEMPTY errors during formatting
- update unit tests for `ensure-root-deps.js`

## Testing
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68737d76940c832db9774c65f80ea62a