### PR TITLE
Handle SIGINT during setup

### DIFF
--- a/backend/tests/runCoverageScript.test.js
+++ b/backend/tests/runCoverageScript.test.js
@@ -3,7 +3,6 @@ const path = require("path");
 const { spawnSync } = require("child_process");
 
 const repoRoot = path.join(__dirname, "..", "..");
-const script = path.join(repoRoot, "scripts", "run-coverage.js");
 
 const env = {
   ...process.env,

--- a/js/index.js
+++ b/js/index.js
@@ -151,7 +151,7 @@ function ensureModelViewerLoaded() {
       document.head.appendChild(fallback);
     };
     document.head.appendChild(s);
-  }
+  });
 
   return new Promise((resolve, reject) => {
     const finalize = (attemptedLocal) => {

--- a/scripts/run-coverage.js
+++ b/scripts/run-coverage.js
@@ -54,22 +54,10 @@ if (start === -1) {
 output = output.slice(start);
 fs.writeFileSync(lcovPath, output);
 console.log(`LCOV written to ${lcovPath}`);
-const summaryPath = path.join(
-  __dirname,
-  "..",
-  "backend",
-  "coverage",
-  "coverage-summary.json",
-);
-if (!fs.existsSync(summaryPath)) {
-  console.error(`Missing coverage summary: ${summaryPath}`);
-  process.exit(1);
-}
 if (result.status) {
   console.error(`Jest exited with code ${result.status}`);
   process.exit(result.status);
 }
-
 const summaryPath = path.join(
   repoRoot,
   "backend",

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -19,6 +19,14 @@ cleanup_npm_cache() {
 }
 
 trap cleanup_npm_cache EXIT
+
+handle_sigint() {
+  echo "Setup interrupted by SIGINT. Please run 'npm run setup' again." >&2
+  rm -f .setup-complete
+  exit 130
+}
+trap handle_sigint SIGINT
+
 cleanup_npm_cache
 
 unset npm_config_http_proxy npm_config_https_proxy

--- a/tests/bin-sigint/npm
+++ b/tests/bin-sigint/npm
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+if [[ "$1" == "ping" ]]; then
+  exit 0
+fi
+if [[ "$1" == "ci" && -z "$SIGINT_DONE" ]]; then
+  echo "npm ERR! canceled" >&2
+  echo "npm ERR! signal SIGINT" >&2
+  export SIGINT_DONE=1
+  exit 130
+fi
+exec "$REAL_NPM" "$@"

--- a/tests/checkCoverageScript.test.js
+++ b/tests/checkCoverageScript.test.js
@@ -12,6 +12,10 @@ const summary = path.join(
 const backup = summary + ".bak";
 const nycrc = path.join(__dirname, "..", ".nycrc");
 const nycBackup = nycrc + ".bak";
+const originalConfig = fs.existsSync(nycrc)
+  ? fs.readFileSync(nycrc, "utf8")
+  : "";
+fs.mkdirSync(path.dirname(summary), { recursive: true });
 
 describe("check-coverage script", () => {
   beforeAll(() => {
@@ -72,7 +76,6 @@ describe("check-coverage script", () => {
   });
 
   test("passes when coverage meets thresholds", () => {
-    const originalConfig = fs.readFileSync(".nycrc", "utf8");
     const goodSummary = {
       total: {
         branches: { pct: 90 },

--- a/tests/setupScriptSigint.test.js
+++ b/tests/setupScriptSigint.test.js
@@ -1,0 +1,28 @@
+const { execSync } = require("child_process");
+const path = require("path");
+const fs = require("fs");
+
+describe("setup script SIGINT handling", () => {
+  test("reports interruption when npm ci is terminated", () => {
+    const env = {
+      ...process.env,
+      HF_TOKEN: "test",
+      AWS_ACCESS_KEY_ID: "id",
+      AWS_SECRET_ACCESS_KEY: "secret",
+      DB_URL: "postgres://user:pass@localhost/db",
+      STRIPE_SECRET_KEY: "sk_test",
+      SKIP_NET_CHECKS: "1",
+      SKIP_PW_DEPS: "1",
+      REAL_NPM: execSync("command -v npm").toString().trim(),
+      PATH: path.join(__dirname, "bin-sigint") + ":" + process.env.PATH,
+    };
+    let output = "";
+    try {
+      execSync("bash scripts/setup.sh", { env, stdio: "pipe" });
+    } catch (err) {
+      output = String(err.stdout || "") + String(err.stderr || "");
+    }
+    expect(output).toMatch(/Setup interrupted by SIGINT/);
+    expect(fs.existsSync(path.join(__dirname, "..", ".setup-complete"))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- handle SIGINT in setup script and add regression test
- fix broken coverage test fixture
- close model viewer script promise correctly
- cleanup run-coverage helper

## Testing
- `npm run format`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6874d2c2090c832dba8935ac4af72150