### PR TITLE
Fix Playwright interruption and add JS syntax test

### DIFF
--- a/backend/tests/runCoverageScript.test.js
+++ b/backend/tests/runCoverageScript.test.js
@@ -31,11 +31,7 @@ describe("run-coverage script", () => {
   test("works when invoked from backend directory", () => {
     const result = spawnSync(
       process.execPath,
-      [
-        "../scripts/run-coverage.js",
-        "--runTestsByPath",
-        "backend/tests/coverage/lcovParse.test.ts",
-      ],
+      [script, "--runTestsByPath", "backend/tests/coverage/lcovParse.test.ts"],
       { cwd: path.join(repoRoot, "backend"), env, encoding: "utf8" },
     );
     expect(result.status).toBe(0);

--- a/js/index.js
+++ b/js/index.js
@@ -151,7 +151,7 @@ function ensureModelViewerLoaded() {
       document.head.appendChild(fallback);
     };
     document.head.appendChild(s);
-  }
+  });
 
   return new Promise((resolve, reject) => {
     const finalize = (attemptedLocal) => {

--- a/scripts/run-coverage.js
+++ b/scripts/run-coverage.js
@@ -55,8 +55,7 @@ output = output.slice(start);
 fs.writeFileSync(lcovPath, output);
 console.log(`LCOV written to ${lcovPath}`);
 const summaryPath = path.join(
-  __dirname,
-  "..",
+  repoRoot,
   "backend",
   "coverage",
   "coverage-summary.json",
@@ -68,15 +67,4 @@ if (!fs.existsSync(summaryPath)) {
 if (result.status) {
   console.error(`Jest exited with code ${result.status}`);
   process.exit(result.status);
-}
-
-const summaryPath = path.join(
-  repoRoot,
-  "backend",
-  "coverage",
-  "coverage-summary.json",
-);
-if (!fs.existsSync(summaryPath)) {
-  console.error(`Missing coverage summary: ${summaryPath}`);
-  process.exit(1);
 }

--- a/tests/checkCoverageScript.test.js
+++ b/tests/checkCoverageScript.test.js
@@ -36,6 +36,7 @@ describe("check-coverage script", () => {
   });
 
   test("fails when coverage below threshold", () => {
+    const originalConfig = fs.readFileSync(".nycrc", "utf8");
     const data = {
       total: {
         branches: { pct: 0 },

--- a/tests/jsSyntax.test.js
+++ b/tests/jsSyntax.test.js
@@ -1,0 +1,13 @@
+const fs = require("fs");
+const path = require("path");
+const parser = require("@babel/parser");
+
+describe("frontend scripts", () => {
+  test("index.js parses without syntax errors", () => {
+    const file = path.join(__dirname, "..", "js", "index.js");
+    const code = fs.readFileSync(file, "utf8");
+    expect(() =>
+      parser.parse(code, { sourceType: "module", plugins: ["dynamicImport"] }),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- ensure `ensureModelViewerLoaded` promise closes properly
- fix `run-coverage.js` duplicate summaryPath
- fix tests referencing `originalConfig`
- use variable in `runCoverageScript.test`
- add new Jest test to parse `js/index.js` with Babel parser

## Testing
- `npm test`
- `npm run format:check`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6874d30bda58832d97776eafb11decc9