### PR TITLE
Add DAL unit tests

### DIFF
--- a/backend/tests/dbAccess.test.js
+++ b/backend/tests/dbAccess.test.js
@@ -1,0 +1,20 @@
+const db = require("../db");
+
+beforeEach(() => {
+  db.query = jest.fn();
+});
+
+test("getRewardOption returns database value when present", async () => {
+  db.query.mockResolvedValueOnce({ rows: [{ amount_cents: 250 }] });
+  const result = await db.getRewardOption(50);
+  expect(db.query).toHaveBeenCalledWith(
+    "SELECT amount_cents FROM reward_options WHERE points=$1",
+    [50],
+  );
+  expect(result).toEqual({ amount_cents: 250 });
+});
+
+test("getRewardOption propagates query error", async () => {
+  db.query.mockRejectedValueOnce(new Error("fail"));
+  await expect(db.getRewardOption(20)).rejects.toThrow("fail");
+});


### PR DESCRIPTION
## Summary
- test DAL reward option helper using mocked DB results

## Testing
- `npm test`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_687635bf3098832db74e3c60800a48f2