### PR TITLE
feat(utils): add strip-ansi utility and tests

### DIFF
--- a/backend/src/utils/stripAnsi.js
+++ b/backend/src/utils/stripAnsi.js
@@ -1,0 +1,6 @@
+function stripAnsi(input) {
+  const pattern =
+    /[\u001B\u009B][[\]()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g;
+  return input.replace(pattern, "");
+}
+module.exports = { stripAnsi };

--- a/backend/src/utils/stripAnsi.ts
+++ b/backend/src/utils/stripAnsi.ts
@@ -1,0 +1,1 @@
+export * from "./stripAnsi.js";

--- a/backend/tests/utils/stripAnsi.test.ts
+++ b/backend/tests/utils/stripAnsi.test.ts
@@ -1,0 +1,18 @@
+const { stripAnsi } = require("../../src/utils/stripAnsi.js");
+
+describe("stripAnsi", () => {
+  test("removes basic color codes", () => {
+    const input = "\u001b[31mred\u001b[0m";
+    expect(stripAnsi(input)).toBe("red");
+  });
+
+  test("handles nested sequences", () => {
+    const input = "\u001b[1m\u001b[32mgreen\u001b[0m";
+    expect(stripAnsi(input)).toBe("green");
+  });
+
+  test("removes cursor commands", () => {
+    const input = "line\u001b[2K";
+    expect(stripAnsi(input)).toBe("line");
+  });
+});


### PR DESCRIPTION
## Summary
- add `stripAnsi` utility under `backend/src/utils`
- cover typical escape sequences with Jest

## Testing
- `npm run format`
- `npm test`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6873fb633c94832da7e56521be00e6c9