### PR TITLE
Fix ensure-deps host check

### DIFF
--- a/backend/scripts/ensure-deps.js
+++ b/backend/scripts/ensure-deps.js
@@ -154,3 +154,12 @@ if (!fs.existsSync(jestPath)) {
     process.exit(1);
   }
 }
+
+// Verify Playwright host dependencies so tests don't fail with missing library errors
+try {
+  const hostDeps = path.join(repoRoot, "scripts", "check-host-deps.js");
+  execSync(`node ${hostDeps}`, { stdio: "inherit" });
+} catch (err) {
+  console.error("Failed to verify Playwright host dependencies:", err.message);
+  process.exit(1);
+}

--- a/tests/ensureDepsHostDeps.test.js
+++ b/tests/ensureDepsHostDeps.test.js
@@ -1,0 +1,21 @@
+const fs = require("fs");
+const child_process = require("child_process");
+
+jest.mock("fs");
+
+describe("ensure-deps host deps check", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    fs.existsSync.mockReturnValue(true);
+    jest.spyOn(child_process, "execSync").mockImplementation(() => {});
+    process.env.SKIP_NODE_CHECK = "1";
+  });
+
+  test("invokes host dependency check", () => {
+    require("../backend/scripts/ensure-deps");
+    expect(child_process.execSync).toHaveBeenCalledWith(
+      expect.stringContaining("check-host-deps.js"),
+      expect.any(Object),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- verify Playwright host dependencies when running backend tests
- add regression test for ensure-deps host check

## Testing
- `SKIP_NET_CHECKS=1 npm test`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_6874e555b234832d9d5964639eb9f910