### PR TITLE
Fix diagnose env vars

### DIFF
--- a/scripts/validate-env.sh
+++ b/scripts/validate-env.sh
@@ -28,6 +28,9 @@ elif [ -f .env.example ]; then
   load_env_file .env.example
 fi
 
+# Disable HTTP/2 for local testing to avoid client errors
+export HTTP2=false
+
 if [[ -z "${STRIPE_TEST_KEY:-}" && -z "${STRIPE_LIVE_KEY:-}" ]]; then
   echo "Using dummy STRIPE_TEST_KEY" >&2
   export STRIPE_TEST_KEY="sk_test_dummy_$(date +%s)"
@@ -38,6 +41,14 @@ if [[ -z "${HF_TOKEN:-}" && -z "${HF_API_KEY:-}" ]]; then
   export HF_API_KEY="$HF_TOKEN"
 elif [[ -z "${HF_API_KEY:-}" ]]; then
   export HF_API_KEY="$HF_TOKEN"
+fi
+# Ensure HF_API_KEY mirrors HF_TOKEN when only one is provided
+if [[ -n "${HF_TOKEN:-}" && -z "${HF_API_KEY:-}" ]]; then
+  export HF_API_KEY="$HF_TOKEN"
+fi
+# Map legacy S3_BUCKET to S3_BUCKET_NAME if needed
+if [[ -n "${S3_BUCKET:-}" && -z "${S3_BUCKET_NAME:-}" ]]; then
+  export S3_BUCKET_NAME="$S3_BUCKET"
 fi
 : "${AWS_ACCESS_KEY_ID:?AWS_ACCESS_KEY_ID must be set}"
 : "${AWS_SECRET_ACCESS_KEY:?AWS_SECRET_ACCESS_KEY must be set}"
@@ -66,8 +77,9 @@ fi
 
 
 if [[ -z "${SKIP_NET_CHECKS:-}" ]]; then
-  network_output=$(node scripts/network-check.js 2>&1) || net_status=$?
-  if [[ -n "$net_status" ]]; then
+  network_output=$(node scripts/network-check.js 2>&1)
+  net_status=$?
+  if [[ $net_status -ne 0 ]]; then
     echo "$network_output" >&2
     if echo "$network_output" | grep -q "Set SKIP_PW_DEPS=1"; then
       echo "Network check failed for Playwright CDN, setting SKIP_PW_DEPS=1." >&2

--- a/tests/checkCoverageScript.test.js
+++ b/tests/checkCoverageScript.test.js
@@ -12,9 +12,7 @@ const summary = path.join(
 const backup = summary + ".bak";
 const nycrc = path.join(__dirname, "..", ".nycrc");
 const nycBackup = nycrc + ".bak";
-let originalConfig = fs.existsSync(nycrc)
-  ? fs.readFileSync(nycrc, "utf8")
-  : "";
+let originalConfig = fs.existsSync(nycrc) ? fs.readFileSync(nycrc, "utf8") : "";
 
 describe("check-coverage script", () => {
   beforeAll(() => {
@@ -52,7 +50,6 @@ describe("check-coverage script", () => {
         statements: { pct: 0 },
       },
     };
-    const originalConfig = fs.readFileSync(".nycrc", "utf8");
     fs.writeFileSync(summary, JSON.stringify(data));
     const prevConfig = fs.existsSync(nycrc)
       ? fs.readFileSync(nycrc, "utf8")
@@ -88,7 +85,7 @@ describe("check-coverage script", () => {
   });
 
   test("passes when coverage meets thresholds", () => {
-    const originalConfig = fs.existsSync(nycrc)
+    const origConfig = fs.existsSync(nycrc)
       ? fs.readFileSync(nycrc, "utf8")
       : "";
     const goodSummary = {

--- a/tests/validateEnv.test.js
+++ b/tests/validateEnv.test.js
@@ -197,4 +197,52 @@ describe("validate-env script", () => {
     expect(output).toContain("Network check failed for Playwright CDN");
     expect(output).toContain("✅ environment OK");
   });
+
+  test("succeeds when sourced under strict mode", () => {
+    const env = {
+      ...process.env,
+      HF_TOKEN: "test",
+      AWS_ACCESS_KEY_ID: "id",
+      AWS_SECRET_ACCESS_KEY: "secret",
+      DB_URL: "postgres://user:pass@localhost/db",
+      STRIPE_SECRET_KEY: "sk_test",
+      CLOUDFRONT_MODEL_DOMAIN: "cdn.test",
+      S3_BUCKET: "bucket",
+      SKIP_NET_CHECKS: "1",
+      SKIP_DB_CHECK: "1",
+    };
+    const result = spawnSync(
+      "bash",
+      ["-euo", "pipefail", "-c", "source scripts/validate-env.sh >/dev/null"],
+      { env, encoding: "utf8" },
+    );
+    expect(result.status).toBe(0);
+  });
+
+  test("maps legacy env vars", () => {
+    const env = {
+      ...process.env,
+      HF_TOKEN: "tok",
+      AWS_ACCESS_KEY_ID: "id",
+      AWS_SECRET_ACCESS_KEY: "secret",
+      DB_URL: "postgres://user:pass@localhost/db",
+      STRIPE_SECRET_KEY: "sk_test",
+      CLOUDFRONT_MODEL_DOMAIN: "cdn.test",
+      S3_BUCKET: "bucket",
+      SKIP_NET_CHECKS: "1",
+      SKIP_DB_CHECK: "1",
+    };
+    const result = spawnSync(
+      "bash",
+      [
+        "-euo",
+        "pipefail",
+        "-c",
+        "source scripts/validate-env.sh >/dev/null; echo $HF_API_KEY $S3_BUCKET_NAME",
+      ],
+      { env, encoding: "utf8" },
+    );
+    expect(result.stdout.trim()).toBe("tok bucket");
+    expect(result.status).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary
- fix validate-env with stricter bash settings
- map legacy env vars for HF_API_KEY and S3_BUCKET_NAME
- default HTTP2 off to avoid client errors
- add tests for strict sourcing and legacy env mappings

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6874e7cc488c832db5635a3979bd1b9e