### PR TITLE
Fix undefined variable in ensureDeps test

### DIFF
--- a/tests/ensureDeps.test.js
+++ b/tests/ensureDeps.test.js
@@ -103,7 +103,7 @@ describe("ensure-deps", () => {
     process.env.SKIP_PW_DEPS = "1";
     fs.existsSync.mockReturnValue(false);
     const calls = [];
-    jest
+    const execMock = jest
       .spyOn(child_process, "execSync")
       .mockImplementation((cmd, opts) => {
         calls.push({ cmd, env: { ...(opts.env || {}) } });
@@ -111,7 +111,6 @@ describe("ensure-deps", () => {
           throw new Error("setup fail");
         }
       });
-    void execMock;
 
     require("../backend/scripts/ensure-deps");
 


### PR DESCRIPTION
## Summary
- declare `execMock` in the `retries without SKIP_PW_DEPS` test

## Testing
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run smoke`
- `SKIP_PW_DEPS=1 npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_6873999d1700832da41dbc938f636b29