### PR TITLE
Fix coverage summary path handling

### DIFF
--- a/scripts/check-coverage.js
+++ b/scripts/check-coverage.js
@@ -2,9 +2,17 @@ const fs = require("fs");
 
 const config = JSON.parse(fs.readFileSync(".nycrc", "utf8"));
 
-const summaryPath = "backend/coverage/coverage-summary.json";
-if (!fs.existsSync(summaryPath)) {
-  console.error(`Missing coverage summary: ${summaryPath}`);
+const possiblePaths = [
+  "backend/coverage/coverage-summary.json",
+  "coverage/coverage-summary.json",
+];
+const summaryPath = possiblePaths.find((p) => fs.existsSync(p));
+if (!summaryPath) {
+  console.error(
+    `Missing coverage summary: ${possiblePaths.join(
+      " or ",
+    )}\nRun 'npm run coverage' first to generate it.`,
+  );
   process.exit(1);
 }
 const summary = JSON.parse(fs.readFileSync(summaryPath, "utf8"));

--- a/tests/checkCoverageScriptRoot.test.js
+++ b/tests/checkCoverageScriptRoot.test.js
@@ -1,0 +1,55 @@
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+const summary = path.join(__dirname, "..", "coverage", "coverage-summary.json");
+const backup = summary + ".bak";
+const nycrc = path.join(__dirname, "..", ".nycrc");
+let originalConfig = fs.existsSync(nycrc) ? fs.readFileSync(nycrc, "utf8") : "";
+
+describe("check-coverage script with root summary", () => {
+  beforeAll(() => {
+    if (fs.existsSync(summary)) fs.renameSync(summary, backup);
+  });
+
+  afterAll(() => {
+    if (fs.existsSync(summary)) fs.unlinkSync(summary);
+    if (fs.existsSync(backup)) fs.renameSync(backup, summary);
+    if (originalConfig !== undefined) {
+      fs.writeFileSync(nycrc, originalConfig);
+    } else if (fs.existsSync(nycrc)) {
+      fs.unlinkSync(nycrc);
+    }
+  });
+
+  test("passes when coverage summary in repo root", () => {
+    const goodSummary = {
+      total: {
+        branches: { pct: 90 },
+        functions: { pct: 90 },
+        lines: { pct: 90 },
+        statements: { pct: 90 },
+      },
+    };
+    fs.mkdirSync(path.dirname(summary), { recursive: true });
+    fs.writeFileSync(summary, JSON.stringify(goodSummary));
+    fs.writeFileSync(
+      nycrc,
+      JSON.stringify({
+        "check-coverage": true,
+        branches: 80,
+        functions: 80,
+        lines: 80,
+        statements: 80,
+      }),
+    );
+    const output = execFileSync(
+      "node",
+      [path.join("scripts", "check-coverage.js")],
+      {
+        encoding: "utf8",
+      },
+    );
+    expect(output).toMatch(/Coverage thresholds met/);
+  });
+});


### PR DESCRIPTION
## Summary
- handle fallback coverage path in `check-coverage.js`
- add test for coverage summary written to repo root

## Testing
- `npm test --prefix backend 2>&1 | grep -E "(Test Suites|PASS|FAIL)" | tail -n 20`
- `npm run format --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_68762b705268832dbd0ea947053aac62