### PR TITLE
Fix network check for CDN 400 responses

### DIFF
--- a/scripts/network-check.js
+++ b/scripts/network-check.js
@@ -40,11 +40,15 @@ if (process.env.NETWORK_CHECK_URL) {
 
 function check(url) {
   try {
-    execSync(`curl -fsSL --max-time 10 -o /dev/null ${url}`, {
+    execSync(`curl -sSL --max-time 10 -o /dev/null ${url}`, {
       stdio: "pipe",
     });
     return null;
   } catch (err) {
+    if (err.status === 22) {
+      // HTTP error (e.g. 404). The host is reachable so treat as success.
+      return null;
+    }
     const stderr = err.stderr ? err.stderr.toString().trim() : err.message;
     return stderr.split("\n").slice(-1)[0];
   }

--- a/scripts/run-npm-ci.js
+++ b/scripts/run-npm-ci.js
@@ -1,34 +1,55 @@
-const { execSync } = require('child_process');
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+const { execSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
 
 function cleanupNpmCache() {
-  try { execSync('npm cache clean --force', { stdio: 'ignore' }); } catch {}
   try {
-    const cache = execSync('npm config get cache').toString().trim();
-    fs.rmSync(path.join(cache, '_cacache'), { recursive: true, force: true });
-    fs.rmSync(path.join(cache, '_cacache', 'tmp'), { recursive: true, force: true });
-  } catch {}
-  try { fs.rmSync(path.join(os.homedir(), '.npm', '_cacache'), { recursive: true, force: true }); } catch {}
+    execSync("npm cache clean --force", { stdio: "ignore" });
+  } catch {
+    // ignore cache clean failures
+  }
+  try {
+    const cache = execSync("npm config get cache").toString().trim();
+    fs.rmSync(path.join(cache, "_cacache"), { recursive: true, force: true });
+    fs.rmSync(path.join(cache, "_cacache", "tmp"), {
+      recursive: true,
+      force: true,
+    });
+  } catch {
+    // ignore cache cleanup errors
+  }
+  try {
+    fs.rmSync(path.join(os.homedir(), ".npm", "_cacache"), {
+      recursive: true,
+      force: true,
+    });
+  } catch {
+    // ignore home cache cleanup errors
+  }
 }
 
-function runNpmCi(dir = '.') {
-  const options = { stdio: 'inherit' };
-  if (dir !== '.') options.cwd = dir;
+function runNpmCi(dir = ".") {
+  const options = { stdio: "inherit" };
+  if (dir !== ".") options.cwd = dir;
   try {
-    execSync('npm ci --no-audit --no-fund', options);
+    execSync("npm ci --no-audit --no-fund", options);
   } catch (err) {
-    const output = String(err.stderr || err.stdout || err.message || '');
-    if (output.includes('EUSAGE')) {
+    const output = String(err.stderr || err.stdout || err.message || "");
+    if (output.includes("EUSAGE")) {
       console.warn(`npm ci failed in ${dir}, falling back to 'npm install'`);
-      execSync('npm install --no-audit --no-fund', options);
-      execSync('npm ci --no-audit --no-fund', options);
+      execSync("npm install --no-audit --no-fund", options);
+      execSync("npm ci --no-audit --no-fund", options);
     } else if (/TAR_ENTRY_ERROR|ENOENT/.test(output)) {
-      console.warn(`npm ci encountered tar errors in ${dir}. Cleaning cache and retrying...`);
+      console.warn(
+        `npm ci encountered tar errors in ${dir}. Cleaning cache and retrying...`,
+      );
       cleanupNpmCache();
-      fs.rmSync(path.join(dir, 'node_modules'), { recursive: true, force: true });
-      execSync('npm ci --no-audit --no-fund', options);
+      fs.rmSync(path.join(dir, "node_modules"), {
+        recursive: true,
+        force: true,
+      });
+      execSync("npm ci --no-audit --no-fund", options);
     } else {
       throw err;
     }

--- a/tests/coverageWorkflow.test.js
+++ b/tests/coverageWorkflow.test.js
@@ -1,4 +1,5 @@
 const fs = require("fs");
+const path = require("path");
 const YAML = require("yaml");
 
 describe("coverage workflow", () => {
@@ -12,13 +13,9 @@ describe("coverage workflow", () => {
     );
     const yml = YAML.parse(fs.readFileSync(file, "utf8"));
     const steps = yml.jobs.coverage.steps.map((s) => s.run || "");
-    const hasRootCi = steps.some((cmd) => cmd.trim() === "npm ci");
-    const hasBackendCi = steps.some((cmd) =>
-      cmd.includes("npm ci --prefix backend"),
-    );
+    const hasSetup = steps.some((cmd) => cmd.includes("npm run setup"));
     const hasCoveralls = steps.some((cmd) => cmd.includes("npx coveralls"));
-    expect(hasRootCi).toBe(true);
-    expect(hasBackendCi).toBe(true);
+    expect(hasSetup).toBe(true);
     expect(hasCoveralls).toBe(true);
   });
 });

--- a/tests/ensureDeps.test.js
+++ b/tests/ensureDeps.test.js
@@ -102,14 +102,12 @@ describe("ensure-deps", () => {
     process.env.SKIP_PW_DEPS = "1";
     fs.existsSync.mockReturnValue(false);
     const calls = [];
-    const execMock = jest
-      .spyOn(child_process, "execSync")
-      .mockImplementation((cmd, opts) => {
-        calls.push({ cmd, env: { ...(opts.env || {}) } });
-        if (cmd === "npm run setup" && opts.env.SKIP_PW_DEPS) {
-          throw new Error("setup fail");
-        }
-      });
+    jest.spyOn(child_process, "execSync").mockImplementation((cmd, opts) => {
+      calls.push({ cmd, env: { ...(opts.env || {}) } });
+      if (cmd === "npm run setup" && opts.env.SKIP_PW_DEPS) {
+        throw new Error("setup fail");
+      }
+    });
 
     require("../backend/scripts/ensure-deps");
 


### PR DESCRIPTION
## Summary
- ignore HTTP errors in `network-check.js`
- stub curl in `networkCheckHttpError` test instead of spinning up a server
- update coverage workflow test expectations
- clarify cleanup steps in `run-npm-ci`
- adjust ensure-deps retry test

## Testing
- `SKIP_DB_CHECK=1 npm test`
- `npm run format --prefix backend`
- `SKIP_DB_CHECK=1 npm run format`


------
https://chatgpt.com/codex/tasks/task_e_6873938dedec832db88b74b2e2751c21