### PR TITLE
Add Express route test stubs

### DIFF
--- a/backend/__tests__/routes/healthz.test.js
+++ b/backend/__tests__/routes/healthz.test.js
@@ -1,0 +1,8 @@
+const request = require("supertest");
+const app = require("../../server");
+
+describe("healthz routes", () => {
+  it("GET /healthz returns 200", async () => {
+    await request(app).get("/healthz").expect(200);
+  });
+});

--- a/backend/__tests__/routes/models.test.js
+++ b/backend/__tests__/routes/models.test.js
@@ -1,0 +1,8 @@
+const request = require("supertest");
+const app = require("../../server");
+
+describe("models routes", () => {
+  it("GET /api/models returns 200", async () => {
+    await request(app).get("/api/models").expect(200);
+  });
+});

--- a/backend/src/lib/storeGlb.js
+++ b/backend/src/lib/storeGlb.js
@@ -17,7 +17,6 @@ async function storeGlb(data, attempts = 3) {
     credentials: { accessKeyId, secretAccessKey },
   });
   const key = `models/${Date.now()}-${Math.random().toString(36).slice(2)}.glb`;
-  let lastError;
   for (let i = 0; i < attempts; i++) {
     try {
       await client.send(
@@ -29,10 +28,8 @@ async function storeGlb(data, attempts = 3) {
           ACL: "public-read",
         }),
       );
-      lastError = undefined;
       break;
     } catch (err) {
-      lastError = err;
       const isNetworkError =
         (err == null ? void 0 : err.name) === "NetworkingError" ||
         /network/i.test((err == null ? void 0 : err.message) || "");

--- a/tests/checkCoverageScript.test.js
+++ b/tests/checkCoverageScript.test.js
@@ -86,9 +86,7 @@ describe("check-coverage script", () => {
   });
 
   test("passes when coverage meets thresholds", () => {
-    const origConfig = fs.existsSync(nycrc)
-      ? fs.readFileSync(nycrc, "utf8")
-      : "";
+    fs.existsSync(nycrc) ? fs.readFileSync(nycrc, "utf8") : "";
     const goodSummary = {
       total: {
         branches: { pct: 90 },

--- a/tests/validateEnv.test.js
+++ b/tests/validateEnv.test.js
@@ -23,23 +23,6 @@ function run(env) {
   return output;
 }
 
-function runAndGetHFAPIKey(env) {
-  const result = spawnSync(
-    "bash",
-    [
-      "-c",
-      'source scripts/validate-env.sh >/dev/null && echo -n "$HF_API_KEY"',
-    ],
-    { env: { SKIP_NET_CHECKS: "1", ...env }, encoding: "utf8" },
-  );
-  if (result.status !== 0) {
-    const error = new Error(result.stdout + result.stderr);
-    error.code = result.status;
-    throw error;
-  }
-  return result.stdout;
-}
-
 describe("validate-env script", () => {
   test("sets dummy Stripe key when missing", () => {
     const env = {
@@ -80,7 +63,6 @@ describe("validate-env script", () => {
     expect(output).toContain("Using dummy HF_TOKEN and HF_API_KEY");
     expect(output).toContain("✅ environment OK");
   });
-
 
   test("injects dummy CLOUDFRONT_MODEL_DOMAIN when missing", () => {
     const env = {


### PR DESCRIPTION
## Summary
- fix lint errors in backend tests and utils
- add Jest+Supertest stubs for healthz and models routes

## Testing
- `npm test` in `backend/`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_687501bf6ae8832db716770f3bd3e997