### PR TITLE
Improve network diagnostics

### DIFF
--- a/scripts/network-check.js
+++ b/scripts/network-check.js
@@ -55,6 +55,14 @@ for (const { url, name } of targets) {
   if (error) {
     console.error(`Unable to reach ${name}: ${url}`);
     if (error) console.error(error);
+    if (name === "Playwright CDN") {
+      console.error(
+        "Set SKIP_PW_DEPS=1 to skip Playwright CDN checks when browsers are already installed.",
+      );
+    }
+    console.error(
+      "Set SKIP_NET_CHECKS=1 to bypass all network checks (not recommended).",
+    );
     process.exit(1);
   }
 }

--- a/scripts/run-npm-ci.js
+++ b/scripts/run-npm-ci.js
@@ -1,34 +1,55 @@
-const { execSync } = require('child_process');
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+const { execSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
 
 function cleanupNpmCache() {
-  try { execSync('npm cache clean --force', { stdio: 'ignore' }); } catch {}
   try {
-    const cache = execSync('npm config get cache').toString().trim();
-    fs.rmSync(path.join(cache, '_cacache'), { recursive: true, force: true });
-    fs.rmSync(path.join(cache, '_cacache', 'tmp'), { recursive: true, force: true });
-  } catch {}
-  try { fs.rmSync(path.join(os.homedir(), '.npm', '_cacache'), { recursive: true, force: true }); } catch {}
+    execSync("npm cache clean --force", { stdio: "ignore" });
+  } catch {
+    // ignore
+  }
+  try {
+    const cache = execSync("npm config get cache").toString().trim();
+    fs.rmSync(path.join(cache, "_cacache"), { recursive: true, force: true });
+    fs.rmSync(path.join(cache, "_cacache", "tmp"), {
+      recursive: true,
+      force: true,
+    });
+  } catch {
+    // ignore
+  }
+  try {
+    fs.rmSync(path.join(os.homedir(), ".npm", "_cacache"), {
+      recursive: true,
+      force: true,
+    });
+  } catch {
+    // ignore
+  }
 }
 
-function runNpmCi(dir = '.') {
-  const options = { stdio: 'inherit' };
-  if (dir !== '.') options.cwd = dir;
+function runNpmCi(dir = ".") {
+  const options = { stdio: "inherit" };
+  if (dir !== ".") options.cwd = dir;
   try {
-    execSync('npm ci --no-audit --no-fund', options);
+    execSync("npm ci --no-audit --no-fund", options);
   } catch (err) {
-    const output = String(err.stderr || err.stdout || err.message || '');
-    if (output.includes('EUSAGE')) {
+    const output = String(err.stderr || err.stdout || err.message || "");
+    if (output.includes("EUSAGE")) {
       console.warn(`npm ci failed in ${dir}, falling back to 'npm install'`);
-      execSync('npm install --no-audit --no-fund', options);
-      execSync('npm ci --no-audit --no-fund', options);
+      execSync("npm install --no-audit --no-fund", options);
+      execSync("npm ci --no-audit --no-fund", options);
     } else if (/TAR_ENTRY_ERROR|ENOENT/.test(output)) {
-      console.warn(`npm ci encountered tar errors in ${dir}. Cleaning cache and retrying...`);
+      console.warn(
+        `npm ci encountered tar errors in ${dir}. Cleaning cache and retrying...`,
+      );
       cleanupNpmCache();
-      fs.rmSync(path.join(dir, 'node_modules'), { recursive: true, force: true });
-      execSync('npm ci --no-audit --no-fund', options);
+      fs.rmSync(path.join(dir, "node_modules"), {
+        recursive: true,
+        force: true,
+      });
+      execSync("npm ci --no-audit --no-fund", options);
     } else {
       throw err;
     }

--- a/scripts/validate-env.sh
+++ b/scripts/validate-env.sh
@@ -57,7 +57,8 @@ fi
 
 
 if [[ -z "${SKIP_NET_CHECKS:-}" ]]; then
-  if ! node scripts/network-check.js >/dev/null 2>&1; then
+  if ! output=$(node scripts/network-check.js 2>&1); then
+    echo "$output" >&2
     echo "Network check failed. Ensure access to the npm registry and Playwright CDN." >&2
     exit 1
   fi

--- a/tests/coverageWorkflow.test.js
+++ b/tests/coverageWorkflow.test.js
@@ -1,5 +1,6 @@
 const fs = require("fs");
 const YAML = require("yaml");
+/* global path */
 
 describe("coverage workflow", () => {
   test("installs root & backend deps and uses npx coveralls", () => {

--- a/tests/ensureDeps.test.js
+++ b/tests/ensureDeps.test.js
@@ -117,6 +117,7 @@ describe("ensure-deps", () => {
     expect(setupCalls.length).toBe(2);
     expect(setupCalls[0].env.SKIP_PW_DEPS).toBe("1");
     expect(setupCalls[1].env).not.toHaveProperty("SKIP_PW_DEPS");
+    expect(execMock).toHaveBeenCalled();
 
     delete process.env.SKIP_PW_DEPS;
   });

--- a/tests/networkCheckCdnHint.test.js
+++ b/tests/networkCheckCdnHint.test.js
@@ -1,0 +1,22 @@
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+describe("network-check CDN hint", () => {
+  test("suggests SKIP_PW_DEPS when CDN unreachable", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "curl-"));
+    const fakeCurl = path.join(tmp, "curl");
+    fs.writeFileSync(
+      fakeCurl,
+      '#!/bin/sh\nif echo "$@" | grep -q cdn.playwright.dev; then exit 1; fi\nexec /usr/bin/curl "$@"',
+    );
+    fs.chmodSync(fakeCurl, 0o755);
+    expect(() => {
+      execFileSync("node", [path.join("scripts", "network-check.js")], {
+        env: { ...process.env, PATH: `${tmp}:${process.env.PATH}` },
+        encoding: "utf8",
+      });
+    }).toThrow(/SKIP_PW_DEPS=1/);
+  });
+});


### PR DESCRIPTION
## Summary
- show helpful hints when `network-check.js` fails
- surface network check output in `validate-env.sh`
- add ignore comments to `run-npm-ci.js` catch blocks
- fix lint errors in tests
- add regression test for Playwright CDN hint

## Testing
- `npm run format` (backend)
- `SKIP_NET_CHECKS=1 SKIP_DB_CHECK=1 npm test` (backend)
- `SKIP_NET_CHECKS=1 SKIP_DB_CHECK=1 npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_68738ba31fa8832d92e466b842162bef