### PR TITLE
Fix model generation URL

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -462,7 +462,7 @@ app.post(
 
       let generatedUrl;
       try {
-        const url = await generateModelPipeline({
+        generatedUrl = await generateModelPipeline({
           prompt: req.body.prompt,
           image: req.file ? req.file.path : undefined,
         });

--- a/backend/tests/frontend/modelViewerFallback.e2e.test.ts
+++ b/backend/tests/frontend/modelViewerFallback.e2e.test.ts
@@ -7,16 +7,19 @@ test("model-viewer falls back to local copy when CDN fails", async () => {
   const { port } = server.address();
   const browser = await chromium.launch();
   const page = await browser.newPage();
-  await page.route(
-    "https://cdn.jsdelivr.net/npm/@google/model-viewer@1.12.0/dist/model-viewer.min.js",
-    (route) => route.abort(),
-  );
-  await page.goto(`http://127.0.0.1:${port}/index.html`);
-  await page.waitForSelector('body[data-viewer-ready="true"]', {
-    timeout: 30000,
-  });
-  const visible = await page.isVisible("#viewer");
-  await browser.close();
-  await new Promise((resolve) => server.close(resolve));
-  expect(visible).toBe(true);
+  try {
+    await page.route(
+      "https://cdn.jsdelivr.net/npm/@google/model-viewer@1.12.0/dist/model-viewer.min.js",
+      (route) => route.abort(),
+    );
+    await page.goto(`http://127.0.0.1:${port}/index.html`);
+    await page.waitForSelector('body[data-viewer-ready="true"]', {
+      timeout: 30000,
+    });
+    const visible = await page.isVisible("#viewer");
+    expect(visible).toBe(true);
+  } finally {
+    await browser.close();
+    await new Promise((resolve) => server.close(resolve));
+  }
 });

--- a/backend/tests/frontend/modelViewerHeadFail.e2e.test.ts
+++ b/backend/tests/frontend/modelViewerHeadFail.e2e.test.ts
@@ -7,22 +7,25 @@ test("model-viewer loads from local copy when CDN HEAD fails", async () => {
   const { port } = server.address();
   const browser = await chromium.launch();
   const page = await browser.newPage();
-  await page.route(
-    "https://cdn.jsdelivr.net/npm/@google/model-viewer@1.12.0/dist/model-viewer.min.js",
-    (route, request) => {
-      if (request.method() === "HEAD") {
-        route.abort();
-      } else {
-        route.continue();
-      }
-    },
-  );
-  await page.goto(`http://127.0.0.1:${port}/index.html`);
-  await page.waitForSelector('body[data-viewer-ready="true"]', {
-    timeout: 30000,
-  });
-  const visible = await page.isVisible("#viewer");
-  await browser.close();
-  await new Promise((resolve) => server.close(resolve));
-  expect(visible).toBe(true);
+  try {
+    await page.route(
+      "https://cdn.jsdelivr.net/npm/@google/model-viewer@1.12.0/dist/model-viewer.min.js",
+      (route, request) => {
+        if (request.method() === "HEAD") {
+          route.abort();
+        } else {
+          route.continue();
+        }
+      },
+    );
+    await page.goto(`http://127.0.0.1:${port}/index.html`);
+    await page.waitForSelector('body[data-viewer-ready="true"]', {
+      timeout: 30000,
+    });
+    const visible = await page.isVisible("#viewer");
+    expect(visible).toBe(true);
+  } finally {
+    await browser.close();
+    await new Promise((resolve) => server.close(resolve));
+  }
 });


### PR DESCRIPTION
## Summary
- capture generated model URL so `/api/generate` responds correctly
- ensure dev server is closed in model viewer fallback tests

## Testing
- `npm run lint --prefix backend`
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`
- `npm run test:a11y`


------
https://chatgpt.com/codex/tasks/task_e_68740e9dc15c832d976e4b3977a87922