### PR TITLE
Fix validate-env fallback and tests

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -466,7 +466,6 @@ app.post(
           prompt: req.body.prompt,
           image: req.file ? req.file.path : undefined,
         });
-        generatedUrl = url;
       } catch (err) {
         console.error("🚨 generateModel() failed:", err);
         return res.status(500).json({ error: err.message });

--- a/backend/tests/validateEnv.test.ts
+++ b/backend/tests/validateEnv.test.ts
@@ -73,6 +73,7 @@ describe("validate-env script", () => {
       SKIP_NET_CHECKS: "1",
     });
     expect(output).toMatch(/Database connection check failed/);
+    expect(output).toMatch(/Falling back to SKIP_DB_CHECK=1/);
     expect(output).toMatch(/environment OK/);
   });
 });

--- a/tests/validateEnv.test.js
+++ b/tests/validateEnv.test.js
@@ -145,7 +145,7 @@ describe("validate-env script", () => {
     const fakeCurl = path.join(tmp, "curl");
     fs.writeFileSync(
       fakeCurl,
-      '#!/usr/bin/env bash\nif echo "$@" | grep -q cdn.playwright.dev; then echo "curl: (6) Could not resolve host" >&2; exit 6; fi\nexec /usr/bin/curl "$@"',
+      '#!/usr/bin/env bash\nif echo "$@" | grep -q cdn.playwright.dev; then echo "curl: (6) Could not resolve host" >&2; exit 6; fi\nexit 0',
     );
     fs.chmodSync(fakeCurl, 0o755);
     const env = {


### PR DESCRIPTION
## Summary
- remove bad assignment in `server.js`
- check DB fallback message in env tests
- stub network check in CDN test

## Testing
- `npm test --prefix backend`
- `node scripts/run-jest.js tests/validateEnv.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6873ef9ec9c0832d98ddc908e9aecbed