### PR TITLE
Improve CDN failure handling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,9 @@ These guidelines apply to all automated agents (e.g. the Codex agent) working on
 6. **Check network access** – ensure the environment can reach both
    `https://registry.npmjs.org` and `https://cdn.playwright.dev`. The setup
    script downloads packages and browsers from these domains. If they are
-   blocked, adjust your environment or proxy settings.
+   blocked, adjust your environment or proxy settings. If the Playwright CDN is
+   unreachable but browsers are already installed, set `SKIP_PW_DEPS=1` to skip
+   the CDN check.
 7. **Install dependencies** – run `npm run setup` at the repository root **before your first `npm run ci`**. Run it again whenever the container is restarted or if Playwright tests fail with messages like "Test was interrupted" or "page.evaluate: Test ended". This script unsets proxy variables, checks registry connectivity, runs `npm ci` in the root and `backend/`, and installs Playwright browsers.
    - If `npm ci` fails with an `EUSAGE` error complaining that packages are missing from the lock file, run `npm install` in the affected directory and then re-run the setup script.
    - Set `SKIP_PW_DEPS=1` before running the setup script if Playwright dependencies are already installed. This skips the long `apt-get` step and reduces CI time. The `smoke` script also runs the setup script, so use `SKIP_PW_DEPS=1 npm run smoke` to avoid reinstalling Playwright dependencies when they are already present.

--- a/scripts/network-check.js
+++ b/scripts/network-check.js
@@ -55,6 +55,11 @@ for (const { url, name } of targets) {
   if (error) {
     console.error(`Unable to reach ${name}: ${url}`);
     if (error) console.error(error);
+    if (name === "Playwright CDN") {
+      console.error(
+        "Set SKIP_PW_DEPS=1 to skip Playwright CDN checks if browsers are preinstalled.",
+      );
+    }
     process.exit(1);
   }
 }

--- a/tests/networkCheckCdnHttpError.test.js
+++ b/tests/networkCheckCdnHttpError.test.js
@@ -1,0 +1,26 @@
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+describe("network-check CDN HTTP error", () => {
+  test("suggests SKIP_PW_DEPS when CDN responds with HTTP error", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "curl-"));
+    const fakeCurl = path.join(tmp, "curl");
+    fs.writeFileSync(
+      fakeCurl,
+      '#!/bin/sh\nif echo "$@" | grep -q cdn.playwright.dev; then echo "curl: (22)" >&2; exit 22; fi\nexec /usr/bin/curl "$@"',
+    );
+    fs.chmodSync(fakeCurl, 0o755);
+    expect(() => {
+      execFileSync("node", [path.join("scripts", "network-check.js")], {
+        env: {
+          ...process.env,
+          PATH: `${tmp}:${process.env.PATH}`,
+          SKIP_NET_CHECKS: "",
+        },
+        encoding: "utf8",
+      });
+    }).toThrow(/SKIP_PW_DEPS=1/);
+  });
+});


### PR DESCRIPTION
## Summary
- show a helpful hint when the Playwright CDN can't be reached
- document how to skip the CDN check when browsers are preinstalled
- cover CDN HTTP failure case with a unit test

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_687392cb23c0832db2cd95bef913f726