### PR TITLE
Fix coverage failure

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -66,7 +66,9 @@ const { verifyTag } = require("./social");
 const QRCode = require("qrcode");
 const generateAdCopy = require("./utils/generateAdCopy");
 const generateShareCard = require("./utils/generateShareCard");
-const { generateModel: generateModelPipeline } = require("./src/pipeline/generateModel");
+const {
+  generateModel: generateModelPipeline,
+} = require("./src/pipeline/generateModel");
 
 const validateStl = require("./utils/validateStl");
 const syncMailingList = require("./scripts/sync-mailing-list");
@@ -460,8 +462,7 @@ app.post(
 
       let generatedUrl;
       try {
-
-        const url = await generateModelPipeline({
+        generatedUrl = await generateModelPipeline({
           prompt: req.body.prompt,
           image: req.file ? req.file.path : undefined,
         });

--- a/backend/tests/sparc3dClient.test.js
+++ b/backend/tests/sparc3dClient.test.js
@@ -58,6 +58,7 @@ describe("generateGlb", () => {
   test("ignores proxy environment variables", async () => {
     process.env.http_proxy = "http://proxy:9999";
     process.env.https_proxy = "http://proxy:9999";
+    const token = process.env.SPARC3D_TOKEN;
     const data = Buffer.from("abc");
     (0, nock_1.default)("https://api.example.com")
       .post("/generate", { prompt: "p2" })


### PR DESCRIPTION
## Summary
- store generated model URL so tests receive value
- define token in proxy environment test

## Testing
- `npm --prefix backend test`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6873ad4bed24832db24f1487986a9616