### PR TITLE
Fix viewer fallback flake

### DIFF
--- a/backend/tests/frontend/modelViewerFallback.e2e.test.ts
+++ b/backend/tests/frontend/modelViewerFallback.e2e.test.ts
@@ -13,7 +13,7 @@ test("model-viewer falls back to local copy when CDN fails", async () => {
   );
   await page.goto(`http://127.0.0.1:${port}/index.html`);
   await page.waitForSelector('body[data-viewer-ready="true"]', {
-    timeout: 10000,
+    timeout: 30000,
   });
   const visible = await page.isVisible("#viewer");
   await browser.close();

--- a/backend/tests/frontend/modelViewerHeadFail.e2e.test.ts
+++ b/backend/tests/frontend/modelViewerHeadFail.e2e.test.ts
@@ -19,7 +19,7 @@ test("model-viewer loads from local copy when CDN HEAD fails", async () => {
   );
   await page.goto(`http://127.0.0.1:${port}/index.html`);
   await page.waitForSelector('body[data-viewer-ready="true"]', {
-    timeout: 10000,
+    timeout: 30000,
   });
   const visible = await page.isVisible("#viewer");
   await browser.close();


### PR DESCRIPTION
## Summary
- increase timeout when waiting for model viewer to load from local fallback

## Testing
- `npm run format`
- `npm test --prefix backend`
- `npm run coverage`


------
https://chatgpt.com/codex/tasks/task_e_6873f01637ec832db6cfdac33c567cb3