### PR TITLE
Fix coverage path mismatch and add tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,11 +84,11 @@ jobs:
 
       - name: Sanitize coverage for Coveralls
         run: |
-          sed -r 's/\x1B\[[0-9;]*[JKmsu]//g' backend/coverage/lcov.info \
-            > backend/coverage/lcov.sanitized.info
+          sed -r 's/\x1B\[[0-9;]*[JKmsu]//g' coverage/lcov.info \
+            > coverage/lcov.sanitized.info
 
       - name: Upload to Coveralls
-        run: cat backend/coverage/lcov.sanitized.info | npx coveralls
+        run: cat coverage/lcov.sanitized.info | npx coveralls
 
       - name: Check bundle size
         run: npm run bundle:size

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,7 +18,7 @@ jobs:
         run: node scripts/check-coverage.js
       - name: Validate LCOV report
         run: |
-          if grep -qE '^TN:|^SF:' backend/coverage/lcov.info; then
+          if grep -qE '^TN:|^SF:' coverage/lcov.info; then
             echo '✅ lcov.info is valid'
           else
             echo '❌ lcov.info malformed or missing'
@@ -26,4 +26,4 @@ jobs:
           fi
       - name: Verify coverage summary
         run: node scripts/run-jest.js backend/__tests__/coverageSummaryExists.test.js
-      - run: cat backend/coverage/lcov.info | npx coveralls
+      - run: cat coverage/lcov.info | npx coveralls

--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ Run coverage after installing dependencies:
 npm run setup
 npm run coverage
 
-cat backend/coverage/lcov.info | npx coveralls
+cat coverage/lcov.info | npx coveralls
 ```
 
 Using `npx coveralls` ensures the CLI runs even if it's not installed globally.
@@ -410,14 +410,14 @@ If Coveralls fails with an `lcovParse` error, the `lcov.info` report may contain
 ANSI color codes. Strip them before uploading:
 
 ```bash
-npx strip-ansi backend/coverage/lcov.info > cleaned.info
+npx strip-ansi coverage/lcov.info > cleaned.info
 cat cleaned.info | npx coveralls
 ```
 
 Verify the file includes `SF:` entries to confirm it's valid:
 
 ```bash
-grep '^SF:' backend/coverage/lcov.info | head
+grep '^SF:' coverage/lcov.info | head
 ```
 
 Missing `SF:` lines usually mean the report was truncated. Re-run `npm run coverage`

--- a/backend/scripts/ensure-deps.js
+++ b/backend/scripts/ensure-deps.js
@@ -91,7 +91,7 @@ function runSetup() {
   }
   try {
     execSync("npm run setup", { stdio: "inherit", cwd: repoRoot, env });
-  } catch (err) {
+  } catch (_err) {
     if (env.SKIP_PW_DEPS) {
       console.warn(
         "Setup failed with SKIP_PW_DEPS, retrying without it to install browsers",

--- a/tests/coverageReadme.test.js
+++ b/tests/coverageReadme.test.js
@@ -7,6 +7,6 @@ describe("README coverage instructions", () => {
       path.join(__dirname, "..", "README.md"),
       "utf8",
     );
-    expect(readme).toContain("cat backend/coverage/lcov.info | npx coveralls");
+    expect(readme).toContain("cat coverage/lcov.info | npx coveralls");
   });
 });

--- a/tests/coverageWorkflow.test.js
+++ b/tests/coverageWorkflow.test.js
@@ -25,9 +25,7 @@ describe("coverage workflow", () => {
     const hasSummaryCheck = steps.some((cmd) =>
       cmd.includes("coverageSummaryExists.test.js"),
     );
-    const usesCat = steps.some((cmd) =>
-      cmd.includes("cat backend/coverage/lcov.info"),
-    );
+    const usesCat = steps.some((cmd) => cmd.includes("cat coverage/lcov.info"));
     expect(hasSetup).toBe(true);
     expect(hasCoverage).toBe(true);
     expect(hasCoveralls).toBe(true);


### PR DESCRIPTION
## Summary
- sanitize coverage upload steps to use `coverage/lcov.info`
- update README instructions for Coveralls
- rename unused catch variable
- adjust tests to expect new LCOV location

## Testing
- `npm run format --prefix backend`
- `npm run lint`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_68762f5f7074832db9ff2d13da14781e