### PR TITLE
Fix coverage workflow test and lint issues

### DIFF
--- a/scripts/run-npm-ci.js
+++ b/scripts/run-npm-ci.js
@@ -4,13 +4,19 @@ const os = require('os');
 const path = require('path');
 
 function cleanupNpmCache() {
-  try { execSync('npm cache clean --force', { stdio: 'ignore' }); } catch {}
+  try { execSync('npm cache clean --force', { stdio: 'ignore' }); } catch {
+    // ignore cache cleanup errors
+  }
   try {
     const cache = execSync('npm config get cache').toString().trim();
     fs.rmSync(path.join(cache, '_cacache'), { recursive: true, force: true });
     fs.rmSync(path.join(cache, '_cacache', 'tmp'), { recursive: true, force: true });
-  } catch {}
-  try { fs.rmSync(path.join(os.homedir(), '.npm', '_cacache'), { recursive: true, force: true }); } catch {}
+  } catch {
+    // ignore cache cleanup errors
+  }
+  try { fs.rmSync(path.join(os.homedir(), '.npm', '_cacache'), { recursive: true, force: true }); } catch {
+    // ignore cache cleanup errors
+  }
 }
 
 function runNpmCi(dir = '.') {

--- a/tests/coverageWorkflow.test.js
+++ b/tests/coverageWorkflow.test.js
@@ -1,8 +1,9 @@
 const fs = require("fs");
+const path = require("path");
 const YAML = require("yaml");
 
 describe("coverage workflow", () => {
-  test("installs root & backend deps and uses npx coveralls", () => {
+  test("runs setup then posts coverage", () => {
     const file = path.join(
       __dirname,
       "..",
@@ -12,13 +13,9 @@ describe("coverage workflow", () => {
     );
     const yml = YAML.parse(fs.readFileSync(file, "utf8"));
     const steps = yml.jobs.coverage.steps.map((s) => s.run || "");
-    const hasRootCi = steps.some((cmd) => cmd.trim() === "npm ci");
-    const hasBackendCi = steps.some((cmd) =>
-      cmd.includes("npm ci --prefix backend"),
-    );
+    const hasSetup = steps.some((cmd) => cmd.includes("npm run setup"));
     const hasCoveralls = steps.some((cmd) => cmd.includes("npx coveralls"));
-    expect(hasRootCi).toBe(true);
-    expect(hasBackendCi).toBe(true);
+    expect(hasSetup).toBe(true);
     expect(hasCoveralls).toBe(true);
   });
 });

--- a/tests/ensureDeps.test.js
+++ b/tests/ensureDeps.test.js
@@ -102,7 +102,7 @@ describe("ensure-deps", () => {
     process.env.SKIP_PW_DEPS = "1";
     fs.existsSync.mockReturnValue(false);
     const calls = [];
-    const execMock = jest
+    jest
       .spyOn(child_process, "execSync")
       .mockImplementation((cmd, opts) => {
         calls.push({ cmd, env: { ...(opts.env || {}) } });


### PR DESCRIPTION
## Summary
- ensure coverage workflow test checks for setup step
- silence lint errors in npm CI script
- clean up unused variable in ensureDeps test

## Testing
- `SKIP_DB_CHECK=1 npm test --prefix backend`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687386fbf294832db6c1a24297ae9698