### PR TITLE
Fix generate API return value

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -462,7 +462,7 @@ app.post(
 
       let generatedUrl;
       try {
-        const url = await generateModelPipeline({
+        generatedUrl = await generateModelPipeline({
           prompt: req.body.prompt,
           image: req.file ? req.file.path : undefined,
         });

--- a/backend/tests/regression/generatePipelineReturn.test.ts
+++ b/backend/tests/regression/generatePipelineReturn.test.ts
@@ -1,6 +1,15 @@
+jest.mock("../../src/pipeline/generateModel", () => ({
+  generateModel: jest.fn(),
+}));
+jest.mock("../../db", () => ({
+  query: jest.fn(),
+  insertGenerationLog: jest.fn(),
+  insertModel: jest.fn(),
+}));
 const request = require("supertest");
-const app = require("../../server");
 const { generateModel } = require("../../src/pipeline/generateModel");
+process.env.STRIPE_WEBHOOK_SECRET = "test";
+const app = require("../../server");
 
 describe("/api/generate regression", () => {
   beforeEach(() => {


### PR DESCRIPTION
## Summary
- return the URL from `generateModelPipeline`
- rename regression test to `.ts` and mock dependencies

## Testing
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6873fe2ca09c832d9e8933a5b817af52