### PR TITLE
Fix diagnose script env sourcing

### DIFF
--- a/backend/tests/runCoverageScript.test.js
+++ b/backend/tests/runCoverageScript.test.js
@@ -3,6 +3,7 @@ const path = require("path");
 const { spawnSync } = require("child_process");
 
 const repoRoot = path.join(__dirname, "..", "..");
+const script = path.join(repoRoot, "scripts", "run-coverage.js");
 
 const env = {
   ...process.env,

--- a/js/index.js
+++ b/js/index.js
@@ -139,7 +139,7 @@ function ensureModelViewerLoaded() {
     s.onload = done;
     s.onerror = done;
     document.head.appendChild(s);
-  });
+  }
 
   return new Promise((resolve, reject) => {
     const finalize = (attemptedLocal) => {
@@ -879,9 +879,9 @@ async function init() {
   try {
     await ensureModelViewerLoaded();
   } catch (err) {
-    console.error('Failed to load model-viewer', err);
+    console.error("Failed to load model-viewer", err);
     if (globalThis.document) {
-      document.body.dataset.viewerReady = 'error';
+      document.body.dataset.viewerReady = "error";
     }
   }
   if (window.customElements?.whenDefined) {

--- a/scripts/diagnose.sh
+++ b/scripts/diagnose.sh
@@ -12,7 +12,8 @@ banner() {
 }
 
 banner "Running environment validation"
-bash scripts/validate-env.sh
+# Source validate-env so exported variables persist in this script
+source scripts/validate-env.sh
 
 banner "Starting dev server"
 pnpm dev &

--- a/tests/checkCoverageScript.test.js
+++ b/tests/checkCoverageScript.test.js
@@ -11,6 +11,7 @@ const summary = path.join(
 );
 const backup = summary + ".bak";
 const nycrc = path.join(__dirname, "..", ".nycrc");
+const nycBackup = nycrc + ".bak";
 let originalConfig = fs.existsSync(nycrc)
   ? fs.readFileSync(nycrc, "utf8")
   : undefined;
@@ -43,9 +44,6 @@ describe("check-coverage script", () => {
   });
 
   test("fails when coverage below threshold", () => {
-    const originalConfig = fs.existsSync(".nycrc")
-      ? fs.readFileSync(".nycrc", "utf8")
-      : "";
     const data = {
       total: {
         branches: { pct: 0 },
@@ -55,7 +53,7 @@ describe("check-coverage script", () => {
       },
     };
     fs.writeFileSync(summary, JSON.stringify(data));
-    const originalConfig = fs.existsSync(nycrc)
+    const prevConfig = fs.existsSync(nycrc)
       ? fs.readFileSync(nycrc, "utf8")
       : "";
     if (fs.existsSync(nycrc)) fs.renameSync(nycrc, nycBackup);
@@ -80,8 +78,8 @@ describe("check-coverage script", () => {
       expect(output).toMatch(/does not meet threshold/);
     } finally {
       fs.unlinkSync(summary);
-      if (originalConfig !== undefined) {
-        fs.writeFileSync(".nycrc", originalConfig);
+      if (prevConfig !== undefined) {
+        fs.writeFileSync(".nycrc", prevConfig);
       } else {
         fs.unlinkSync(".nycrc");
       }

--- a/tests/diagnoseScript.test.js
+++ b/tests/diagnoseScript.test.js
@@ -12,7 +12,7 @@ describe("diagnose script", () => {
       path.join(__dirname, "..", "scripts", "diagnose.sh"),
       "utf8",
     );
-    expect(content).toMatch(/validate-env\.sh/);
+    expect(content).toMatch(/source scripts\/validate-env\.sh/);
     expect(content).toMatch(/test-full-pipeline\.js/);
     expect(content).toMatch(/DIAGNOSTICS PASSED/);
     expect(content).toMatch(/run-jest\.js/);


### PR DESCRIPTION
## Summary
- ensure diagnose.sh sources environment variables
- fix model-viewer script syntax error
- update diagnoseScript test expectations
- clean up coverage script tests
- define run-coverage path in tests

## Testing
- `npm test --prefix backend`
- `node scripts/run-jest.js`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6874da935228832db1280af0919f2d01