### PR TITLE
chore(ci): cache Playwright browsers between runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,11 @@ jobs:
           npm config delete https-proxy
         env:
           NPM_CONFIG_LEGACY_PEER_DEPS: true
+      - name: Cache Playwright browsers
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('backend/package-lock.json') }}
       - run: npm install --no-audit --no-fund
       - name: Cache Playwright browsers
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary
- add caching step for Playwright browsers before installing dependencies

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6873fb70b298832db03895463d0e673d