### PR TITLE
Fix generator url assignment

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -466,7 +466,6 @@ app.post(
           prompt: req.body.prompt,
           image: req.file ? req.file.path : undefined,
         });
-        generatedUrl = url;
       } catch (err) {
         console.error("🚨 generateModel() failed:", err);
         return res.status(500).json({ error: err.message });


### PR DESCRIPTION
## Summary
- return the URL from `generateModelPipeline` instead of overwriting it

## Testing
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_6873f0442588832d9be26fa12cf32eaa