### PR TITLE
Fix smoke connectivity checks

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -466,7 +466,6 @@ app.post(
           prompt: req.body.prompt,
           image: req.file ? req.file.path : undefined,
         });
-        generatedUrl = url;
       } catch (err) {
         console.error("🚨 generateModel() failed:", err);
         return res.status(500).json({ error: err.message });

--- a/e2e/smoke.test.js
+++ b/e2e/smoke.test.js
@@ -17,7 +17,9 @@ if (process.env.JEST_WORKER_ID) {
 const { execSync } = require('child_process');
 function canFetchSync(url) {
   try {
-    execSync(`curl -Is --max-time 5 --noproxy '*' ${url}`, { stdio: 'ignore' });
+    execSync(`curl -fIs --max-time 5 --noproxy '*' ${url}`, {
+      stdio: 'ignore',
+    });
     return true;
   } catch {
     return false;

--- a/tests/smokeCanFetchFailFast.test.js
+++ b/tests/smokeCanFetchFailFast.test.js
@@ -1,0 +1,7 @@
+const fs = require("fs");
+const path = require("path");
+
+test("smoke test connectivity uses -f", () => {
+  const content = fs.readFileSync(path.join("e2e", "smoke.test.js"), "utf8");
+  expect(content).toMatch(/curl -fIs/);
+});


### PR DESCRIPTION
## Summary
- ensure smoke test connectivity check fails on HTTP errors
- drop stray assignment in server
- check for `curl -fIs` in smoke test via Jest

## Testing
- `npm test` in `backend/`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_6873f0368394832d8423f994dbb821d1