### PR TITLE
Fix dev server port handling and test

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -66,7 +66,9 @@ const { verifyTag } = require("./social");
 const QRCode = require("qrcode");
 const generateAdCopy = require("./utils/generateAdCopy");
 const generateShareCard = require("./utils/generateShareCard");
-const { generateModel: generateModelPipeline } = require("./src/pipeline/generateModel");
+const {
+  generateModel: generateModelPipeline,
+} = require("./src/pipeline/generateModel");
 
 const validateStl = require("./utils/validateStl");
 const syncMailingList = require("./scripts/sync-mailing-list");
@@ -460,8 +462,7 @@ app.post(
 
       let generatedUrl;
       try {
-
-        const url = await generateModelPipeline({
+        generatedUrl = await generateModelPipeline({
           prompt: req.body.prompt,
           image: req.file ? req.file.path : undefined,
         });

--- a/backend/tests/sparc3dClient.test.js
+++ b/backend/tests/sparc3dClient.test.js
@@ -58,6 +58,7 @@ describe("generateGlb", () => {
   test("ignores proxy environment variables", async () => {
     process.env.http_proxy = "http://proxy:9999";
     process.env.https_proxy = "http://proxy:9999";
+    const token = process.env.SPARC3D_TOKEN;
     const data = Buffer.from("abc");
     (0, nock_1.default)("https://api.example.com")
       .post("/generate", { prompt: "p2" })

--- a/scripts/dev-server.js
+++ b/scripts/dev-server.js
@@ -25,9 +25,15 @@ app.get("/healthz", (_req, res) => {
 });
 
 function startDevServer(port = 3000) {
-  return app.listen(port, () => {
-    console.log(`Dev server listening on http://localhost:${port}`);
-  });
+  const server = app
+    .listen(port, () => {
+      console.log(`Dev server listening on http://localhost:${port}`);
+    })
+    .on("error", (err) => {
+      console.error("Dev server failed", err.message);
+      process.exit(1);
+    });
+  return server;
 }
 
 if (require.main === module) {


### PR DESCRIPTION
## Summary
- handle server startup errors cleanly
- store generated URL from pipeline
- ensure proxy test defines auth token

## Testing
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_6873aeac374c832db0dc6a37432f01c4