### PR TITLE
Fix diagnose env loading

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,10 +21,11 @@ SPARC3D_ENDPOINT=https://api-inference.huggingface.co/models/print2/Sparc3D
 SPARC3D_TOKEN=your-token-here
 HF_TOKEN=your-huggingface-token
 STABILITY_KEY=your-stability-key-here
-HF_TOKEN=your-huggingface-token
+HF_API_KEY=your-huggingface-api-key
 AWS_ACCESS_KEY_ID=your-aws-access-key-id
 AWS_SECRET_ACCESS_KEY=your-aws-secret-access-key
 S3_BUCKET=your-s3-bucket
+S3_BUCKET_NAME=your-s3-bucket
 
 # Optional admin user setup
 # ADMIN_USERNAME=admin

--- a/backend/server.js
+++ b/backend/server.js
@@ -462,7 +462,7 @@ app.post(
 
       let generatedUrl;
       try {
-        const url = await generateModelPipeline({
+        generatedUrl = await generateModelPipeline({
           prompt: req.body.prompt,
           image: req.file ? req.file.path : undefined,
         });

--- a/scripts/diagnose.sh
+++ b/scripts/diagnose.sh
@@ -12,7 +12,9 @@ banner() {
 }
 
 banner "Running environment validation"
-bash scripts/validate-env.sh
+set +u
+source scripts/validate-env.sh
+set -u
 
 banner "Starting dev server"
 pnpm dev &

--- a/scripts/test-full-pipeline.js
+++ b/scripts/test-full-pipeline.js
@@ -1,19 +1,20 @@
 #!/usr/bin/env node
-console.log(`⚠️  If this fails, Codex should search:\n- \`backend/server.js\` route for \`/api/generate\`\n- \`generateModel()\` and \`sparc3dClient.ts\`\n- Check \`.env.example\` and validate-env.sh\n- Ensure Cloudflare secrets match\n`);
+console.log(
+  `⚠️  If this fails, Codex should search:\n- \`backend/server.js\` route for \`/api/generate\`\n- \`generateModel()\` and \`sparc3dClient.ts\`\n- Check \`.env.example\` and validate-env.sh\n- Ensure Cloudflare secrets match\n`,
+);
 
-const fs = require('fs');
-const path = require('path');
-const axios = require('axios');
-const FormData = require('form-data');
-require('dotenv').config();
+const fs = require("fs");
+const path = require("path");
+const axios = require("axios");
+const FormData = require("form-data");
+require("dotenv").config();
 
 const required = [
-  'SPARC3D_ENDPOINT',
-  'HF_API_KEY',
-  'AWS_ACCESS_KEY_ID',
-  'AWS_SECRET_ACCESS_KEY',
-  'S3_BUCKET_NAME',
-  'CLOUDFRONT_MODEL_DOMAIN',
+  "SPARC3D_ENDPOINT",
+  "HF_API_KEY",
+  "AWS_ACCESS_KEY_ID",
+  "AWS_SECRET_ACCESS_KEY",
+  "CLOUDFRONT_MODEL_DOMAIN",
 ];
 for (const key of required) {
   if (!process.env[key]) {
@@ -22,29 +23,38 @@ for (const key of required) {
   }
 }
 
+const bucket = process.env.S3_BUCKET || process.env.S3_BUCKET_NAME;
+if (!bucket) {
+  console.error("❌ Missing required env var: S3_BUCKET or S3_BUCKET_NAME");
+  process.exit(1);
+}
+
 async function main() {
   const form = new FormData();
-  form.append('prompt', 'diagnostic monkey');
-  const samplePath = path.join(__dirname, 'sample.png');
+  form.append("prompt", "diagnostic monkey");
+  const samplePath = path.join(__dirname, "sample.png");
   if (fs.existsSync(samplePath)) {
-    form.append('image', fs.createReadStream(samplePath));
+    form.append("image", fs.createReadStream(samplePath));
   }
 
   try {
-    const res = await axios.post('http://localhost:3000/api/generate', form, {
+    const res = await axios.post("http://localhost:3000/api/generate", form, {
       headers: form.getHeaders(),
       validateStatus: () => true,
       maxBodyLength: Infinity,
     });
-    console.log('POST /api/generate status', res.status, 'body', res.data);
-    if (res.status !== 200) throw new Error(`/api/generate returned ${res.status}`);
+    console.log("POST /api/generate status", res.status, "body", res.data);
+    if (res.status !== 200)
+      throw new Error(`/api/generate returned ${res.status}`);
     const { glb_url } = res.data || {};
-    const fallback = 'https://modelviewer.dev/shared-assets/models/Astronaut.glb';
-    if (!glb_url) throw new Error('glb_url missing');
-    if (glb_url === fallback) throw new Error('glb_url is fallback');
+    const fallback =
+      "https://modelviewer.dev/shared-assets/models/Astronaut.glb";
+    if (!glb_url) throw new Error("glb_url missing");
+    if (glb_url === fallback) throw new Error("glb_url is fallback");
     const head = await axios.head(glb_url, { validateStatus: () => true });
-    console.log('HEAD', glb_url, head.status);
-    if (head.status !== 200) throw new Error(`HEAD ${glb_url} returned ${head.status}`);
+    console.log("HEAD", glb_url, head.status);
+    if (head.status !== 200)
+      throw new Error(`HEAD ${glb_url} returned ${head.status}`);
     console.log(`✅ All good – ${glb_url}`);
   } catch (err) {
     console.error(`❌ ${err.message}`);

--- a/tests/diagnoseScript.test.js
+++ b/tests/diagnoseScript.test.js
@@ -12,7 +12,7 @@ describe("diagnose script", () => {
       path.join(__dirname, "..", "scripts", "diagnose.sh"),
       "utf8",
     );
-    expect(content).toMatch(/validate-env\.sh/);
+    expect(content).toMatch(/source scripts\/validate-env\.sh/);
     expect(content).toMatch(/test-full-pipeline\.js/);
     expect(content).toMatch(/DIAGNOSTICS PASSED/);
     expect(content).toMatch(/run-jest\.js/);


### PR DESCRIPTION
## Summary
- add missing env vars to `.env.example`
- use `source` for `validate-env.sh` in diagnose script
- check both `S3_BUCKET` and `S3_BUCKET_NAME` in pipeline test
- fix unused variable in `backend/server.js`
- ensure diagnose test checks `source` usage

## Testing
- `npm run format`
- `npm run format --prefix backend`
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_68740cb03210832db7431b46dc0440bc