### PR TITLE
Add tests for prepareImage helper

### DIFF
--- a/backend/tests/prepareImage.test.ts
+++ b/backend/tests/prepareImage.test.ts
@@ -1,0 +1,52 @@
+const fs = require("fs");
+const path = require("path");
+
+jest.mock("../src/lib/uploadS3", () => ({
+  uploadFile: jest.fn().mockResolvedValue("https://cdn.test/image.png"),
+}));
+
+const { prepareImage } = require("../src/lib/prepareImage.ts");
+
+describe("prepareImage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("returns http url unchanged", async () => {
+    const url = await prepareImage("http://example.com/img.png");
+    expect(url).toBe("http://example.com/img.png");
+  });
+
+  test("uploads existing local file", async () => {
+    const tmp = path.join("/tmp", `test-${Date.now()}.png`);
+    fs.writeFileSync(tmp, "data");
+    const { uploadFile } = require("../src/lib/uploadS3");
+    const url = await prepareImage(tmp);
+    expect(uploadFile).toHaveBeenCalledWith(tmp, "image/png");
+    expect(url).toBe("https://cdn.test/image.png");
+    fs.unlinkSync(tmp);
+  });
+
+  test("uploads data url and cleans up", async () => {
+    const data = Buffer.from("data").toString("base64");
+    const dataURL = `data:image/png;base64,${data}`;
+    const unlinkSpy = jest
+      .spyOn(fs, "unlink")
+      .mockImplementation((_, cb) => cb && cb());
+    const { uploadFile } = require("../src/lib/uploadS3");
+    const url = await prepareImage(dataURL);
+    expect(uploadFile).toHaveBeenCalledWith(
+      expect.stringMatching(/\/tmp\//),
+      "image/png",
+    );
+    expect(url).toBe("https://cdn.test/image.png");
+    expect(unlinkSpy).toHaveBeenCalled();
+    unlinkSpy.mockRestore();
+  });
+
+  test("throws when file missing", async () => {
+    await expect(prepareImage("/does/not/exist.png")).rejects.toThrow(
+      "image file not found",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add coverage for `prepareImage` helper covering URL passthrough, data URL logic and missing file
- format repo and run test suite

## Testing
- `npm run format` in `backend`
- `npm test` in `backend`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_687635cc8cb4832d9c3ec8fcad9ee1bb