### PR TITLE
Add code scanning validation script

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "diagnose": "bash scripts/diagnose.sh",
     "test:generate": "node scripts/test-generate.js",
     "test:webhook": "node scripts/test-webhook.js",
+    "check:code-scanning": "node scripts/check-code-scanning.js",
     "commitlint": "commitlint --from=HEAD~1",
     "lint:md": "markdownlint-cli2 \"**/*.md\""
   },

--- a/scripts/check-code-scanning.js
+++ b/scripts/check-code-scanning.js
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+const https = require("https");
+
+const owner = process.env.CI_REPO_OWNER || "print3git";
+const repo = process.env.CI_REPO_NAME || "MVP-website";
+const token = process.env.GITHUB_TOKEN;
+
+if (!token) {
+  console.error("GITHUB_TOKEN not provided");
+  process.exit(1);
+}
+
+const options = {
+  hostname: "api.github.com",
+  path: `/repos/${owner}/${repo}/code-scanning/alerts`,
+  headers: {
+    "User-Agent": "code-scanning-check",
+    Authorization: `token ${token}`,
+    Accept: "application/vnd.github+json",
+  },
+};
+
+https
+  .get(options, (res) => {
+    if (res.statusCode === 404) {
+      console.error("Code scanning is not enabled for this repository.");
+      res.resume();
+      process.exit(1);
+    } else {
+      res.resume();
+      res.on("end", () => process.exit(0));
+    }
+  })
+  .on("error", (err) => {
+    console.error(err.message);
+    process.exit(1);
+  });

--- a/tests/checkCodeScanningScript.test.js
+++ b/tests/checkCodeScanningScript.test.js
@@ -1,0 +1,12 @@
+const fs = require("fs");
+const pkg = require("../package.json");
+
+test("package.json has code scanning check script", () => {
+  expect(pkg.scripts["check:code-scanning"]).toBe(
+    "node scripts/check-code-scanning.js",
+  );
+});
+
+test("check-code-scanning.js exists", () => {
+  expect(fs.existsSync("scripts/check-code-scanning.js")).toBe(true);
+});


### PR DESCRIPTION
## Summary
- check if GitHub code scanning is enabled via new script
- expose the script with an npm alias
- test for new script

## Testing
- `node scripts/run-jest.js tests/checkCodeScanningScript.test.js`
- `npm run format`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68763414b210832db082b4e7565b57ee