### PR TITLE
Add Dockerfile for backend

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+npm-debug.log

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,16 @@
+# Stage 1: build
+FROM node:20 AS builder
+WORKDIR /app
+COPY backend/package*.json ./
+RUN npm ci
+COPY backend/ .
+RUN npm run build
+
+# Stage 2: runtime
+FROM node:20-alpine
+WORKDIR /app
+COPY --from=builder /app/dist ./dist
+COPY backend/package*.json ./
+RUN npm ci --only=production
+EXPOSE 3000
+CMD ["node", "dist/server.js"]


### PR DESCRIPTION
## Summary
- add multi-stage Dockerfile under `backend`
- include `.dockerignore` for backend container builds

## Testing
- `npm run format` in `backend/`
- `npm test` *(fails: Network check failed)*
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_6874fae1d1fc832dae4cbe10cb7a9f57