### PR TITLE
Add LCOV linter test

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,13 +17,7 @@ jobs:
       - name: Check coverage thresholds
         run: node scripts/check-coverage.js
       - name: Validate LCOV report
-        run: |
-          if grep -qE '^TN:|^SF:' coverage/lcov.info; then
-            echo '✅ lcov.info is valid'
-          else
-            echo '❌ lcov.info malformed or missing'
-            exit 1
-          fi
+        run: node scripts/run-jest.js backend/__tests__/lcovExists.test.js
       - name: Verify coverage summary
         run: node scripts/run-jest.js backend/__tests__/coverageSummaryExists.test.js
       - run: cat coverage/lcov.info | npx coveralls

--- a/backend/__tests__/lcovExists.test.js
+++ b/backend/__tests__/lcovExists.test.js
@@ -1,0 +1,10 @@
+const fs = require("fs");
+const path = require("path");
+
+const lcov = path.join(__dirname, "..", "..", "coverage", "lcov.info");
+
+(process.env.CI ? test : test.skip)("lcov.info exists and is valid", () => {
+  expect(fs.existsSync(lcov)).toBe(true);
+  const content = fs.readFileSync(lcov, "utf8");
+  expect(/^(TN|SF):/m.test(content)).toBe(true);
+});


### PR DESCRIPTION
## Summary
- add `lcovExists.test.js` to ensure coverage output is present and valid
- call the new test in the coverage workflow

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_687635db6910832db657df328f3151a2