### PR TITLE
Fix a11y setup check and add test

### DIFF
--- a/backend/scripts/ensure-deps.js
+++ b/backend/scripts/ensure-deps.js
@@ -91,7 +91,7 @@ function runSetup() {
   }
   try {
     execSync("npm run setup", { stdio: "inherit", cwd: repoRoot, env });
-  } catch (err) {
+  } catch (_err) {
     if (env.SKIP_PW_DEPS) {
       console.warn(
         "Setup failed with SKIP_PW_DEPS, retrying without it to install browsers",

--- a/scripts/validate-env.sh
+++ b/scripts/validate-env.sh
@@ -109,10 +109,18 @@ if [[ -z "${SKIP_PW_DEPS:-}" ]]; then
   fi
 fi
 
+
 if [[ -z "${SKIP_DB_CHECK:-}" ]]; then
   if ! node scripts/check-db.js >/dev/null 2>&1; then
     echo "Database connection check failed. Falling back to SKIP_DB_CHECK=1." >&2
     export SKIP_DB_CHECK=1
+  fi
+fi
+
+if [[ -n "${PLAYWRIGHT_BASE_URL:-}" ]]; then
+  if ! curl -fsI --max-time 5 "$PLAYWRIGHT_BASE_URL" >/dev/null; then
+    echo "PLAYWRIGHT_BASE_URL unreachable: $PLAYWRIGHT_BASE_URL" >&2
+    exit 1
   fi
 fi
 

--- a/tests/validateEnv.test.js
+++ b/tests/validateEnv.test.js
@@ -235,4 +235,19 @@ describe("validate-env script", () => {
     expect(result.stdout.trim()).toBe("tok bucket");
     expect(result.status).toBe(0);
   });
+
+  test("fails when PLAYWRIGHT_BASE_URL unreachable", () => {
+    const env = {
+      ...process.env,
+      HF_TOKEN: "test",
+      AWS_ACCESS_KEY_ID: "id",
+      AWS_SECRET_ACCESS_KEY: "secret",
+      DB_URL: "postgres://user:pass@localhost/db",
+      STRIPE_SECRET_KEY: "sk_test",
+      PLAYWRIGHT_BASE_URL: "http://127.0.0.1:9",
+      SKIP_NET_CHECKS: "1",
+      SKIP_DB_CHECK: "1",
+    };
+    expect(() => run(env)).toThrow(/PLAYWRIGHT_BASE_URL unreachable/);
+  });
 });


### PR DESCRIPTION
## Summary
- allow unused error variable name
- validate PLAYWRIGHT_BASE_URL in validate-env
- test for unreachable PLAYWRIGHT_BASE_URL

## Testing
- `npm test --prefix backend`
- `npx prettier -w tests/validateEnv.test.js`
- `npm run test:a11y`


------
https://chatgpt.com/codex/tasks/task_e_68762b4de568832dab2df69b05d62d29