### PR TITLE
Fix coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,4 +11,5 @@ jobs:
         with:
           node-version: "20"
       - run: SKIP_PW_DEPS=1 npm run setup
-      - run: npm run coverage -- --reporter=text-lcov | npx coveralls
+      - run: npm run coverage
+      - run: npx coveralls < backend/coverage/lcov.info

--- a/README.md
+++ b/README.md
@@ -388,7 +388,8 @@ Run coverage after installing dependencies:
 
 ```bash
 npm run setup
-npm run coverage -- --reporter=text-lcov | npx coveralls
+npm run coverage
+npx coveralls < backend/coverage/lcov.info
 ```
 
 Using `npx coveralls` ensures the CLI runs even if it's not installed globally.

--- a/scripts/run-npm-ci.js
+++ b/scripts/run-npm-ci.js
@@ -4,13 +4,23 @@ const os = require('os');
 const path = require('path');
 
 function cleanupNpmCache() {
-  try { execSync('npm cache clean --force', { stdio: 'ignore' }); } catch {}
+  try {
+    execSync('npm cache clean --force', { stdio: 'ignore' });
+  } catch {
+    // ignore cache cleanup failures
+  }
   try {
     const cache = execSync('npm config get cache').toString().trim();
     fs.rmSync(path.join(cache, '_cacache'), { recursive: true, force: true });
     fs.rmSync(path.join(cache, '_cacache', 'tmp'), { recursive: true, force: true });
-  } catch {}
-  try { fs.rmSync(path.join(os.homedir(), '.npm', '_cacache'), { recursive: true, force: true }); } catch {}
+  } catch {
+    // ignore cache removal errors
+  }
+  try {
+    fs.rmSync(path.join(os.homedir(), '.npm', '_cacache'), { recursive: true, force: true });
+  } catch {
+    // ignore cache removal errors
+  }
 }
 
 function runNpmCi(dir = '.') {

--- a/tests/coverageWorkflow.test.js
+++ b/tests/coverageWorkflow.test.js
@@ -1,8 +1,9 @@
 const fs = require("fs");
+const path = require("path");
 const YAML = require("yaml");
 
 describe("coverage workflow", () => {
-  test("installs root & backend deps and uses npx coveralls", () => {
+  test("runs setup, coverage, and pipes lcov to coveralls", () => {
     const file = path.join(
       __dirname,
       "..",
@@ -12,13 +13,13 @@ describe("coverage workflow", () => {
     );
     const yml = YAML.parse(fs.readFileSync(file, "utf8"));
     const steps = yml.jobs.coverage.steps.map((s) => s.run || "");
-    const hasRootCi = steps.some((cmd) => cmd.trim() === "npm ci");
-    const hasBackendCi = steps.some((cmd) =>
-      cmd.includes("npm ci --prefix backend"),
+    const hasSetup = steps.some((cmd) => cmd.includes("npm run setup"));
+    const hasCoverage = steps.some((cmd) => cmd.trim() === "npm run coverage");
+    const hasCoveralls = steps.some((cmd) =>
+      cmd.includes("npx coveralls < backend/coverage/lcov.info"),
     );
-    const hasCoveralls = steps.some((cmd) => cmd.includes("npx coveralls"));
-    expect(hasRootCi).toBe(true);
-    expect(hasBackendCi).toBe(true);
+    expect(hasSetup).toBe(true);
+    expect(hasCoverage).toBe(true);
     expect(hasCoveralls).toBe(true);
   });
 });

--- a/tests/ensureDeps.test.js
+++ b/tests/ensureDeps.test.js
@@ -110,6 +110,7 @@ describe("ensure-deps", () => {
           throw new Error("setup fail");
         }
       });
+    void execMock;
 
     require("../backend/scripts/ensure-deps");
 


### PR DESCRIPTION
## Summary
- pipe coverage file to coveralls
- update coverage readme instructions
- ignore cache cleanup errors
- adjust coverage workflow test
- fix lint error in ensureDeps test

## Testing
- `npm run format --prefix backend`
- `SKIP_DB_CHECK=1 npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_68738c215098832da7589c242b4e8c96