### PR TITLE
Improve host dependency handling

### DIFF
--- a/backend/tests/checkHostDeps.test.ts
+++ b/backend/tests/checkHostDeps.test.ts
@@ -1,0 +1,25 @@
+const { spawnSync } = require("child_process");
+const path = require("path");
+
+const script = path.join(
+  __dirname,
+  "..",
+  "..",
+  "scripts",
+  "check-host-deps.js",
+);
+const stub = path.join(__dirname, "stubMissingDeps.js");
+
+test("auto installs host deps when SKIP_PW_DEPS is set", () => {
+  const result = spawnSync(process.execPath, [script], {
+    env: {
+      ...process.env,
+      SKIP_PW_DEPS: "1",
+      SKIP_NET_CHECKS: "1",
+      NODE_OPTIONS: `--require ${stub}`,
+    },
+    encoding: "utf8",
+  });
+  expect(result.status).toBe(0);
+  expect(result.stderr).toMatch(/Installing anyway/);
+});

--- a/backend/tests/stubMissingDeps.js
+++ b/backend/tests/stubMissingDeps.js
@@ -1,0 +1,7 @@
+const child_process = require("child_process");
+child_process.execSync = function (cmd) {
+  if (cmd.includes("playwright install --with-deps --dry-run")) {
+    return Buffer.from("Host system is missing dependencies");
+  }
+  return Buffer.from("");
+};

--- a/scripts/check-host-deps.js
+++ b/scripts/check-host-deps.js
@@ -32,12 +32,12 @@ checkNetwork();
 
 if (!hostDepsInstalled()) {
   if (process.env.SKIP_PW_DEPS) {
-    console.error(
-      "Playwright host dependencies are missing. Run 'npx playwright install --with-deps' or remove SKIP_PW_DEPS.",
+    console.warn(
+      "SKIP_PW_DEPS is set but Playwright host dependencies are missing. Installing anyway...",
     );
-    process.exit(1);
+  } else {
+    console.log("Playwright host dependencies missing. Installing...");
   }
-  console.log("Playwright host dependencies missing. Installing...");
   try {
     execSync("CI=1 npx playwright install --with-deps", { stdio: "inherit" });
   } catch (err) {

--- a/tests/checkHostDeps.test.js
+++ b/tests/checkHostDeps.test.js
@@ -48,17 +48,18 @@ test("skips network check when SKIP_NET_CHECKS is set", () => {
   delete process.env.SKIP_NET_CHECKS;
 });
 
-test("fails when SKIP_PW_DEPS is set and deps are missing", () => {
+test("installs deps when SKIP_PW_DEPS is set but missing", () => {
   process.env.SKIP_PW_DEPS = "1";
   child_process.execSync
     .mockReturnValueOnce("network ok")
     .mockReturnValueOnce("Host system is missing dependencies")
     .mockReturnValueOnce("");
-  const exitSpy = jest.spyOn(process, "exit").mockImplementation(() => {
-    throw new Error("exit");
-  });
-  expect(() => require("../scripts/check-host-deps.js")).toThrow("exit");
-  expect(exitSpy).toHaveBeenCalledWith(1);
+  require("../scripts/check-host-deps.js");
+  expect(child_process.execSync).toHaveBeenNthCalledWith(
+    3,
+    "CI=1 npx playwright install --with-deps",
+    { stdio: "inherit" },
+  );
   expect(child_process.execSync).toHaveBeenNthCalledWith(
     1,
     "node scripts/network-check.js",
@@ -69,13 +70,11 @@ test("fails when SKIP_PW_DEPS is set and deps are missing", () => {
     "npx playwright install --with-deps --dry-run 2>&1",
     { encoding: "utf8" },
   );
-  expect(child_process.execSync).toHaveBeenCalledTimes(2);
-
-  expect(exitSpy).toHaveBeenCalledWith(1);
+  expect(child_process.execSync).toHaveBeenCalledTimes(3);
   delete process.env.SKIP_PW_DEPS;
 });
 
-test("fails when SKIP_PW_DEPS is set and warning is printed", () => {
+test("installs deps when warning printed with SKIP_PW_DEPS", () => {
   process.env.SKIP_PW_DEPS = "1";
   child_process.execSync
     .mockReturnValueOnce("network ok")
@@ -83,10 +82,7 @@ test("fails when SKIP_PW_DEPS is set and warning is printed", () => {
       "Playwright Host validation warning: Host system is missing dependencies",
     )
     .mockReturnValueOnce("");
-  const exitSpy = jest.spyOn(process, "exit").mockImplementation(() => {
-    throw new Error("exit");
-  });
-  expect(() => require("../scripts/check-host-deps.js")).toThrow("exit");
+  require("../scripts/check-host-deps.js");
   expect(child_process.execSync).toHaveBeenNthCalledWith(
     1,
     "node scripts/network-check.js",
@@ -97,8 +93,12 @@ test("fails when SKIP_PW_DEPS is set and warning is printed", () => {
     "npx playwright install --with-deps --dry-run 2>&1",
     { encoding: "utf8" },
   );
-  expect(child_process.execSync).toHaveBeenCalledTimes(2);
-  expect(exitSpy).toHaveBeenCalledWith(1);
+  expect(child_process.execSync).toHaveBeenNthCalledWith(
+    3,
+    "CI=1 npx playwright install --with-deps",
+    { stdio: "inherit" },
+  );
+  expect(child_process.execSync).toHaveBeenCalledTimes(3);
   delete process.env.SKIP_PW_DEPS;
 });
 


### PR DESCRIPTION
## Summary
- auto-install Playwright host dependencies even if SKIP_PW_DEPS is set
- add regression test for this behavior

## Testing
- `npm run format` *(excerpt)*
- `SKIP_NET_CHECKS=1 npm test --silent` *(excerpt)*

------
https://chatgpt.com/codex/tasks/task_e_6874f8da97c4832db4540e5335fb458c