### PR TITLE
Fix env defaults for smoke test

### DIFF
--- a/scripts/run-smoke.js
+++ b/scripts/run-smoke.js
@@ -38,6 +38,7 @@ function initEnv(baseEnv = process.env) {
   ensureDefault("STRIPE_SECRET_KEY", "sk_test_dummy");
   ensureDefault("STRIPE_TEST_KEY", `sk_test_dummy_${Date.now()}`);
   ensureDefault("SKIP_DB_CHECK", "1");
+  ensureDefault("CLOUDFRONT_MODEL_DOMAIN", "cdn.test");
 
   const required = [
     "STRIPE_TEST_KEY",

--- a/tests/runSmoke.defaults.test.js
+++ b/tests/runSmoke.defaults.test.js
@@ -40,6 +40,7 @@ test("run-smoke supplies default env vars", () => {
       expect(env.STRIPE_SECRET_KEY).toBe("sk_test_dummy");
       expect(env.STRIPE_TEST_KEY).toMatch(/^sk_test_dummy/);
       expect(env.SKIP_DB_CHECK).toBe("1");
+      expect(env.CLOUDFRONT_MODEL_DOMAIN).toBe("cdn.test");
     });
   });
 });


### PR DESCRIPTION
## Summary
- ensure `CLOUDFRONT_MODEL_DOMAIN` has a default value in `run-smoke.js`
- assert this default in `runSmoke.defaults.test.js`

## Testing
- `npm test -- --runInBand --colors=false | grep -E "Test Suites" | tail -n 2`
- `npm run format`
- `SKIP_PW_DEPS=1 npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_687622f509e4832db8e248f9b9781455