### PR TITLE
Fix validate-env tests without DB

### DIFF
--- a/backend/tests/envValidation.test.js
+++ b/backend/tests/envValidation.test.js
@@ -12,6 +12,7 @@ describe("validate-env script", () => {
     DB_URL: "postgres://user:pass@localhost/db",
     STRIPE_SECRET_KEY: "sk_test",
     SKIP_NET_CHECKS: "1",
+    SKIP_DB_CHECK: "1",
     http_proxy: "",
     https_proxy: "",
     npm_config_http_proxy: "",

--- a/backend/tests/validateEnv.test.ts
+++ b/backend/tests/validateEnv.test.ts
@@ -5,7 +5,7 @@ const fs = require("fs");
 const root = path.resolve(__dirname, "..", "..");
 
 function run(env, clean = true) {
-  const e = { ...process.env, SKIP_NET_CHECKS: "1", ...env };
+  const e = { ...process.env, SKIP_NET_CHECKS: "1", SKIP_DB_CHECK: "1", ...env };
   if (clean) {
     delete e.npm_config_http_proxy;
     delete e.npm_config_https_proxy;
@@ -59,5 +59,19 @@ describe("validate-env script", () => {
       AWS_SECRET_ACCESS_KEY: "secret",
     });
     expect(output).toContain("environment OK");
+  });
+
+  test("fails when database unreachable without SKIP_DB_CHECK", () => {
+    expect(() =>
+      run({
+        STRIPE_TEST_KEY: "test",
+        HF_TOKEN: "token",
+        AWS_ACCESS_KEY_ID: "id",
+        AWS_SECRET_ACCESS_KEY: "secret",
+        DB_URL: "postgres://user:pass@127.0.0.1:9/db",
+        STRIPE_SECRET_KEY: "sk_test_dummy",
+        SKIP_DB_CHECK: "",
+      })
+    ).toThrow(/Database connection check failed/);
   });
 });

--- a/backend/tests/validateEnvNodeVersion.test.ts
+++ b/backend/tests/validateEnvNodeVersion.test.ts
@@ -14,6 +14,7 @@ describe("validate-env node version check", () => {
       STRIPE_SECRET_KEY: "sk",
       SKIP_NET_CHECKS: "1",
       SKIP_PW_DEPS: "1",
+      SKIP_DB_CHECK: "1",
     };
     expect(() => {
       execFileSync(

--- a/scripts/run-npm-ci.js
+++ b/scripts/run-npm-ci.js
@@ -4,13 +4,23 @@ const os = require('os');
 const path = require('path');
 
 function cleanupNpmCache() {
-  try { execSync('npm cache clean --force', { stdio: 'ignore' }); } catch {}
+  try {
+    execSync('npm cache clean --force', { stdio: 'ignore' });
+  } catch {
+    // ignore cache cleanup errors
+  }
   try {
     const cache = execSync('npm config get cache').toString().trim();
     fs.rmSync(path.join(cache, '_cacache'), { recursive: true, force: true });
     fs.rmSync(path.join(cache, '_cacache', 'tmp'), { recursive: true, force: true });
-  } catch {}
-  try { fs.rmSync(path.join(os.homedir(), '.npm', '_cacache'), { recursive: true, force: true }); } catch {}
+  } catch {
+    // ignore cache removal errors
+  }
+  try {
+    fs.rmSync(path.join(os.homedir(), '.npm', '_cacache'), { recursive: true, force: true });
+  } catch {
+    // ignore removal errors
+  }
 }
 
 function runNpmCi(dir = '.') {

--- a/tests/coverageWorkflow.test.js
+++ b/tests/coverageWorkflow.test.js
@@ -1,4 +1,5 @@
 const fs = require("fs");
+const path = require("path");
 const YAML = require("yaml");
 
 describe("coverage workflow", () => {

--- a/tests/ensureDeps.test.js
+++ b/tests/ensureDeps.test.js
@@ -102,14 +102,12 @@ describe("ensure-deps", () => {
     process.env.SKIP_PW_DEPS = "1";
     fs.existsSync.mockReturnValue(false);
     const calls = [];
-    const execMock = jest
-      .spyOn(child_process, "execSync")
-      .mockImplementation((cmd, opts) => {
-        calls.push({ cmd, env: { ...(opts.env || {}) } });
-        if (cmd === "npm run setup" && opts.env.SKIP_PW_DEPS) {
-          throw new Error("setup fail");
-        }
-      });
+    jest.spyOn(child_process, "execSync").mockImplementation((cmd, opts) => {
+      calls.push({ cmd, env: { ...(opts.env || {}) } });
+      if (cmd === "npm run setup" && opts.env.SKIP_PW_DEPS) {
+        throw new Error("setup fail");
+      }
+    });
 
     require("../backend/scripts/ensure-deps");
 


### PR DESCRIPTION
## Summary
- default to SKIP_DB_CHECK when running validate-env tests
- cover failing DB connection in validate-env test suite
- skip DB check in envValidation and node version tests
- clarify catch blocks in `run-npm-ci.js`
- fix missing `path` require in coverage workflow test
- clean up unused variable in ensureDeps test

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_687392fd3884832dbecb189a0b838e15