### PR TITLE
Fix CI test failures and formatting

### DIFF
--- a/backend/tests/runCoverageScript.test.js
+++ b/backend/tests/runCoverageScript.test.js
@@ -3,7 +3,6 @@ const path = require("path");
 const { spawnSync } = require("child_process");
 
 const repoRoot = path.join(__dirname, "..", "..");
-const script = path.join(repoRoot, "scripts", "run-coverage.js");
 
 const env = {
   ...process.env,

--- a/js/index.js
+++ b/js/index.js
@@ -151,7 +151,7 @@ function ensureModelViewerLoaded() {
       document.head.appendChild(fallback);
     };
     document.head.appendChild(s);
-  }
+  });
 
   return new Promise((resolve, reject) => {
     const finalize = (attemptedLocal) => {

--- a/scripts/run-coverage.js
+++ b/scripts/run-coverage.js
@@ -55,8 +55,7 @@ output = output.slice(start);
 fs.writeFileSync(lcovPath, output);
 console.log(`LCOV written to ${lcovPath}`);
 const summaryPath = path.join(
-  __dirname,
-  "..",
+  repoRoot,
   "backend",
   "coverage",
   "coverage-summary.json",
@@ -68,15 +67,4 @@ if (!fs.existsSync(summaryPath)) {
 if (result.status) {
   console.error(`Jest exited with code ${result.status}`);
   process.exit(result.status);
-}
-
-const summaryPath = path.join(
-  repoRoot,
-  "backend",
-  "coverage",
-  "coverage-summary.json",
-);
-if (!fs.existsSync(summaryPath)) {
-  console.error(`Missing coverage summary: ${summaryPath}`);
-  process.exit(1);
 }

--- a/tests/checkCoverageScript.test.js
+++ b/tests/checkCoverageScript.test.js
@@ -44,7 +44,11 @@ describe("check-coverage script", () => {
         statements: { pct: 0 },
       },
     };
+    fs.mkdirSync(path.dirname(summary), { recursive: true });
     fs.writeFileSync(summary, JSON.stringify(data));
+    const originalConfig = fs.existsSync(nycrc)
+      ? fs.readFileSync(nycrc, "utf8")
+      : "";
     if (fs.existsSync(nycrc)) fs.renameSync(nycrc, nycBackup);
     fs.writeFileSync(
       nycrc,
@@ -72,7 +76,9 @@ describe("check-coverage script", () => {
   });
 
   test("passes when coverage meets thresholds", () => {
-    const originalConfig = fs.readFileSync(".nycrc", "utf8");
+    const originalConfig = fs.existsSync(nycrc)
+      ? fs.readFileSync(nycrc, "utf8")
+      : "";
     const goodSummary = {
       total: {
         branches: { pct: 90 },
@@ -81,6 +87,7 @@ describe("check-coverage script", () => {
         statements: { pct: 90 },
       },
     };
+    fs.mkdirSync(path.dirname(summary), { recursive: true });
     fs.writeFileSync(summary, JSON.stringify(goodSummary));
     fs.writeFileSync(
       ".nycrc",


### PR DESCRIPTION
## Summary
- close Promise syntax in `js/index.js`
- dedupe logic in `scripts/run-coverage.js`
- remove unused variable from `runCoverageScript.test.js`
- handle missing `.nycrc` in `checkCoverageScript.test.js`

## Testing
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6874d32cd114832d9d8e77d2de30d4fe