### PR TITLE
Fix generate URL assignment and add Playwright install test

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -66,7 +66,9 @@ const { verifyTag } = require("./social");
 const QRCode = require("qrcode");
 const generateAdCopy = require("./utils/generateAdCopy");
 const generateShareCard = require("./utils/generateShareCard");
-const { generateModel: generateModelPipeline } = require("./src/pipeline/generateModel");
+const {
+  generateModel: generateModelPipeline,
+} = require("./src/pipeline/generateModel");
 
 const validateStl = require("./utils/validateStl");
 const syncMailingList = require("./scripts/sync-mailing-list");
@@ -460,8 +462,7 @@ app.post(
 
       let generatedUrl;
       try {
-
-        const url = await generateModelPipeline({
+        generatedUrl = await generateModelPipeline({
           prompt: req.body.prompt,
           image: req.file ? req.file.path : undefined,
         });

--- a/backend/tests/sparc3dClient.test.js
+++ b/backend/tests/sparc3dClient.test.js
@@ -58,6 +58,7 @@ describe("generateGlb", () => {
   test("ignores proxy environment variables", async () => {
     process.env.http_proxy = "http://proxy:9999";
     process.env.https_proxy = "http://proxy:9999";
+    const token = process.env.SPARC3D_TOKEN;
     const data = Buffer.from("abc");
     (0, nock_1.default)("https://api.example.com")
       .post("/generate", { prompt: "p2" })

--- a/tests/installPlaywright.test.js
+++ b/tests/installPlaywright.test.js
@@ -3,28 +3,33 @@ const path = require("path");
 const os = require("os");
 const { execFileSync } = require("child_process");
 /**
- * Run the install-playwright script in the provided directory using a stub npx binary that records whether it was called.
+ * Run the install-playwright script using a stub npx that records the arguments.
  * @param {string} dir temporary working directory
- * @returns {boolean} true if the stub npx executed
+ * @param {string[]} args script arguments
+ * @param {object} envOverride environment variables to override
+ * @returns {string} arguments passed to the stub npx
  */
-function run(dir) {
+function run(dir, args = [], envOverride = {}) {
   const stubDir = fs.mkdtempSync(path.join(os.tmpdir(), "npx-"));
   const log = path.join(dir, "npx.log");
   const stub = path.join(stubDir, "npx");
-  fs.writeFileSync(stub, '#!/bin/sh\necho called >> "$NPX_LOG"\n');
+  fs.writeFileSync(stub, '#!/bin/sh\necho "$@" >> "$NPX_LOG"\n');
   fs.chmodSync(stub, 0o755);
   const env = {
     ...process.env,
     PATH: `${stubDir}:${process.env.PATH}`,
     NPX_LOG: log,
-    SKIP_PW_DEPS: "1",
+    ...envOverride,
   };
   execFileSync(
     "bash",
-    [path.resolve(__dirname, "..", "scripts", "install-playwright.sh")],
+    [
+      path.resolve(__dirname, "..", "scripts", "install-playwright.sh"),
+      ...args,
+    ],
     { cwd: dir, env },
   );
-  return fs.existsSync(log);
+  return fs.readFileSync(log, "utf8").trim();
 }
 
 describe("install-playwright script", () => {
@@ -40,6 +45,18 @@ describe("install-playwright script", () => {
     fs.mkdirSync(binDir, { recursive: true });
     fs.writeFileSync(path.join(binDir, "playwright"), "");
     fs.chmodSync(path.join(binDir, "playwright"), 0o755);
-    expect(run(dir)).toBe(true);
+    expect(run(dir, ["chromium"], { SKIP_PW_DEPS: "1" })).toBe(
+      "install chromium",
+    );
+  });
+
+  test("passes --with-deps when not skipped", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pwtest-"));
+    const binDir = path.join(dir, "node_modules", ".bin");
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.writeFileSync(path.join(binDir, "playwright"), "");
+    fs.chmodSync(path.join(binDir, "playwright"), 0o755);
+    const args = run(dir, ["chromium"], {});
+    expect(args).toBe("install chromium --with-deps");
   });
 });


### PR DESCRIPTION
## Summary
- ensure generatedUrl captures pipeline result
- declare token in sparc3dClient test
- verify install-playwright script passes `--with-deps`

## Testing
- `npm run format`
- `npm run format` in `backend/`
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6873adf848f0832da122d0a3e5c88ec3