### PR TITLE
Add coverage tests for root summary

### DIFF
--- a/tests/checkCoverageScriptRoot.test.js
+++ b/tests/checkCoverageScriptRoot.test.js
@@ -52,4 +52,53 @@ describe("check-coverage script with root summary", () => {
     );
     expect(output).toMatch(/Coverage thresholds met/);
   });
+
+  test("fails gracefully when root summary missing", () => {
+    try {
+      execFileSync("node", [path.join("scripts", "check-coverage.js")], {
+        encoding: "utf8",
+        stdio: "pipe",
+      });
+      throw new Error("script did not exit");
+    } catch (err) {
+      const output = (err.stdout || "") + (err.stderr || "");
+      expect(output).toMatch(/Missing coverage summary/);
+    }
+  });
+
+  test("fails when root coverage below threshold", () => {
+    const badSummary = {
+      total: {
+        branches: { pct: 0 },
+        functions: { pct: 0 },
+        lines: { pct: 0 },
+        statements: { pct: 0 },
+      },
+    };
+    fs.mkdirSync(path.dirname(summary), { recursive: true });
+    fs.writeFileSync(summary, JSON.stringify(badSummary));
+    fs.writeFileSync(
+      nycrc,
+      JSON.stringify({
+        "check-coverage": true,
+        branches: 80,
+        functions: 80,
+        lines: 80,
+        statements: 80,
+      }),
+    );
+    try {
+      execFileSync("node", [path.join("scripts", "check-coverage.js")], {
+        encoding: "utf8",
+        stdio: "pipe",
+      });
+      throw new Error("script did not exit");
+    } catch (err) {
+      const output = (err.stdout || "") + (err.stderr || "");
+      expect(output).toMatch(/does not meet threshold/);
+    } finally {
+      fs.unlinkSync(summary);
+      fs.writeFileSync(nycrc, originalConfig);
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- extend `checkCoverageScriptRoot` tests

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687635c28fb8832d81bb5aa3491cd74e