### PR TITLE
Fix network check handling and tests

### DIFF
--- a/scripts/check-node-version.js
+++ b/scripts/check-node-version.js
@@ -1,9 +1,9 @@
 const child_process = require("child_process");
 const requiredMajor = parseInt(process.env.REQUIRED_NODE_MAJOR || "20", 10);
 const major = parseInt(process.versions.node.split(".")[0], 10);
-if (major !== requiredMajor) {
+if (major < requiredMajor) {
   console.error(
-    `Node ${requiredMajor} is required, current version is ${process.versions.node}`,
+    `Node ${requiredMajor} or newer is required, current version is ${process.versions.node}`,
   );
   try {
     child_process.execSync(`mise use -g node@${requiredMajor}`, {

--- a/scripts/network-check.js
+++ b/scripts/network-check.js
@@ -40,10 +40,17 @@ if (process.env.NETWORK_CHECK_URL) {
 
 function check(url) {
   try {
-    execSync(`curl -fsSL --max-time 10 -o /dev/null ${url}`, {
-      stdio: "pipe",
-    });
-    return null;
+    const code = execSync(
+      `curl -sSL --max-time 10 -o /dev/null -w "%{http_code}" ${url}`,
+      { stdio: "pipe" },
+    )
+      .toString()
+      .trim();
+    const status = parseInt(code, 10);
+    if (!Number.isNaN(status) && status < 500) {
+      return null;
+    }
+    return `HTTP ${code}`;
   } catch (err) {
     const stderr = err.stderr ? err.stderr.toString().trim() : err.message;
     return stderr.split("\n").slice(-1)[0];

--- a/scripts/run-npm-ci.js
+++ b/scripts/run-npm-ci.js
@@ -1,34 +1,50 @@
-const { execSync } = require('child_process');
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+/* eslint-disable no-empty */
+const { execSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
 
 function cleanupNpmCache() {
-  try { execSync('npm cache clean --force', { stdio: 'ignore' }); } catch {}
   try {
-    const cache = execSync('npm config get cache').toString().trim();
-    fs.rmSync(path.join(cache, '_cacache'), { recursive: true, force: true });
-    fs.rmSync(path.join(cache, '_cacache', 'tmp'), { recursive: true, force: true });
+    execSync("npm cache clean --force", { stdio: "ignore" });
   } catch {}
-  try { fs.rmSync(path.join(os.homedir(), '.npm', '_cacache'), { recursive: true, force: true }); } catch {}
+  try {
+    const cache = execSync("npm config get cache").toString().trim();
+    fs.rmSync(path.join(cache, "_cacache"), { recursive: true, force: true });
+    fs.rmSync(path.join(cache, "_cacache", "tmp"), {
+      recursive: true,
+      force: true,
+    });
+  } catch {}
+  try {
+    fs.rmSync(path.join(os.homedir(), ".npm", "_cacache"), {
+      recursive: true,
+      force: true,
+    });
+  } catch {}
 }
 
-function runNpmCi(dir = '.') {
-  const options = { stdio: 'inherit' };
-  if (dir !== '.') options.cwd = dir;
+function runNpmCi(dir = ".") {
+  const options = { stdio: "inherit" };
+  if (dir !== ".") options.cwd = dir;
   try {
-    execSync('npm ci --no-audit --no-fund', options);
+    execSync("npm ci --no-audit --no-fund", options);
   } catch (err) {
-    const output = String(err.stderr || err.stdout || err.message || '');
-    if (output.includes('EUSAGE')) {
+    const output = String(err.stderr || err.stdout || err.message || "");
+    if (output.includes("EUSAGE")) {
       console.warn(`npm ci failed in ${dir}, falling back to 'npm install'`);
-      execSync('npm install --no-audit --no-fund', options);
-      execSync('npm ci --no-audit --no-fund', options);
+      execSync("npm install --no-audit --no-fund", options);
+      execSync("npm ci --no-audit --no-fund", options);
     } else if (/TAR_ENTRY_ERROR|ENOENT/.test(output)) {
-      console.warn(`npm ci encountered tar errors in ${dir}. Cleaning cache and retrying...`);
+      console.warn(
+        `npm ci encountered tar errors in ${dir}. Cleaning cache and retrying...`,
+      );
       cleanupNpmCache();
-      fs.rmSync(path.join(dir, 'node_modules'), { recursive: true, force: true });
-      execSync('npm ci --no-audit --no-fund', options);
+      fs.rmSync(path.join(dir, "node_modules"), {
+        recursive: true,
+        force: true,
+      });
+      execSync("npm ci --no-audit --no-fund", options);
     } else {
       throw err;
     }

--- a/tests/checkNodeVersionScript.test.js
+++ b/tests/checkNodeVersionScript.test.js
@@ -16,4 +16,12 @@ describe("check-node-version script", () => {
       expect(output).toMatch(/mise use -g node@25/);
     }
   });
+
+  test("succeeds when current version is higher", () => {
+    execFileSync("node", [path.join("scripts", "check-node-version.js")], {
+      env: { ...process.env, REQUIRED_NODE_MAJOR: "18" },
+      encoding: "utf8",
+      stdio: "pipe",
+    });
+  });
 });

--- a/tests/coverageWorkflow.test.js
+++ b/tests/coverageWorkflow.test.js
@@ -1,4 +1,5 @@
 const fs = require("fs");
+const path = require("path");
 const YAML = require("yaml");
 
 describe("coverage workflow", () => {

--- a/tests/ensureDeps.test.js
+++ b/tests/ensureDeps.test.js
@@ -110,6 +110,7 @@ describe("ensure-deps", () => {
           throw new Error("setup fail");
         }
       });
+    void execMock;
 
     require("../backend/scripts/ensure-deps");
 

--- a/tests/networkCheckHttpError.test.js
+++ b/tests/networkCheckHttpError.test.js
@@ -3,22 +3,25 @@ const http = require("http");
 const path = require("path");
 
 describe("network-check HTTP errors", () => {
-  test("fails on non-2xx status", (done) => {
+  test("ignores 4xx responses", (done) => {
     const server = http.createServer((req, res) => {
       res.statusCode = 404;
       res.end();
     });
     server.listen(0, () => {
       const { port } = server.address();
-      expect(() => {
-        execFileSync("node", [path.join("scripts", "network-check.js")], {
+      const out = execFileSync(
+        "node",
+        [path.join("scripts", "network-check.js")],
+        {
           env: {
             ...process.env,
             NETWORK_CHECK_URL: `http://127.0.0.1:${port}`,
           },
           encoding: "utf8",
-        });
-      }).toThrow(/Unable to reach/);
+        },
+      );
+      expect(out).toContain("✅ network OK");
       server.close(done);
     });
   });


### PR DESCRIPTION
## Summary
- handle CDN 400 errors in network-check
- relax check-node-version to allow newer Node
- skip ESLint empty block warnings in run-npm-ci script
- update tests for new behavior

## Testing
- `npm test`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_68738b946a04832d945a2ec66667dc30