### PR TITLE
Fix coverage summary error

### DIFF
--- a/scripts/check-coverage.js
+++ b/scripts/check-coverage.js
@@ -1,9 +1,13 @@
 const fs = require("fs");
 
 const config = JSON.parse(fs.readFileSync(".nycrc", "utf8"));
-const summary = JSON.parse(
-  fs.readFileSync("backend/coverage/coverage-summary.json", "utf8"),
-);
+
+const summaryPath = "backend/coverage/coverage-summary.json";
+if (!fs.existsSync(summaryPath)) {
+  console.error(`Missing coverage summary: ${summaryPath}`);
+  process.exit(1);
+}
+const summary = JSON.parse(fs.readFileSync(summaryPath, "utf8"));
 
 const metrics = ["branches", "functions", "lines", "statements"];
 let failed = false;

--- a/tests/checkCoverageScript.test.js
+++ b/tests/checkCoverageScript.test.js
@@ -1,0 +1,35 @@
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+const summary = path.join(
+  __dirname,
+  "..",
+  "backend",
+  "coverage",
+  "coverage-summary.json",
+);
+const backup = summary + ".bak";
+
+describe("check-coverage script", () => {
+  beforeAll(() => {
+    if (fs.existsSync(summary)) fs.renameSync(summary, backup);
+  });
+
+  afterAll(() => {
+    if (fs.existsSync(backup)) fs.renameSync(backup, summary);
+  });
+
+  test("fails gracefully when summary missing", () => {
+    try {
+      execFileSync("node", [path.join("scripts", "check-coverage.js")], {
+        encoding: "utf8",
+        stdio: "pipe",
+      });
+      throw new Error("script did not exit");
+    } catch (err) {
+      const output = (err.stdout || "") + (err.stderr || "");
+      expect(output).toMatch(/Missing coverage summary/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- avoid crashing when the coverage summary is missing
- ensure check-coverage exits cleanly if it cannot find coverage data
- test the failure mode of the check-coverage script

## Testing
- `npm run format:check`
- `npm run ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68741fe04500832d9c1db028903aa356