### PR TITLE
Fix lint failures in coverage scripts

### DIFF
--- a/backend/tests/runCoverageScript.test.js
+++ b/backend/tests/runCoverageScript.test.js
@@ -3,6 +3,7 @@ const path = require("path");
 const { spawnSync } = require("child_process");
 
 const repoRoot = path.join(__dirname, "..", "..");
+const script = path.join(repoRoot, "scripts", "run-coverage.js");
 
 const env = {
   ...process.env,

--- a/js/index.js
+++ b/js/index.js
@@ -139,7 +139,7 @@ function ensureModelViewerLoaded() {
     s.onload = done;
     s.onerror = done;
     document.head.appendChild(s);
-  });
+  }
 
   return new Promise((resolve, reject) => {
     const finalize = (attemptedLocal) => {
@@ -879,9 +879,9 @@ async function init() {
   try {
     await ensureModelViewerLoaded();
   } catch (err) {
-    console.error('Failed to load model-viewer', err);
+    console.error("Failed to load model-viewer", err);
     if (globalThis.document) {
-      document.body.dataset.viewerReady = 'error';
+      document.body.dataset.viewerReady = "error";
     }
   }
   if (window.customElements?.whenDefined) {

--- a/tests/checkCoverageScript.test.js
+++ b/tests/checkCoverageScript.test.js
@@ -11,6 +11,7 @@ const summary = path.join(
 );
 const backup = summary + ".bak";
 const nycrc = path.join(__dirname, "..", ".nycrc");
+const nycBackup = nycrc + ".bak";
 let originalConfig = fs.existsSync(nycrc)
   ? fs.readFileSync(nycrc, "utf8")
   : undefined;
@@ -43,8 +44,8 @@ describe("check-coverage script", () => {
   });
 
   test("fails when coverage below threshold", () => {
-    const originalConfig = fs.existsSync(".nycrc")
-      ? fs.readFileSync(".nycrc", "utf8")
+    const origConfig = fs.existsSync(nycrc)
+      ? fs.readFileSync(nycrc, "utf8")
       : "";
     const data = {
       total: {
@@ -55,9 +56,6 @@ describe("check-coverage script", () => {
       },
     };
     fs.writeFileSync(summary, JSON.stringify(data));
-    const originalConfig = fs.existsSync(nycrc)
-      ? fs.readFileSync(nycrc, "utf8")
-      : "";
     if (fs.existsSync(nycrc)) fs.renameSync(nycrc, nycBackup);
     fs.writeFileSync(
       nycrc,
@@ -80,10 +78,10 @@ describe("check-coverage script", () => {
       expect(output).toMatch(/does not meet threshold/);
     } finally {
       fs.unlinkSync(summary);
-      if (originalConfig !== undefined) {
-        fs.writeFileSync(".nycrc", originalConfig);
-      } else {
-        fs.unlinkSync(".nycrc");
+      if (origConfig) {
+        fs.writeFileSync(nycrc, origConfig);
+      } else if (fs.existsSync(nycrc)) {
+        fs.unlinkSync(nycrc);
       }
     }
   });


### PR DESCRIPTION
## Summary
- correct syntax in `js/index.js`
- fix duplicate declarations in coverage tests
- define script path in runCoverageScript test

## Testing
- `npm run format`
- `npm test`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_6874dab5a760832d85ca0487790ad498