### PR TITLE
Fix undefined URL in generation pipeline

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -462,7 +462,7 @@ app.post(
 
       let generatedUrl;
       try {
-        generatedUrl = await generateModelPipeline({
+        const url = await generateModelPipeline({
           prompt: req.body.prompt,
           image: req.file ? req.file.path : undefined,
         });

--- a/backend/tests/regression/generatePipelineReturn.test.js
+++ b/backend/tests/regression/generatePipelineReturn.test.js
@@ -1,0 +1,18 @@
+const request = require("supertest");
+const app = require("../../server");
+const { generateModel } = require("../../src/pipeline/generateModel");
+
+describe("/api/generate regression", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("returns the URL from generateModel pipeline", async () => {
+    generateModel.mockResolvedValueOnce("/models/regression.glb");
+    const res = await request(app)
+      .post("/api/generate")
+      .send({ prompt: "regression" });
+    expect(res.status).toBe(200);
+    expect(res.body.glb_url).toBe("/models/regression.glb");
+  });
+});


### PR DESCRIPTION
## Summary
- fix reference error in `/api/generate` route
- add regression test for generateModel pipeline

## Testing
- `npm run format` (`backend/`)
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6873ef914108832d862d8cfe6f25d0e6