### PR TITLE
Fix logger output noise in tests

### DIFF
--- a/backend/tests/logger.test.js
+++ b/backend/tests/logger.test.js
@@ -1,5 +1,15 @@
 const { capture } = require("../src/lib/logger");
+const logger = require("../src/logger");
+const { transports } = require("winston");
 
 test("capture does not throw without DSN", () => {
   expect(() => capture(new Error("boom"))).not.toThrow();
+});
+
+test("logger is silent in test env", () => {
+  const consoleTransport = logger.transports.find(
+    (t) => t instanceof transports.Console,
+  );
+  expect(logger.level).toBe("error");
+  expect(consoleTransport.silent).toBe(true);
 });

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,9 +1,12 @@
 const { createLogger, format, transports } = require("winston");
 
+const isTest = process.env.NODE_ENV === "test";
+const level = process.env.LOG_LEVEL || (isTest ? "error" : "info");
+
 const logger = createLogger({
-  level: "info",
+  level,
   format: format.combine(format.timestamp(), format.json()),
-  transports: [new transports.Console()],
+  transports: [new transports.Console({ silent: isTest })],
 });
 
 module.exports = logger;


### PR DESCRIPTION
## Summary
- silence Winston console logs during tests
- verify logger configuration in test suite

## Testing
- `npm test` in `backend/`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_687633a244d8832d94855f353741b1f2