### PR TITLE
Fix db check fallback and add test

### DIFF
--- a/scripts/check-db.js
+++ b/scripts/check-db.js
@@ -5,11 +5,15 @@ try {
   pg = require("pg");
 } catch {
   try {
-    pg = require(require.resolve("pg", {
-      paths: [path.join(__dirname, "..", "backend", "node_modules")],
-    }));
+    pg = require(
+      require.resolve("pg", {
+        paths: [path.join(__dirname, "..", "backend", "node_modules")],
+      }),
+    );
   } catch {
-    console.error("Unable to load 'pg' module. Run 'npm run setup' to install dependencies.");
+    console.error(
+      "Unable to load 'pg' module. Run 'npm run setup' to install dependencies.",
+    );
     process.exit(1);
   }
 }
@@ -24,6 +28,12 @@ const dbUrl = process.env.DB_URL;
 if (!dbUrl) {
   console.error("DB_URL is not set");
   process.exit(1);
+}
+
+const placeholderDb = "postgres://user:password@localhost:5432/your_database";
+if (dbUrl === placeholderDb) {
+  console.log("Skipping DB check for placeholder DB_URL");
+  process.exit(0);
 }
 
 (async () => {

--- a/tests/dbCheckPlaceholder.test.js
+++ b/tests/dbCheckPlaceholder.test.js
@@ -1,0 +1,18 @@
+const { execFileSync } = require("child_process");
+const path = require("path");
+const repoRoot = path.resolve(__dirname, "..");
+const nodePath = path.join(repoRoot, "backend", "node_modules");
+
+describe("db-check placeholder URL", () => {
+  test("skips when DB_URL is placeholder", () => {
+    const out = execFileSync("node", [path.join("scripts", "check-db.js")], {
+      env: {
+        ...process.env,
+        DB_URL: "postgres://user:password@localhost:5432/your_database",
+        NODE_PATH: nodePath,
+      },
+      encoding: "utf8",
+    });
+    expect(out).toContain("Skipping DB check for placeholder DB_URL");
+  });
+});


### PR DESCRIPTION
## Summary
- skip `check-db` when the placeholder DB URL is set
- add test for placeholder DB URL handling

## Testing
- `npm test`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6873ae0ca610832d804069d72daacf69