### PR TITLE
Ensure coverage summary check

### DIFF
--- a/scripts/run-coverage.js
+++ b/scripts/run-coverage.js
@@ -52,6 +52,17 @@ if (start === -1) {
 output = output.slice(start);
 fs.writeFileSync(lcovPath, output);
 console.log(`LCOV written to ${lcovPath}`);
+const summaryPath = path.join(
+  __dirname,
+  "..",
+  "backend",
+  "coverage",
+  "coverage-summary.json",
+);
+if (!fs.existsSync(summaryPath)) {
+  console.error(`Missing coverage summary: ${summaryPath}`);
+  process.exit(1);
+}
 if (result.status) {
   console.error(`Jest exited with code ${result.status}`);
   process.exit(result.status);


### PR DESCRIPTION
## Summary
- verify coverage summary file after running tests to prevent silent CI failures

## Testing
- `npm test --prefix backend`
- `npm run coverage`


------
https://chatgpt.com/codex/tasks/task_e_68742c9f598c832db0a146f505382c9c