### PR TITLE
Fix network check with SKIP_PW_DEPS

### DIFF
--- a/scripts/check-host-deps.js
+++ b/scripts/check-host-deps.js
@@ -2,7 +2,7 @@
 const { execSync } = require("child_process");
 
 function checkNetwork() {
-  if (process.env.SKIP_NET_CHECKS) {
+  if (process.env.SKIP_NET_CHECKS || process.env.SKIP_PW_DEPS) {
     return;
   }
   try {

--- a/tests/checkHostDeps.test.js
+++ b/tests/checkHostDeps.test.js
@@ -48,28 +48,33 @@ test("skips network check when SKIP_NET_CHECKS is set", () => {
   delete process.env.SKIP_NET_CHECKS;
 });
 
+test("skips network check when SKIP_PW_DEPS is set", () => {
+  process.env.SKIP_PW_DEPS = "1";
+  child_process.execSync.mockReturnValueOnce("deps ok");
+  require("../scripts/check-host-deps.js");
+  expect(child_process.execSync).toHaveBeenCalledTimes(1);
+  expect(child_process.execSync).toHaveBeenCalledWith(
+    "npx playwright install --with-deps --dry-run 2>&1",
+    { encoding: "utf8" },
+  );
+  delete process.env.SKIP_PW_DEPS;
+});
+
 test("fails when SKIP_PW_DEPS is set and deps are missing", () => {
   process.env.SKIP_PW_DEPS = "1";
-  child_process.execSync
-    .mockReturnValueOnce("network ok")
-    .mockReturnValueOnce("Host system is missing dependencies")
-    .mockReturnValueOnce("");
+  child_process.execSync.mockReturnValueOnce(
+    "Host system is missing dependencies",
+  );
   const exitSpy = jest.spyOn(process, "exit").mockImplementation(() => {
     throw new Error("exit");
   });
   expect(() => require("../scripts/check-host-deps.js")).toThrow("exit");
   expect(exitSpy).toHaveBeenCalledWith(1);
-  expect(child_process.execSync).toHaveBeenNthCalledWith(
-    1,
-    "node scripts/network-check.js",
-    { stdio: "ignore" },
-  );
-  expect(child_process.execSync).toHaveBeenNthCalledWith(
-    2,
+  expect(child_process.execSync).toHaveBeenCalledTimes(1);
+  expect(child_process.execSync).toHaveBeenCalledWith(
     "npx playwright install --with-deps --dry-run 2>&1",
     { encoding: "utf8" },
   );
-  expect(child_process.execSync).toHaveBeenCalledTimes(2);
 
   expect(exitSpy).toHaveBeenCalledWith(1);
   delete process.env.SKIP_PW_DEPS;
@@ -77,48 +82,31 @@ test("fails when SKIP_PW_DEPS is set and deps are missing", () => {
 
 test("fails when SKIP_PW_DEPS is set and warning is printed", () => {
   process.env.SKIP_PW_DEPS = "1";
-  child_process.execSync
-    .mockReturnValueOnce("network ok")
-    .mockReturnValueOnce(
-      "Playwright Host validation warning: Host system is missing dependencies",
-    )
-    .mockReturnValueOnce("");
+  child_process.execSync.mockReturnValueOnce(
+    "Playwright Host validation warning: Host system is missing dependencies",
+  );
   const exitSpy = jest.spyOn(process, "exit").mockImplementation(() => {
     throw new Error("exit");
   });
   expect(() => require("../scripts/check-host-deps.js")).toThrow("exit");
-  expect(child_process.execSync).toHaveBeenNthCalledWith(
-    1,
-    "node scripts/network-check.js",
-    { stdio: "ignore" },
-  );
-  expect(child_process.execSync).toHaveBeenNthCalledWith(
-    2,
+  expect(child_process.execSync).toHaveBeenCalledTimes(1);
+  expect(child_process.execSync).toHaveBeenCalledWith(
     "npx playwright install --with-deps --dry-run 2>&1",
     { encoding: "utf8" },
   );
-  expect(child_process.execSync).toHaveBeenCalledTimes(2);
   expect(exitSpy).toHaveBeenCalledWith(1);
   delete process.env.SKIP_PW_DEPS;
 });
 
 test("skips install when deps satisfied even if SKIP_PW_DEPS is set", () => {
   process.env.SKIP_PW_DEPS = "1";
-  child_process.execSync
-    .mockReturnValueOnce("network ok")
-    .mockReturnValueOnce("deps ok");
+  child_process.execSync.mockReturnValueOnce("deps ok");
   require("../scripts/check-host-deps.js");
-  expect(child_process.execSync).toHaveBeenNthCalledWith(
-    1,
-    "node scripts/network-check.js",
-    { stdio: "ignore" },
-  );
-  expect(child_process.execSync).toHaveBeenNthCalledWith(
-    2,
+  expect(child_process.execSync).toHaveBeenCalledTimes(1);
+  expect(child_process.execSync).toHaveBeenCalledWith(
     "npx playwright install --with-deps --dry-run 2>&1",
     { encoding: "utf8" },
   );
-  expect(child_process.execSync).toHaveBeenCalledTimes(2);
   delete process.env.SKIP_PW_DEPS;
 });
 


### PR DESCRIPTION
## Summary
- skip check-host-deps network check when Playwright deps are skipped
- adjust checkHostDeps tests for new logic and add coverage

## Testing
- `npm run format` (in backend)
- `SKIP_PW_DEPS=1 npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874f89b2548832d981c65a33dc9b660