### PR TITLE
test(coverage): add unit tests for lcovParse error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ uploads/
 reports/
 backend/coverage/
 coverage/
+!backend/tests/coverage/
 # ignore compiled and binary files
 *.exe
 *.dll

--- a/backend/server.js
+++ b/backend/server.js
@@ -462,7 +462,7 @@ app.post(
 
       let generatedUrl;
       try {
-        const url = await generateModelPipeline({
+        generatedUrl = await generateModelPipeline({
           prompt: req.body.prompt,
           image: req.file ? req.file.path : undefined,
         });

--- a/backend/tests/coverage/lcovParse.test.ts
+++ b/backend/tests/coverage/lcovParse.test.ts
@@ -1,0 +1,20 @@
+import parse = require('lcov-parse');
+
+describe('lcovParse error handling', () => {
+  test('rejects empty string', done => {
+    parse('', (err, data) => {
+      expect(err).toBeTruthy();
+      expect(data).toBeUndefined();
+      done();
+    });
+  });
+
+  test('rejects malformed LCOV data', done => {
+    const invalid = 'SF:file.js\nDA:1,1\n'; // missing end_of_record
+    parse(invalid, (err, data) => {
+      expect(err).toBeTruthy();
+      expect(data).toBeUndefined();
+      done();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- fix unused variable lint issue in backend/server
- allow backend/tests/coverage path
- test invalid lcov input handling

## Testing
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `SKIP_PW_DEPS=1 npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_6873fb67557c832dac4b931ff33c7118