### PR TITLE
Fix missing URL return

### DIFF
--- a/backend/tests/apiGenerateRoute.test.ts
+++ b/backend/tests/apiGenerateRoute.test.ts
@@ -1,0 +1,26 @@
+const request = require("supertest");
+
+jest.mock("../db", () => ({
+  query: jest.fn(),
+  insertGenerationLog: jest.fn(),
+}));
+
+jest.mock("../src/pipeline/generateModel", () => ({
+  generateModel: jest.fn(),
+}));
+
+process.env.STRIPE_WEBHOOK_SECRET = process.env.STRIPE_WEBHOOK_SECRET || "whsec";
+
+const { generateModel } = require("../src/pipeline/generateModel");
+const app = require("../server");
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+test("POST /api/generate returns glb url from pipeline", async () => {
+  generateModel.mockResolvedValue("/models/test.glb");
+  const res = await request(app).post("/api/generate").send({ prompt: "test" });
+  expect(res.status).toBe(200);
+  expect(res.body.glb_url).toBe("/models/test.glb");
+});


### PR DESCRIPTION
## Summary
- ensure `generateModelPipeline` result is returned
- add regression test for `/api/generate` route

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68740c8c4060832d887f9dbb15f12c13