### PR TITLE
Fix ensure-deps setup fallback

### DIFF
--- a/backend/scripts/ensure-deps.js
+++ b/backend/scripts/ensure-deps.js
@@ -99,8 +99,13 @@ function runSetup() {
       delete env.SKIP_PW_DEPS;
       execSync("npm run setup", { stdio: "inherit", cwd: repoRoot, env });
     } else {
-      console.error("Failed to run setup:", err.message);
-      process.exit(1);
+      console.warn(
+        "Setup failed, retrying with SKIP_PW_DEPS=1 to skip Playwright dependencies",
+      );
+      env.SKIP_PW_DEPS = "1";
+      env.PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD =
+        env.PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD || "1";
+      execSync("npm run setup", { stdio: "inherit", cwd: repoRoot, env });
     }
   }
 }


### PR DESCRIPTION
## Summary
- retry setup with `SKIP_PW_DEPS=1` when initial attempt fails
- test ensure-deps fallback logic

## Testing
- `node scripts/run-jest.js tests/ensureDeps.test.js`
- `npm test` in `backend/`

------
https://chatgpt.com/codex/tasks/task_e_68762427c950832d86e3582d3304b5f7