### PR TITLE
Fix prettier and lint failures

### DIFF
--- a/backend/tests/runCoverageScript.test.js
+++ b/backend/tests/runCoverageScript.test.js
@@ -31,11 +31,7 @@ describe("run-coverage script", () => {
   test("works when invoked from backend directory", () => {
     const result = spawnSync(
       process.execPath,
-      [
-        "../scripts/run-coverage.js",
-        "--runTestsByPath",
-        "backend/tests/coverage/lcovParse.test.ts",
-      ],
+      [script, "--runTestsByPath", "backend/tests/coverage/lcovParse.test.ts"],
       { cwd: path.join(repoRoot, "backend"), env, encoding: "utf8" },
     );
     expect(result.status).toBe(0);

--- a/js/index.js
+++ b/js/index.js
@@ -151,7 +151,7 @@ function ensureModelViewerLoaded() {
       document.head.appendChild(fallback);
     };
     document.head.appendChild(s);
-  }
+  });
 
   return new Promise((resolve, reject) => {
     const finalize = (attemptedLocal) => {

--- a/scripts/run-coverage.js
+++ b/scripts/run-coverage.js
@@ -55,8 +55,7 @@ output = output.slice(start);
 fs.writeFileSync(lcovPath, output);
 console.log(`LCOV written to ${lcovPath}`);
 const summaryPath = path.join(
-  __dirname,
-  "..",
+  repoRoot,
   "backend",
   "coverage",
   "coverage-summary.json",
@@ -68,15 +67,4 @@ if (!fs.existsSync(summaryPath)) {
 if (result.status) {
   console.error(`Jest exited with code ${result.status}`);
   process.exit(result.status);
-}
-
-const summaryPath = path.join(
-  repoRoot,
-  "backend",
-  "coverage",
-  "coverage-summary.json",
-);
-if (!fs.existsSync(summaryPath)) {
-  console.error(`Missing coverage summary: ${summaryPath}`);
-  process.exit(1);
 }

--- a/tests/checkCoverageScript.test.js
+++ b/tests/checkCoverageScript.test.js
@@ -36,6 +36,9 @@ describe("check-coverage script", () => {
   });
 
   test("fails when coverage below threshold", () => {
+    const originalConfig = fs.existsSync(nycrc)
+      ? fs.readFileSync(nycrc, "utf8")
+      : "";
     const data = {
       total: {
         branches: { pct: 0 },

--- a/tests/rootFormat.test.js
+++ b/tests/rootFormat.test.js
@@ -1,0 +1,7 @@
+const { execSync } = require("child_process");
+
+describe("root format", () => {
+  test("prettier check passes", () => {
+    execSync("npm run format:check", { stdio: "inherit" });
+  });
+});


### PR DESCRIPTION
## Summary
- fix missing Promise closing in `js/index.js`
- remove duplicate variable in `scripts/run-coverage.js`
- use captured config in coverage tests
- fix unused variable in runCoverageScript test
- add root formatting test

## Testing
- `npm run format`
- `npm test --prefix backend --silent`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_6874d33aa9c0832dba885011992a3cf9