### PR TITLE
Fix env script DB dependency resolution

### DIFF
--- a/scripts/check-db.js
+++ b/scripts/check-db.js
@@ -1,5 +1,11 @@
 #!/usr/bin/env node
-const { Client } = require("pg");
+const path = require("path");
+let Client;
+try {
+  ({ Client } = require("pg"));
+} catch {
+  ({ Client } = require(path.join(__dirname, "..", "backend", "node_modules", "pg")));
+}
 
 if (process.env.SKIP_DB_CHECK) {
   console.log("Skipping DB check due to SKIP_DB_CHECK");

--- a/scripts/run-npm-ci.js
+++ b/scripts/run-npm-ci.js
@@ -4,13 +4,19 @@ const os = require('os');
 const path = require('path');
 
 function cleanupNpmCache() {
-  try { execSync('npm cache clean --force', { stdio: 'ignore' }); } catch {}
+  try { execSync('npm cache clean --force', { stdio: 'ignore' }); } catch {
+    /* ignore errors */
+  }
   try {
     const cache = execSync('npm config get cache').toString().trim();
     fs.rmSync(path.join(cache, '_cacache'), { recursive: true, force: true });
     fs.rmSync(path.join(cache, '_cacache', 'tmp'), { recursive: true, force: true });
-  } catch {}
-  try { fs.rmSync(path.join(os.homedir(), '.npm', '_cacache'), { recursive: true, force: true }); } catch {}
+  } catch {
+    /* ignore errors */
+  }
+  try { fs.rmSync(path.join(os.homedir(), '.npm', '_cacache'), { recursive: true, force: true }); } catch {
+    /* ignore errors */
+  }
 }
 
 function runNpmCi(dir = '.') {

--- a/tests/coverageWorkflow.test.js
+++ b/tests/coverageWorkflow.test.js
@@ -1,4 +1,5 @@
 const fs = require("fs");
+const path = require("path");
 const YAML = require("yaml");
 
 describe("coverage workflow", () => {
@@ -12,10 +13,8 @@ describe("coverage workflow", () => {
     );
     const yml = YAML.parse(fs.readFileSync(file, "utf8"));
     const steps = yml.jobs.coverage.steps.map((s) => s.run || "");
-    const hasRootCi = steps.some((cmd) => cmd.trim() === "npm ci");
-    const hasBackendCi = steps.some((cmd) =>
-      cmd.includes("npm ci --prefix backend"),
-    );
+    const hasRootCi = steps.some((cmd) => cmd.trim() === "SKIP_PW_DEPS=1 npm run setup");
+    const hasBackendCi = steps.some((cmd) => cmd.includes("npm run coverage"));
     const hasCoveralls = steps.some((cmd) => cmd.includes("npx coveralls"));
     expect(hasRootCi).toBe(true);
     expect(hasBackendCi).toBe(true);

--- a/tests/dbCheckScriptResolve.test.js
+++ b/tests/dbCheckScriptResolve.test.js
@@ -1,0 +1,14 @@
+const { execFileSync } = require("child_process");
+const path = require("path");
+const repoRoot = path.resolve(__dirname, "..");
+
+describe("db-check module resolution", () => {
+  test("loads pg from backend when not installed in root", () => {
+    const out = execFileSync("node", [path.join("scripts", "check-db.js")], {
+      cwd: repoRoot,
+      env: { ...process.env, SKIP_DB_CHECK: "1", NODE_PATH: "" },
+      encoding: "utf8",
+    });
+    expect(out).toContain("Skipping DB check");
+  });
+});

--- a/tests/ensureDeps.test.js
+++ b/tests/ensureDeps.test.js
@@ -102,14 +102,12 @@ describe("ensure-deps", () => {
     process.env.SKIP_PW_DEPS = "1";
     fs.existsSync.mockReturnValue(false);
     const calls = [];
-    const execMock = jest
-      .spyOn(child_process, "execSync")
-      .mockImplementation((cmd, opts) => {
-        calls.push({ cmd, env: { ...(opts.env || {}) } });
-        if (cmd === "npm run setup" && opts.env.SKIP_PW_DEPS) {
-          throw new Error("setup fail");
-        }
-      });
+    jest.spyOn(child_process, "execSync").mockImplementation((cmd, opts) => {
+      calls.push({ cmd, env: { ...(opts.env || {}) } });
+      if (cmd === "npm run setup" && opts.env.SKIP_PW_DEPS) {
+        throw new Error("setup fail");
+      }
+    });
 
     require("../backend/scripts/ensure-deps");
 


### PR DESCRIPTION
## Summary
- avoid failing when `pg` isn't installed at repo root
- make `run-npm-ci` catch blocks eslint friendly
- update coverage workflow test expectations
- fix an unused variable in `ensureDeps` test
- add regression test for `check-db.js` resolution

## Testing
- `npm run lint`
- `SKIP_NET_CHECKS=1 SKIP_DB_CHECK=1 npm test`
- `SKIP_DB_CHECK=1 SKIP_NET_CHECKS=1 SKIP_PW_DEPS=1 npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_68738be40b60832da4023fb5a475794d