### PR TITLE
Fix jest path pattern and test run-jest on JS files

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -8,7 +8,7 @@ module.exports = {
   transform: {
     "^.+\\.[tj]s$": "babel-jest",
   },
-  testMatch: ["**/?(*.)+(spec|test).ts?(x)"],
+  testMatch: ["**/?(*.)+(spec|test).[jt]s?(x)"],
   moduleFileExtensions: ["ts", "js", "json"],
   testTimeout: 10000,
   coverageDirectory: "coverage",

--- a/tests/runJestBackendJsIntegration.test.js
+++ b/tests/runJestBackendJsIntegration.test.js
@@ -1,0 +1,20 @@
+const { execFileSync } = require("child_process");
+
+test("run-jest runs JS backend unit test", () => {
+  const env = {
+    ...process.env,
+    HF_TOKEN: "x",
+    AWS_ACCESS_KEY_ID: "id",
+    AWS_SECRET_ACCESS_KEY: "secret",
+    DB_URL: "postgres://user:pass@localhost/db",
+    STRIPE_SECRET_KEY: "sk_test",
+    SKIP_NET_CHECKS: "1",
+    SKIP_PW_DEPS: "1",
+    SKIP_DB_CHECK: "1",
+  };
+  execFileSync(
+    "node",
+    ["scripts/run-jest.js", "backend/__tests__/items.test.js"],
+    { stdio: "inherit", env },
+  );
+});


### PR DESCRIPTION
## Summary
- allow Jest to match `.js` tests in backend
- add regression test ensuring `run-jest.js` can execute JS backend tests

## Testing
- `npm run format`
- `npm test --prefix backend --silent`
- `node scripts/run-jest.js backend/__tests__/items.test.js --runInBand --silent`

------
https://chatgpt.com/codex/tasks/task_e_687633f0ab78832d937703d1fdc7570f