### PR TITLE
Fix smoke script wait-on invocation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,6 +9,7 @@ A clear and concise description of what the bug is.
 
 **To Reproduce**
 Steps to reproduce the behavior:
+
 1. Go to '...'
 2. Click on '...'
 3. See error
@@ -20,9 +21,10 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Environment (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+
+- OS: [e.g. iOS]
+- Browser [e.g. chrome, safari]
+- Version [e.g. 22]
 
 **Additional context**
 Add any other context about the problem here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,9 @@
 ## Summary
-- 
+
+-
 
 ## Testing
+
 - [ ] `npm run format`
 - [ ] `npm test`
 - [ ] `npm run ci`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,23 +3,25 @@
 Thank you for helping improve this project! Please follow these steps to keep our history clean and CI green.
 
 ## Branches
+
 - Fork the repo and create a feature branch from `dev`.
 - Use the pattern `yourname/short-topic`, for example `alice/add-login-tests`.
 
 ## Commits
+
 - We use [Conventional Commits](https://www.conventionalcommits.org/) for all commit messages.
 - Format each message as `type: short description` (e.g. `fix: handle null user`).
 - Allowed types include `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `style`, `perf`, `ci`, and `build`.
 
 ## Pull Requests
+
 1. Run `npm run setup` after checking out the repo. This installs dependencies and Playwright browsers.
 2. Format code in `backend/` with `npm run format` and ensure linting passes via `npm run ci`.
 3. Execute `npm test` and, if possible, `npm run smoke` before opening the PR.
 4. Open a PR against the `dev` branch and request review.
 
 ## Tests
+
 - All new code should include appropriate tests.
 - CI runs `npm run ci` and `npm test`; please ensure these succeed locally.
 - If Playwright dependencies are already installed you can set `SKIP_PW_DEPS=1` when running setup or CI to skip the lengthy install step.
-
-

--- a/scripts/run-smoke.js
+++ b/scripts/run-smoke.js
@@ -67,7 +67,7 @@ function main() {
       ? `-t ${process.env.WAIT_ON_TIMEOUT} `
       : "";
     run(
-      `npx -y concurrently -k -s first "npm run serve" "wait-on ${waitArgs}http://localhost:3000 && npx playwright test e2e/smoke.test.js"`,
+      `npx -y concurrently -k -s first "npm run serve" "npx -y wait-on ${waitArgs}http://localhost:3000 && npx playwright test e2e/smoke.test.js"`,
     );
   } catch (err) {
     dumpDiagnostics(err);

--- a/tests/smokeScriptWaitOn.test.js
+++ b/tests/smokeScriptWaitOn.test.js
@@ -1,0 +1,12 @@
+const fs = require("fs");
+const path = require("path");
+
+describe("smoke script wait-on", () => {
+  test("run-smoke.js invokes wait-on via npx", () => {
+    const content = fs.readFileSync(
+      path.join(__dirname, "..", "scripts", "run-smoke.js"),
+      "utf8",
+    );
+    expect(content).toMatch(/npx -y wait-on/);
+  });
+});


### PR DESCRIPTION
## Summary
- call `wait-on` via `npx` to ensure it resolves in CI
- verify the smoke script uses `npx wait-on`
- update Markdown files with `npm run format`

## Testing
- `npm run format:check`
- `npm test --prefix backend`
- `npm run test:ci`
- `npm run test:a11y`


------
https://chatgpt.com/codex/tasks/task_e_68741c594f48832db418adccc369188b