### PR TITLE
feat(coverage): wrap lcovParse in more detailed try/catch

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -462,7 +462,7 @@ app.post(
 
       let generatedUrl;
       try {
-        const url = await generateModelPipeline({
+        generatedUrl = await generateModelPipeline({
           prompt: req.body.prompt,
           image: req.file ? req.file.path : undefined,
         });

--- a/patches/coveralls+3.1.1.patch
+++ b/patches/coveralls+3.1.1.patch
@@ -1,0 +1,34 @@
+*** Begin Patch
+*** Update File: node_modules/coveralls/lib/convertLcovToCoveralls.js
+@@
+-  lcovParse(input, (err, parsed) => {
+-    if (err) {
+-      logger.error('error from lcovParse: ', err);
+-      logger.error('input: ', input);
+-      return cb(err);
+-    }
++  try {
++    lcovParse(input, (err, parsed) => {
++      if (err) {
++        const snippet = String(input).slice(0, 200);
++        logger.error(
++          `${new Date().toISOString()} lcovParse error for ${filepath}:`,
++          err,
++        );
++        logger.error('snippet: ', snippet);
++        return cb(err);
++      }
+@@
+-  });
++    });
++  } catch (e) {
++    const snippet = String(input).slice(0, 200);
++    logger.error(
++      `${new Date().toISOString()} lcovParse threw for ${filepath}:`,
++      e,
++    );
++    logger.error('snippet: ', snippet);
++    return cb(e);
++  }
+ };
+*** End Patch


### PR DESCRIPTION
## Summary
- log coverage parsing failures with more context
- fix unused variable when generating models
- patch coveralls to capture lcovParse errors

## Testing
- `npx prettier backend/server.js -w`
- `npm test`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_6873fb7437a8832d8216f57b35ccdff7