### PR TITLE
Fix coverage scripts and add tests

### DIFF
--- a/scripts/check-coverage.js
+++ b/scripts/check-coverage.js
@@ -1,9 +1,14 @@
 const fs = require("fs");
 
 const config = JSON.parse(fs.readFileSync(".nycrc", "utf8"));
-const summary = JSON.parse(
-  fs.readFileSync("backend/coverage/coverage-summary.json", "utf8"),
-);
+const summaryPath = "backend/coverage/coverage-summary.json";
+if (!fs.existsSync(summaryPath)) {
+  console.error(
+    `Coverage summary not found at ${summaryPath}. Run "npm run coverage" first.`,
+  );
+  process.exit(1);
+}
+const summary = JSON.parse(fs.readFileSync(summaryPath, "utf8"));
 
 const metrics = ["branches", "functions", "lines", "statements"];
 let failed = false;

--- a/scripts/run-coverage.js
+++ b/scripts/run-coverage.js
@@ -14,6 +14,7 @@ const jestArgs = [
   "--maxWorkers=2",
   "--detectOpenHandles",
   "--forceExit",
+  "--coverageReporters=json-summary",
   "--coverageReporters=text-lcov",
   "--coverageThreshold={}",
   "--silent",
@@ -40,7 +41,7 @@ const result = spawnSync(jestBin, jestArgs, {
   },
 });
 
-const lcovPath = path.join("coverage", "lcov.info");
+const lcovPath = path.join("backend", "coverage", "lcov.info");
 fs.mkdirSync(path.dirname(lcovPath), { recursive: true });
 let output = result.stdout || "";
 const start = output.indexOf("TN:");

--- a/tests/checkCoverageMissing.test.js
+++ b/tests/checkCoverageMissing.test.js
@@ -1,0 +1,30 @@
+const fs = require("fs");
+const path = require("path");
+const { execFileSync } = require("child_process");
+
+describe("check-coverage script", () => {
+  test("fails when coverage summary is missing", () => {
+    const tmp = fs.mkdtempSync(path.join(__dirname, "tmp-"));
+    fs.copyFileSync(
+      path.join(__dirname, "..", ".nycrc"),
+      path.join(tmp, ".nycrc"),
+    );
+    try {
+      execFileSync(
+        "node",
+        [path.resolve(__dirname, "..", "scripts", "check-coverage.js")],
+        {
+          cwd: tmp,
+          encoding: "utf8",
+          stdio: "pipe",
+        },
+      );
+      throw new Error("script did not exit");
+    } catch (err) {
+      const output = (err.stdout || "") + (err.stderr || "");
+      expect(output).toMatch(/coverage summary not found/i);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/runCoverageScript.test.js
+++ b/tests/runCoverageScript.test.js
@@ -6,7 +6,7 @@ describe("run-coverage script", () => {
   test("generates lcov report", () => {
     execFileSync(
       "node",
-      ["scripts/run-coverage.js", "backend/tests/analytics.test.js"],
+      ["scripts/run-coverage.js", "backend/tests/apiGenerateRoute.test.ts"],
       {
         env: {
           ...process.env,
@@ -17,8 +17,10 @@ describe("run-coverage script", () => {
         encoding: "utf8",
       },
     );
-    const file = path.join("coverage", "lcov.info");
-    expect(fs.existsSync(file)).toBe(true);
+    const lcov = path.join("backend", "coverage", "lcov.info");
+    const summary = path.join("backend", "coverage", "coverage-summary.json");
+    expect(fs.existsSync(lcov)).toBe(true);
+    expect(fs.existsSync(summary)).toBe(true);
   });
 
   test("fails when coverage cannot be parsed", () => {


### PR DESCRIPTION
## Summary
- ensure coverage runner outputs json-summary and writes to backend/coverage
- handle missing coverage summary gracefully
- update coverage script test
- add regression test for missing coverage report

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6874223efa24832da8fe4f53099cdaa2