### PR TITLE
Add test for smoke env defaults

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -21,3 +21,4 @@ coverage/**
 # (optional) you can list more generated folders here, e.g. build, dist
 # ----------------------------------------------------------
 package-lock.json
+js/model-viewer.min.js

--- a/tests/runSmoke.defaults.test.js
+++ b/tests/runSmoke.defaults.test.js
@@ -1,0 +1,44 @@
+const fs = require("fs");
+
+function withNoEnvFiles(fn) {
+  const files = [".env", ".env.example"];
+  const backups = [];
+  for (const file of files) {
+    if (fs.existsSync(file)) {
+      const tmp = `${file}.bak`;
+      fs.renameSync(file, tmp);
+      backups.push([tmp, file]);
+    }
+  }
+  const saved = {
+    AWS_ACCESS_KEY_ID: process.env.AWS_ACCESS_KEY_ID,
+    AWS_SECRET_ACCESS_KEY: process.env.AWS_SECRET_ACCESS_KEY,
+    DB_URL: process.env.DB_URL,
+    STRIPE_SECRET_KEY: process.env.STRIPE_SECRET_KEY,
+  };
+  delete process.env.AWS_ACCESS_KEY_ID;
+  delete process.env.AWS_SECRET_ACCESS_KEY;
+  delete process.env.DB_URL;
+  delete process.env.STRIPE_SECRET_KEY;
+  try {
+    fn();
+  } finally {
+    for (const [tmp, file] of backups) {
+      fs.renameSync(tmp, file);
+    }
+    Object.assign(process.env, saved);
+  }
+}
+
+test("run-smoke supplies default env vars", () => {
+  withNoEnvFiles(() => {
+    jest.isolateModules(() => {
+      const { env } = require("../scripts/run-smoke.js");
+      expect(env.AWS_ACCESS_KEY_ID).toBe("dummy");
+      expect(env.AWS_SECRET_ACCESS_KEY).toBe("dummy");
+      expect(env.DB_URL).toBe("postgres://user:pass@localhost/db");
+      expect(env.STRIPE_SECRET_KEY).toBe("sk_test_dummy");
+      expect(env.SKIP_DB_CHECK).toBe("1");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- ignore `js/model-viewer.min.js` in Prettier to avoid parse errors
- add `runSmoke.defaults.test.js` to verify `run-smoke.js` sets dummy env vars

## Testing
- `npm run format`
- `npm run format --prefix backend`
- `node scripts/run-jest.js tests/runSmoke.defaults.test.js`
- `SKIP_PW_DEPS=1 npm run smoke`

Some backend tests fail and CI linting fails in the repository (see `/tmp/test_backend.log` and `/tmp/ci.log`).

------
https://chatgpt.com/codex/tasks/task_e_68740c9e42b0832d9bb8a7b0bee93235