### PR TITLE
Improve network-check flexibility

### DIFF
--- a/tests/networkCheckOptionalHosts.test.js
+++ b/tests/networkCheckOptionalHosts.test.js
@@ -1,0 +1,25 @@
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+describe("network-check optional hosts", () => {
+  test("continues when optional hosts fail", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "curl-"));
+    const fakeCurl = path.join(tmp, "curl");
+    fs.writeFileSync(
+      fakeCurl,
+      '#!/bin/sh\nif echo "$@" | grep -q esm.sh; then exit 7; fi\nif echo "$@" | grep -q jsdelivr; then exit 7; fi\nexec /usr/bin/curl "$@"',
+    );
+    fs.chmodSync(fakeCurl, 0o755);
+    const out = execFileSync(
+      "node",
+      [path.join("scripts", "network-check.js")],
+      {
+        env: { ...process.env, PATH: `${tmp}:${process.env.PATH}` },
+        encoding: "utf8",
+      },
+    );
+    expect(out).toContain("✅ network OK");
+  });
+});

--- a/tests/networkCheckSkipApt.test.js
+++ b/tests/networkCheckSkipApt.test.js
@@ -1,0 +1,29 @@
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+describe("network-check skip apt", () => {
+  test("skips apt archive check when SKIP_PW_DEPS=1", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "curl-"));
+    const fakeCurl = path.join(tmp, "curl");
+    fs.writeFileSync(
+      fakeCurl,
+      '#!/bin/sh\nif echo "$@" | grep -q archive.ubuntu.com; then exit 7; fi\nexec /usr/bin/curl "$@"',
+    );
+    fs.chmodSync(fakeCurl, 0o755);
+    const out = execFileSync(
+      "node",
+      [path.join("scripts", "network-check.js")],
+      {
+        env: {
+          ...process.env,
+          PATH: `${tmp}:${process.env.PATH}`,
+          SKIP_PW_DEPS: "1",
+        },
+        encoding: "utf8",
+      },
+    );
+    expect(out).toContain("✅ network OK");
+  });
+});


### PR DESCRIPTION
## Summary
- relax network-check to skip optional hosts when unreachable
- skip apt archive check if SKIP_PW_DEPS is set
- fix unused variable in backend server
- add regression tests for optional host and apt skipping

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68740ddcd768832d88f3ea08a7294373