### PR TITLE
Add lint rule regression test

### DIFF
--- a/tests/noUnusedVars.test.js
+++ b/tests/noUnusedVars.test.js
@@ -1,0 +1,10 @@
+const { execSync } = require("child_process");
+
+test("no-unused-vars lint rule passes", () => {
+  const output = execSync("npx eslint . -f json", { encoding: "utf8" });
+  const results = JSON.parse(output);
+  const unused = results
+    .flatMap((r) => r.messages)
+    .filter((m) => m.ruleId === "no-unused-vars");
+  expect(unused).toEqual([]);
+});


### PR DESCRIPTION
## Summary
- add a regression test to verify `no-unused-vars` never fails

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_6876240f6d3c832dbc8a1f608582ad5b