### PR TITLE
Improve checkout route test coverage

### DIFF
--- a/backend/tests/checkout.edgecases.test.ts
+++ b/backend/tests/checkout.edgecases.test.ts
@@ -1,0 +1,78 @@
+const request = require("supertest");
+const Stripe = require("stripe");
+
+process.env.STRIPE_TEST_KEY = "sk_test";
+process.env.STRIPE_LIVE_KEY = "sk_live";
+process.env.STRIPE_WEBHOOK_SECRET = "whsec";
+
+jest.mock("stripe");
+const stripeMock = {
+  checkout: {
+    sessions: {
+      create: jest.fn(),
+    },
+  },
+};
+Stripe.mockImplementation(() => stripeMock);
+
+const app = require("../src/app");
+const { orders } = require("../src/routes/checkout");
+
+afterEach(() => {
+  orders.clear();
+  jest.clearAllMocks();
+});
+
+describe("checkout edge cases", () => {
+  test("missing email returns 400", async () => {
+    const res = await request(app).post("/api/checkout").send({ slug: "m1" });
+    expect(res.status).toBe(400);
+    expect(orders.size).toBe(0);
+  });
+
+  test("missing slug returns 400", async () => {
+    const res = await request(app)
+      .post("/api/checkout")
+      .send({ email: "a@a.com" });
+    expect(res.status).toBe(400);
+    expect(orders.size).toBe(0);
+  });
+
+  test("stripe rejects invalid payment method", async () => {
+    stripeMock.checkout.sessions.create.mockRejectedValueOnce(
+      new Error("invalid"),
+    );
+    const res = await request(app)
+      .post("/api/checkout")
+      .send({ slug: "m1", email: "a@a.com" });
+    expect(res.status).toBe(500);
+  });
+
+  test("network timeout handled with 500", async () => {
+    stripeMock.checkout.sessions.create.mockRejectedValueOnce(
+      new Error("timeout"),
+    );
+    const res = await request(app)
+      .post("/api/checkout")
+      .send({ slug: "m1", email: "a@a.com" });
+    expect(res.status).toBe(500);
+  });
+
+  test("successful checkout stores order and returns url", async () => {
+    stripeMock.checkout.sessions.create.mockResolvedValueOnce({
+      id: "cs_ok",
+      url: "http://ok",
+    });
+    const setSpy = jest.spyOn(orders, "set");
+    const res = await request(app)
+      .post("/api/checkout")
+      .send({ slug: "m1", email: "a@a.com" });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ checkoutUrl: "http://ok" });
+    expect(setSpy).toHaveBeenCalledWith("cs_ok", {
+      slug: "m1",
+      email: "a@a.com",
+      paid: false,
+    });
+  });
+});

--- a/tests/checkCoverageScript.test.js
+++ b/tests/checkCoverageScript.test.js
@@ -12,9 +12,7 @@ const summary = path.join(
 const backup = summary + ".bak";
 const nycrc = path.join(__dirname, "..", ".nycrc");
 const nycBackup = nycrc + ".bak";
-let originalConfig = fs.existsSync(nycrc)
-  ? fs.readFileSync(nycrc, "utf8")
-  : "";
+let originalConfig = fs.existsSync(nycrc) ? fs.readFileSync(nycrc, "utf8") : "";
 
 describe("check-coverage script", () => {
   beforeAll(() => {
@@ -52,7 +50,6 @@ describe("check-coverage script", () => {
         statements: { pct: 0 },
       },
     };
-    const originalConfig = fs.readFileSync(".nycrc", "utf8");
     fs.writeFileSync(summary, JSON.stringify(data));
     const prevConfig = fs.existsSync(nycrc)
       ? fs.readFileSync(nycrc, "utf8")
@@ -118,6 +115,6 @@ describe("check-coverage script", () => {
     );
     expect(output).toMatch(/Coverage thresholds met/);
     fs.unlinkSync(summary);
-    fs.writeFileSync(".nycrc", origConfig);
+    fs.writeFileSync(".nycrc", originalConfig);
   });
 });


### PR DESCRIPTION
## Summary
- fix & format `checkCoverageScript.test.js`
- add edge case tests for checkout route

## Testing
- `npm run format:check`
- `npm run lint`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_6874e8154f4c832d97a1c97a1eef8263