### PR TITLE
fix: generate JSON coverage summary

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -3,5 +3,6 @@
   "branches": 80,
   "functions": 80,
   "lines": 80,
-  "statements": 80
+  "statements": 80,
+  "reporter": ["lcov", "text", "json-summary"]
 }


### PR DESCRIPTION
## Summary
- ensure NYC outputs `json-summary`

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_68742d9d189c832dbeda24554671be69