### PR TITLE
Fix CDN fallback in validate-env

### DIFF
--- a/scripts/validate-env.sh
+++ b/scripts/validate-env.sh
@@ -63,9 +63,19 @@ fi
 
 
 if [[ -z "${SKIP_NET_CHECKS:-}" ]]; then
-  if ! node scripts/network-check.js >/dev/null 2>&1; then
-    echo "Network check failed. Ensure access to the npm registry and Playwright CDN." >&2
-    exit 1
+  network_output=$(node scripts/network-check.js 2>&1) || net_status=$?
+  if [[ -n "$net_status" ]]; then
+    echo "$network_output" >&2
+    if echo "$network_output" | grep -q "Set SKIP_PW_DEPS=1"; then
+      echo "Network check failed for Playwright CDN, setting SKIP_PW_DEPS=1." >&2
+      export SKIP_PW_DEPS=1
+    elif echo "$network_output" | grep -q "Playwright CDN"; then
+      echo "Network check failed for Playwright CDN, setting SKIP_PW_DEPS=1." >&2
+      export SKIP_PW_DEPS=1
+    else
+      echo "Network check failed. Ensure access to the npm registry and Playwright CDN." >&2
+      exit 1
+    fi
   fi
 fi
 

--- a/tests/validateEnv.test.js
+++ b/tests/validateEnv.test.js
@@ -1,6 +1,8 @@
 /** @file Tests for validate-env script */
 const { spawnSync } = require("child_process");
 const path = require("path");
+const fs = require("fs");
+const os = require("os");
 
 /**
  * Run the validate-env script with the provided environment variables.
@@ -12,7 +14,13 @@ function run(env) {
     env: { SKIP_NET_CHECKS: "1", ...env },
     encoding: "utf8",
   });
-  return (result.stdout || "") + (result.stderr || "");
+  const output = (result.stdout || "") + (result.stderr || "");
+  if (result.status) {
+    const err = new Error(output);
+    err.code = result.status;
+    throw err;
+  }
+  return output;
 }
 
 describe("validate-env script", () => {
@@ -109,7 +117,8 @@ describe("validate-env script", () => {
       CLOUDFRONT_MODEL_DOMAIN: "cdn.test",
       SKIP_NET_CHECKS: "1",
     };
-    expect(() => run(env)).toThrow(/Database connection check failed/);
+    const output = run(env);
+    expect(output).toMatch(/Database connection check failed/);
   });
 
   test("falls back to SKIP_PW_DEPS when apt check fails", () => {
@@ -126,6 +135,30 @@ describe("validate-env script", () => {
     };
     const output = run(env);
     expect(output).toContain("APT repository check failed");
+    expect(output).toContain("✅ environment OK");
+  });
+
+  test("falls back to SKIP_PW_DEPS when CDN unreachable", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "curl-"));
+    const fakeCurl = path.join(tmp, "curl");
+    fs.writeFileSync(
+      fakeCurl,
+      '#!/usr/bin/env bash\nif echo "$@" | grep -q cdn.playwright.dev; then echo "curl: (6) Could not resolve host" >&2; exit 6; fi\nexec /usr/bin/curl "$@"',
+    );
+    fs.chmodSync(fakeCurl, 0o755);
+    const env = {
+      ...process.env,
+      HF_TOKEN: "test",
+      AWS_ACCESS_KEY_ID: "id",
+      AWS_SECRET_ACCESS_KEY: "secret",
+      DB_URL: "postgres://user:pass@localhost/db",
+      STRIPE_SECRET_KEY: "sk_test",
+      CLOUDFRONT_MODEL_DOMAIN: "cdn.test",
+      PATH: `${tmp}:${process.env.PATH}`,
+      SKIP_NET_CHECKS: "",
+    };
+    const output = run(env);
+    expect(output).toContain("Network check failed for Playwright CDN");
     expect(output).toContain("✅ environment OK");
   });
 });


### PR DESCRIPTION
## Summary
- auto set `SKIP_PW_DEPS` when the Playwright CDN is unreachable
- add regression test for the CDN fallback logic

## Testing
- `npm test --prefix backend`
- `node scripts/run-jest.js tests/validateEnv.test.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6873ae7c5ea4832d81ab71226c31b2ee