### PR TITLE
Add SKIP_COVERAGE_CHECK flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,10 @@ By piping the generated `lcov.info` file instead of test output we avoid
 Running coverage without installing dependencies or omitting `npx` may lead to
 `coveralls: command not found` or `jest: not found` errors.
 
+Set `SKIP_COVERAGE_CHECK=1` before running the coverage scripts if you expect
+coverage to fall below the configured thresholds. This prevents the
+`check-coverage` step from failing CI.
+
 #### Troubleshooting
 
 If Coveralls fails with an `lcovParse` error, the `lcov.info` report may contain

--- a/scripts/check-coverage.js
+++ b/scripts/check-coverage.js
@@ -1,5 +1,10 @@
 const fs = require("fs");
 
+if (process.env.SKIP_COVERAGE_CHECK) {
+  console.log("Skipping coverage check due to SKIP_COVERAGE_CHECK");
+  process.exit(0);
+}
+
 const config = JSON.parse(fs.readFileSync(".nycrc", "utf8"));
 
 const summaryPath = "backend/coverage/coverage-summary.json";

--- a/tests/checkCoverageScript.test.js
+++ b/tests/checkCoverageScript.test.js
@@ -32,4 +32,17 @@ describe("check-coverage script", () => {
       expect(output).toMatch(/Missing coverage summary/);
     }
   });
+
+  test("skips check when SKIP_COVERAGE_CHECK=1", () => {
+    const output = execFileSync(
+      "node",
+      [path.join("scripts", "check-coverage.js")],
+      {
+        encoding: "utf8",
+        stdio: "pipe",
+        env: { ...process.env, SKIP_COVERAGE_CHECK: "1" },
+      },
+    );
+    expect(output).toMatch(/Skipping coverage check/);
+  });
 });


### PR DESCRIPTION
## Summary
- allow skipping the coverage threshold check with `SKIP_COVERAGE_CHECK`
- mention the flag in the coverage docs
- test skipping coverage check

## Testing
- `npm run format`
- `npm test` in `backend/`
- `npm run ci`
- `npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_687433dd5ce8832d9e268f2dda3338bb