### PR TITLE
Add contributor docs and PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,17 @@
 ## Summary
 
--
+<!-- one-sentence summary of your changes -->
 
-## Testing
+## Related Issue
 
-- [ ] `npm run format`
-- [ ] `npm test`
-- [ ] `npm run ci`
+<!-- link to the issue, if any -->
+
+## Testing Instructions
+
+<!-- how to run the tests for this change -->
+
+### Checklist
+
+- [ ] linted
+- [ ] tested
+- [ ] coverage ≥80%

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,3 +25,14 @@ Thank you for helping improve this project! Please follow these steps to keep ou
 - All new code should include appropriate tests.
 - CI runs `npm run ci` and `npm test`; please ensure these succeed locally.
 - If Playwright dependencies are already installed you can set `SKIP_PW_DEPS=1` when running setup or CI to skip the lengthy install step.
+
+## How to run tests / lint / coverage / smoke
+
+Run the following commands from the repository root:
+
+```bash
+npm run lint      # check code style
+npm test          # execute unit tests
+npm run coverage  # generate coverage report
+SKIP_PW_DEPS=1 npm run smoke  # run the Playwright smoke test
+```


### PR DESCRIPTION
## Summary
- document how to run tests, lint, coverage and smoke checks
- provide a concise PR template for contributors

## Testing
- `npm run format`
- `SKIP_NET_CHECKS=1 SKIP_PW_DEPS=1 npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Code style issues found in 2 files)*
- `SKIP_PW_DEPS=1 npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_6874fa9d6a14832dad6c145d3b842f21