### PR TITLE
Fix js syntax error and update coverage tests

### DIFF
--- a/backend/tests/runCoverageScript.test.js
+++ b/backend/tests/runCoverageScript.test.js
@@ -3,6 +3,7 @@ const path = require("path");
 const { spawnSync } = require("child_process");
 
 const repoRoot = path.join(__dirname, "..", "..");
+const script = path.join(repoRoot, "scripts", "run-coverage.js");
 
 const env = {
   ...process.env,

--- a/js/index.js
+++ b/js/index.js
@@ -139,7 +139,7 @@ function ensureModelViewerLoaded() {
     s.onload = done;
     s.onerror = done;
     document.head.appendChild(s);
-  });
+  }
 
   return new Promise((resolve, reject) => {
     const finalize = (attemptedLocal) => {
@@ -879,9 +879,9 @@ async function init() {
   try {
     await ensureModelViewerLoaded();
   } catch (err) {
-    console.error('Failed to load model-viewer', err);
+    console.error("Failed to load model-viewer", err);
     if (globalThis.document) {
-      document.body.dataset.viewerReady = 'error';
+      document.body.dataset.viewerReady = "error";
     }
   }
   if (window.customElements?.whenDefined) {

--- a/tests/checkCoverageScript.test.js
+++ b/tests/checkCoverageScript.test.js
@@ -44,9 +44,6 @@ describe("check-coverage script", () => {
   });
 
   test("fails when coverage below threshold", () => {
-    const originalConfig = fs.existsSync(".nycrc")
-      ? fs.readFileSync(".nycrc", "utf8")
-      : "";
     const data = {
       total: {
         branches: { pct: 0 },
@@ -55,11 +52,7 @@ describe("check-coverage script", () => {
         statements: { pct: 0 },
       },
     };
-    const originalConfig = fs.readFileSync(".nycrc", "utf8");
     fs.writeFileSync(summary, JSON.stringify(data));
-    const originalConfig = fs.existsSync(nycrc)
-      ? fs.readFileSync(nycrc, "utf8")
-      : "";
     if (fs.existsSync(nycrc)) fs.renameSync(nycrc, nycBackup);
     fs.writeFileSync(
       nycrc,
@@ -91,9 +84,6 @@ describe("check-coverage script", () => {
   });
 
   test("passes when coverage meets thresholds", () => {
-    const originalConfig = fs.existsSync(nycrc)
-      ? fs.readFileSync(nycrc, "utf8")
-      : "";
     const goodSummary = {
       total: {
         branches: { pct: 90 },
@@ -105,7 +95,7 @@ describe("check-coverage script", () => {
     fs.mkdirSync(path.dirname(summary), { recursive: true });
     fs.writeFileSync(summary, JSON.stringify(goodSummary));
     fs.writeFileSync(
-      ".nycrc",
+      nycrc,
       JSON.stringify({
         "check-coverage": true,
         branches: 80,
@@ -117,10 +107,12 @@ describe("check-coverage script", () => {
     const output = execFileSync(
       "node",
       [path.join("scripts", "check-coverage.js")],
-      { encoding: "utf8" },
+      {
+        encoding: "utf8",
+      },
     );
     expect(output).toMatch(/Coverage thresholds met/);
     fs.unlinkSync(summary);
-    fs.writeFileSync(".nycrc", origConfig);
+    fs.writeFileSync(nycrc, originalConfig);
   });
 });


### PR DESCRIPTION
## Summary
- fix missing brace in `js/index.js`
- add path definition to coverage test helper
- clean duplicate variables in coverage script test

## Testing
- `npm run format`
- `npm test` in `backend/`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6874e1b533bc832d890a3515c86eef2c