### PR TITLE
Add tests for DALL-E mock server

### DIFF
--- a/backend/__tests__/server.test.ts
+++ b/backend/__tests__/server.test.ts
@@ -1,0 +1,25 @@
+const request = require("supertest");
+
+jest.mock("../../src/logger", () => ({ info: jest.fn() }));
+
+let app;
+beforeEach(() => {
+  jest.resetModules();
+  app = require("../dalle_server/server");
+});
+
+describe("dalle_server /generate", () => {
+  test("returns image when prompt provided", async () => {
+    const res = await request(app).post("/generate").send({ prompt: "hi" });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      image: expect.stringContaining("data:image/png;base64"),
+    });
+  });
+
+  test("returns 400 when prompt missing", async () => {
+    const res = await request(app).post("/generate").send({});
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: "prompt required" });
+  });
+});


### PR DESCRIPTION
## Summary
- cover DALL-E mock server endpoints

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_6874d48a4560832d894dd90282a9787a