### PR TITLE
Fix smoke port conflicts

### DIFF
--- a/backend/scripts/ensure-deps.js
+++ b/backend/scripts/ensure-deps.js
@@ -91,7 +91,7 @@ function runSetup() {
   }
   try {
     execSync("npm run setup", { stdio: "inherit", cwd: repoRoot, env });
-  } catch (err) {
+  } catch (_err) {
     if (env.SKIP_PW_DEPS) {
       console.warn(
         "Setup failed with SKIP_PW_DEPS, retrying without it to install browsers",

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "http-server": "^14.1.1",
         "husky": "^9.1.7",
         "i18next-parser": "^9.3.0",
+        "kill-port": "^2.0.1",
         "lint-staged": "^16.1.2",
         "lockfile-diff": "^0.1.0",
         "markdownlint-cli2": "^0.10.0",
@@ -7906,6 +7907,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-them-args": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/get-them-args/-/get-them-args-1.3.2.tgz",
+      "integrity": "sha512-LRn8Jlk+DwZE4GTlDbT3Hikd1wSHgLMme/+7ddlqKd7ldwR6LjJgTVWzBnR01wnYGe4KgrXjg287RaI22UHmAw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/get-tsconfig": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
@@ -9895,6 +9903,20 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/kill-port": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/kill-port/-/kill-port-2.0.1.tgz",
+      "integrity": "sha512-e0SVOV5jFo0mx8r7bS29maVWp17qGqLBZ5ricNSajON6//kmb7qqqNnml4twNE8Dtj97UQD+gNFOaipS/q1zzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-them-args": "1.3.2",
+        "shell-exec": "1.0.2"
+      },
+      "bin": {
+        "kill-port": "cli.js"
       }
     },
     "node_modules/kuler": {
@@ -13661,6 +13683,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/shell-exec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/shell-exec/-/shell-exec-1.0.2.tgz",
+      "integrity": "sha512-jyVd+kU2X+mWKMmGhx4fpWbPsjvD53k9ivqetutVW/BQ+WIZoDoP4d8vUMGezV6saZsiNoW2f9GIhg9Dondohg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/shell-quote": {
       "version": "1.8.3",

--- a/package.json
+++ b/package.json
@@ -103,8 +103,10 @@
     "http-server": "^14.1.1",
     "husky": "^9.1.7",
     "i18next-parser": "^9.3.0",
+    "kill-port": "^2.0.1",
     "lint-staged": "^16.1.2",
     "lockfile-diff": "^0.1.0",
+    "markdownlint-cli2": "^0.10.0",
     "playwright": "^1.54.1",
     "prettier": "^3.5.3",
     "size-limit": "^11.2.0",
@@ -112,8 +114,7 @@
     "tslib": "^2.8.1",
     "typescript": "^5.8.3",
     "wait-on": "^8.0.3",
-    "yaml": "^2.8.0",
-    "markdownlint-cli2": "^0.10.0"
+    "yaml": "^2.8.0"
   },
   "husky": {
     "hooks": {

--- a/scripts/run-smoke.js
+++ b/scripts/run-smoke.js
@@ -3,6 +3,14 @@ const { execSync } = require("child_process");
 const fs = require("fs");
 const path = require("path");
 
+function freePort(port) {
+  try {
+    execSync(`npx -y kill-port ${port}`, { stdio: "inherit" });
+  } catch (err) {
+    console.warn(`kill-port ${port} failed`, err.message);
+  }
+}
+
 function initEnv(baseEnv = process.env) {
   const env = { ...baseEnv };
 
@@ -82,6 +90,7 @@ function main() {
   try {
     run("npm run validate-env");
     run("npm run setup");
+    freePort(3000);
     if (!process.env.SKIP_PW_DEPS) {
       run("npx -y playwright install --with-deps");
     }
@@ -104,4 +113,4 @@ if (require.main === module) {
   main();
 }
 
-module.exports = { main, env, run, initEnv };
+module.exports = { main, env, run, initEnv, freePort };

--- a/tests/runSmoke.freePort.test.js
+++ b/tests/runSmoke.freePort.test.js
@@ -1,0 +1,21 @@
+const http = require("http");
+const net = require("net");
+const { freePort } = require("../scripts/run-smoke.js");
+
+test("freePort terminates existing listener", (done) => {
+  http
+    .createServer(() => {})
+    .listen(3000, () => {
+      freePort(3000);
+      setTimeout(() => {
+        const socket = net.connect({ port: 3000 });
+        socket.on("error", () => {
+          done();
+        });
+        socket.on("connect", () => {
+          socket.end();
+          done(new Error("port still open"));
+        });
+      }, 300);
+    });
+});


### PR DESCRIPTION
## Summary
- add kill-port to dev dependencies
- automatically free port 3000 in `run-smoke.js`
- update ensure-deps catch variable to satisfy linter
- test port cleanup in new Jest test

## Testing
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_687630f37cd8832d821437bb84eb8e39