### PR TITLE
Fix npm ci tarball errors

### DIFF
--- a/scripts/run-npm-ci.js
+++ b/scripts/run-npm-ci.js
@@ -40,7 +40,9 @@ function runNpmCi(dir = ".") {
       console.warn(`npm ci failed in ${dir}, falling back to 'npm install'`);
       execSync("npm install --no-audit --no-fund", options);
       execSync("npm ci --no-audit --no-fund", options);
-    } else if (/TAR_ENTRY_ERROR|ENOENT/.test(output)) {
+    } else if (
+      /TAR_ENTRY_ERROR|ENOENT|ENOTEMPTY|tarball .*corrupted/.test(output)
+    ) {
       console.warn(
         `npm ci encountered tar errors in ${dir}. Cleaning cache and retrying...`,
       );

--- a/tests/runNpmCi.test.js
+++ b/tests/runNpmCi.test.js
@@ -39,4 +39,21 @@ describe("runNpmCi", () => {
     );
     expect(execSync.mock.calls.pop()[0]).toBe("npm ci --no-audit --no-fund");
   });
+
+  test("cleans cache on corrupted tarball", () => {
+    execSync.mockImplementationOnce(() => {
+      const err = new Error("corrupt");
+      err.stderr =
+        "npm WARN tarball tarball data for package@https://registry.npmjs.org/package/-/package-1.0.0.tgz (sha512-abc) seems to be corrupted";
+      throw err;
+    });
+    const { runNpmCi } = require("../scripts/run-npm-ci");
+    runNpmCi();
+    expect(execSync.mock.calls[0][0]).toBe("npm ci --no-audit --no-fund");
+    expect(rmSync).toHaveBeenCalledWith(
+      expect.stringContaining("node_modules"),
+      expect.any(Object),
+    );
+    expect(execSync.mock.calls.pop()[0]).toBe("npm ci --no-audit --no-fund");
+  });
 });


### PR DESCRIPTION
## Summary
- retry npm ci when tarball corruption or ENOTEMPTY errors occur
- test runNpmCi tarball corruption handling

## Testing
- `npm run format`
- `node scripts/run-jest.js tests/runNpmCi.test.js`
- `SKIP_PW_DEPS=1 npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_687634ecb740832d98e167daec3e4e19