### PR TITLE
Add coverage reporting script

### DIFF
--- a/scripts/list-uncovered.js
+++ b/scripts/list-uncovered.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+const fs = require("fs");
+const path = require("path");
+
+const summaryFile = path.join("coverage", "coverage-summary.json");
+let summary;
+try {
+  summary = JSON.parse(fs.readFileSync(summaryFile, "utf8"));
+} catch {
+  console.error(`Could not read ${summaryFile}`);
+  process.exit(0);
+}
+
+const uncovered = [];
+for (const [file, data] of Object.entries(summary)) {
+  if (file === "total") continue;
+  const pct = Math.min(data.lines.pct, data.statements.pct);
+  if (pct < 80) {
+    uncovered.push({ file, pct });
+  }
+}
+
+if (uncovered.length) {
+  console.log("Uncovered (<80%):\n");
+  for (const u of uncovered) {
+    console.log(`    ${u.file} (${u.pct.toFixed(1)}%)\n`);
+  }
+}
+process.exit(0);


### PR DESCRIPTION
## Summary
- add `scripts/list-uncovered.js` to report files with <80% coverage

## Testing
- `npm --prefix backend run test`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_687501d6f2d8832d906099f828fd816d