### PR TITLE
chore(coverage): enforce minimum coverage thresholds

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,6 +12,8 @@ jobs:
           node-version: "20"
       - run: SKIP_PW_DEPS=1 npm run setup
       - run: npm run coverage
+      - name: Check coverage thresholds
+        run: node scripts/check-coverage.js
       - name: Validate LCOV report
         run: |
           if grep -qE '^TN:|^SF:' backend/coverage/lcov.info; then

--- a/.nycrc
+++ b/.nycrc
@@ -1,0 +1,7 @@
+{
+  "check-coverage": true,
+  "branches": 80,
+  "functions": 80,
+  "lines": 80,
+  "statements": 80
+}

--- a/backend/server.js
+++ b/backend/server.js
@@ -462,7 +462,7 @@ app.post(
 
       let generatedUrl;
       try {
-        const url = await generateModelPipeline({
+        generatedUrl = await generateModelPipeline({
           prompt: req.body.prompt,
           image: req.file ? req.file.path : undefined,
         });

--- a/scripts/check-coverage.js
+++ b/scripts/check-coverage.js
@@ -1,0 +1,21 @@
+const fs = require("fs");
+
+const config = JSON.parse(fs.readFileSync(".nycrc", "utf8"));
+const summary = JSON.parse(
+  fs.readFileSync("backend/coverage/coverage-summary.json", "utf8"),
+);
+
+const metrics = ["branches", "functions", "lines", "statements"];
+let failed = false;
+for (const m of metrics) {
+  const actual = summary.total[m].pct;
+  const threshold = config[m];
+  if (typeof threshold === "number" && actual < threshold) {
+    console.error(
+      `Coverage for ${m} ${actual}% does not meet threshold ${threshold}%`,
+    );
+    failed = true;
+  }
+}
+if (failed) process.exit(1);
+console.log("Coverage thresholds met.");


### PR DESCRIPTION
## Summary
- add `.nycrc` config with coverage thresholds
- check coverage in CI workflow
- assign generated URL properly in `server.js`

## Testing
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6873fba85a18832dbc6df9be65bdc0c2