### PR TITLE
Fix network check CDN handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,10 @@ These guidelines apply to all automated agents (e.g. the Codex agent) working on
 6. **Check network access** – ensure the environment can reach both
    `https://registry.npmjs.org` and `https://cdn.playwright.dev`. The setup
    script downloads packages and browsers from these domains. If they are
-   blocked, adjust your environment or proxy settings.
+   blocked, adjust your environment or proxy settings. When access to the
+   Playwright CDN fails (for example the proxy returns HTTP 4xx responses), set
+   `SKIP_PW_DEPS=1` before running the setup or validate scripts so the CDN check
+   is skipped.
 7. **Install dependencies** – run `npm run setup` at the repository root **before your first `npm run ci`**. Run it again whenever the container is restarted or if Playwright tests fail with messages like "Test was interrupted" or "page.evaluate: Test ended". This script unsets proxy variables, checks registry connectivity, runs `npm ci` in the root and `backend/`, and installs Playwright browsers.
    - If `npm ci` fails with an `EUSAGE` error complaining that packages are missing from the lock file, run `npm install` in the affected directory and then re-run the setup script.
    - Set `SKIP_PW_DEPS=1` before running the setup script if Playwright dependencies are already installed. This skips the long `apt-get` step and reduces CI time. The `smoke` script also runs the setup script, so use `SKIP_PW_DEPS=1 npm run smoke` to avoid reinstalling Playwright dependencies when they are already present.
@@ -29,7 +32,6 @@ These guidelines apply to all automated agents (e.g. the Codex agent) working on
 18. **Avoid PRs with failing tests** – if `npm run ci` or the smoke tests fail for reasons other than environment limitations, do not open a pull request. Fix the issues or open an issue summarizing the failure instead.
 19. **Avoid committing binary files** – Codex cannot generate patches for binary changes. Do not modify images, audio, or other binary assets. If adding new ones, update `.gitattributes` so they are treated as binary.
 20. **Pin GitHub Action versions** – use explicit tags instead of broad majors to prevent resolution errors (e.g. `aquasecurity/tfsec-action@v1.0.3`).
-
 
 ## Troubleshooting
 

--- a/scripts/network-check.js
+++ b/scripts/network-check.js
@@ -55,6 +55,9 @@ for (const { url, name } of targets) {
   if (error) {
     console.error(`Unable to reach ${name}: ${url}`);
     if (error) console.error(error);
+    if (name === "Playwright CDN" && /error:\s*[45][0-9]{2}/i.test(error)) {
+      console.error("Set SKIP_PW_DEPS=1 to skip Playwright dependencies.");
+    }
     process.exit(1);
   }
 }

--- a/scripts/run-npm-ci.js
+++ b/scripts/run-npm-ci.js
@@ -1,34 +1,55 @@
-const { execSync } = require('child_process');
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+const { execSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
 
 function cleanupNpmCache() {
-  try { execSync('npm cache clean --force', { stdio: 'ignore' }); } catch {}
   try {
-    const cache = execSync('npm config get cache').toString().trim();
-    fs.rmSync(path.join(cache, '_cacache'), { recursive: true, force: true });
-    fs.rmSync(path.join(cache, '_cacache', 'tmp'), { recursive: true, force: true });
-  } catch {}
-  try { fs.rmSync(path.join(os.homedir(), '.npm', '_cacache'), { recursive: true, force: true }); } catch {}
+    execSync("npm cache clean --force", { stdio: "ignore" });
+  } catch {
+    // ignore failures cleaning npm cache
+  }
+  try {
+    const cache = execSync("npm config get cache").toString().trim();
+    fs.rmSync(path.join(cache, "_cacache"), { recursive: true, force: true });
+    fs.rmSync(path.join(cache, "_cacache", "tmp"), {
+      recursive: true,
+      force: true,
+    });
+  } catch {
+    // ignore cache lookup failures
+  }
+  try {
+    fs.rmSync(path.join(os.homedir(), ".npm", "_cacache"), {
+      recursive: true,
+      force: true,
+    });
+  } catch {
+    // ignore home cache removal failures
+  }
 }
 
