### PR TITLE
Fix ensure-deps offline behavior

### DIFF
--- a/backend/scripts/ensure-deps.js
+++ b/backend/scripts/ensure-deps.js
@@ -48,6 +48,11 @@ function canReachRegistry() {
 function runSetup() {
   console.log("Setup flag missing. Running 'npm run setup'...");
   const env = { ...process.env };
+  if (process.env.SKIP_NET_CHECKS && !env.SKIP_PW_DEPS) {
+    console.log("SKIP_NET_CHECKS detected; forcing SKIP_PW_DEPS");
+    env.SKIP_PW_DEPS = "1";
+    env.PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1";
+  }
   if (!env.SKIP_PW_DEPS) {
     try {
       execSync(`node ${aptCheck}`, { stdio: "inherit" });

--- a/scripts/__tests__/ensure-deps-offline.test.ts
+++ b/scripts/__tests__/ensure-deps-offline.test.ts
@@ -1,0 +1,7 @@
+const { execSync } = require('child_process');
+
+test('ensure-deps skips Playwright setup when offline', () => {
+  const out = execSync('SKIP_NET_CHECKS=1 node backend/scripts/ensure-deps.js', { encoding: 'utf8' });
+  expect(out).toMatch(/SKIP_NET_CHECKS detected; forcing SKIP_PW_DEPS/);
+});
+


### PR DESCRIPTION
## Summary
- skip Playwright installation when network checks are disabled
- add regression test for offline ensure-deps run

## Testing
- `npm run format --prefix backend`
- `SKIP_NET_CHECKS=1 SKIP_DB_CHECK=1 npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_687393c00c04832da1d018e12ab2be9e