### PR TITLE
Fix CI lint issues

### DIFF
--- a/backend/tests/runCoverageScript.test.js
+++ b/backend/tests/runCoverageScript.test.js
@@ -31,11 +31,7 @@ describe("run-coverage script", () => {
   test("works when invoked from backend directory", () => {
     const result = spawnSync(
       process.execPath,
-      [
-        "../scripts/run-coverage.js",
-        "--runTestsByPath",
-        "backend/tests/coverage/lcovParse.test.ts",
-      ],
+      [script, "--runTestsByPath", "backend/tests/coverage/lcovParse.test.ts"],
       { cwd: path.join(repoRoot, "backend"), env, encoding: "utf8" },
     );
     expect(result.status).toBe(0);

--- a/js/index.js
+++ b/js/index.js
@@ -151,7 +151,7 @@ function ensureModelViewerLoaded() {
       document.head.appendChild(fallback);
     };
     document.head.appendChild(s);
-  }
+  });
 
   return new Promise((resolve, reject) => {
     const finalize = (attemptedLocal) => {

--- a/scripts/run-coverage.js
+++ b/scripts/run-coverage.js
@@ -69,14 +69,3 @@ if (result.status) {
   console.error(`Jest exited with code ${result.status}`);
   process.exit(result.status);
 }
-
-const summaryPath = path.join(
-  repoRoot,
-  "backend",
-  "coverage",
-  "coverage-summary.json",
-);
-if (!fs.existsSync(summaryPath)) {
-  console.error(`Missing coverage summary: ${summaryPath}`);
-  process.exit(1);
-}

--- a/tests/checkCoverageScript.test.js
+++ b/tests/checkCoverageScript.test.js
@@ -12,6 +12,7 @@ const summary = path.join(
 const backup = summary + ".bak";
 const nycrc = path.join(__dirname, "..", ".nycrc");
 const nycBackup = nycrc + ".bak";
+let originalConfig = fs.existsSync(nycrc) ? fs.readFileSync(nycrc, "utf8") : "";
 
 describe("check-coverage script", () => {
   beforeAll(() => {
@@ -72,7 +73,6 @@ describe("check-coverage script", () => {
   });
 
   test("passes when coverage meets thresholds", () => {
-    const originalConfig = fs.readFileSync(".nycrc", "utf8");
     const goodSummary = {
       total: {
         branches: { pct: 90 },


### PR DESCRIPTION
## Summary
- close missing paren in js/index.js
- remove duplicate code in scripts/run-coverage.js
- store `.nycrc` config for tests
- use the helper variable in runCoverageScript.test.js

## Testing
- `npm run format`
- `npm run lint`
- `npm run typecheck`
- `npm run i18n:lint`
- `npm run test:ci`
- `npm run test:a11y`
- `SKIP_PW_DEPS=1 npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_6874d24a1ff8832d961ede72709c0512