### PR TITLE
Add node version check for backend tests

### DIFF
--- a/backend/scripts/ensure-deps.js
+++ b/backend/scripts/ensure-deps.js
@@ -2,6 +2,22 @@ const fs = require("fs");
 const path = require("path");
 const { execSync } = require("child_process");
 
+// Fail fast when using the wrong Node version unless disabled for tests.
+if (!process.env.SKIP_NODE_CHECK) {
+  const nodeCheck = path.join(
+    __dirname,
+    "..",
+    "..",
+    "scripts",
+    "check-node-version.js",
+  );
+  try {
+    execSync(`node ${nodeCheck}`, { stdio: "inherit" });
+  } catch {
+    process.exit(1);
+  }
+}
+
 const jestPath = "node_modules/.bin/jest";
 const repoRoot = path.join(__dirname, "..", "..");
 const expressPath = path.join(repoRoot, "node_modules", "express");

--- a/tests/ensureDeps.test.js
+++ b/tests/ensureDeps.test.js
@@ -11,6 +11,7 @@ describe("ensure-deps", () => {
     fs.existsSync.mockReset();
     jest.spyOn(child_process, "execSync").mockReset();
     delete process.env.SKIP_NET_CHECKS;
+    process.env.SKIP_NODE_CHECK = "1";
   });
 
   test("checks network then installs", () => {

--- a/tests/ensureDepsMissingDeps.test.js
+++ b/tests/ensureDepsMissingDeps.test.js
@@ -2,14 +2,14 @@ const fs = require("fs");
 const child_process = require("child_process");
 
 jest.mock("fs");
-jest.mock("child_process", () => ({ execSync: jest.fn() }));
 
 describe("ensure-deps missing dependency handling", () => {
   beforeEach(() => {
     jest.resetModules();
     fs.existsSync.mockReset();
-    child_process.execSync.mockReset();
+    jest.spyOn(child_process, "execSync").mockImplementation(() => {});
     delete process.env.SKIP_NET_CHECKS;
+    process.env.SKIP_NODE_CHECK = "1";
   });
 
   function run() {

--- a/tests/ensureDepsNodeVersion.test.js
+++ b/tests/ensureDepsNodeVersion.test.js
@@ -1,0 +1,24 @@
+const fs = require("fs");
+const child_process = require("child_process");
+
+jest.mock("fs");
+
+describe("ensure-deps node version check", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    fs.existsSync.mockReset();
+    jest.spyOn(child_process, "execSync").mockReset();
+  });
+
+  test("runs check-node-version first", () => {
+    fs.existsSync.mockReturnValue(true);
+    const execMock = jest
+      .spyOn(child_process, "execSync")
+      .mockImplementation(() => {});
+    require("../backend/scripts/ensure-deps");
+    expect(execMock).toHaveBeenCalledWith(
+      expect.stringContaining("check-node-version.js"),
+      expect.any(Object),
+    );
+  });
+});

--- a/tests/ensureDepsSkipNetCheck.test.js
+++ b/tests/ensureDepsSkipNetCheck.test.js
@@ -6,6 +6,7 @@ describe("ensure-deps SKIP_NET_CHECKS", () => {
     jest.resetModules();
     jest.spyOn(child_process, "execSync").mockImplementation(() => {});
     jest.spyOn(fs, "existsSync").mockReturnValue(false);
+    process.env.SKIP_NODE_CHECK = "1";
   });
 
   test("skips network check when SKIP_NET_CHECKS is set", () => {


### PR DESCRIPTION
## Summary
- enforce node version in backend pretest by running `check-node-version.js`
- allow skipping this check with `SKIP_NODE_CHECK` for tests
- add unit test ensuring the node version check runs
- update existing ensure-deps tests to disable the node version check during testing

## Testing
- `npm run format --silent --workspace=backend`
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_6873fd0063dc832d853b791ea19b5039