### PR TITLE
Fix model pipeline response

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -466,7 +466,6 @@ app.post(
           prompt: req.body.prompt,
           image: req.file ? req.file.path : undefined,
         });
-        generatedUrl = url;
       } catch (err) {
         console.error("🚨 generateModel() failed:", err);
         return res.status(500).json({ error: err.message });

--- a/tests/pipeline.spec.ts
+++ b/tests/pipeline.spec.ts
@@ -1,30 +1,31 @@
-import 'dotenv/config';
-import request from 'supertest';
-import axios from 'axios';
-const app = require('../backend/server');
+require("dotenv/config");
+const request = require("../backend/node_modules/supertest");
+const axios = require("axios");
+const app = require("../backend/server");
 
-const FALLBACK_GLB = 'https://modelviewer.dev/shared-assets/models/Astronaut.glb';
+const FALLBACK_GLB =
+  "https://modelviewer.dev/shared-assets/models/Astronaut.glb";
 
-describe('full pipeline', () => {
-  test('health endpoint', async () => {
-    console.log('→ GET /api/health');
-    const res = await request(app).get('/api/health');
-    console.log('← status', res.status);
+describe("full pipeline", () => {
+  test("health endpoint", async () => {
+    console.log("→ GET /api/health");
+    const res = await request(app).get("/api/health");
+    console.log("← status", res.status);
     expect(res.status).toBe(200);
   });
 
-  test('generate model from prompt', async () => {
-    console.log('→ POST /api/generate');
+  test("generate model from prompt", async () => {
+    console.log("→ POST /api/generate");
     const res = await request(app)
-      .post('/api/generate')
-      .field('prompt', 'diagnostic monkey');
-    console.log('← status', res.status, 'body', res.body);
+      .post("/api/generate")
+      .field("prompt", "diagnostic monkey");
+    console.log("← status", res.status, "body", res.body);
     expect(res.status).toBe(200);
     const url = res.body.glb_url;
     expect(url).toBeDefined();
     expect(url).not.toBe(FALLBACK_GLB);
     const head = await axios.head(url, { validateStatus: () => true });
-    console.log('HEAD', head.status);
+    console.log("HEAD", head.status);
     expect(head.status).toBe(200);
   });
 });


### PR DESCRIPTION
## Summary
- remove unused url assignment in backend server
- make pipeline e2e test use CommonJS so lint-staged can run it

## Testing
- `npm test`
- `SKIP_PW_DEPS=1 node scripts/run-coverage.js`


------
https://chatgpt.com/codex/tasks/task_e_6873f02587ac832d8f4e401bdf8eb4e2