### PR TITLE
Fix smoke tests DB validation

### DIFF
--- a/backend/tests/validateEnv.test.ts
+++ b/backend/tests/validateEnv.test.ts
@@ -5,7 +5,7 @@ const fs = require("fs");
 const root = path.resolve(__dirname, "..", "..");
 
 function run(env, clean = true) {
-  const e = { ...process.env, SKIP_NET_CHECKS: "1", ...env };
+  const e = { ...process.env, SKIP_NET_CHECKS: "1", SKIP_DB_CHECK: "1", ...env };
   if (clean) {
     delete e.npm_config_http_proxy;
     delete e.npm_config_https_proxy;

--- a/scripts/run-npm-ci.js
+++ b/scripts/run-npm-ci.js
@@ -4,13 +4,23 @@ const os = require('os');
 const path = require('path');
 
 function cleanupNpmCache() {
-  try { execSync('npm cache clean --force', { stdio: 'ignore' }); } catch {}
+  try {
+    execSync('npm cache clean --force', { stdio: 'ignore' });
+  } catch {
+    /* ignore */
+  }
   try {
     const cache = execSync('npm config get cache').toString().trim();
     fs.rmSync(path.join(cache, '_cacache'), { recursive: true, force: true });
     fs.rmSync(path.join(cache, '_cacache', 'tmp'), { recursive: true, force: true });
-  } catch {}
-  try { fs.rmSync(path.join(os.homedir(), '.npm', '_cacache'), { recursive: true, force: true }); } catch {}
+  } catch {
+    /* ignore */
+  }
+  try {
+    fs.rmSync(path.join(os.homedir(), '.npm', '_cacache'), { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
 }
 
 function runNpmCi(dir = '.') {

--- a/scripts/run-smoke.js
+++ b/scripts/run-smoke.js
@@ -35,6 +35,7 @@ ensureDefault("AWS_ACCESS_KEY_ID", "dummy");
 ensureDefault("AWS_SECRET_ACCESS_KEY", "dummy");
 ensureDefault("DB_URL", "postgres://user:pass@localhost/db");
 ensureDefault("STRIPE_SECRET_KEY", "sk_test_dummy");
+ensureDefault("SKIP_DB_CHECK", "1");
 
 let lastCommand = "";
 

--- a/tests/coverageWorkflow.test.js
+++ b/tests/coverageWorkflow.test.js
@@ -1,4 +1,5 @@
 const fs = require("fs");
+const path = require("path");
 const YAML = require("yaml");
 
 describe("coverage workflow", () => {

--- a/tests/ensureDeps.test.js
+++ b/tests/ensureDeps.test.js
@@ -102,7 +102,7 @@ describe("ensure-deps", () => {
     process.env.SKIP_PW_DEPS = "1";
     fs.existsSync.mockReturnValue(false);
     const calls = [];
-    const execMock = jest
+    jest
       .spyOn(child_process, "execSync")
       .mockImplementation((cmd, opts) => {
         calls.push({ cmd, env: { ...(opts.env || {}) } });

--- a/tests/runSmoke.skipDBCheck.test.js
+++ b/tests/runSmoke.skipDBCheck.test.js
@@ -1,0 +1,5 @@
+const { env } = require("../scripts/run-smoke.js");
+
+test("run-smoke sets SKIP_DB_CHECK=1 by default", () => {
+  expect(env.SKIP_DB_CHECK).toBe("1");
+});


### PR DESCRIPTION
## Summary
- skip DB check in run-smoke script
- keep validate-env tests from hitting the DB
- silence eslint on empty catch blocks
- add regression test for SKIP_DB_CHECK default

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_NET_CHECKS=1 SKIP_DB_CHECK=1 SKIP_PW_DEPS=1 npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_68738bf28dcc832d9e690ae936fb1719