### PR TITLE
Fix mise validation and add missing test

### DIFF
--- a/scripts/validate-env.sh
+++ b/scripts/validate-env.sh
@@ -4,7 +4,9 @@ set -e
 # Ensure mise activates the configured Node version so npm commands work even
 # when the shell hasn't sourced mise's hook. This prevents "node: command not
 # found" errors in fresh environments.
-eval "$(mise activate bash)"
+if command -v mise >/dev/null 2>&1; then
+  eval "$(mise activate bash)"
+fi
 
 # Silence mise warnings about untrusted config files
 mise trust . >/dev/null 2>&1 || true

--- a/tests/validateEnvMiseMissing.test.js
+++ b/tests/validateEnvMiseMissing.test.js
@@ -1,0 +1,21 @@
+const { execFileSync } = require("child_process");
+const path = require("path");
+
+describe("validate-env without mise", () => {
+  test("script succeeds when mise command missing", () => {
+    const env = {
+      ...process.env,
+      PATH: "/usr/bin:/bin",
+      AWS_ACCESS_KEY_ID: "id",
+      AWS_SECRET_ACCESS_KEY: "secret",
+      DB_URL: "postgres://u:p@h/db",
+      STRIPE_SECRET_KEY: "sk_test",
+      SKIP_NET_CHECKS: "1",
+      SKIP_PW_DEPS: "1",
+    };
+    execFileSync("bash", [path.join("scripts", "validate-env.sh")], {
+      env,
+      stdio: "inherit",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- tolerate missing mise binary in `validate-env.sh`
- add regression test ensuring validate-env works without mise

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_687622c84fe0832db10ca0c110977d21