### PR TITLE
Add test for coverage summary presence

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,4 +22,6 @@ jobs:
             echo '❌ lcov.info malformed or missing'
             exit 1
           fi
+      - name: Verify coverage summary
+        run: node scripts/run-jest.js backend/__tests__/coverageSummaryExists.test.js
       - run: cat backend/coverage/lcov.info | npx coveralls

--- a/backend/__tests__/coverageSummaryExists.test.js
+++ b/backend/__tests__/coverageSummaryExists.test.js
@@ -1,0 +1,7 @@
+const fs = require("fs");
+
+const summary = "backend/coverage/coverage-summary.json";
+
+(process.env.CI ? test : test.skip)("coverage summary exists", () => {
+  expect(fs.existsSync(summary)).toBe(true);
+});

--- a/tests/coverageWorkflow.test.js
+++ b/tests/coverageWorkflow.test.js
@@ -22,6 +22,9 @@ describe("coverage workflow", () => {
       cmd.trim().startsWith("npm run coverage"),
     );
     const hasCoveralls = steps.some((cmd) => cmd.includes("npx coveralls"));
+    const hasSummaryCheck = steps.some((cmd) =>
+      cmd.includes("coverageSummaryExists.test.js"),
+    );
     const usesCat = steps.some((cmd) =>
       cmd.includes("cat backend/coverage/lcov.info"),
     );
@@ -29,5 +32,6 @@ describe("coverage workflow", () => {
     expect(hasCoverage).toBe(true);
     expect(hasCoveralls).toBe(true);
     expect(usesCat).toBe(true);
+    expect(hasSummaryCheck).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- ensure CI checks for coverage summary file
- verify workflow includes summary check step

## Testing
- `npm run format`
- `npm test`
- `node scripts/run-jest.js tests/coverageWorkflow.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6874388f61ac832d93ce8d9bd140795b