### PR TITLE
Update docs to address npm ci tar errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,12 @@ The `npm run setup` script now performs this cleanup before and after installing
 dependencies, so new clones shouldn't hit this error. If you still encounter it,
 re-run `npm run setup` to ensure the cache directory is cleared.
 
+### TAR\_ENTRY\_ERROR or ENOENT during `npm ci`
+
+If `npm run format` exits with errors like `TAR_ENTRY_ERROR` or `ENOENT`, the
+package cache may be corrupted. Running `npm run setup` in the repository root
+cleans the cache and reinstalls dependencies, usually resolving these failures.
+
 ### Playwright host validation warnings
 
 If Playwright prints a message like `Host system is missing dependencies to run browsers`,


### PR DESCRIPTION
## Summary
- clarify how to recover from `TAR_ENTRY_ERROR` and `ENOENT` failures in README

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend -- --runInBand`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_687635078bdc832da5e5c411d6c845fc