-function runNpmCi(dir = '.') {
-  const options = { stdio: 'inherit' };
-  if (dir !== '.') options.cwd = dir;
+function runNpmCi(dir = ".") {
+  const options = { stdio: "inherit" };
+  if (dir !== ".") options.cwd = dir;
   try {
-    execSync('npm ci --no-audit --no-fund', options);
+    execSync("npm ci --no-audit --no-fund", options);
   } catch (err) {
-    const output = String(err.stderr || err.stdout || err.message || '');
-    if (output.includes('EUSAGE')) {
+    const output = String(err.stderr || err.stdout || err.message || "");
+    if (output.includes("EUSAGE")) {
       console.warn(`npm ci failed in ${dir}, falling back to 'npm install'`);
-      execSync('npm install --no-audit --no-fund', options);
-      execSync('npm ci --no-audit --no-fund', options);
+      execSync("npm install --no-audit --no-fund", options);
+      execSync("npm ci --no-audit --no-fund", options);
     } else if (/TAR_ENTRY_ERROR|ENOENT/.test(output)) {
-      console.warn(`npm ci encountered tar errors in ${dir}. Cleaning cache and retrying...`);
+      console.warn(
+        `npm ci encountered tar errors in ${dir}. Cleaning cache and retrying...`,
+      );
       cleanupNpmCache();
-      fs.rmSync(path.join(dir, 'node_modules'), { recursive: true, force: true });
-      execSync('npm ci --no-audit --no-fund', options);
+      fs.rmSync(path.join(dir, "node_modules"), {
+        recursive: true,
+        force: true,
+      });
+      execSync("npm ci --no-audit --no-fund", options);
     } else {
       throw err;
     }

--- a/tests/coverageWorkflow.test.js
+++ b/tests/coverageWorkflow.test.js
@@ -1,4 +1,5 @@
 const fs = require("fs");
+const path = require("path");
 const YAML = require("yaml");
 
 describe("coverage workflow", () => {

--- a/tests/ensureDeps.test.js
+++ b/tests/ensureDeps.test.js
@@ -119,5 +119,6 @@ describe("ensure-deps", () => {
     expect(setupCalls[1].env).not.toHaveProperty("SKIP_PW_DEPS");
 
     delete process.env.SKIP_PW_DEPS;
+    execMock.mockRestore();
   });
 });

--- a/tests/networkCheckCdnHttpError.test.js
+++ b/tests/networkCheckCdnHttpError.test.js
@@ -1,0 +1,22 @@
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+describe("network-check CDN HTTP error", () => {
+  test("suggests SKIP_PW_DEPS when CDN returns 4xx", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "curl-"));
+    const fakeCurl = path.join(tmp, "curl");
+    fs.writeFileSync(
+      fakeCurl,
+      '#!/bin/sh\nif echo "$@" | grep -q cdn.playwright.dev; then echo "curl: (22) The requested URL returned error: 400" >&2; exit 22; fi\nexec /usr/bin/curl "$@"',
+    );
+    fs.chmodSync(fakeCurl, 0o755);
+    expect(() => {
+      execFileSync("node", [path.join("scripts", "network-check.js")], {
+        env: { ...process.env, PATH: `${tmp}:${process.env.PATH}` },
+        encoding: "utf8",
+      });
+    }).toThrow(/Set SKIP_PW_DEPS=1/);
+  });
+});


### PR DESCRIPTION
## Summary
- handle Playwright CDN HTTP errors by suggesting `SKIP_PW_DEPS=1`
- document the workaround in `AGENTS.md`
- silence lint warnings in `run-npm-ci.js`
- import `path` in `coverageWorkflow.test.js`
- restore spy in `ensureDeps.test.js`
- add regression test for CDN HTTP errors

## Testing
- `SKIP_PW_DEPS=1 npm run format --prefix backend`
- `SKIP_PW_DEPS=1 SKIP_DB_CHECK=1 npm test --prefix backend`
- `SKIP_PW_DEPS=1 SKIP_DB_CHECK=1 npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68738bb6c598832da4ddde7fba28be7c