### PR TITLE
chore: add .github/labels.yml for issue labeling

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,18 @@
+- name: bug
+  color: F00000
+  description: Something isn't working
+- name: feature
+  color: 0E8A16
+  description: New feature or request
+- name: docs
+  color: 0075ca
+  description: Improvements or additions to documentation
+- name: chore
+  color: FBCA04
+  description: Routine tasks and maintenance
+- name: enhancement
+  color: a2eeef
+  description: Enhancements or optimizations
+- name: question
+  color: d876e3
+  description: Further information requested

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,16 @@
+name: Sync Labels
+on:
+  push:
+    paths:
+      - '.github/labels.yml'
+      - '.github/workflows/labels.yml'
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: EndBug/label-sync@v2
+        with:
+          config-file: .github/labels.yml
+          delete-other-labels: false

--- a/backend/server.js
+++ b/backend/server.js
@@ -462,7 +462,7 @@ app.post(
 
       let generatedUrl;
       try {
-        const url = await generateModelPipeline({
+        generatedUrl = await generateModelPipeline({
           prompt: req.body.prompt,
           image: req.file ? req.file.path : undefined,
         });


### PR DESCRIPTION
## Summary
- define default issue labels
- add workflow to sync labels on push
- fix unused variable causing lint error in `server.js`

## Testing
- `npm test`
- `npm run format`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6873fc753c3c832db52a9fbbd9463843