### PR TITLE
Add fallback verification for model viewer

### DIFF
--- a/backend/tests/frontend/modelViewerFallback.e2e.test.ts
+++ b/backend/tests/frontend/modelViewerFallback.e2e.test.ts
@@ -16,7 +16,9 @@ test("model-viewer falls back to local copy when CDN fails", async () => {
     timeout: 30000,
   });
   const visible = await page.isVisible("#viewer");
+  const source = await page.evaluate(() => window["modelViewerSource"]);
   await browser.close();
   await new Promise((resolve) => server.close(resolve));
   expect(visible).toBe(true);
+  expect(source).toBe("local");
 });

--- a/backend/tests/frontend/modelViewerHeadFail.e2e.test.ts
+++ b/backend/tests/frontend/modelViewerHeadFail.e2e.test.ts
@@ -22,7 +22,9 @@ test("model-viewer loads from local copy when CDN HEAD fails", async () => {
     timeout: 30000,
   });
   const visible = await page.isVisible("#viewer");
+  const source = await page.evaluate(() => window["modelViewerSource"]);
   await browser.close();
   await new Promise((resolve) => server.close(resolve));
   expect(visible).toBe(true);
+  expect(source).toBe("local");
 });

--- a/js/index.js
+++ b/js/index.js
@@ -161,10 +161,12 @@ function ensureModelViewerLoaded() {
     })
       .then(() => {
         clearTimeout(timer);
+        window.modelViewerSource = "cdn";
         loadScript(cdnUrl, finalize);
       })
       .catch(() => {
         clearTimeout(timer);
+        window.modelViewerSource = "local";
         loadScript(localUrl, finalize);
       });
   });


### PR DESCRIPTION
## Summary
- track whether `<model-viewer>` loads from the CDN or local copy
- assert the source in frontend fallback tests

## Testing
- `npm test`
- `npm run coverage`


------
https://chatgpt.com/codex/tasks/task_e_6873fe017634832d82b2521a981ed4ea