### PR TITLE
Fix viewer readiness timeouts

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -466,7 +466,6 @@ app.post(
           prompt: req.body.prompt,
           image: req.file ? req.file.path : undefined,
         });
-        generatedUrl = url;
       } catch (err) {
         console.error("🚨 generateModel() failed:", err);
         return res.status(500).json({ error: err.message });

--- a/e2e/smoke.test.js
+++ b/e2e/smoke.test.js
@@ -68,7 +68,7 @@ test('model generator page', async ({ page }) => {
   // Allow extra time for the viewer to load when the CDN script fails and the
   // page falls back to the local copy.
   await page.waitForSelector('body[data-viewer-ready="true"]', {
-    timeout: 60000,
+    timeout: 120000,
   });
   await expect(page.locator('#viewer')).toBeVisible();
 });
@@ -100,7 +100,7 @@ test('generate flow', async ({ page }) => {
   // Wait for the viewer to signal readiness before checking the canvas.
   // This prevents flaky timeouts when external scripts load slowly.
   await page.waitForSelector('body[data-viewer-ready="true"]', {
-    timeout: 60000,
+    timeout: 120000,
   });
   // Wait longer for the model viewer to load on slow networks
   await page.waitForSelector('canvas', { state: 'visible', timeout: 60000 });

--- a/tests/smokeViewerReady.test.js
+++ b/tests/smokeViewerReady.test.js
@@ -4,4 +4,5 @@ const path = require("path");
 test("smoke test waits for viewer readiness", () => {
   const content = fs.readFileSync(path.join("e2e", "smoke.test.js"), "utf8");
   expect(content).toMatch(/body\[data-viewer-ready="true"\]/);
+  expect(content).toMatch(/timeout:\s*120000/);
 });


### PR DESCRIPTION
## Summary
- wait longer for model viewer readiness in smoke test
- check for new timeout in smokeViewerReady test
- remove stray assignment in backend server

## Testing
- `npm run format` (backend)
- `npm test` (backend)


------
https://chatgpt.com/codex/tasks/task_e_6873f05a5b1c832db32a0e8a558cbc30