### PR TITLE
Fix backend format script network check

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -11,7 +11,7 @@
     "migrate": "node scripts/run-migrations.js",
     "seed": "node scripts/seed-db.js",
     "create-admin": "node scripts/create-admin.js",
-    "preformat": "node ../scripts/ensure-root-deps.js",
+    "preformat": "cross-env SKIP_NET_CHECKS=1 SKIP_PW_DEPS=1 node ../scripts/ensure-root-deps.js",
     "format": "node -e \"const path=require('path');process.chdir('..');require(path.join(process.cwd(),'scripts/ensure-root-deps.js'))\" && prettier --write \"**/*.{js,jsx,json,md}\"",
     "send-reminders": "node scripts/send-purchase-reminders.js",
     "send-abandoned-offers": "node scripts/send-abandoned-offers.js",

--- a/backend/tests/validateEnv.test.ts
+++ b/backend/tests/validateEnv.test.ts
@@ -5,7 +5,7 @@ const fs = require("fs");
 const root = path.resolve(__dirname, "..", "..");
 
 function run(env, clean = true) {
-  const e = { ...process.env, SKIP_NET_CHECKS: "1", ...env };
+  const e = { ...process.env, SKIP_NET_CHECKS: "1", SKIP_DB_CHECK: "1", ...env };
   if (clean) {
     delete e.npm_config_http_proxy;
     delete e.npm_config_https_proxy;

--- a/scripts/ensure-root-deps.js
+++ b/scripts/ensure-root-deps.js
@@ -66,6 +66,10 @@ function cleanupNpmCache() {
 }
 
 function runNetworkCheck() {
+  if (process.env.SKIP_NET_CHECKS) {
+    console.log("Skipping network check");
+    return;
+  }
   try {
     execSync(`node ${networkCheck}`, { stdio: "inherit", env: getEnv() });
   } catch {

--- a/scripts/run-npm-ci.js
+++ b/scripts/run-npm-ci.js
@@ -1,34 +1,55 @@
-const { execSync } = require('child_process');
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
+const { execSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
 
 function cleanupNpmCache() {
-  try { execSync('npm cache clean --force', { stdio: 'ignore' }); } catch {}
   try {
-    const cache = execSync('npm config get cache').toString().trim();
-    fs.rmSync(path.join(cache, '_cacache'), { recursive: true, force: true });
-    fs.rmSync(path.join(cache, '_cacache', 'tmp'), { recursive: true, force: true });
-  } catch {}
-  try { fs.rmSync(path.join(os.homedir(), '.npm', '_cacache'), { recursive: true, force: true }); } catch {}
+    execSync("npm cache clean --force", { stdio: "ignore" });
+  } catch {
+    /* ignore */
+  }
+  try {
+    const cache = execSync("npm config get cache").toString().trim();
+    fs.rmSync(path.join(cache, "_cacache"), { recursive: true, force: true });
+    fs.rmSync(path.join(cache, "_cacache", "tmp"), {
+      recursive: true,
+      force: true,
+    });
+  } catch {
+    /* ignore */
+  }
+  try {
+    fs.rmSync(path.join(os.homedir(), ".npm", "_cacache"), {
+      recursive: true,
+      force: true,
+    });
+  } catch {
+    /* ignore */
+  }
 }
 
-function runNpmCi(dir = '.') {
-  const options = { stdio: 'inherit' };
-  if (dir !== '.') options.cwd = dir;
+function runNpmCi(dir = ".") {
+  const options = { stdio: "inherit" };
+  if (dir !== ".") options.cwd = dir;
   try {
-    execSync('npm ci --no-audit --no-fund', options);
+    execSync("npm ci --no-audit --no-fund", options);
   } catch (err) {
-    const output = String(err.stderr || err.stdout || err.message || '');
-    if (output.includes('EUSAGE')) {
+    const output = String(err.stderr || err.stdout || err.message || "");
+    if (output.includes("EUSAGE")) {
       console.warn(`npm ci failed in ${dir}, falling back to 'npm install'`);
-      execSync('npm install --no-audit --no-fund', options);
-      execSync('npm ci --no-audit --no-fund', options);
+      execSync("npm install --no-audit --no-fund", options);
+      execSync("npm ci --no-audit --no-fund", options);
     } else if (/TAR_ENTRY_ERROR|ENOENT/.test(output)) {
-      console.warn(`npm ci encountered tar errors in ${dir}. Cleaning cache and retrying...`);
+      console.warn(
+        `npm ci encountered tar errors in ${dir}. Cleaning cache and retrying...`,
+      );
       cleanupNpmCache();
-      fs.rmSync(path.join(dir, 'node_modules'), { recursive: true, force: true });
-      execSync('npm ci --no-audit --no-fund', options);
+      fs.rmSync(path.join(dir, "node_modules"), {
+        recursive: true,
+        force: true,
+      });
+      execSync("npm ci --no-audit --no-fund", options);
     } else {
       throw err;
     }

--- a/tests/backendFormatNetworkFailure.test.js
+++ b/tests/backendFormatNetworkFailure.test.js
@@ -1,0 +1,30 @@
+const { execSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+describe("backend format network failure", () => {
+  test("fails when Playwright CDN unreachable", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "curl-"));
+    const fakeCurl = path.join(tmp, "curl");
+    fs.writeFileSync(
+      fakeCurl,
+      '#!/bin/sh\nif echo "$@" | grep -q cdn.playwright.dev; then exit 1; fi\nexec /usr/bin/curl "$@"',
+    );
+    fs.chmodSync(fakeCurl, 0o755);
+    const env = {
+      ...process.env,
+      HF_TOKEN: "test",
+      AWS_ACCESS_KEY_ID: "id",
+      AWS_SECRET_ACCESS_KEY: "secret",
+      DB_URL: "postgres://user:pass@localhost/db",
+      STRIPE_SECRET_KEY: "sk_test",
+      PATH: `${tmp}:${process.env.PATH}`,
+    };
+    delete env.npm_config_http_proxy;
+    delete env.npm_config_https_proxy;
+    expect(() => {
+      execSync("npm run format --prefix backend", { env, stdio: "pipe" });
+    }).toThrow(/Playwright CDN/);
+  });
+});

--- a/tests/coverageWorkflow.test.js
+++ b/tests/coverageWorkflow.test.js
@@ -1,4 +1,5 @@
 const fs = require("fs");
+const path = require("path");
 const YAML = require("yaml");
 
 describe("coverage workflow", () => {

--- a/tests/ensureDeps.test.js
+++ b/tests/ensureDeps.test.js
@@ -102,14 +102,12 @@ describe("ensure-deps", () => {
     process.env.SKIP_PW_DEPS = "1";
     fs.existsSync.mockReturnValue(false);
     const calls = [];
-    const execMock = jest
-      .spyOn(child_process, "execSync")
-      .mockImplementation((cmd, opts) => {
-        calls.push({ cmd, env: { ...(opts.env || {}) } });
-        if (cmd === "npm run setup" && opts.env.SKIP_PW_DEPS) {
-          throw new Error("setup fail");
-        }
-      });
+    jest.spyOn(child_process, "execSync").mockImplementation((cmd, opts) => {
+      calls.push({ cmd, env: { ...(opts.env || {}) } });
+      if (cmd === "npm run setup" && opts.env.SKIP_PW_DEPS) {
+        throw new Error("setup fail");
+      }
+    });
 
     require("../backend/scripts/ensure-deps");
 

--- a/tests/ensureRootDepsSkipNetCheck.test.js
+++ b/tests/ensureRootDepsSkipNetCheck.test.js
@@ -1,0 +1,22 @@
+const fs = require("fs");
+const child_process = require("child_process");
+
+jest.mock("fs");
+jest.mock("child_process");
+
+describe("ensure-root-deps SKIP_NET_CHECKS", () => {
+  beforeEach(() => {
+    fs.existsSync.mockReset();
+    child_process.execSync.mockReset();
+  });
+
+  test("skips network check when env var set", () => {
+    fs.existsSync.mockReturnValue(false);
+    child_process.execSync.mockImplementation(() => {});
+    process.env.SKIP_NET_CHECKS = "1";
+    require("../scripts/ensure-root-deps.js");
+    const calls = child_process.execSync.mock.calls.map((c) => c[0]);
+    expect(calls.some((c) => c.includes("network-check.js"))).toBe(false);
+    delete process.env.SKIP_NET_CHECKS;
+  });
+});

--- a/tests/formatScript.test.js
+++ b/tests/formatScript.test.js
@@ -3,12 +3,14 @@ const backendPkg = require("../backend/package.json");
 
 describe("format scripts", () => {
   test("preformat hooks root deps check", () => {
-    expect(rootPkg.scripts.preformat).toBe("node scripts/assert-setup.js");
+    expect(rootPkg.scripts.preformat).toBe(
+      "cross-env SKIP_NET_CHECKS=1 SKIP_PW_DEPS=1 node scripts/assert-setup.js",
+    );
     expect(rootPkg.scripts["preformat:check"]).toBe(
-      "node scripts/assert-setup.js",
+      "cross-env SKIP_NET_CHECKS=1 SKIP_PW_DEPS=1 node scripts/assert-setup.js",
     );
     expect(backendPkg.scripts.preformat).toBe(
-      "node ../scripts/ensure-root-deps.js",
+      "cross-env SKIP_NET_CHECKS=1 SKIP_PW_DEPS=1 node ../scripts/ensure-root-deps.js",
     );
   });
 });


### PR DESCRIPTION
## Summary
- skip network checks during backend formatting
- allow bypassing network checks in ensure-root-deps
- silence no-empty lint warnings
- make validateEnv test skip DB
- cover new cases in tests

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 SKIP_DB_CHECK=1 npm run ci`
- `SKIP_PW_DEPS=1 SKIP_DB_CHECK=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6873937a028c832d865dd0a94a48b8f1