### PR TITLE
Fix format step and lint issues

### DIFF
--- a/scripts/run-npm-ci.js
+++ b/scripts/run-npm-ci.js
@@ -1,34 +1,55 @@
-const { execSync } = require('child_process');
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+const { execSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
 
 function cleanupNpmCache() {
-  try { execSync('npm cache clean --force', { stdio: 'ignore' }); } catch {}
   try {
-    const cache = execSync('npm config get cache').toString().trim();
-    fs.rmSync(path.join(cache, '_cacache'), { recursive: true, force: true });
-    fs.rmSync(path.join(cache, '_cacache', 'tmp'), { recursive: true, force: true });
-  } catch {}
-  try { fs.rmSync(path.join(os.homedir(), '.npm', '_cacache'), { recursive: true, force: true }); } catch {}
+    execSync("npm cache clean --force", { stdio: "ignore" });
+  } catch {
+    // ignore errors cleaning cache
+  }
+  try {
+    const cache = execSync("npm config get cache").toString().trim();
+    fs.rmSync(path.join(cache, "_cacache"), { recursive: true, force: true });
+    fs.rmSync(path.join(cache, "_cacache", "tmp"), {
+      recursive: true,
+      force: true,
+    });
+  } catch {
+    // ignore errors removing npm cache
+  }
+  try {
+    fs.rmSync(path.join(os.homedir(), ".npm", "_cacache"), {
+      recursive: true,
+      force: true,
+    });
+  } catch {
+    // ignore errors removing user cache
+  }
 }
 
-function runNpmCi(dir = '.') {
-  const options = { stdio: 'inherit' };
-  if (dir !== '.') options.cwd = dir;
+function runNpmCi(dir = ".") {
+  const options = { stdio: "inherit" };
+  if (dir !== ".") options.cwd = dir;
   try {
-    execSync('npm ci --no-audit --no-fund', options);
+    execSync("npm ci --no-audit --no-fund", options);
   } catch (err) {
-    const output = String(err.stderr || err.stdout || err.message || '');
-    if (output.includes('EUSAGE')) {
+    const output = String(err.stderr || err.stdout || err.message || "");
+    if (output.includes("EUSAGE")) {
       console.warn(`npm ci failed in ${dir}, falling back to 'npm install'`);
-      execSync('npm install --no-audit --no-fund', options);
-      execSync('npm ci --no-audit --no-fund', options);
+      execSync("npm install --no-audit --no-fund", options);
+      execSync("npm ci --no-audit --no-fund", options);
     } else if (/TAR_ENTRY_ERROR|ENOENT/.test(output)) {
-      console.warn(`npm ci encountered tar errors in ${dir}. Cleaning cache and retrying...`);
+      console.warn(
+        `npm ci encountered tar errors in ${dir}. Cleaning cache and retrying...`,
+      );
       cleanupNpmCache();
-      fs.rmSync(path.join(dir, 'node_modules'), { recursive: true, force: true });
-      execSync('npm ci --no-audit --no-fund', options);
+      fs.rmSync(path.join(dir, "node_modules"), {
+        recursive: true,
+        force: true,
+      });
+      execSync("npm ci --no-audit --no-fund", options);
     } else {
       throw err;
     }

--- a/tests/coverageWorkflow.test.js
+++ b/tests/coverageWorkflow.test.js
@@ -1,4 +1,5 @@
 const fs = require("fs");
+const path = require("path");
 const YAML = require("yaml");
 
 describe("coverage workflow", () => {

--- a/tests/ensureDeps.test.js
+++ b/tests/ensureDeps.test.js
@@ -102,14 +102,12 @@ describe("ensure-deps", () => {
     process.env.SKIP_PW_DEPS = "1";
     fs.existsSync.mockReturnValue(false);
     const calls = [];
-    const execMock = jest
-      .spyOn(child_process, "execSync")
-      .mockImplementation((cmd, opts) => {
-        calls.push({ cmd, env: { ...(opts.env || {}) } });
-        if (cmd === "npm run setup" && opts.env.SKIP_PW_DEPS) {
-          throw new Error("setup fail");
-        }
-      });
+    jest.spyOn(child_process, "execSync").mockImplementation((cmd, opts) => {
+      calls.push({ cmd, env: { ...(opts.env || {}) } });
+      if (cmd === "npm run setup" && opts.env.SKIP_PW_DEPS) {
+        throw new Error("setup fail");
+      }
+    });
 
     require("../backend/scripts/ensure-deps");
 


### PR DESCRIPTION
## Summary
- silence cleanup errors in `scripts/run-npm-ci.js`
- include missing `path` import in `coverageWorkflow.test.js`
- fix unused variable in `ensureDeps.test.js`

## Testing
- `npm run format --prefix backend`
- `SKIP_DB_CHECK=1 npm test --prefix backend`
- `SKIP_NET_CHECKS=1 SKIP_PW_DEPS=1 SKIP_DB_CHECK=1 npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_68737ff99804832dbd44a50d7fed786e