### PR TITLE
Fix npm tarball corruption handling

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -462,7 +462,7 @@ app.post(
 
       let generatedUrl;
       try {
-        const url = await generateModelPipeline({
+        generatedUrl = await generateModelPipeline({
           prompt: req.body.prompt,
           image: req.file ? req.file.path : undefined,
         });

--- a/scripts/run-npm-ci.js
+++ b/scripts/run-npm-ci.js
@@ -5,19 +5,25 @@ const path = require("path");
 
 function cleanupNpmCache() {
   try {
-    execSync('npm cache clean --force', { stdio: 'ignore' });
+    execSync("npm cache clean --force", { stdio: "ignore" });
   } catch {
     /* ignore */
   }
   try {
-    const cache = execSync('npm config get cache').toString().trim();
-    fs.rmSync(path.join(cache, '_cacache'), { recursive: true, force: true });
-    fs.rmSync(path.join(cache, '_cacache', 'tmp'), { recursive: true, force: true });
+    const cache = execSync("npm config get cache").toString().trim();
+    fs.rmSync(path.join(cache, "_cacache"), { recursive: true, force: true });
+    fs.rmSync(path.join(cache, "_cacache", "tmp"), {
+      recursive: true,
+      force: true,
+    });
   } catch {
     /* ignore */
   }
   try {
-    fs.rmSync(path.join(os.homedir(), '.npm', '_cacache'), { recursive: true, force: true });
+    fs.rmSync(path.join(os.homedir(), ".npm", "_cacache"), {
+      recursive: true,
+      force: true,
+    });
   } catch {
     /* ignore */
   }
@@ -34,7 +40,7 @@ function runNpmCi(dir = ".") {
       console.warn(`npm ci failed in ${dir}, falling back to 'npm install'`);
       execSync("npm install --no-audit --no-fund", options);
       execSync("npm ci --no-audit --no-fund", options);
-    } else if (/TAR_ENTRY_ERROR|ENOENT/.test(output)) {
+    } else if (/TAR_ENTRY_ERROR|ENOENT|tarball .*corrupted/.test(output)) {
       console.warn(
         `npm ci encountered tar errors in ${dir}. Cleaning cache and retrying...`,
       );

--- a/tests/runNpmCi.test.js
+++ b/tests/runNpmCi.test.js
@@ -1,39 +1,57 @@
-jest.mock('child_process', () => ({ execSync: jest.fn() }));
-jest.mock('fs', () => ({ rmSync: jest.fn() }));
-const { execSync } = require('child_process');
-const { rmSync } = require('fs');
+jest.mock("child_process", () => ({ execSync: jest.fn() }));
+jest.mock("fs", () => ({ rmSync: jest.fn() }));
+const { execSync } = require("child_process");
+const { rmSync } = require("fs");
 
-describe('runNpmCi', () => {
+describe("runNpmCi", () => {
   beforeEach(() => {
     execSync.mockReset();
     rmSync.mockReset();
   });
 
-  test('retries with npm install on EUSAGE', () => {
+  test("retries with npm install on EUSAGE", () => {
     execSync.mockImplementationOnce(() => {
-      const err = new Error('EUSAGE');
-      err.stderr = 'npm ERR! EUSAGE';
+      const err = new Error("EUSAGE");
+      err.stderr = "npm ERR! EUSAGE";
       throw err;
     });
-    const { runNpmCi } = require('../scripts/run-npm-ci');
+    const { runNpmCi } = require("../scripts/run-npm-ci");
     runNpmCi();
-    expect(execSync.mock.calls.map(c => c[0])).toEqual([
-      'npm ci --no-audit --no-fund',
-      'npm install --no-audit --no-fund',
-      'npm ci --no-audit --no-fund'
+    expect(execSync.mock.calls.map((c) => c[0])).toEqual([
+      "npm ci --no-audit --no-fund",
+      "npm install --no-audit --no-fund",
+      "npm ci --no-audit --no-fund",
     ]);
   });
 
-  test('cleans cache on tar errors', () => {
+  test("cleans cache on tar errors", () => {
     execSync.mockImplementationOnce(() => {
-      const err = new Error('tar');
-      err.stderr = 'TAR_ENTRY_ERROR';
+      const err = new Error("tar");
+      err.stderr = "TAR_ENTRY_ERROR";
       throw err;
     });
-    const { runNpmCi } = require('../scripts/run-npm-ci');
-    runNpmCi('backend');
-    expect(execSync.mock.calls[0][0]).toBe('npm ci --no-audit --no-fund');
-    expect(rmSync).toHaveBeenCalledWith(expect.stringContaining('backend/node_modules'), expect.any(Object));
-    expect(execSync.mock.calls.pop()[0]).toBe('npm ci --no-audit --no-fund');
+    const { runNpmCi } = require("../scripts/run-npm-ci");
+    runNpmCi("backend");
+    expect(execSync.mock.calls[0][0]).toBe("npm ci --no-audit --no-fund");
+    expect(rmSync).toHaveBeenCalledWith(
+      expect.stringContaining("backend/node_modules"),
+      expect.any(Object),
+    );
+    expect(execSync.mock.calls.pop()[0]).toBe("npm ci --no-audit --no-fund");
+  });
+
+  test("retries on tarball corruption warnings", () => {
+    execSync.mockImplementationOnce(() => {
+      const err = new Error("corrupted");
+      err.stderr =
+        "npm WARN tarball tarball data for foo@https://registry.npmjs.org/foo/-/foo-1.0.0.tgz (sha512-deadbeef) seems to be corrupted. Trying again.";
+      throw err;
+    });
+    const { runNpmCi } = require("../scripts/run-npm-ci");
+    runNpmCi();
+    expect(execSync.mock.calls.map((c) => c[0])).toEqual([
+      "npm ci --no-audit --no-fund",
+      "npm ci --no-audit --no-fund",
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- retry `npm ci` when tarball data appears corrupted
- capture generated model URL instead of discarding it
- test corrupted tarball handling

## Testing
- `npm test --silent`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_68740bcbe0b4832d985246b6cb1b1236