### PR TITLE
Fix coverage workflow for Coveralls

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,4 +11,6 @@ jobs:
         with:
           node-version: "20"
       - run: SKIP_PW_DEPS=1 npm run setup
-      - run: npm run coverage -- --reporter=text-lcov | npx coveralls
+      - run: |
+          npm run coverage
+          cat backend/coverage/lcov.info | npx coveralls

--- a/README.md
+++ b/README.md
@@ -388,7 +388,8 @@ Run coverage after installing dependencies:
 
 ```bash
 npm run setup
-npm run coverage -- --reporter=text-lcov | npx coveralls
+npm run coverage
+cat backend/coverage/lcov.info | npx coveralls
 ```
 
 Using `npx coveralls` ensures the CLI runs even if it's not installed globally.

--- a/tests/coverageWorkflow.test.js
+++ b/tests/coverageWorkflow.test.js
@@ -3,7 +3,7 @@ const path = require("path");
 const YAML = require("yaml");
 
 describe("coverage workflow", () => {
-  test("installs root & backend deps and uses npx coveralls", () => {
+  test("runs setup and posts lcov to coveralls", () => {
     const file = path.join(
       __dirname,
       "..",
@@ -13,13 +13,17 @@ describe("coverage workflow", () => {
     );
     const yml = YAML.parse(fs.readFileSync(file, "utf8"));
     const steps = yml.jobs.coverage.steps.map((s) => s.run || "");
-    const hasRootCi = steps.some((cmd) => cmd.trim() === "npm ci");
-    const hasBackendCi = steps.some((cmd) =>
-      cmd.includes("npm ci --prefix backend"),
+    const hasSetup = steps.some((cmd) => cmd.includes("npm run setup"));
+    const hasCoverage = steps.some((cmd) =>
+      cmd.trim().startsWith("npm run coverage"),
     );
     const hasCoveralls = steps.some((cmd) => cmd.includes("npx coveralls"));
-    expect(hasRootCi).toBe(true);
-    expect(hasBackendCi).toBe(true);
+    const usesCat = steps.some((cmd) =>
+      cmd.includes("cat backend/coverage/lcov.info"),
+    );
+    expect(hasSetup).toBe(true);
+    expect(hasCoverage).toBe(true);
     expect(hasCoveralls).toBe(true);
+    expect(usesCat).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- pipe lcov file to coveralls instead of stdout
- document new coverage instructions
- test workflow uses cat and setup

## Testing
- `npm run format --prefix backend`
- `SKIP_DB_CHECK=1 npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_6873944315a4832d801e6ce7e74ae82b