### PR TITLE
Fix generateModel URL assignment

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -466,7 +466,6 @@ app.post(
           prompt: req.body.prompt,
           image: req.file ? req.file.path : undefined,
         });
-        generatedUrl = url;
       } catch (err) {
         console.error("🚨 generateModel() failed:", err);
         return res.status(500).json({ error: err.message });


### PR DESCRIPTION
## Summary
- remove stray assignment in backend `generateModel` API route

## Testing
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6873f0754644832da9c888284490f845