### PR TITLE
Fix network check when SKIP_PW_DEPS used

### DIFF
--- a/scripts/network-check.js
+++ b/scripts/network-check.js
@@ -4,7 +4,17 @@ const { execSync } = require("child_process");
 // Use the npm ping endpoint to ensure the registry fully responds.
 const targets = [
   { url: "https://registry.npmjs.org/-/ping", name: "npm registry" },
-  { url: "https://cdn.playwright.dev/browser.json", name: "Playwright CDN" },
+  // Skip the Playwright CDN check if the browsers are already installed or the
+  // caller explicitly sets SKIP_PW_DEPS. This allows tests to run without
+  // network access to the CDN when Playwright is preinstalled.
+  ...(process.env.SKIP_PW_DEPS
+    ? []
+    : [
+        {
+          url: "https://cdn.playwright.dev/browser.json",
+          name: "Playwright CDN",
+        },
+      ]),
   { url: "https://esm.sh", name: "esm.sh" },
   {
     url: "https://cdn.jsdelivr.net/npm/@google/model-viewer@1.12.0/dist/model-viewer.min.js",

--- a/tests/networkCheckSkipPwDeps.test.js
+++ b/tests/networkCheckSkipPwDeps.test.js
@@ -1,0 +1,24 @@
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+describe("network-check SKIP_PW_DEPS", () => {
+  test("skips Playwright CDN when SKIP_PW_DEPS=1", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "curl-"));
+    const fakeCurl = path.join(tmp, "curl");
+    fs.writeFileSync(
+      fakeCurl,
+      `#!/bin/sh\nif echo "$@" | grep -q cdn.playwright.dev; then exit 7; fi`,
+    );
+    fs.chmodSync(fakeCurl, 0o755);
+    execFileSync("node", [path.join("scripts", "network-check.js")], {
+      env: {
+        ...process.env,
+        PATH: `${tmp}:${process.env.PATH}`,
+        SKIP_PW_DEPS: "1",
+      },
+      encoding: "utf8",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- skip checking the Playwright CDN if SKIP_PW_DEPS is set
- add regression test for skipping the CDN check

## Testing
- `npm run format --prefix backend`
- `SKIP_PW_DEPS=1 npm test --prefix backend`
- `node scripts/run-jest.js tests/networkCheckSkipPwDeps.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68737d4d47b0832da50086cc4c4649d6