### PR TITLE
Fix coverage script path handling

### DIFF
--- a/backend/tests/runCoverageScript.test.js
+++ b/backend/tests/runCoverageScript.test.js
@@ -1,0 +1,51 @@
+const fs = require("fs");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+const repoRoot = path.join(__dirname, "..", "..");
+const script = path.join(repoRoot, "scripts", "run-coverage.js");
+
+const env = {
+  ...process.env,
+  HF_TOKEN: "x",
+  AWS_ACCESS_KEY_ID: "id",
+  AWS_SECRET_ACCESS_KEY: "secret",
+  DB_URL: "db",
+  STRIPE_SECRET_KEY: "sk",
+  SKIP_NET_CHECKS: "1",
+  SKIP_PW_DEPS: "1",
+};
+
+describe("run-coverage script", () => {
+  afterEach(() => {
+    fs.rmSync(path.join(repoRoot, "coverage"), {
+      recursive: true,
+      force: true,
+    });
+    fs.rmSync(path.join(repoRoot, "backend", "coverage"), {
+      recursive: true,
+      force: true,
+    });
+  });
+
+  test("works when invoked from backend directory", () => {
+    const result = spawnSync(
+      process.execPath,
+      [
+        "../scripts/run-coverage.js",
+        "--runTestsByPath",
+        "backend/tests/coverage/lcovParse.test.ts",
+      ],
+      { cwd: path.join(repoRoot, "backend"), env, encoding: "utf8" },
+    );
+    expect(result.status).toBe(0);
+    expect(fs.existsSync(path.join(repoRoot, "coverage", "lcov.info"))).toBe(
+      true,
+    );
+    expect(
+      fs.existsSync(
+        path.join(repoRoot, "backend", "coverage", "coverage-summary.json"),
+      ),
+    ).toBe(true);
+  });
+});

--- a/scripts/run-coverage.js
+++ b/scripts/run-coverage.js
@@ -3,6 +3,8 @@ const { spawnSync } = require("child_process");
 const fs = require("fs");
 const path = require("path");
 
+const repoRoot = path.join(__dirname, "..");
+
 // Ensure the active Node version matches the project's requirement so the
 // coverage run doesn't silently use a wrong version when mise wasn't activated.
 require("./check-node-version.js");
@@ -41,7 +43,7 @@ const result = spawnSync(jestBin, jestArgs, {
   },
 });
 
-const lcovPath = path.join("coverage", "lcov.info");
+const lcovPath = path.join(repoRoot, "coverage", "lcov.info");
 fs.mkdirSync(path.dirname(lcovPath), { recursive: true });
 let output = result.stdout || "";
 const start = output.indexOf("TN:");
@@ -57,7 +59,12 @@ if (result.status) {
   process.exit(result.status);
 }
 
-const summaryPath = path.join("backend", "coverage", "coverage-summary.json");
+const summaryPath = path.join(
+  repoRoot,
+  "backend",
+  "coverage",
+  "coverage-summary.json",
+);
 if (!fs.existsSync(summaryPath)) {
   console.error(`Missing coverage summary: ${summaryPath}`);
   process.exit(1);


### PR DESCRIPTION
## Summary
- ensure `run-coverage.js` resolves files from repo root
- add regression test invoking coverage script from `backend`

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run coverage`

------
https://chatgpt.com/codex/tasks/task_e_68742cb4f258832dbc7fef617b81a633