### PR TITLE
fix: auto-install mise if missing

### DIFF
--- a/scripts/install-mise.sh
+++ b/scripts/install-mise.sh
@@ -8,3 +8,4 @@ fi
 curl -fsSL https://mise.run | bash
 # mise installer adds ~/.local/bin to PATH but it may not be active yet
 export PATH="$HOME/.local/bin:$PATH"
+echo "mise installed"

--- a/scripts/validate-env.sh
+++ b/scripts/validate-env.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 set -e
 
+# Ensure mise is available for toolchain management
+if ! command -v mise >/dev/null 2>&1; then
+  "$(dirname "$0")/install-mise.sh" >/dev/null
+fi
+
 # Ensure mise activates the configured Node version so npm commands work even
 # when the shell hasn't sourced mise's hook. This prevents "node: command not
 # found" errors in fresh environments.

--- a/tests/bin-install-mise/curl
+++ b/tests/bin-install-mise/curl
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+cat <<'SCRIPT'
+#!/usr/bin/env bash
+mkdir -p "$HOME/.local/bin"
+cat <<'EOS' > "$HOME/.local/bin/mise"
+#!/usr/bin/env bash
+echo "mise version stub"
+EOS
+chmod +x "$HOME/.local/bin/mise"
+echo "mise installed"
+SCRIPT

--- a/tests/validateEnvInstallMise.test.js
+++ b/tests/validateEnvInstallMise.test.js
@@ -1,0 +1,13 @@
+const fs = require("fs");
+const path = require("path");
+
+describe("validate-env installs mise when missing", () => {
+  test("script contains install logic", () => {
+    const content = fs.readFileSync(
+      path.join(__dirname, "..", "scripts", "validate-env.sh"),
+      "utf8",
+    );
+    expect(content).toMatch(/command -v mise/);
+    expect(content).toMatch(/install-mise\.sh/);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure validate-env installs mise when not present
- log installation from install-mise
- add regression test for install logic

## Testing
- `npm run format`
- `npm run smoke`

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68762ba07154832d8cec9956997976db