### PR TITLE
Add users route error test

### DIFF
--- a/backend/__tests__/users.test.js
+++ b/backend/__tests__/users.test.js
@@ -1,0 +1,30 @@
+const request = require("supertest");
+
+jest.mock("../users", () => ({
+  findUserById: jest.fn(),
+}));
+
+const users = require("../users");
+
+let app;
+
+beforeAll(() => {
+  process.env.NODE_ENV = "test";
+  process.env.STRIPE_WEBHOOK_SECRET = "whsec";
+  process.env.S3_BUCKET = "test-bucket";
+  process.env.CLOUDFRONT_MODEL_DOMAIN = "cdn.test";
+  app = require("../server");
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("GET /api/users/:id", () => {
+  test("returns 500 when findUserById throws", async () => {
+    users.findUserById.mockRejectedValue(new Error("boom"));
+    const res = await request(app).get("/api/users/123");
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: "Internal Server Error" });
+  });
+});

--- a/backend/routes/users.js
+++ b/backend/routes/users.js
@@ -1,0 +1,15 @@
+const express = require("express");
+const router = express.Router();
+const users = require("../users");
+
+router.get("/:id", async (req, res, next) => {
+  try {
+    const user = await users.findUserById(req.params.id);
+    if (!user) return res.status(404).json({ error: "User not found" });
+    res.json(user);
+  } catch (err) {
+    next(err);
+  }
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -30,6 +30,7 @@ const jwt = require("jsonwebtoken");
 const db = require("./db");
 const modelsRouter = require("./routes/models");
 const healthzRouter = require("./routes/healthz");
+const usersRouter = require("./routes/users");
 const axios = require("axios");
 const fs = require("fs");
 const logger = require("../src/logger");
@@ -191,6 +192,7 @@ app.get("/api-docs", (req, res) => {
 app.use("/docs", swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 app.use(healthzRouter);
 app.use("/api/models", modelsRouter);
+app.use("/api/users", usersRouter);
 const staticOptions = {
   setHeaders(res, filePath) {
     if (/\.(?:glb|hdr|js|css|png|jpe?g|gif|svg)$/i.test(filePath)) {

--- a/backend/users.js
+++ b/backend/users.js
@@ -1,0 +1,13 @@
+const db = require("./db");
+
+async function findUserById(id) {
+  const { rows } = await db.query(
+    "SELECT id, username, email FROM users WHERE id=$1",
+    [id],
+  );
+  return rows[0];
+}
+
+module.exports = {
+  findUserById,
+};


### PR DESCRIPTION
## Summary
- mock users module and assert 500 error for `/api/users/:id`
- expose `/api/users` route backed by a `findUserById` helper

## Testing
- `npm run format --prefix backend`
- `SKIP_NET_CHECKS=1 SKIP_PW_DEPS=1 npm test --prefix backend --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_6874fbc63c2c832da4622d1553cf447b