### PR TITLE
Fix model-viewer fallback

### DIFF
--- a/backend/tests/frontend/modelViewerLoader.test.js
+++ b/backend/tests/frontend/modelViewerLoader.test.js
@@ -20,9 +20,11 @@ function ensureModelViewerLoaded() {
   }
 
   return new Promise((resolve, reject) => {
-    const finalize = () => {
+    const finalize = (attemptedLocal) => {
       if (global.window.customElements?.get("model-viewer")) {
         resolve();
+      } else if (!attemptedLocal) {
+        loadScript(localUrl, () => finalize(true));
       } else {
         reject(new Error("model-viewer failed to load"));
       }
@@ -39,11 +41,11 @@ function ensureModelViewerLoaded() {
       })
       .then(() => {
         clearTimeout(timer);
-        loadScript(cdnUrl, finalize);
+        loadScript(cdnUrl, () => finalize(false));
       })
       .catch(() => {
         clearTimeout(timer);
-        loadScript(localUrl, finalize);
+        loadScript(localUrl, () => finalize(true));
       });
   });
 }

--- a/js/index.js
+++ b/js/index.js
@@ -143,9 +143,12 @@ function ensureModelViewerLoaded() {
   }
 
   return new Promise((resolve, reject) => {
-    const finalize = () => {
+    const finalize = (attemptedLocal) => {
       if (window.customElements?.get("model-viewer")) {
         resolve();
+      } else if (!attemptedLocal) {
+        window.modelViewerSource = "local";
+        loadScript(localUrl, () => finalize(true));
       } else {
         reject(new Error("model-viewer failed to load"));
       }
@@ -162,12 +165,12 @@ function ensureModelViewerLoaded() {
       .then(() => {
         clearTimeout(timer);
         window.modelViewerSource = "cdn";
-        loadScript(cdnUrl, finalize);
+        loadScript(cdnUrl, () => finalize(false));
       })
       .catch(() => {
         clearTimeout(timer);
         window.modelViewerSource = "local";
-        loadScript(localUrl, finalize);
+        loadScript(localUrl, () => finalize(true));
       });
   });
 }


### PR DESCRIPTION
## Summary
- handle CDN load failure by falling back to local script
- test ensureModelViewerLoaded fallback logic

## Testing
- `npm test`
- `npm run ci`
- `npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_6874227f64cc832db22f26be2cb803bb