### PR TITLE
Fix generateModel return and add regression test

### DIFF
--- a/backend/config.js
+++ b/backend/config.js
@@ -8,7 +8,6 @@ const optionalGlb = [
   "SPARC3D_TOKEN",
 ];
 
-
 const missing = required.filter((key) => !getEnv(key));
 if (missing.length) {
   console.warn(`Missing required env vars: ${missing.join(", ")}`);

--- a/backend/generated_ads.json
+++ b/backend/generated_ads.json
@@ -40,5 +40,19 @@
     "copy": "Bring r/test creativity to life. Print with us today.",
     "image": "imgdata",
     "status": "approved"
+  },
+  {
+    "id": "b2ec18ae-d971-4a64-9656-8c88574882cc",
+    "subreddit": "test",
+    "copy": "Bring r/test creativity to life. Print with us today.",
+    "image": "imgdata",
+    "status": "pending"
+  },
+  {
+    "id": "016f532d-4525-4bfa-baa0-802ee8ddf635",
+    "subreddit": "test",
+    "copy": "Hey r/test – your next favorite model is just a click away!",
+    "image": "imgdata",
+    "status": "approved"
   }
 ]

--- a/backend/server.js
+++ b/backend/server.js
@@ -462,7 +462,7 @@ app.post(
 
       let generatedUrl;
       try {
-        const url = await generateModelPipeline({
+        generatedUrl = await generateModelPipeline({
           prompt: req.body.prompt,
           image: req.file ? req.file.path : undefined,
         });

--- a/backend/tests/regression/generatePipelineReturn.test.ts
+++ b/backend/tests/regression/generatePipelineReturn.test.ts
@@ -1,5 +1,19 @@
+process.env.STRIPE_SECRET_KEY = "test";
+process.env.STRIPE_WEBHOOK_SECRET = "whsec";
+process.env.DB_URL = "postgres://user:pass@localhost/db";
+
+jest.mock("../../db", () => ({
+  query: jest.fn().mockResolvedValue({ rows: [] }),
+  insertGenerationLog: jest.fn().mockResolvedValue({}),
+}));
+
 const request = require("supertest");
 const app = require("../../server");
+
+jest.mock("../../src/pipeline/generateModel", () => ({
+  generateModel: jest.fn(),
+}));
+
 const { generateModel } = require("../../src/pipeline/generateModel");
 
 describe("/api/generate regression", () => {


### PR DESCRIPTION
## Summary
- return pipeline URL in `/api/generate`
- convert regression test to TypeScript and ensure required mocks are set

## Testing
- `npm run format`
- `npm test`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_68740b699dbc832d8520886b3ccbcd77