### PR TITLE
Fix coverage upload to Coveralls

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,4 +11,5 @@ jobs:
         with:
           node-version: "20"
       - run: SKIP_PW_DEPS=1 npm run setup
-      - run: npm run coverage -- --reporter=text-lcov | npx coveralls
+      - run: npm run coverage
+      - run: npx coveralls < backend/coverage/lcov.info

--- a/README.md
+++ b/README.md
@@ -388,7 +388,8 @@ Run coverage after installing dependencies:
 
 ```bash
 npm run setup
-npm run coverage -- --reporter=text-lcov | npx coveralls
+npm run coverage
+npx coveralls < backend/coverage/lcov.info
 ```
 
 Using `npx coveralls` ensures the CLI runs even if it's not installed globally.

--- a/tests/coverageReadme.test.js
+++ b/tests/coverageReadme.test.js
@@ -1,0 +1,12 @@
+const fs = require("fs");
+const path = require("path");
+
+describe("README coverage section", () => {
+  test("uses file redirection for coveralls", () => {
+    const file = path.join(__dirname, "..", "README.md");
+    const content = fs.readFileSync(file, "utf8");
+    expect(content).toMatch(
+      /npm run coverage\s*\n\s*npx coveralls < backend\/coverage\/lcov.info/,
+    );
+  });
+});

--- a/tests/coverageWorkflow.test.js
+++ b/tests/coverageWorkflow.test.js
@@ -1,8 +1,9 @@
 const fs = require("fs");
+const path = require("path");
 const YAML = require("yaml");
 
 describe("coverage workflow", () => {
-  test("installs root & backend deps and uses npx coveralls", () => {
+  test("runs setup, generates coverage, and uploads via coveralls", () => {
     const file = path.join(
       __dirname,
       "..",
@@ -12,13 +13,14 @@ describe("coverage workflow", () => {
     );
     const yml = YAML.parse(fs.readFileSync(file, "utf8"));
     const steps = yml.jobs.coverage.steps.map((s) => s.run || "");
-    const hasRootCi = steps.some((cmd) => cmd.trim() === "npm ci");
-    const hasBackendCi = steps.some((cmd) =>
-      cmd.includes("npm ci --prefix backend"),
+    const hasSetup = steps.some((cmd) => cmd.includes("npm run setup"));
+    const hasCoverage = steps.some((cmd) => cmd.trim() === "npm run coverage");
+    const hasCoveralls = steps.some(
+      (cmd) =>
+        cmd.includes("npx coveralls") && cmd.includes("coverage/lcov.info"),
     );
-    const hasCoveralls = steps.some((cmd) => cmd.includes("npx coveralls"));
-    expect(hasRootCi).toBe(true);
-    expect(hasBackendCi).toBe(true);
+    expect(hasSetup).toBe(true);
+    expect(hasCoverage).toBe(true);
     expect(hasCoveralls).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- pipe coverage file to Coveralls
- mention updated instructions in README
- update workflow test to check new command
- add test to verify README shows new Coveralls usage

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68738c54dfdc832dbe35ec063da4f5ae