### PR TITLE
Improve smoke test failure diagnostics

### DIFF
--- a/e2e/smoke.test.js
+++ b/e2e/smoke.test.js
@@ -69,9 +69,18 @@ test('model generator page', async ({ page }) => {
   await page.waitForFunction(() => window.customElements.get('model-viewer'));
   // Allow extra time for the viewer to load when the CDN script fails and the
   // page falls back to the local copy. Bail out if the viewer fails entirely.
-  await page.waitForFunction(() => document.body.dataset.viewerReady, {
-    timeout: 120000,
-  });
+  try {
+    await page.waitForFunction(() => document.body.dataset.viewerReady, {
+      timeout: 120000,
+    });
+  } catch (err) {
+    if (err.name === 'TimeoutError') {
+      await page.screenshot({
+        path: `test-results/failure-${Date.now()}.png`,
+      });
+    }
+    throw err;
+  }
   const ready = await page.evaluate(() => document.body.dataset.viewerReady);
   test.skip(ready !== 'true', 'model viewer failed to load');
   await expect(page.locator('#viewer')).toBeVisible();
@@ -103,9 +112,18 @@ test('generate flow', async ({ page }) => {
   await page.click('#gen-submit');
   // Wait for the viewer to signal readiness before checking the canvas.
   // This prevents flaky timeouts when external scripts load slowly.
-  await page.waitForFunction(() => document.body.dataset.viewerReady, {
-    timeout: 120000,
-  });
+  try {
+    await page.waitForFunction(() => document.body.dataset.viewerReady, {
+      timeout: 120000,
+    });
+  } catch (err) {
+    if (err.name === 'TimeoutError') {
+      await page.screenshot({
+        path: `test-results/failure-${Date.now()}.png`,
+      });
+    }
+    throw err;
+  }
   const ready2 = await page.evaluate(() => document.body.dataset.viewerReady);
   test.skip(ready2 !== 'true', 'model viewer failed to load');
   // Wait longer for the model viewer to load on slow networks

--- a/tests/checkCoverageScript.test.js
+++ b/tests/checkCoverageScript.test.js
@@ -12,9 +12,7 @@ const summary = path.join(
 const backup = summary + ".bak";
 const nycrc = path.join(__dirname, "..", ".nycrc");
 const nycBackup = nycrc + ".bak";
-let originalConfig = fs.existsSync(nycrc)
-  ? fs.readFileSync(nycrc, "utf8")
-  : "";
+let originalConfig = fs.existsSync(nycrc) ? fs.readFileSync(nycrc, "utf8") : "";
 
 describe("check-coverage script", () => {
   beforeAll(() => {
@@ -52,7 +50,6 @@ describe("check-coverage script", () => {
         statements: { pct: 0 },
       },
     };
-    const originalConfig = fs.readFileSync(".nycrc", "utf8");
     fs.writeFileSync(summary, JSON.stringify(data));
     const prevConfig = fs.existsSync(nycrc)
       ? fs.readFileSync(nycrc, "utf8")
@@ -118,6 +115,6 @@ describe("check-coverage script", () => {
     );
     expect(output).toMatch(/Coverage thresholds met/);
     fs.unlinkSync(summary);
-    fs.writeFileSync(".nycrc", origConfig);
+    fs.writeFileSync(".nycrc", originalConfig);
   });
 });


### PR DESCRIPTION
## Summary
- handle timeouts in smoke tests by capturing screenshots
- fix a small lint issue in checkCoverageScript test

## Testing
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6874e9614384832d82e8b763afbb9c99