### PR TITLE
Fix coverage workflow lint issues

### DIFF
--- a/scripts/run-npm-ci.js
+++ b/scripts/run-npm-ci.js
@@ -1,16 +1,26 @@
-const { execSync } = require('child_process');
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+const { execSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
 
 function cleanupNpmCache() {
-  try { execSync('npm cache clean --force', { stdio: 'ignore' }); } catch {}
+  try {
+    execSync('npm cache clean --force', { stdio: 'ignore' });
+  } catch {
+    /* empty */
+  }
   try {
     const cache = execSync('npm config get cache').toString().trim();
     fs.rmSync(path.join(cache, '_cacache'), { recursive: true, force: true });
     fs.rmSync(path.join(cache, '_cacache', 'tmp'), { recursive: true, force: true });
-  } catch {}
-  try { fs.rmSync(path.join(os.homedir(), '.npm', '_cacache'), { recursive: true, force: true }); } catch {}
+  } catch {
+    /* empty */
+  }
+  try {
+    fs.rmSync(path.join(os.homedir(), '.npm', '_cacache'), { recursive: true, force: true });
+  } catch {
+    /* empty */
+  }
 }
 
 function runNpmCi(dir = '.') {

--- a/tests/coverageWorkflow.test.js
+++ b/tests/coverageWorkflow.test.js
@@ -1,4 +1,5 @@
 const fs = require("fs");
+const path = require("path");
 const YAML = require("yaml");
 
 describe("coverage workflow", () => {

--- a/tests/ensureDeps.test.js
+++ b/tests/ensureDeps.test.js
@@ -118,6 +118,8 @@ describe("ensure-deps", () => {
     expect(setupCalls[0].env.SKIP_PW_DEPS).toBe("1");
     expect(setupCalls[1].env).not.toHaveProperty("SKIP_PW_DEPS");
 
+    expect(execMock).toHaveBeenCalled();
+
     delete process.env.SKIP_PW_DEPS;
   });
 });


### PR DESCRIPTION
## Summary
- fix lint warnings in `run-npm-ci.js`
- add missing `path` import in coverage workflow test
- ensure `ensureDeps` test uses the spy

## Testing
- `npm run format` in `backend/`
- `SKIP_DB_CHECK=1 npm test` in `backend/`
- `SKIP_PW_DEPS=1 SKIP_DB_CHECK=1 SKIP_NET_CHECKS=1 npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_68738c392e70832db2e56209139b1110