### PR TITLE
Fix coverage path mismatch

### DIFF
--- a/backend/tests/runCoverageScript.test.js
+++ b/backend/tests/runCoverageScript.test.js
@@ -39,6 +39,9 @@ describe("run-coverage script", () => {
       true,
     );
     expect(
+      fs.existsSync(path.join(repoRoot, "backend", "coverage", "lcov.info")),
+    ).toBe(true);
+    expect(
       fs.existsSync(
         path.join(repoRoot, "backend", "coverage", "coverage-summary.json"),
       ),

--- a/scripts/run-coverage.js
+++ b/scripts/run-coverage.js
@@ -18,6 +18,7 @@ const jestArgs = [
   "--forceExit",
   "--coverageReporters=text-lcov",
   "--coverageReporters=json-summary",
+  "--coverageReporters=lcov",
   "--coverageThreshold={}",
   "--silent",
   "--config",


### PR DESCRIPTION
## Summary
- generate lcov report in `backend/coverage`
- test for backend lcov file

## Testing
- `npm test`
- `npm run coverage`

------
https://chatgpt.com/codex/tasks/task_e_68762f6a9fe4832da9d85a66d353a012