### PR TITLE
Fix broken markup in index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -298,8 +298,8 @@
     <main
       class="flex-1 flex flex-col items-center justify-start gap-4 px-4 lg:px-16"
       style="margin-top: -4rem"
-      <div id="gen-app" class="my-4 w-full max-w-md"></div>
     >
+      <div id="gen-app" class="my-4 w-full max-w-md"></div>
       <!-- 3-D preview ---------------------------------------------------- -->
       <div class="relative flex justify-center w-full max-w-lg">
         <section


### PR DESCRIPTION
## Summary
- fix malformed `<main>` tag in index.html

## Testing
- `npm run format`
- `npm test --silent -- --runInBand` *(partial output shown)*
- `SKIP_PW_DEPS=1 npm run ci` *(partial output shown)*
- `SKIP_PW_DEPS=1 npm run smoke` *(partial output shown)*


------
https://chatgpt.com/codex/tasks/task_e_687622d57d38832da337052660198809