### PR TITLE
Ensure model-viewer e2e tests remain skipped

### DIFF
--- a/tests/e2eSkip.test.js
+++ b/tests/e2eSkip.test.js
@@ -1,0 +1,29 @@
+const fs = require("fs");
+const path = require("path");
+
+describe("frontend e2e tests remain skipped", () => {
+  const files = [
+    path.join(
+      __dirname,
+      "..",
+      "backend",
+      "tests",
+      "frontend",
+      "modelViewerFallback.e2e.test.ts",
+    ),
+    path.join(
+      __dirname,
+      "..",
+      "backend",
+      "tests",
+      "frontend",
+      "modelViewerHeadFail.e2e.test.ts",
+    ),
+  ];
+  for (const file of files) {
+    test(path.basename(file) + " uses test.skip", () => {
+      const src = fs.readFileSync(file, "utf8");
+      expect(src.includes("test.skip(")).toBe(true);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add regression test verifying model-viewer e2e suites stay skipped

## Testing
- `npm run format`
- `npm test`
- `npm run coverage`


------
https://chatgpt.com/codex/tasks/task_e_68741b6344e4832da8c26d00f6f3c785