### PR TITLE
Fix CodeQL upload permissions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,6 +5,11 @@ on:
     branches: [dev]
   pull_request:
 
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
 jobs:
   analyze:
     name: Analyze

--- a/tests/codeqlWorkflow.test.js
+++ b/tests/codeqlWorkflow.test.js
@@ -1,0 +1,21 @@
+const fs = require("fs");
+const path = require("path");
+const YAML = require("yaml");
+
+describe("codeql workflow", () => {
+  test("has security-events write permission", () => {
+    const file = path.join(
+      __dirname,
+      "..",
+      ".github",
+      "workflows",
+      "codeql.yml",
+    );
+    const yml = YAML.parse(fs.readFileSync(file, "utf8"));
+    const perms =
+      yml.permissions ||
+      (yml.jobs && yml.jobs.analyze && yml.jobs.analyze.permissions) ||
+      {};
+    expect(perms["security-events"]).toBe("write");
+  });
+});

--- a/tests/codeqlWorkflowLint.test.js
+++ b/tests/codeqlWorkflowLint.test.js
@@ -1,0 +1,7 @@
+const { execSync } = require("child_process");
+
+test("codeql workflow test passes eslint", () => {
+  expect(() => {
+    execSync("npx eslint tests/codeqlWorkflow.test.js", { stdio: "pipe" });
+  }).not.toThrow();
+});


### PR DESCRIPTION
## Summary
- grant security-events write permission in the CodeQL workflow
- add tests for workflow permissions

## Testing
- `npm test` (backend)
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6876229d836c832d87e1bf9230393f9d