### PR TITLE
Fix CI setup and failing tests

### DIFF
--- a/backend/tests/runCoverageScript.test.js
+++ b/backend/tests/runCoverageScript.test.js
@@ -3,6 +3,7 @@ const path = require("path");
 const { spawnSync } = require("child_process");
 
 const repoRoot = path.join(__dirname, "..", "..");
+const script = path.join(repoRoot, "scripts", "run-coverage.js");
 
 const env = {
   ...process.env,

--- a/js/index.js
+++ b/js/index.js
@@ -139,7 +139,7 @@ function ensureModelViewerLoaded() {
     s.onload = done;
     s.onerror = done;
     document.head.appendChild(s);
-  });
+  }
 
   return new Promise((resolve, reject) => {
     const finalize = (attemptedLocal) => {
@@ -879,9 +879,9 @@ async function init() {
   try {
     await ensureModelViewerLoaded();
   } catch (err) {
-    console.error('Failed to load model-viewer', err);
+    console.error("Failed to load model-viewer", err);
     if (globalThis.document) {
-      document.body.dataset.viewerReady = 'error';
+      document.body.dataset.viewerReady = "error";
     }
   }
   if (window.customElements?.whenDefined) {

--- a/tests/checkCoverageScript.test.js
+++ b/tests/checkCoverageScript.test.js
@@ -11,6 +11,7 @@ const summary = path.join(
 );
 const backup = summary + ".bak";
 const nycrc = path.join(__dirname, "..", ".nycrc");
+const nycBackup = nycrc + ".bak";
 let originalConfig = fs.existsSync(nycrc)
   ? fs.readFileSync(nycrc, "utf8")
   : undefined;
@@ -43,9 +44,6 @@ describe("check-coverage script", () => {
   });
 
   test("fails when coverage below threshold", () => {
-    const originalConfig = fs.existsSync(".nycrc")
-      ? fs.readFileSync(".nycrc", "utf8")
-      : "";
     const data = {
       total: {
         branches: { pct: 0 },


### PR DESCRIPTION
## Summary
- fix script loading bug in `js/index.js`
- ensure `.nycrc` backup handling in coverage tests
- add missing script path for run-coverage test

## Testing
- `npm run format`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_6874dac69f14832d8006448c2884a9ce