### PR TITLE
Fix generate route url handling

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -466,7 +466,6 @@ app.post(
           prompt: req.body.prompt,
           image: req.file ? req.file.path : undefined,
         });
-        generatedUrl = url;
       } catch (err) {
         console.error("🚨 generateModel() failed:", err);
         return res.status(500).json({ error: err.message });

--- a/backend/tests/api.test.js
+++ b/backend/tests/api.test.js
@@ -119,6 +119,13 @@ test("POST /api/generate returns glb url", async () => {
   expect(res.body.glb_url).toBe("/models/test.glb");
 });
 
+test("POST /api/generate returns string url", async () => {
+  generateModel.mockResolvedValue("/models/test.glb");
+  const res = await request(app).post("/api/generate").send({ prompt: "test" });
+  expect(res.status).toBe(200);
+  expect(typeof res.body.glb_url).toBe("string");
+});
+
 test("GET /api/status returns job", async () => {
   db.query.mockResolvedValueOnce({
     rows: [


### PR DESCRIPTION
## Summary
- fix generateModel result assignment in server
- ensure returned URL is a string in API tests

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_6873eff0600c832d8027ab5510d5119f