### PR TITLE
chore(ci): strip ANSI escape sequences from coverage report before Coveralls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,14 @@ jobs:
       - name: Run coverage
         run: npm run coverage
 
+      - name: Sanitize coverage for Coveralls
+        run: |
+          sed -r 's/\x1B\[[0-9;]*[JKmsu]//g' backend/coverage/lcov.info \
+            > backend/coverage/lcov.sanitized.info
+
+      - name: Upload to Coveralls
+        run: cat backend/coverage/lcov.sanitized.info | npx coveralls
+
       - name: Check bundle size
         run: npm run bundle:size
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -462,7 +462,7 @@ app.post(
 
       let generatedUrl;
       try {
-        const url = await generateModelPipeline({
+        generatedUrl = await generateModelPipeline({
           prompt: req.body.prompt,
           image: req.file ? req.file.path : undefined,
         });


### PR DESCRIPTION
## Summary
- sanitize lcov before uploading to Coveralls
- assign the generated URL from `generateModelPipeline`

## Testing
- `npm run format` (in backend)
- `npm test` (in backend)
- `SKIP_PW_DEPS=1 npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_6873fb5d6d90832da74e4f9f1cb300e3