### PR TITLE
Fix validate-env tests to skip DB checks

### DIFF
--- a/backend/tests/envValidation.test.js
+++ b/backend/tests/envValidation.test.js
@@ -12,6 +12,7 @@ describe("validate-env script", () => {
     DB_URL: "postgres://user:pass@localhost/db",
     STRIPE_SECRET_KEY: "sk_test",
     SKIP_NET_CHECKS: "1",
+    SKIP_DB_CHECK: "1",
     http_proxy: "",
     https_proxy: "",
     npm_config_http_proxy: "",
@@ -91,5 +92,20 @@ describe("validate-env script", () => {
     }
     fs.renameSync(backup, example);
     expect(threw).toBe(true);
+  });
+
+  test("fails when database unreachable", () => {
+    expect(() =>
+      execSync(`bash ${script}`, {
+        env: {
+          ...process.env,
+          ...baseEnv,
+          DB_URL: "postgres://user:pass@127.0.0.1:9/db",
+          SKIP_NET_CHECKS: "1",
+          SKIP_DB_CHECK: "",
+        },
+        stdio: "pipe",
+      }),
+    ).toThrow(/Database connection check failed/);
   });
 });

--- a/backend/tests/validateEnv.test.ts
+++ b/backend/tests/validateEnv.test.ts
@@ -30,6 +30,7 @@ describe("validate-env script", () => {
       DB_URL: "postgres://user:pass@localhost/db",
       STRIPE_SECRET_KEY: "sk_test_dummy",
       SKIP_NET_CHECKS: "1",
+      SKIP_DB_CHECK: "1",
     });
     expect(output).toContain("environment OK");
   });
@@ -57,7 +58,21 @@ describe("validate-env script", () => {
       HF_API_KEY: "",
       AWS_ACCESS_KEY_ID: "id",
       AWS_SECRET_ACCESS_KEY: "secret",
+      SKIP_DB_CHECK: "1",
     });
     expect(output).toContain("environment OK");
+  });
+
+  test("fails when database unreachable", () => {
+    expect(() =>
+      run({
+        STRIPE_TEST_KEY: "test",
+        HF_TOKEN: "token",
+        AWS_ACCESS_KEY_ID: "id",
+        AWS_SECRET_ACCESS_KEY: "secret",
+        DB_URL: "postgres://user:pass@127.0.0.1:9/db",
+        SKIP_NET_CHECKS: "1",
+      }),
+    ).toThrow(/Database connection check failed/);
   });
 });

--- a/tests/validateEnv.test.js
+++ b/tests/validateEnv.test.js
@@ -31,6 +31,7 @@ describe("validate-env script", () => {
       http_proxy: "http://proxy",
       https_proxy: "http://proxy",
       SKIP_NET_CHECKS: "1",
+      SKIP_DB_CHECK: "1",
     };
     const output = run(env);
     expect(output).toContain("✅ environment OK");
@@ -47,6 +48,7 @@ describe("validate-env script", () => {
       DB_URL: "postgres://user:pass@localhost/db",
       STRIPE_SECRET_KEY: "sk_test_dummy",
       CLOUDFRONT_MODEL_DOMAIN: "cdn.test",
+      SKIP_DB_CHECK: "1",
     };
     const output = run(env);
     expect(output).toContain("✅ environment OK");
@@ -93,6 +95,20 @@ describe("validate-env script", () => {
       SKIP_NET_CHECKS: "",
     };
     expect(() => run(env)).toThrow(/Network check failed/);
+  });
+
+  test("fails when database unreachable", () => {
+    const env = {
+      ...process.env,
+      HF_TOKEN: "test",
+      AWS_ACCESS_KEY_ID: "id",
+      AWS_SECRET_ACCESS_KEY: "secret",
+      STRIPE_TEST_KEY: "sk_test",
+      DB_URL: "postgres://user:pass@127.0.0.1:9/db",
+      CLOUDFRONT_MODEL_DOMAIN: "cdn.test",
+      SKIP_NET_CHECKS: "1",
+    };
+    expect(() => run(env)).toThrow(/Database connection check failed/);
   });
 
   test("falls back to SKIP_PW_DEPS when apt check fails", () => {


### PR DESCRIPTION
## Summary
- skip database check in validate-env tests
- add tests for DB connection failures

## Testing
- `SKIP_NET_CHECKS=1 npm run format --prefix backend`
- `SKIP_PW_DEPS=1 npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_687393445708832d83e0242353a15c23