### PR TITLE
Fix network check output handling

### DIFF
--- a/scripts/check-host-deps.js
+++ b/scripts/check-host-deps.js
@@ -6,10 +6,16 @@ function checkNetwork() {
     return;
   }
   try {
-    execSync("node scripts/network-check.js", { stdio: "ignore" });
-  } catch {
+    const script = require("path").join(__dirname, "network-check.js");
+    execSync(`node ${script}`, {
+      stdio: "pipe",
+      encoding: "utf8",
+    });
+  } catch (err) {
+    if (err.stdout) process.stdout.write(err.stdout);
+    if (err.stderr) process.stderr.write(err.stderr);
     console.error(
-      "Network check failed. Ensure access to the npm registry and Playwright CDN.",
+      "Network check failed. Ensure access to the npm registry and Playwright CDN. Set SKIP_PW_DEPS=1 to skip Playwright dependencies.",
     );
     process.exit(1);
   }


### PR DESCRIPTION
## Summary
- show underlying network errors when Playwright host dependency checks run
- update host dependency tests to expect diagnostic output

## Testing
- `npm run format`
- `node scripts/run-jest.js tests/checkHostDeps.test.js --runInBand --silent`

------
https://chatgpt.com/codex/tasks/task_e_6874f8bd1dac832dad135c7a9755c5f6