### PR TITLE
Fix Coveralls parsing

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,4 +11,5 @@ jobs:
         with:
           node-version: "20"
       - run: SKIP_PW_DEPS=1 npm run setup
-      - run: npm run coverage -- --reporter=text-lcov | npx coveralls
+      - run: npm run coverage
+      - run: npx coveralls < backend/coverage/lcov.info

--- a/README.md
+++ b/README.md
@@ -388,10 +388,13 @@ Run coverage after installing dependencies:
 
 ```bash
 npm run setup
-npm run coverage -- --reporter=text-lcov | npx coveralls
+npm run coverage
+npx coveralls < backend/coverage/lcov.info
 ```
 
 Using `npx coveralls` ensures the CLI runs even if it's not installed globally.
+By piping the generated `lcov.info` file instead of test output we avoid
+`Failed to parse string` errors from Coveralls when console logs appear.
 Running coverage without installing dependencies or omitting `npx` may lead to
 `coveralls: command not found` or `jest: not found` errors.
 

--- a/backend/tests/setupGlobals.js
+++ b/backend/tests/setupGlobals.js
@@ -63,6 +63,9 @@ if (!process.env.DB_URL) {
 if (!process.env.STRIPE_SECRET_KEY) {
   process.env.STRIPE_SECRET_KEY = "sk_test";
 }
+if (!process.env.STRIPE_PUBLISHABLE_KEY) {
+  process.env.STRIPE_PUBLISHABLE_KEY = "pk_test";
+}
 
 // Ensure any proxy environment variables do not interfere with HTTP mocking
 for (const key of [

--- a/tests/coverageWorkflow.test.js
+++ b/tests/coverageWorkflow.test.js
@@ -1,8 +1,9 @@
 const fs = require("fs");
+const path = require("path");
 const YAML = require("yaml");
 
 describe("coverage workflow", () => {
-  test("installs root & backend deps and uses npx coveralls", () => {
+  test("runs coverage and uploads lcov info via coveralls", () => {
     const file = path.join(
       __dirname,
       "..",
@@ -12,13 +13,15 @@ describe("coverage workflow", () => {
     );
     const yml = YAML.parse(fs.readFileSync(file, "utf8"));
     const steps = yml.jobs.coverage.steps.map((s) => s.run || "");
-    const hasRootCi = steps.some((cmd) => cmd.trim() === "npm ci");
-    const hasBackendCi = steps.some((cmd) =>
-      cmd.includes("npm ci --prefix backend"),
+    const hasSetup = steps.some((cmd) => cmd.includes("npm run setup"));
+    const hasCoverage = steps.some((cmd) => cmd.trim() === "npm run coverage");
+    const hasCoveralls = steps.some(
+      (cmd) =>
+        cmd.includes("npx coveralls") &&
+        cmd.includes("< backend/coverage/lcov.info"),
     );
-    const hasCoveralls = steps.some((cmd) => cmd.includes("npx coveralls"));
-    expect(hasRootCi).toBe(true);
-    expect(hasBackendCi).toBe(true);
+    expect(hasSetup).toBe(true);
+    expect(hasCoverage).toBe(true);
     expect(hasCoveralls).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- pipe lcov file into Coveralls to avoid log parsing errors
- document the new coverage commands
- test coverage workflow command format
- ensure publishable key is present during tests

## Testing
- `npm run format --prefix backend`
- `SKIP_NET_CHECKS=1 SKIP_DB_CHECK=1 npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_68738c47e0c4832dbe1c5dc929dbe3ff