### PR TITLE
Fix model viewer tests and add Node version guard

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -462,7 +462,7 @@ app.post(
 
       let generatedUrl;
       try {
-        const url = await generateModelPipeline({
+        generatedUrl = await generateModelPipeline({
           prompt: req.body.prompt,
           image: req.file ? req.file.path : undefined,
         });

--- a/backend/tests/frontend/modelViewerHeadFail.e2e.test.ts
+++ b/backend/tests/frontend/modelViewerHeadFail.e2e.test.ts
@@ -1,5 +1,5 @@
 /** @jest-environment node */
-const { chromium } = require("playwright");
+const { chromium } = require("playwright-core");
 const { startDevServer } = require("../../../scripts/dev-server");
 
 test("model-viewer loads from local copy when CDN HEAD fails", async () => {

--- a/tests/nodeVersion.test.js
+++ b/tests/nodeVersion.test.js
@@ -23,4 +23,12 @@ describe("node version", () => {
       .trim();
     expect(version.replace(/^v/, "")).toMatch(/^20/);
   });
+
+  test(".tool-versions pins Node 20", () => {
+    const tv = fs
+      .readFileSync(path.join(__dirname, "..", ".tool-versions"), "utf8")
+      .trim();
+    const match = tv.match(/node\s+(\d+)/);
+    expect(match && match[1]).toBe("20");
+  });
 });


### PR DESCRIPTION
## Summary
- update e2e test to use `playwright-core`
- verify `.tool-versions` in node version test
- fix unused variable in server

## Testing
- `npm test --prefix backend`
- `npm run coverage`
- `SKIP_PW_DEPS=1 npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_6873fcaa2b9c832da26837296bf889fe