### PR TITLE
Fix smoke script

### DIFF
--- a/scripts/run-smoke.js
+++ b/scripts/run-smoke.js
@@ -59,6 +59,15 @@ function initEnv(baseEnv = process.env) {
 
 const env = initEnv(process.env);
 
+// Skip Playwright dependency installation when the setup flag exists.
+// This prevents repeated apt-get runs in CI environments.
+if (
+  !env.SKIP_PW_DEPS &&
+  fs.existsSync(path.join(process.cwd(), ".setup-complete"))
+) {
+  env.SKIP_PW_DEPS = "1";
+}
+
 let lastCommand = "";
 
 function run(cmd) {

--- a/tests/runSmoke.setupFlag.test.js
+++ b/tests/runSmoke.setupFlag.test.js
@@ -1,0 +1,27 @@
+const fs = require("fs");
+const path = require("path");
+
+const flag = path.join(__dirname, "..", ".setup-complete");
+
+afterEach(() => {
+  if (fs.existsSync(flag)) fs.unlinkSync(flag);
+  delete process.env.SKIP_PW_DEPS;
+  jest.resetModules();
+});
+
+test("run-smoke sets SKIP_PW_DEPS when setup flag exists", () => {
+  fs.writeFileSync(flag, "");
+  jest.isolateModules(() => {
+    const { env } = require("../scripts/run-smoke.js");
+    expect(env.SKIP_PW_DEPS).toBe("1");
+  });
+});
+
+test("existing SKIP_PW_DEPS is preserved", () => {
+  fs.writeFileSync(flag, "");
+  process.env.SKIP_PW_DEPS = "0";
+  jest.isolateModules(() => {
+    const { env } = require("../scripts/run-smoke.js");
+    expect(env.SKIP_PW_DEPS).toBe("0");
+  });
+});


### PR DESCRIPTION
## Summary
- skip Playwright setup in smoke script when `.setup-complete` exists
- test `run-smoke.js` logic for auto-setting `SKIP_PW_DEPS`

## Testing
- `npm run format`
- `CI=1 npm test --silent` *(partial log)*


------
https://chatgpt.com/codex/tasks/task_e_68762bcd3c70832da3c2775fb3e61eb9