### PR TITLE
Fix generate URL lint error

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -462,7 +462,7 @@ app.post(
 
       let generatedUrl;
       try {
-        const url = await generateModelPipeline({
+        generatedUrl = await generateModelPipeline({
           prompt: req.body.prompt,
           image: req.file ? req.file.path : undefined,
         });

--- a/backend/tests/regression/generatePipelineReturn.test.js
+++ b/backend/tests/regression/generatePipelineReturn.test.js
@@ -1,5 +1,8 @@
 const request = require("supertest");
 const app = require("../../server");
+jest.mock("../../src/pipeline/generateModel", () => ({
+  generateModel: jest.fn(),
+}));
 const { generateModel } = require("../../src/pipeline/generateModel");
 
 describe("/api/generate regression", () => {


### PR DESCRIPTION
## Summary
- ensure generated URL is assigned properly
- mock generateModel in regression test to avoid errors

## Testing
- `npm test` in `backend/`
- `SKIP_PW_DEPS=1 npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_68740e5f5a80832da67a13713cad7e60