### PR TITLE
Fix check-host-deps path

### DIFF
--- a/scripts/check-host-deps.js
+++ b/scripts/check-host-deps.js
@@ -1,12 +1,14 @@
 #!/usr/bin/env node
 const { execSync } = require("child_process");
+const path = require("path");
 
 function checkNetwork() {
   if (process.env.SKIP_NET_CHECKS) {
     return;
   }
   try {
-    execSync("node scripts/network-check.js", { stdio: "ignore" });
+    const networkCheck = path.join(__dirname, "network-check.js");
+    execSync(`node ${networkCheck}`, { stdio: "ignore" });
   } catch {
     console.error(
       "Network check failed. Ensure access to the npm registry and Playwright CDN.",

--- a/tests/checkHostDeps.test.js
+++ b/tests/checkHostDeps.test.js
@@ -14,7 +14,7 @@ test("runs network check before installing", () => {
   require("../scripts/check-host-deps.js");
   expect(child_process.execSync).toHaveBeenNthCalledWith(
     1,
-    "node scripts/network-check.js",
+    expect.stringContaining("network-check.js"),
     { stdio: "ignore" },
   );
   expect(child_process.execSync).toHaveBeenNthCalledWith(
@@ -61,7 +61,7 @@ test("fails when SKIP_PW_DEPS is set and deps are missing", () => {
   expect(exitSpy).toHaveBeenCalledWith(1);
   expect(child_process.execSync).toHaveBeenNthCalledWith(
     1,
-    "node scripts/network-check.js",
+    expect.stringContaining("network-check.js"),
     { stdio: "ignore" },
   );
   expect(child_process.execSync).toHaveBeenNthCalledWith(
@@ -89,7 +89,7 @@ test("fails when SKIP_PW_DEPS is set and warning is printed", () => {
   expect(() => require("../scripts/check-host-deps.js")).toThrow("exit");
   expect(child_process.execSync).toHaveBeenNthCalledWith(
     1,
-    "node scripts/network-check.js",
+    expect.stringContaining("network-check.js"),
     { stdio: "ignore" },
   );
   expect(child_process.execSync).toHaveBeenNthCalledWith(
@@ -110,7 +110,7 @@ test("skips install when deps satisfied even if SKIP_PW_DEPS is set", () => {
   require("../scripts/check-host-deps.js");
   expect(child_process.execSync).toHaveBeenNthCalledWith(
     1,
-    "node scripts/network-check.js",
+    expect.stringContaining("network-check.js"),
     { stdio: "ignore" },
   );
   expect(child_process.execSync).toHaveBeenNthCalledWith(


### PR DESCRIPTION
## Summary
- resolve relative path in `check-host-deps.js`
- update tests for new command string

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6874f8a991e8832d961de9b58bb04cbb