### PR TITLE
Fix coverage check when summary missing

### DIFF
--- a/scripts/check-coverage.js
+++ b/scripts/check-coverage.js
@@ -1,9 +1,15 @@
 const fs = require("fs");
 
-const config = JSON.parse(fs.readFileSync(".nycrc", "utf8"));
-const summary = JSON.parse(
-  fs.readFileSync("backend/coverage/coverage-summary.json", "utf8"),
-);
+const configPath = ".nycrc";
+const summaryPath = "backend/coverage/coverage-summary.json";
+const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+if (!fs.existsSync(summaryPath)) {
+  console.error(
+    `Coverage summary missing at ${summaryPath}. Did you run \`npm run coverage\`?`,
+  );
+  process.exit(1);
+}
+const summary = JSON.parse(fs.readFileSync(summaryPath, "utf8"));
 
 const metrics = ["branches", "functions", "lines", "statements"];
 let failed = false;

--- a/tests/checkCoverageMissingFile.test.js
+++ b/tests/checkCoverageMissingFile.test.js
@@ -1,0 +1,25 @@
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+describe("check-coverage missing summary", () => {
+  test("fails with helpful message", () => {
+    const script = path.join(__dirname, "..", "scripts", "check-coverage.js");
+    const summary = path.join(
+      __dirname,
+      "..",
+      "backend",
+      "coverage",
+      "coverage-summary.json",
+    );
+    const backup = `${summary}.bak`;
+    fs.renameSync(summary, backup);
+    try {
+      expect(() => execFileSync("node", [script], { stdio: "pipe" })).toThrow(
+        /Coverage summary missing/,
+      );
+    } finally {
+      fs.renameSync(backup, summary);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- handle missing `backend/coverage/coverage-summary.json` gracefully
- add regression test for missing coverage summary

## Testing
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `node scripts/run-jest.js tests/checkCoverageMissingFile.test.js`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6874224c6544832d87b79391d78026bd