### PR TITLE
Add test for duplicate lines in package.json

### DIFF
--- a/tests/packageJsonDuplicateLines.test.js
+++ b/tests/packageJsonDuplicateLines.test.js
@@ -1,0 +1,20 @@
+const fs = require("fs");
+const path = require("path");
+
+const repoRoot = path.resolve(__dirname, "..");
+
+const files = [
+  path.join(repoRoot, "package.json"),
+  path.join(repoRoot, "backend", "package.json"),
+];
+
+describe("package.json files", () => {
+  for (const file of files) {
+    test(`${path.relative(repoRoot, file)} has no duplicate consecutive lines`, () => {
+      const lines = fs.readFileSync(file, "utf8").split(/\r?\n/);
+      for (let i = 1; i < lines.length; i++) {
+        expect(lines[i]).not.toBe(lines[i - 1]);
+      }
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add regression test ensuring package.json files don't contain duplicated consecutive lines

## Testing
- `npm run format --prefix backend`
- `backend/node_modules/.bin/jest tests/packageJsonDuplicateLines.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6873b41c6ea8832db63636b899bd004a