### PR TITLE
Fix a11y test failure and add host deps check test

### DIFF
--- a/tests/assertSetup.test.js
+++ b/tests/assertSetup.test.js
@@ -89,4 +89,20 @@ describe("assert-setup script", () => {
 
     expect(ensureRootDeps).toHaveBeenCalled();
   });
+
+  test("checks Playwright host dependencies", () => {
+    setEnv();
+    fs.existsSync.mockReturnValue(true);
+    fs.readdirSync.mockReturnValue(["chromium"]);
+    child_process.execSync.mockImplementation(() => {});
+
+    jest.isolateModules(() => {
+      require("../scripts/assert-setup.js");
+    });
+
+    expect(child_process.execSync).toHaveBeenCalledWith(
+      "node scripts/check-host-deps.js",
+      { stdio: "inherit" },
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- run Prettier to satisfy format check
- ensure `assert-setup.js` verifies host dependencies
- add regression test

## Testing
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run i18n:lint`
- `npm run test:ci`
- `npm run test:a11y`
- `npm run smoke`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_68762b4c8f60832dae0a043c96774cd3