### PR TITLE
Fix coverage script summary path

### DIFF
--- a/backend/tests/runCoverageScript.test.js
+++ b/backend/tests/runCoverageScript.test.js
@@ -31,11 +31,7 @@ describe("run-coverage script", () => {
   test("works when invoked from backend directory", () => {
     const result = spawnSync(
       process.execPath,
-      [
-        "../scripts/run-coverage.js",
-        "--runTestsByPath",
-        "backend/tests/coverage/lcovParse.test.ts",
-      ],
+      [script, "--runTestsByPath", "backend/tests/coverage/lcovParse.test.ts"],
       { cwd: path.join(repoRoot, "backend"), env, encoding: "utf8" },
     );
     expect(result.status).toBe(0);

--- a/js/index.js
+++ b/js/index.js
@@ -151,7 +151,7 @@ function ensureModelViewerLoaded() {
       document.head.appendChild(fallback);
     };
     document.head.appendChild(s);
-  }
+  });
 
   return new Promise((resolve, reject) => {
     const finalize = (attemptedLocal) => {

--- a/scripts/run-coverage.js
+++ b/scripts/run-coverage.js
@@ -55,8 +55,7 @@ output = output.slice(start);
 fs.writeFileSync(lcovPath, output);
 console.log(`LCOV written to ${lcovPath}`);
 const summaryPath = path.join(
-  __dirname,
-  "..",
+  repoRoot,
   "backend",
   "coverage",
   "coverage-summary.json",
@@ -69,14 +68,9 @@ if (result.status) {
   console.error(`Jest exited with code ${result.status}`);
   process.exit(result.status);
 }
-
-const summaryPath = path.join(
-  repoRoot,
-  "backend",
-  "coverage",
-  "coverage-summary.json",
-);
-if (!fs.existsSync(summaryPath)) {
-  console.error(`Missing coverage summary: ${summaryPath}`);
+try {
+  JSON.parse(fs.readFileSync(summaryPath, "utf8"));
+} catch (err) {
+  console.error(`Failed to read ${summaryPath}: ${err.message}`);
   process.exit(1);
 }

--- a/tests/checkCoverageScript.test.js
+++ b/tests/checkCoverageScript.test.js
@@ -12,6 +12,7 @@ const summary = path.join(
 const backup = summary + ".bak";
 const nycrc = path.join(__dirname, "..", ".nycrc");
 const nycBackup = nycrc + ".bak";
+let originalConfig = "";
 
 describe("check-coverage script", () => {
   beforeAll(() => {
@@ -20,6 +21,10 @@ describe("check-coverage script", () => {
 
   afterAll(() => {
     if (fs.existsSync(backup)) fs.renameSync(backup, summary);
+  });
+
+  beforeEach(() => {
+    originalConfig = fs.existsSync(nycrc) ? fs.readFileSync(nycrc, "utf8") : "";
   });
 
   test("fails gracefully when summary missing", () => {


### PR DESCRIPTION
## Summary
- dedupe `summaryPath` in `scripts/run-coverage.js`
- guard summary parsing with try/catch
- fix js/index.js syntax
- fix tests so lint passes

## Testing
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6874389128c8832db1baad7dfb6f3662