### PR TITLE
Fix lint errors and add coverage workflow lint test

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -66,7 +66,9 @@ const { verifyTag } = require("./social");
 const QRCode = require("qrcode");
 const generateAdCopy = require("./utils/generateAdCopy");
 const generateShareCard = require("./utils/generateShareCard");
-const { generateModel: generateModelPipeline } = require("./src/pipeline/generateModel");
+const {
+  generateModel: generateModelPipeline,
+} = require("./src/pipeline/generateModel");
 
 const validateStl = require("./utils/validateStl");
 const syncMailingList = require("./scripts/sync-mailing-list");
@@ -460,8 +462,7 @@ app.post(
 
       let generatedUrl;
       try {
-
-        const url = await generateModelPipeline({
+        generatedUrl = await generateModelPipeline({
           prompt: req.body.prompt,
           image: req.file ? req.file.path : undefined,
         });

--- a/backend/tests/sparc3dClient.test.js
+++ b/backend/tests/sparc3dClient.test.js
@@ -58,6 +58,7 @@ describe("generateGlb", () => {
   test("ignores proxy environment variables", async () => {
     process.env.http_proxy = "http://proxy:9999";
     process.env.https_proxy = "http://proxy:9999";
+    const token = process.env.SPARC3D_TOKEN;
     const data = Buffer.from("abc");
     (0, nock_1.default)("https://api.example.com")
       .post("/generate", { prompt: "p2" })

--- a/tests/coverageWorkflowLint.test.js
+++ b/tests/coverageWorkflowLint.test.js
@@ -1,0 +1,7 @@
+const { execSync } = require("child_process");
+
+test("coverage workflow test passes eslint", () => {
+  expect(() => {
+    execSync("npx eslint tests/coverageWorkflow.test.js", { stdio: "pipe" });
+  }).not.toThrow();
+});


### PR DESCRIPTION
## Summary
- fix missing token in sparc3dClient test
- assign pipeline result to `generatedUrl` in server
- add test to ensure coverage workflow test passes ESLint

## Testing
- `npm test`
- `npm run format --prefix backend`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6873ae8f1820832db1e65d7d6cd0bd4a