### PR TITLE
Add tests for dailyPrints compute function

### DIFF
--- a/backend/tests/utils/dailyPrints.test.js
+++ b/backend/tests/utils/dailyPrints.test.js
@@ -1,0 +1,14 @@
+const { _computeDailyPrintsSold } = require("../../utils/dailyPrints");
+
+describe("_computeDailyPrintsSold", () => {
+  test("returns deterministic value for a given date", () => {
+    const date = new Date("2023-01-01T12:00:00Z");
+    expect(_computeDailyPrintsSold(date)).toBe(37);
+  });
+
+  test("value is within expected range", () => {
+    const val = _computeDailyPrintsSold(new Date());
+    expect(val).toBeGreaterThanOrEqual(30);
+    expect(val).toBeLessThanOrEqual(50);
+  });
+});

--- a/backend/utils/dailyPrints.js
+++ b/backend/utils/dailyPrints.js
@@ -49,4 +49,5 @@ module.exports = {
   initDailyPrintsSold,
   getDailyPrintsSold,
   _setDailyPrintsSold,
+  _computeDailyPrintsSold: computeDailyPrintsSold,
 };


### PR DESCRIPTION
## Summary
- expose `computeDailyPrintsSold` for tests
- add unit tests covering dailyPrints logic

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687622b265e0832db99821e3ccbdbf17