### PR TITLE
Fix coverage script bug

### DIFF
--- a/backend/tests/runCoverageScript.test.js
+++ b/backend/tests/runCoverageScript.test.js
@@ -31,11 +31,7 @@ describe("run-coverage script", () => {
   test("works when invoked from backend directory", () => {
     const result = spawnSync(
       process.execPath,
-      [
-        "../scripts/run-coverage.js",
-        "--runTestsByPath",
-        "backend/tests/coverage/lcovParse.test.ts",
-      ],
+      [script, "--runTestsByPath", "backend/tests/coverage/lcovParse.test.ts"],
       { cwd: path.join(repoRoot, "backend"), env, encoding: "utf8" },
     );
     expect(result.status).toBe(0);

--- a/js/index.js
+++ b/js/index.js
@@ -132,24 +132,12 @@ function ensureModelViewerLoaded() {
     "https://cdn.jsdelivr.net/npm/@google/model-viewer@1.12.0/dist/model-viewer.min.js";
   const localUrl = "js/model-viewer.min.js";
 
-  return new Promise((resolve) => {
+  function loadScript(src, done) {
     const s = document.createElement("script");
     s.type = "module";
-    s.src = cdnUrl;
-    s.onload = () => {
-      window.modelViewerSource = "cdn";
-      resolve();
-    };
-    s.onerror = () => {
-      s.remove();
-      window.modelViewerSource = "local";
-      const fallback = document.createElement("script");
-      fallback.type = "module";
-      fallback.src = localUrl;
-      fallback.onload = resolve;
-      fallback.onerror = resolve;
-      document.head.appendChild(fallback);
-    };
+    s.src = src;
+    s.onload = done;
+    s.onerror = done;
     document.head.appendChild(s);
   }
 

--- a/scripts/run-coverage.js
+++ b/scripts/run-coverage.js
@@ -55,8 +55,7 @@ output = output.slice(start);
 fs.writeFileSync(lcovPath, output);
 console.log(`LCOV written to ${lcovPath}`);
 const summaryPath = path.join(
-  __dirname,
-  "..",
+  repoRoot,
   "backend",
   "coverage",
   "coverage-summary.json",
@@ -68,15 +67,4 @@ if (!fs.existsSync(summaryPath)) {
 if (result.status) {
   console.error(`Jest exited with code ${result.status}`);
   process.exit(result.status);
-}
-
-const summaryPath = path.join(
-  repoRoot,
-  "backend",
-  "coverage",
-  "coverage-summary.json",
-);
-if (!fs.existsSync(summaryPath)) {
-  console.error(`Missing coverage summary: ${summaryPath}`);
-  process.exit(1);
 }

--- a/tests/checkCoverageScript.test.js
+++ b/tests/checkCoverageScript.test.js
@@ -11,7 +11,9 @@ const summary = path.join(
 );
 const backup = summary + ".bak";
 const nycrc = path.join(__dirname, "..", ".nycrc");
-const nycBackup = nycrc + ".bak";
+let originalConfig = fs.existsSync(nycrc)
+  ? fs.readFileSync(nycrc, "utf8")
+  : undefined;
 
 describe("check-coverage script", () => {
   beforeAll(() => {
@@ -20,6 +22,11 @@ describe("check-coverage script", () => {
 
   afterAll(() => {
     if (fs.existsSync(backup)) fs.renameSync(backup, summary);
+    if (originalConfig !== undefined) {
+      fs.writeFileSync(nycrc, originalConfig);
+    } else if (fs.existsSync(nycrc)) {
+      fs.unlinkSync(nycrc);
+    }
   });
 
   test("fails gracefully when summary missing", () => {
@@ -45,7 +52,7 @@ describe("check-coverage script", () => {
       },
     };
     fs.writeFileSync(summary, JSON.stringify(data));
-    if (fs.existsSync(nycrc)) fs.renameSync(nycrc, nycBackup);
+    if (fs.existsSync(nycrc)) fs.unlinkSync(nycrc);
     fs.writeFileSync(
       nycrc,
       JSON.stringify({
@@ -67,7 +74,11 @@ describe("check-coverage script", () => {
       expect(output).toMatch(/does not meet threshold/);
     } finally {
       fs.unlinkSync(summary);
-      fs.writeFileSync(".nycrc", originalConfig);
+      if (originalConfig !== undefined) {
+        fs.writeFileSync(".nycrc", originalConfig);
+      } else {
+        fs.unlinkSync(".nycrc");
+      }
     }
   });
 


### PR DESCRIPTION
## Summary
- define helper in `ensureModelViewerLoaded` and remove unreachable code
- dedupe `summaryPath` in `run-coverage.js`
- fix lint errors in run coverage tests
- keep `.nycrc` original contents in coverage tests

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_68743523f018832d834bf4d6e3ebd400