### PR TITLE
Fix coverage script duplicates

### DIFF
--- a/backend/tests/runCoverageScript.test.js
+++ b/backend/tests/runCoverageScript.test.js
@@ -3,7 +3,6 @@ const path = require("path");
 const { spawnSync } = require("child_process");
 
 const repoRoot = path.join(__dirname, "..", "..");
-const script = path.join(repoRoot, "scripts", "run-coverage.js");
 
 const env = {
   ...process.env,

--- a/js/index.js
+++ b/js/index.js
@@ -151,7 +151,7 @@ function ensureModelViewerLoaded() {
       document.head.appendChild(fallback);
     };
     document.head.appendChild(s);
-  }
+  });
 
   return new Promise((resolve, reject) => {
     const finalize = (attemptedLocal) => {

--- a/scripts/run-coverage.js
+++ b/scripts/run-coverage.js
@@ -69,14 +69,3 @@ if (result.status) {
   console.error(`Jest exited with code ${result.status}`);
   process.exit(result.status);
 }
-
-const summaryPath = path.join(
-  repoRoot,
-  "backend",
-  "coverage",
-  "coverage-summary.json",
-);
-if (!fs.existsSync(summaryPath)) {
-  console.error(`Missing coverage summary: ${summaryPath}`);
-  process.exit(1);
-}

--- a/tests/checkCoverageScript.test.js
+++ b/tests/checkCoverageScript.test.js
@@ -12,6 +12,9 @@ const summary = path.join(
 const backup = summary + ".bak";
 const nycrc = path.join(__dirname, "..", ".nycrc");
 const nycBackup = nycrc + ".bak";
+const originalConfig = fs.existsSync(nycrc)
+  ? fs.readFileSync(nycrc, "utf8")
+  : "";
 
 describe("check-coverage script", () => {
   beforeAll(() => {
@@ -20,6 +23,8 @@ describe("check-coverage script", () => {
 
   afterAll(() => {
     if (fs.existsSync(backup)) fs.renameSync(backup, summary);
+    if (fs.existsSync(nycBackup)) fs.renameSync(nycBackup, nycrc);
+    else fs.writeFileSync(nycrc, originalConfig);
   });
 
   test("fails gracefully when summary missing", () => {
@@ -72,7 +77,7 @@ describe("check-coverage script", () => {
   });
 
   test("passes when coverage meets thresholds", () => {
-    const originalConfig = fs.readFileSync(".nycrc", "utf8");
+    const currentConfig = fs.readFileSync(".nycrc", "utf8");
     const goodSummary = {
       total: {
         branches: { pct: 90 },
@@ -99,6 +104,6 @@ describe("check-coverage script", () => {
     );
     expect(output).toMatch(/Coverage thresholds met/);
     fs.unlinkSync(summary);
-    fs.writeFileSync(".nycrc", originalConfig);
+    fs.writeFileSync(".nycrc", currentConfig);
   });
 });


### PR DESCRIPTION
## Summary
- cleanup duplicate `summaryPath` in coverage script
- fix missing closing brace in `js/index.js`
- update coverage tests to save config safely
- remove unused `script` var from runCoverageScript test

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874361c3d28832d9a66c984326cc76a