### PR TITLE
Fix eslint catch var rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -44,7 +44,10 @@ module.exports = [
   {
     plugins: { jsdoc },
     rules: {
-      "no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
+      "no-unused-vars": [
+        "error",
+        { argsIgnorePattern: "^_", caughtErrorsIgnorePattern: "^_" },
+      ],
       "jsdoc/require-param": "error",
     },
   },

--- a/tests/backendScriptsLint.test.js
+++ b/tests/backendScriptsLint.test.js
@@ -1,0 +1,7 @@
+const { execSync } = require("child_process");
+
+describe("backend scripts lint", () => {
+  test("ensure-deps.js passes eslint", () => {
+    execSync("npx eslint backend/scripts/ensure-deps.js", { stdio: "pipe" });
+  });
+});


### PR DESCRIPTION
## Summary
- ignore unused catch vars with underscore
- ensure `backend/scripts/ensure-deps.js` stays lint-free

## Testing
- `npm run format --prefix backend`
- `LOG_LEVEL=error npm test --prefix backend --silent`
- `LOG_LEVEL=error SKIP_PW_DEPS=1 npm run ci --silent`

------
https://chatgpt.com/codex/tasks/task_e_687632f25038832d990eb3fffd06ad41