### PR TITLE
Add utility tests

### DIFF
--- a/backend/tests/queue/routing.test.js
+++ b/backend/tests/queue/routing.test.js
@@ -55,3 +55,20 @@ test("overflows to secondary hub when queue high", async () => {
   const hub = await selectHub(mClient, { state: "CA" });
   expect(hub.id).toBe(2);
 });
+
+test("returns null when no hubs", async () => {
+  mClient.query.mockResolvedValueOnce({ rows: [] });
+  const hub = await selectHub(mClient, {});
+  expect(hub).toBeNull();
+});
+
+test("skips offline printers when calculating queue", async () => {
+  mClient.query
+    .mockResolvedValueOnce({ rows: [{ id: 1, location: "CA" }] })
+    .mockResolvedValueOnce({ rows: [{ id: 10, hub_id: 1 }] })
+    .mockResolvedValueOnce({
+      rows: [{ printer_id: 10, status: "busy", queue_length: 5, error: null }],
+    });
+  const hub = await selectHub(mClient, { state: "CA" });
+  expect(hub.id).toBe(1);
+});

--- a/backend/tests/utils/dailyPrints.test.js
+++ b/backend/tests/utils/dailyPrints.test.js
@@ -1,4 +1,8 @@
-const { _computeDailyPrintsSold } = require("../../utils/dailyPrints");
+const {
+  _computeDailyPrintsSold,
+  _setDailyPrintsSold,
+  getDailyPrintsSold,
+} = require("../../utils/dailyPrints");
 
 describe("_computeDailyPrintsSold", () => {
   test("returns deterministic value for a given date", () => {
@@ -10,5 +14,12 @@ describe("_computeDailyPrintsSold", () => {
     const val = _computeDailyPrintsSold(new Date());
     expect(val).toBeGreaterThanOrEqual(30);
     expect(val).toBeLessThanOrEqual(50);
+  });
+});
+
+describe("getDailyPrintsSold", () => {
+  test("reflects internal counter", () => {
+    _setDailyPrintsSold(42);
+    expect(getDailyPrintsSold()).toBe(42);
   });
 });

--- a/backend/tests/utils/generateAdCopy.test.js
+++ b/backend/tests/utils/generateAdCopy.test.js
@@ -41,4 +41,22 @@ describe("generateAdCopy", () => {
     const text = await generateAdCopy("baz");
     expect(text).toBe("Ad for baz");
   });
+
+  test("uses template when API response missing text", async () => {
+    process.env.LLM_API_URL = "http://api";
+    axios.post.mockResolvedValue({ data: {} });
+    Math.random = jest.fn(() => 0);
+    const text = await generateAdCopy("qux");
+    expect(text).toBe("Ad for qux");
+  });
+
+  test("handles undefined context", async () => {
+    process.env.LLM_API_URL = "http://api";
+    axios.post.mockResolvedValue({ data: { text: "Res" } });
+    const text = await generateAdCopy("sub");
+    expect(axios.post).toHaveBeenCalledWith("http://api", {
+      prompt: "Write a short advert for r/sub. Context: ",
+    });
+    expect(text).toBe("Res");
+  });
 });

--- a/backend/tests/utils/generateShareCard.test.js
+++ b/backend/tests/utils/generateShareCard.test.js
@@ -1,0 +1,46 @@
+const Jimp = require("jimp");
+const fs = require("fs");
+const path = require("path");
+
+jest.mock("jimp");
+
+const generateShareCard = require("../../utils/generateShareCard");
+
+describe("generateShareCard", () => {
+  const tmpDir = fs.mkdtempSync(path.join(__dirname, "sharecard-"));
+  const outPath = path.join(tmpDir, "card.png");
+
+  const mImage = { print: jest.fn().mockReturnThis(), writeAsync: jest.fn() };
+
+  beforeEach(() => {
+    Jimp.mockClear();
+    Jimp.loadFont.mockResolvedValue("FONT");
+    Jimp.mockResolvedValue(mImage);
+    mImage.print.mockClear();
+    mImage.writeAsync.mockClear();
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("creates image with model id", async () => {
+    await generateShareCard(123, outPath);
+    expect(Jimp).toHaveBeenCalledWith(600, 400, "#ffffff");
+    expect(Jimp.loadFont).toHaveBeenCalledWith(Jimp.FONT_SANS_32_BLACK);
+    expect(mImage.print).toHaveBeenCalledWith(
+      "FONT",
+      20,
+      20,
+      "Gifted Model 123",
+    );
+    expect(mImage.writeAsync).toHaveBeenCalledWith(outPath);
+  });
+
+  test("handles string id and write error", async () => {
+    mImage.writeAsync.mockRejectedValue(new Error("disk full"));
+    await expect(generateShareCard("abc", outPath)).rejects.toThrow(
+      "disk full",
+    );
+  });
+});

--- a/backend/tests/utils/generateTitle.test.js
+++ b/backend/tests/utils/generateTitle.test.js
@@ -18,4 +18,8 @@ describe("generateTitle", () => {
   test("capitalizes and trims words", () => {
     expect(generateTitle(" hello world ")).toBe("Hello World");
   });
+
+  test("ignores punctuation and numbers", () => {
+    expect(generateTitle("foo123 bar! baz?")).toBe("Foo123 Bar Baz");
+  });
 });

--- a/backend/tests/utils/getEnv.test.js
+++ b/backend/tests/utils/getEnv.test.js
@@ -23,4 +23,9 @@ describe("getEnv", () => {
   test("throws when required and missing", () => {
     expect(() => getEnv(KEY, { required: true })).toThrow();
   });
+
+  test("uses default when env empty", () => {
+    process.env[KEY] = "";
+    expect(getEnv(KEY, { default: "x" })).toBe("x");
+  });
 });

--- a/backend/tests/utils/validateStl.test.js
+++ b/backend/tests/utils/validateStl.test.js
@@ -25,6 +25,21 @@ describe("validateStl", () => {
     expect(validateStl(file)).toBe(true);
   });
 
+  test("returns false for ascii missing endsolid", () => {
+    const file = path.join(tmpDir, "bad_ascii.stl");
+    fs.writeFileSync(file, "solid test\nendsolid");
+    expect(validateStl(file)).toBe(false);
+  });
+
+  test("returns false for binary with zero tri", () => {
+    const file = path.join(tmpDir, "bad_bin.stl");
+    const buf = Buffer.alloc(84);
+    buf.write("BINARY", 0, "ascii");
+    buf.writeUInt32LE(0, 80);
+    fs.writeFileSync(file, buf);
+    expect(validateStl(file)).toBe(false);
+  });
+
   test("returns false for invalid file", () => {
     const file = path.join(tmpDir, "invalid.stl");
     fs.writeFileSync(file, "bad");


### PR DESCRIPTION
## Summary
- test utils with more varied cases
- add Jimp mock tests for generateShareCard

## Testing
- `npm test --silent | grep -E "Test Suites:|Tests:" | tail -n 20`
- `SKIP_PW_DEPS=1 npm run ci --silent 2>&1 | grep -E "Test Suites:|Tests:" | tail -n 20`
- `SKIP_PW_DEPS=1 npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_687635a38e28832dbbd5f212ca2b7f3d