### PR TITLE
Fix /api/generate response and add Stripe key test

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -466,7 +466,6 @@ app.post(
           prompt: req.body.prompt,
           image: req.file ? req.file.path : undefined,
         });
-        generatedUrl = url;
       } catch (err) {
         console.error("🚨 generateModel() failed:", err);
         return res.status(500).json({ error: err.message });

--- a/backend/tests/additionalApi.test.js
+++ b/backend/tests/additionalApi.test.js
@@ -712,6 +712,12 @@ test("GET /api/payment-init bundles payment data", async () => {
   expect(res.body.publishableKey).toBeDefined();
 });
 
+test("GET /api/config/stripe returns key", async () => {
+  const res = await request(app).get("/api/config/stripe");
+  expect(res.status).toBe(200);
+  expect(res.body.publishableKey).toBeDefined();
+});
+
 test("GET /api/campaign returns campaign info", async () => {
   const res = await request(app).get("/api/campaign");
   expect(res.status).toBe(200);


### PR DESCRIPTION
## Summary
- fix return value in `/api/generate`
- ensure Stripe publishable key endpoint works

## Testing
- `npm test`
- `npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`
- `npm run coverage`


------
https://chatgpt.com/codex/tasks/task_e_6873ef14916c832db5234861eb5e3c45