### PR TITLE
Remove deprecated stripe types

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -42,7 +42,6 @@
         "@babel/preset-typescript": "^7.27.1",
         "@eslint/js": "^9.30.1",
         "@types/jest": "^30.0.0",
-        "@types/stripe": "^8.0.417",
         "babel-jest": "^30.0.4",
         "coverage-badges-cli": "^2.1.0",
         "eslint": "^9.30.1",
@@ -6374,17 +6373,6 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/stripe": {
-      "version": "8.0.417",
-      "resolved": "https://registry.npmjs.org/@types/stripe/-/stripe-8.0.417.tgz",
-      "integrity": "sha512-PTuqskh9YKNENnOHGVJBm4sM0zE8B1jZw1JIskuGAPkMB+OH236QeN8scclhYGPA4nG6zTtPXgwpXdp+HPDTVw==",
-      "deprecated": "This is a stub types definition. stripe provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "stripe": "*"
-      }
     },
     "node_modules/@types/tedious": {
       "version": "4.0.14",

--- a/backend/package.json
+++ b/backend/package.json
@@ -75,7 +75,6 @@
     "@babel/preset-typescript": "^7.27.1",
     "@eslint/js": "^9.30.1",
     "@types/jest": "^30.0.0",
-    "@types/stripe": "^8.0.417",
     "babel-jest": "^30.0.4",
     "coverage-badges-cli": "^2.1.0",
     "eslint": "^9.30.1",


### PR DESCRIPTION
## Summary
- drop `@types/stripe` from backend dependencies

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68762bb5b3b0832d8ddffb8da2b68334