### PR TITLE
Add placeholder utils tests

### DIFF
--- a/backend/__tests__/utils/dailyPrints.test.js
+++ b/backend/__tests__/utils/dailyPrints.test.js
@@ -1,0 +1,7 @@
+const dailyPrints = require("../../utils/dailyPrints");
+
+describe("dailyPrints utility", () => {
+  it("should be defined", () => {
+    expect(dailyPrints).toBeTruthy();
+  });
+});

--- a/backend/__tests__/utils/generateAdCopy.test.js
+++ b/backend/__tests__/utils/generateAdCopy.test.js
@@ -1,0 +1,7 @@
+const generateAdCopy = require("../../utils/generateAdCopy");
+
+describe("generateAdCopy utility", () => {
+  it("should be defined", () => {
+    expect(generateAdCopy).toBeTruthy();
+  });
+});

--- a/backend/__tests__/utils/generateShareCard.test.js
+++ b/backend/__tests__/utils/generateShareCard.test.js
@@ -1,0 +1,7 @@
+const generateShareCard = require("../../utils/generateShareCard");
+
+describe("generateShareCard utility", () => {
+  it("should be defined", () => {
+    expect(generateShareCard).toBeTruthy();
+  });
+});

--- a/backend/__tests__/utils/generateTitle.test.js
+++ b/backend/__tests__/utils/generateTitle.test.js
@@ -1,0 +1,7 @@
+const generateTitle = require("../../utils/generateTitle");
+
+describe("generateTitle utility", () => {
+  it("should be defined", () => {
+    expect(generateTitle).toBeTruthy();
+  });
+});

--- a/backend/__tests__/utils/getEnv.test.js
+++ b/backend/__tests__/utils/getEnv.test.js
@@ -1,0 +1,7 @@
+const getEnv = require("../../utils/getEnv");
+
+describe("getEnv utility", () => {
+  it("should be defined", () => {
+    expect(getEnv).toBeTruthy();
+  });
+});

--- a/backend/__tests__/utils/routing.test.js
+++ b/backend/__tests__/utils/routing.test.js
@@ -1,0 +1,7 @@
+const routing = require("../../utils/routing");
+
+describe("routing utility", () => {
+  it("should be defined", () => {
+    expect(routing).toBeTruthy();
+  });
+});

--- a/backend/__tests__/utils/validateStl.test.js
+++ b/backend/__tests__/utils/validateStl.test.js
@@ -1,0 +1,7 @@
+const validateStl = require("../../utils/validateStl");
+
+describe("validateStl utility", () => {
+  it("should be defined", () => {
+    expect(validateStl).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- add basic Jest tests for each utility module in `backend/utils`

## Testing
- `npm run format` (root and backend)
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687501c56168832d970c34d8b1b8977c