### PR TITLE
Fix coverage script variable and add test

### DIFF
--- a/backend/tests/coverage-summary.test.ts
+++ b/backend/tests/coverage-summary.test.ts
@@ -1,0 +1,36 @@
+const { execSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+const repoRoot = path.join(__dirname, "..", "..");
+
+const env = {
+  ...process.env,
+  HF_TOKEN: "x",
+  AWS_ACCESS_KEY_ID: "id",
+  AWS_SECRET_ACCESS_KEY: "secret",
+  DB_URL: "db",
+  STRIPE_SECRET_KEY: "sk",
+  SKIP_NET_CHECKS: "1",
+  SKIP_PW_DEPS: "1",
+};
+
+describe("npm run coverage", () => {
+  afterAll(() => {
+    fs.rmSync(path.join(repoRoot, "coverage"), { recursive: true, force: true });
+    fs.rmSync(path.join(repoRoot, "backend", "coverage"), {
+      recursive: true,
+      force: true,
+    });
+  });
+
+  test("produces parsable summary", () => {
+    execSync(
+      "npm run coverage --silent -- backend/tests/coverage/lcovParse.test.ts",
+      { cwd: repoRoot, env },
+    );
+    const summaryPath = path.join(repoRoot, "backend", "coverage", "coverage-summary.json");
+    expect(fs.existsSync(summaryPath)).toBe(true);
+    expect(() => JSON.parse(fs.readFileSync(summaryPath, "utf8"))).not.toThrow();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -62,6 +62,9 @@
   },
   "type": "commonjs",
   "prettier": {},
+  "nyc": {
+    "reporter": ["lcov", "json-summary"]
+  },
   "devDependencies": {
     "@axe-core/cli": "^4.10.2",
     "@axe-core/playwright": "^4.10.2",

--- a/scripts/run-coverage.js
+++ b/scripts/run-coverage.js
@@ -69,14 +69,3 @@ if (result.status) {
   console.error(`Jest exited with code ${result.status}`);
   process.exit(result.status);
 }
-
-const summaryPath = path.join(
-  repoRoot,
-  "backend",
-  "coverage",
-  "coverage-summary.json",
-);
-if (!fs.existsSync(summaryPath)) {
-  console.error(`Missing coverage summary: ${summaryPath}`);
-  process.exit(1);
-}


### PR DESCRIPTION
## Summary
- remove duplicate `summaryPath` declaration in run-coverage.js
- configure nyc reporters in package.json
- test that `npm run coverage` writes a parsable summary file

## Testing
- `node scripts/run-jest.js backend/tests/coverage-summary.test.ts >/tmp/test.log && tail -n 20 /tmp/test.log`

------
https://chatgpt.com/codex/tasks/task_e_687435975120832daa4ed7dc38046131