### PR TITLE
Update nyc configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,18 @@
 {
   "name": "mvp-website",
   "version": "1.0.0",
+  "nyc": {
+    "reporter": [
+      "lcov",
+      "text",
+      "json-summary"
+    ],
+    "check-coverage": true,
+    "branches": 80,
+    "functions": 80,
+    "lines": 80,
+    "statements": 80
+  },
   "description": "This repository contains the early MVP code for print2's website and backend.",
   "main": "index.js",
   "directories": {
@@ -62,13 +74,6 @@
   },
   "type": "commonjs",
   "prettier": {},
-  "nyc": {
-    "reporter": [
-      "lcov",
-      "text",
-      "json-summary"
-    ]
-  },
   "devDependencies": {
     "@axe-core/cli": "^4.10.2",
     "@axe-core/playwright": "^4.10.2",


### PR DESCRIPTION
## Summary
- move nyc settings near the top of package.json
- enable text and json-summary reporters with coverage checks

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_6874e2a6da64832da232ef75d10c5f86