### PR TITLE
Fix syntax error in index and update tests

### DIFF
--- a/backend/tests/runCoverageScript.test.js
+++ b/backend/tests/runCoverageScript.test.js
@@ -3,6 +3,7 @@ const path = require("path");
 const { spawnSync } = require("child_process");
 
 const repoRoot = path.join(__dirname, "..", "..");
+const script = path.join(repoRoot, "scripts", "run-coverage.js");
 
 const env = {
   ...process.env,

--- a/js/index.js
+++ b/js/index.js
@@ -139,7 +139,7 @@ function ensureModelViewerLoaded() {
     s.onload = done;
     s.onerror = done;
     document.head.appendChild(s);
-  });
+  }
 
   return new Promise((resolve, reject) => {
     const finalize = (attemptedLocal) => {
@@ -879,9 +879,9 @@ async function init() {
   try {
     await ensureModelViewerLoaded();
   } catch (err) {
-    console.error('Failed to load model-viewer', err);
+    console.error("Failed to load model-viewer", err);
     if (globalThis.document) {
-      document.body.dataset.viewerReady = 'error';
+      document.body.dataset.viewerReady = "error";
     }
   }
   if (window.customElements?.whenDefined) {

--- a/tests/checkCoverageScript.test.js
+++ b/tests/checkCoverageScript.test.js
@@ -44,8 +44,8 @@ describe("check-coverage script", () => {
   });
 
   test("fails when coverage below threshold", () => {
-    const originalConfig = fs.existsSync(".nycrc")
-      ? fs.readFileSync(".nycrc", "utf8")
+    const origConfig = fs.existsSync(nycrc)
+      ? fs.readFileSync(nycrc, "utf8")
       : "";
     const data = {
       total: {
@@ -55,11 +55,7 @@ describe("check-coverage script", () => {
         statements: { pct: 0 },
       },
     };
-    const originalConfig = fs.readFileSync(".nycrc", "utf8");
     fs.writeFileSync(summary, JSON.stringify(data));
-    const originalConfig = fs.existsSync(nycrc)
-      ? fs.readFileSync(nycrc, "utf8")
-      : "";
     if (fs.existsSync(nycrc)) fs.renameSync(nycrc, nycBackup);
     fs.writeFileSync(
       nycrc,
@@ -85,13 +81,13 @@ describe("check-coverage script", () => {
       if (fs.existsSync(nycBackup)) {
         fs.renameSync(nycBackup, nycrc);
       } else {
-        fs.unlinkSync(nycrc);
+        fs.writeFileSync(nycrc, origConfig);
       }
     }
   });
 
   test("passes when coverage meets thresholds", () => {
-    const originalConfig = fs.existsSync(nycrc)
+    const origConfig = fs.existsSync(nycrc)
       ? fs.readFileSync(nycrc, "utf8")
       : "";
     const goodSummary = {
@@ -105,7 +101,7 @@ describe("check-coverage script", () => {
     fs.mkdirSync(path.dirname(summary), { recursive: true });
     fs.writeFileSync(summary, JSON.stringify(goodSummary));
     fs.writeFileSync(
-      ".nycrc",
+      nycrc,
       JSON.stringify({
         "check-coverage": true,
         branches: 80,
@@ -117,10 +113,12 @@ describe("check-coverage script", () => {
     const output = execFileSync(
       "node",
       [path.join("scripts", "check-coverage.js")],
-      { encoding: "utf8" },
+      {
+        encoding: "utf8",
+      },
     );
     expect(output).toMatch(/Coverage thresholds met/);
     fs.unlinkSync(summary);
-    fs.writeFileSync(".nycrc", origConfig);
+    fs.writeFileSync(nycrc, origConfig);
   });
 });


### PR DESCRIPTION
## Summary
- fix `js/index.js` syntax error
- ensure run-coverage test references script path
- clean up checkCoverageScript.test.js

## Testing
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`
- `npm run format --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_6874deb29834832dbb884f0c5b86dd15