### PR TITLE
Add cross-env availability test

### DIFF
--- a/tests/crossEnvInstalled.test.js
+++ b/tests/crossEnvInstalled.test.js
@@ -1,0 +1,20 @@
+const { execSync, spawnSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+test("cross-env available after setup", () => {
+  execSync("SKIP_PW_DEPS=1 SKIP_NET_CHECKS=1 bash scripts/setup.sh", {
+    stdio: "inherit",
+  });
+  const binPath = path.join(
+    __dirname,
+    "..",
+    "node_modules",
+    ".bin",
+    "cross-env",
+  );
+  expect(fs.existsSync(binPath)).toBe(true);
+  const result = spawnSync(binPath, ["echo", "hello"], { encoding: "utf8" });
+  expect(result.status).toBe(0);
+  expect(result.stdout.trim()).toBe("hello");
+});


### PR DESCRIPTION
## Summary
- ensure `cross-env` works after running the setup script

## Testing
- `npm run format:check`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_687433f81e1c832d94ff8e57303370b8