### PR TITLE
Fix format errors blocking CI

### DIFF
--- a/backend/tests/runCoverageScript.test.js
+++ b/backend/tests/runCoverageScript.test.js
@@ -3,7 +3,6 @@ const path = require("path");
 const { spawnSync } = require("child_process");
 
 const repoRoot = path.join(__dirname, "..", "..");
-const script = path.join(repoRoot, "scripts", "run-coverage.js");
 
 const env = {
   ...process.env,

--- a/js/index.js
+++ b/js/index.js
@@ -151,7 +151,7 @@ function ensureModelViewerLoaded() {
       document.head.appendChild(fallback);
     };
     document.head.appendChild(s);
-  }
+  });
 
   return new Promise((resolve, reject) => {
     const finalize = (attemptedLocal) => {

--- a/scripts/run-coverage.js
+++ b/scripts/run-coverage.js
@@ -55,8 +55,7 @@ output = output.slice(start);
 fs.writeFileSync(lcovPath, output);
 console.log(`LCOV written to ${lcovPath}`);
 const summaryPath = path.join(
-  __dirname,
-  "..",
+  repoRoot,
   "backend",
   "coverage",
   "coverage-summary.json",
@@ -68,15 +67,4 @@ if (!fs.existsSync(summaryPath)) {
 if (result.status) {
   console.error(`Jest exited with code ${result.status}`);
   process.exit(result.status);
-}
-
-const summaryPath = path.join(
-  repoRoot,
-  "backend",
-  "coverage",
-  "coverage-summary.json",
-);
-if (!fs.existsSync(summaryPath)) {
-  console.error(`Missing coverage summary: ${summaryPath}`);
-  process.exit(1);
 }

--- a/tests/checkCoverageScript.test.js
+++ b/tests/checkCoverageScript.test.js
@@ -44,8 +44,12 @@ describe("check-coverage script", () => {
         statements: { pct: 0 },
       },
     };
+    fs.mkdirSync(path.dirname(summary), { recursive: true });
     fs.writeFileSync(summary, JSON.stringify(data));
-    if (fs.existsSync(nycrc)) fs.renameSync(nycrc, nycBackup);
+    const hadConfig = fs.existsSync(nycrc);
+    if (hadConfig) {
+      fs.renameSync(nycrc, nycBackup);
+    }
     fs.writeFileSync(
       nycrc,
       JSON.stringify({
@@ -67,7 +71,11 @@ describe("check-coverage script", () => {
       expect(output).toMatch(/does not meet threshold/);
     } finally {
       fs.unlinkSync(summary);
-      fs.writeFileSync(".nycrc", originalConfig);
+      if (hadConfig) {
+        fs.renameSync(nycBackup, nycrc);
+      } else {
+        fs.unlinkSync(nycrc);
+      }
     }
   });
 
@@ -81,6 +89,7 @@ describe("check-coverage script", () => {
         statements: { pct: 90 },
       },
     };
+    fs.mkdirSync(path.dirname(summary), { recursive: true });
     fs.writeFileSync(summary, JSON.stringify(goodSummary));
     fs.writeFileSync(
       ".nycrc",


### PR DESCRIPTION
## Summary
- close dangling Promise in `js/index.js`
- dedupe summary path logic in `run-coverage.js`
- repair `checkCoverageScript.test.js` to handle missing `.nycrc`
- remove unused variable in `runCoverageScript.test.js`

## Testing
- `npm run format:check`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874d2723910832da5d8a88e36444989