### PR TITLE
Fix Playwright setup issues

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -466,7 +466,6 @@ app.post(
           prompt: req.body.prompt,
           image: req.file ? req.file.path : undefined,
         });
-        generatedUrl = url;
       } catch (err) {
         console.error("🚨 generateModel() failed:", err);
         return res.status(500).json({ error: err.message });

--- a/backend/tests/serverExport.test.js
+++ b/backend/tests/serverExport.test.js
@@ -1,0 +1,7 @@
+process.env.CLOUDFRONT_MODEL_DOMAIN = "cdn.test";
+const app = require("../server");
+
+test("server exports express app", () => {
+  expect(typeof app).toBe("function");
+  expect(typeof app.use).toBe("function");
+});


### PR DESCRIPTION
## Summary
- remove leftover variable assignment in the API route
- add a regression test confirming server module exports the express app

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6873ef7a7cf8832d98d7adcd3c48e2b3