### PR TITLE
Add lint test for unused vars

### DIFF
--- a/tests/lintUnusedVars.test.js
+++ b/tests/lintUnusedVars.test.js
@@ -1,0 +1,15 @@
+const { ESLint } = require("eslint");
+
+test("no unused vars in tests", async () => {
+  const eslint = new ESLint({
+    useEslintrc: true,
+    overrideConfig: {
+      rules: { "no-unused-vars": ["error", { argsIgnorePattern: "^_" }] },
+    },
+  });
+  const results = await eslint.lintFiles(["tests/**/*.js"]);
+  const unused = results.flatMap((r) =>
+    r.messages.filter((m) => m.ruleId === "no-unused-vars"),
+  );
+  expect(unused).toEqual([]);
+});


### PR DESCRIPTION
## Summary
- add regression test ensuring no unused variables in tests

## Testing
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run i18n:lint`
- `npm test --prefix backend`
- `node scripts/run-jest.js`
- `SKIP_PW_DEPS=1 npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_687623f8b8f8832d9c1e41f3c9bac851