### PR TITLE
test: check cross-spawn dependency installed

### DIFF
--- a/tests/crossSpawnInstalled.test.js
+++ b/tests/crossSpawnInstalled.test.js
@@ -1,0 +1,10 @@
+const fs = require("fs");
+const path = require("path");
+
+describe("root dependencies", () => {
+  test("cross-spawn is installed", () => {
+    const pkgPath = path.join(__dirname, "..", "node_modules", "cross-spawn");
+    expect(fs.existsSync(pkgPath)).toBe(true);
+    expect(() => require("cross-spawn")).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- add regression test for cross-spawn

## Testing
- `node scripts/run-jest.js tests/crossSpawnInstalled.test.js`
- `npm test --prefix backend`
- `npm run format --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_6873ef55d770832d9618309bc612a3ab