### PR TITLE
Add regression test for npm test

### DIFF
--- a/backend/tests/sparc3dClient.test.js
+++ b/backend/tests/sparc3dClient.test.js
@@ -9,6 +9,8 @@ const nock_1 = __importDefault(require("nock"));
 const sparc3dClient_1 = require("../src/lib/sparc3dClient");
 describe("generateGlb", () => {
   beforeEach(() => {
+    process.env.SPARC3D_ENDPOINT = "https://api.example.com/generate";
+    process.env.SPARC3D_TOKEN = "token";
     delete process.env.http_proxy;
     delete process.env.https_proxy;
     delete process.env.HTTP_PROXY;
@@ -58,6 +60,7 @@ describe("generateGlb", () => {
   test("ignores proxy environment variables", async () => {
     process.env.http_proxy = "http://proxy:9999";
     process.env.https_proxy = "http://proxy:9999";
+    const token = process.env.SPARC3D_TOKEN;
     const data = Buffer.from("abc");
     (0, nock_1.default)("https://api.example.com")
       .post("/generate", { prompt: "p2" })

--- a/tests/backendNpmTestIntegration.test.js
+++ b/tests/backendNpmTestIntegration.test.js
@@ -1,0 +1,20 @@
+const { execFileSync } = require("child_process");
+
+test("npm test runs a backend unit test without errors", () => {
+  const env = {
+    ...process.env,
+    HF_TOKEN: "x",
+    AWS_ACCESS_KEY_ID: "id",
+    AWS_SECRET_ACCESS_KEY: "secret",
+    DB_URL: "postgres://user:pass@localhost/db",
+    STRIPE_SECRET_KEY: "sk_test",
+    SKIP_NET_CHECKS: "1",
+    SKIP_PW_DEPS: "1",
+    SKIP_DB_CHECK: "1",
+  };
+  execFileSync(
+    "node",
+    ["scripts/run-jest.js", "backend/tests/generateModel.test.ts"],
+    { stdio: "inherit", env },
+  );
+});


### PR DESCRIPTION
## Summary
- add integration test ensuring `npm test` works with env vars
- inject required env vars in `sparc3dClient` tests

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_6873ae6b96b8832dbe50c1031d398aa0