### PR TITLE
Fix network check path

### DIFF
--- a/scripts/check-host-deps.js
+++ b/scripts/check-host-deps.js
@@ -1,12 +1,14 @@
 #!/usr/bin/env node
 const { execSync } = require("child_process");
+const path = require("path");
 
 function checkNetwork() {
   if (process.env.SKIP_NET_CHECKS) {
     return;
   }
   try {
-    execSync("node scripts/network-check.js", { stdio: "ignore" });
+    const networkCheck = path.join(__dirname, "network-check.js");
+    execSync(`node ${networkCheck}`, { stdio: "ignore" });
   } catch {
     console.error(
       "Network check failed. Ensure access to the npm registry and Playwright CDN.",

--- a/tests/checkCoverageScript.test.js
+++ b/tests/checkCoverageScript.test.js
@@ -12,9 +12,7 @@ const summary = path.join(
 const backup = summary + ".bak";
 const nycrc = path.join(__dirname, "..", ".nycrc");
 const nycBackup = nycrc + ".bak";
-let originalConfig = fs.existsSync(nycrc)
-  ? fs.readFileSync(nycrc, "utf8")
-  : "";
+let originalConfig = fs.existsSync(nycrc) ? fs.readFileSync(nycrc, "utf8") : "";
 
 describe("check-coverage script", () => {
   beforeAll(() => {
@@ -52,7 +50,6 @@ describe("check-coverage script", () => {
         statements: { pct: 0 },
       },
     };
-    const originalConfig = fs.readFileSync(".nycrc", "utf8");
     fs.writeFileSync(summary, JSON.stringify(data));
     const prevConfig = fs.existsSync(nycrc)
       ? fs.readFileSync(nycrc, "utf8")
@@ -118,6 +115,6 @@ describe("check-coverage script", () => {
     );
     expect(output).toMatch(/Coverage thresholds met/);
     fs.unlinkSync(summary);
-    fs.writeFileSync(".nycrc", origConfig);
+    fs.writeFileSync(".nycrc", originalConfig);
   });
 });

--- a/tests/checkHostDeps.test.js
+++ b/tests/checkHostDeps.test.js
@@ -12,9 +12,15 @@ test("runs network check before installing", () => {
     .mockReturnValueOnce("network ok")
     .mockReturnValueOnce("deps ok");
   require("../scripts/check-host-deps.js");
+  const networkCheck = require("path").join(
+    __dirname,
+    "..",
+    "scripts",
+    "network-check.js",
+  );
   expect(child_process.execSync).toHaveBeenNthCalledWith(
     1,
-    "node scripts/network-check.js",
+    `node ${networkCheck}`,
     { stdio: "ignore" },
   );
   expect(child_process.execSync).toHaveBeenNthCalledWith(
@@ -59,9 +65,15 @@ test("fails when SKIP_PW_DEPS is set and deps are missing", () => {
   });
   expect(() => require("../scripts/check-host-deps.js")).toThrow("exit");
   expect(exitSpy).toHaveBeenCalledWith(1);
+  const networkCheck = require("path").join(
+    __dirname,
+    "..",
+    "scripts",
+    "network-check.js",
+  );
   expect(child_process.execSync).toHaveBeenNthCalledWith(
     1,
-    "node scripts/network-check.js",
+    `node ${networkCheck}`,
     { stdio: "ignore" },
   );
   expect(child_process.execSync).toHaveBeenNthCalledWith(
@@ -87,9 +99,15 @@ test("fails when SKIP_PW_DEPS is set and warning is printed", () => {
     throw new Error("exit");
   });
   expect(() => require("../scripts/check-host-deps.js")).toThrow("exit");
+  const networkCheck = require("path").join(
+    __dirname,
+    "..",
+    "scripts",
+    "network-check.js",
+  );
   expect(child_process.execSync).toHaveBeenNthCalledWith(
     1,
-    "node scripts/network-check.js",
+    `node ${networkCheck}`,
     { stdio: "ignore" },
   );
   expect(child_process.execSync).toHaveBeenNthCalledWith(
@@ -108,9 +126,15 @@ test("skips install when deps satisfied even if SKIP_PW_DEPS is set", () => {
     .mockReturnValueOnce("network ok")
     .mockReturnValueOnce("deps ok");
   require("../scripts/check-host-deps.js");
+  const networkCheck = require("path").join(
+    __dirname,
+    "..",
+    "scripts",
+    "network-check.js",
+  );
   expect(child_process.execSync).toHaveBeenNthCalledWith(
     1,
-    "node scripts/network-check.js",
+    `node ${networkCheck}`,
     { stdio: "ignore" },
   );
   expect(child_process.execSync).toHaveBeenNthCalledWith(


### PR DESCRIPTION
## Summary
- fix path resolution in `check-host-deps.js`
- update tests for new path handling
- clean up unused variable in coverage tests

## Testing
- `npm run format`
- `SKIP_PW_DEPS=1 npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_6874f707b094832d8ca27d55f9c5c7b0