### PR TITLE
Fix coverage job and add test for README instructions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,4 +11,5 @@ jobs:
         with:
           node-version: "20"
       - run: SKIP_PW_DEPS=1 npm run setup
-      - run: npm run coverage -- --reporter=text-lcov | npx coveralls
+      - run: npm run coverage
+      - run: cat backend/coverage/lcov.info | npx coveralls

--- a/README.md
+++ b/README.md
@@ -388,7 +388,8 @@ Run coverage after installing dependencies:
 
 ```bash
 npm run setup
-npm run coverage -- --reporter=text-lcov | npx coveralls
+npm run coverage
+cat backend/coverage/lcov.info | npx coveralls
 ```
 
 Using `npx coveralls` ensures the CLI runs even if it's not installed globally.

--- a/tests/coverageReadme.test.js
+++ b/tests/coverageReadme.test.js
@@ -1,0 +1,12 @@
+const fs = require("fs");
+const path = require("path");
+
+describe("README coverage instructions", () => {
+  test("show updated coveralls command", () => {
+    const readme = fs.readFileSync(
+      path.join(__dirname, "..", "README.md"),
+      "utf8",
+    );
+    expect(readme).toContain("cat backend/coverage/lcov.info | npx coveralls");
+  });
+});

--- a/tests/coverageWorkflow.test.js
+++ b/tests/coverageWorkflow.test.js
@@ -3,7 +3,7 @@ const path = require("path");
 const YAML = require("yaml");
 
 describe("coverage workflow", () => {
-  test("installs root & backend deps and uses npx coveralls", () => {
+  test("runs setup, coverage and uploads to coveralls", () => {
     const file = path.join(
       __dirname,
       "..",
@@ -13,13 +13,13 @@ describe("coverage workflow", () => {
     );
     const yml = YAML.parse(fs.readFileSync(file, "utf8"));
     const steps = yml.jobs.coverage.steps.map((s) => s.run || "");
-    const hasRootCi = steps.some((cmd) => cmd.trim() === "npm ci");
-    const hasBackendCi = steps.some((cmd) =>
-      cmd.includes("npm ci --prefix backend"),
+    const hasSetup = steps.some((cmd) => cmd.includes("npm run setup"));
+    const hasCoverage = steps.some((cmd) => cmd.trim() === "npm run coverage");
+    const hasCoveralls = steps.some((cmd) =>
+      cmd.includes("cat backend/coverage/lcov.info | npx coveralls"),
     );
-    const hasCoveralls = steps.some((cmd) => cmd.includes("npx coveralls"));
-    expect(hasRootCi).toBe(true);
-    expect(hasBackendCi).toBe(true);
+    expect(hasSetup).toBe(true);
+    expect(hasCoverage).toBe(true);
     expect(hasCoveralls).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- update README to use `cat` to send coverage to coveralls
- update GitHub Actions workflow to upload lcov.info directly
- adjust test for coverage workflow
- add a test that checks README instructions

## Testing
- `npm run format --prefix backend`
- `SKIP_DB_CHECK=1 npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_6873942ac0a8832dbcf375442854dbbf