### PR TITLE
Add coverage checks

### DIFF
--- a/backend/tests/checkCoverageScript.test.js
+++ b/backend/tests/checkCoverageScript.test.js
@@ -1,0 +1,20 @@
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+const script = path.join(__dirname, "..", "..", "scripts", "check-coverage.js");
+
+describe("check-coverage script", () => {
+  test("fails when coverage summary is missing", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "cov-"));
+    fs.writeFileSync(path.join(tmp, ".nycrc"), "{}");
+    const result = spawnSync(process.execPath, [script], {
+      cwd: tmp,
+      encoding: "utf8",
+    });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("Missing coverage summary");
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+});

--- a/scripts/run-coverage.js
+++ b/scripts/run-coverage.js
@@ -55,3 +55,9 @@ if (result.status) {
   console.error(`Jest exited with code ${result.status}`);
   process.exit(result.status);
 }
+
+const summaryPath = path.join("backend", "coverage", "coverage-summary.json");
+if (!fs.existsSync(summaryPath)) {
+  console.error(`Missing coverage summary: ${summaryPath}`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- check for missing coverage summary in `run-coverage.js`
- add test covering `check-coverage.js` failure case

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `node scripts/run-coverage.js`

------
https://chatgpt.com/codex/tasks/task_e_687425419aec832da513e5602e608bb0