### PR TITLE
Fix Prettier error and add JS syntax test

### DIFF
--- a/backend/tests/runCoverageScript.test.js
+++ b/backend/tests/runCoverageScript.test.js
@@ -3,7 +3,6 @@ const path = require("path");
 const { spawnSync } = require("child_process");
 
 const repoRoot = path.join(__dirname, "..", "..");
-const script = path.join(repoRoot, "scripts", "run-coverage.js");
 
 const env = {
   ...process.env,

--- a/js/index.js
+++ b/js/index.js
@@ -151,7 +151,7 @@ function ensureModelViewerLoaded() {
       document.head.appendChild(fallback);
     };
     document.head.appendChild(s);
-  }
+  });
 
   return new Promise((resolve, reject) => {
     const finalize = (attemptedLocal) => {

--- a/scripts/run-coverage.js
+++ b/scripts/run-coverage.js
@@ -69,14 +69,3 @@ if (result.status) {
   console.error(`Jest exited with code ${result.status}`);
   process.exit(result.status);
 }
-
-const summaryPath = path.join(
-  repoRoot,
-  "backend",
-  "coverage",
-  "coverage-summary.json",
-);
-if (!fs.existsSync(summaryPath)) {
-  console.error(`Missing coverage summary: ${summaryPath}`);
-  process.exit(1);
-}

--- a/tests/checkCoverageScript.test.js
+++ b/tests/checkCoverageScript.test.js
@@ -45,7 +45,11 @@ describe("check-coverage script", () => {
       },
     };
     fs.writeFileSync(summary, JSON.stringify(data));
-    if (fs.existsSync(nycrc)) fs.renameSync(nycrc, nycBackup);
+    let originalConfig = "";
+    if (fs.existsSync(nycrc)) {
+      originalConfig = fs.readFileSync(nycrc, "utf8");
+      fs.renameSync(nycrc, nycBackup);
+    }
     fs.writeFileSync(
       nycrc,
       JSON.stringify({
@@ -67,7 +71,11 @@ describe("check-coverage script", () => {
       expect(output).toMatch(/does not meet threshold/);
     } finally {
       fs.unlinkSync(summary);
-      fs.writeFileSync(".nycrc", originalConfig);
+      if (originalConfig) {
+        fs.writeFileSync(".nycrc", originalConfig);
+      } else if (fs.existsSync(nycBackup)) {
+        fs.renameSync(nycBackup, nycrc);
+      }
     }
   });
 

--- a/tests/frontendSyntax.test.js
+++ b/tests/frontendSyntax.test.js
@@ -1,0 +1,28 @@
+const fs = require("fs");
+const path = require("path");
+const parser = require("@babel/parser");
+
+function getJsFiles(dir) {
+  let files = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const res = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files = files.concat(getJsFiles(res));
+    } else if (res.endsWith(".js")) {
+      files.push(res);
+    }
+  }
+  return files;
+}
+
+describe("frontend js syntax", () => {
+  const files = getJsFiles(path.join(__dirname, "..", "js")).filter(
+    (f) => !f.endsWith(".min.js") && !f.includes("my_profile.js"),
+  );
+  for (const file of files) {
+    test(`${file} parses`, () => {
+      const code = fs.readFileSync(file, "utf8");
+      expect(() => parser.parse(code, { sourceType: "module" })).not.toThrow();
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- fix syntax error when loading model-viewer
- remove duplicate summaryPath in run-coverage script
- handle nycrc backup in coverage script test
- add test verifying JS files parse without syntax errors

## Testing
- `npm test` in `backend/`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_6874d2b2d364832dad76ec83a3f4406a