### PR TITLE
Fix ensure-root-deps node version check

### DIFF
--- a/scripts/ensure-root-deps.js
+++ b/scripts/ensure-root-deps.js
@@ -3,6 +3,15 @@ const path = require("path");
 const { execSync } = require("child_process");
 const os = require("os");
 
+const requiredMajor = parseInt(process.env.REQUIRED_NODE_MAJOR || "20", 10);
+const currentMajor = parseInt(process.versions.node.split(".")[0], 10);
+if (currentMajor < requiredMajor) {
+  console.error(
+    `Node ${requiredMajor} or newer is required. Current version: ${process.versions.node}`,
+  );
+  process.exit(1);
+}
+
 function getEnv() {
   const env = { ...process.env };
   delete env.npm_config_http_proxy;

--- a/tests/ensureRootDeps.test.js
+++ b/tests/ensureRootDeps.test.js
@@ -55,4 +55,17 @@ describe("ensure-root-deps", () => {
     delete process.env.npm_config_http_proxy;
     delete process.env.npm_config_https_proxy;
   });
+
+  test("fails when node version is too low", () => {
+    fs.existsSync.mockReturnValue(true);
+    const originalVersions = process.versions;
+    Object.defineProperty(process, "versions", {
+      value: { ...process.versions, node: "18.0.0" },
+    });
+    jest.isolateModules(() => {
+      require("../scripts/ensure-root-deps.js");
+    });
+    expect(process.exit).toHaveBeenCalledWith(1);
+    Object.defineProperty(process, "versions", { value: originalVersions });
+  });
 });


### PR DESCRIPTION
## Summary
- verify Node version in `ensure-root-deps.js`
- test the version check in `ensureRootDeps.test.js`

## Testing
- `npm --prefix backend run format`
- `SKIP_PW_DEPS=1 npm test --prefix backend`
- `node scripts/run-jest.js tests/ensureRootDeps.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6876375c1ea0832da485142cb218c278