### PR TITLE
Fix coverage script node check

### DIFF
--- a/scripts/run-coverage.js
+++ b/scripts/run-coverage.js
@@ -3,6 +3,10 @@ const { spawnSync } = require("child_process");
 const fs = require("fs");
 const path = require("path");
 
+// Ensure the active Node version matches the project's requirement so the
+// coverage run doesn't silently use a wrong version when mise wasn't activated.
+require("./check-node-version.js");
+
 const extraArgs = process.argv.slice(2);
 const jestArgs = [
   "--ci",

--- a/tests/coverageNodeVersion.test.js
+++ b/tests/coverageNodeVersion.test.js
@@ -1,0 +1,20 @@
+const { execFileSync } = require("child_process");
+const path = require("path");
+
+describe("run-coverage node version check", () => {
+  test("fails when node version does not match requirement", () => {
+    const major = parseInt(process.versions.node.split(".")[0], 10);
+    const env = { ...process.env, REQUIRED_NODE_MAJOR: String(major + 5) };
+    try {
+      execFileSync("node", [path.join("scripts", "run-coverage.js")], {
+        env,
+        encoding: "utf8",
+        stdio: "pipe",
+      });
+      throw new Error("script did not exit");
+    } catch (err) {
+      const output = (err.stdout || "") + (err.stderr || "");
+      expect(output).toMatch(new RegExp(`Node ${major + 5}`));
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- validate Node version in `run-coverage.js`
- add regression test for coverage script

## Testing
- `npm test`
- `npm run coverage`


------
https://chatgpt.com/codex/tasks/task_e_68740ecc8ff8832d9da5fd0499f835fe