### PR TITLE
Add /health test for backend

### DIFF
--- a/backend/__tests__/health.test.js
+++ b/backend/__tests__/health.test.js
@@ -1,0 +1,16 @@
+const request = require("supertest");
+const app = require("../server");
+
+beforeAll(() => {
+  // setup mocks here if needed
+});
+
+afterAll(() => {
+  jest.restoreAllMocks();
+});
+
+test("GET /health returns ok", async () => {
+  const res = await request(app).get("/health");
+  expect(res.status).toBe(200);
+  expect(res.body).toEqual({ status: "ok" });
+});

--- a/backend/routes/healthz.js
+++ b/backend/routes/healthz.js
@@ -6,4 +6,9 @@ router.get("/healthz", (req, res) => {
   res.json({ status: "ok" });
 });
 
+// Allow legacy /health endpoint for compatibility
+router.get("/health", (req, res) => {
+  res.json({ status: "ok" });
+});
+
 module.exports = router;


### PR DESCRIPTION
## Summary
- add regression test for `/health` endpoint
- support `/health` route alongside `/healthz`

## Testing
- `npm run format` in `backend/`
- `node scripts/run-jest.js backend/__tests__/health.test.js --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_6874fbc0bec4832dabb4108bd460d3d6