### PR TITLE
Handle Playwright CDN 400 response

### DIFF
--- a/scripts/network-check.js
+++ b/scripts/network-check.js
@@ -40,7 +40,9 @@ if (process.env.NETWORK_CHECK_URL) {
 
 function check(url) {
   try {
-    execSync(`curl -fsSL --max-time 10 -o /dev/null ${url}`, {
+    // Use HEAD requests without `-f` so HTTP errors (e.g. 400) still
+    // indicate connectivity instead of failing the check.
+    execSync(`curl -sSIL --max-time 10 -o /dev/null ${url}`, {
       stdio: "pipe",
     });
     return null;

--- a/tests/networkCheckCdn400.test.js
+++ b/tests/networkCheckCdn400.test.js
@@ -1,0 +1,26 @@
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+/** Simulate the CDN returning HTTP 400 but with exit status 0. */
+describe("network-check CDN 400", () => {
+  test("succeeds when CDN returns HTTP 400", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "curl-"));
+    const fakeCurl = path.join(tmp, "curl");
+    fs.writeFileSync(
+      fakeCurl,
+      '#!/bin/sh\nif echo "$@" | grep -q cdn.playwright.dev; then echo "HTTP/1.1 400 Bad Request"; exit 0; fi\nexec /usr/bin/curl "$@"',
+    );
+    fs.chmodSync(fakeCurl, 0o755);
+    const out = execFileSync(
+      "node",
+      [path.join("scripts", "network-check.js")],
+      {
+        env: { ...process.env, PATH: `${tmp}:${process.env.PATH}` },
+        encoding: "utf8",
+      },
+    );
+    expect(out).toContain("✅ network OK");
+  });
+});


### PR DESCRIPTION
## Summary
- relax CDN check in `network-check.js` so HTTP 400 doesn't fail
- add regression test for CDN 400 case

## Testing
- `SKIP_DB_CHECK=1 npm run format`
- `SKIP_DB_CHECK=1 npm test`

------
https://chatgpt.com/codex/tasks/task_e_68738c724790832dba33780abb10ef32