### PR TITLE
Add backend error handling tests

### DIFF
--- a/backend/__tests__/users.test.js
+++ b/backend/__tests__/users.test.js
@@ -27,4 +27,16 @@ describe("GET /api/users/:id", () => {
     expect(res.status).toBe(500);
     expect(res.body).toEqual({ error: "Internal Server Error" });
   });
+  test("returns 404 when user missing", async () => {
+    users.findUserById.mockResolvedValue(undefined);
+    const res = await request(app).get("/api/users/456");
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: "User not found" });
+  });
+
+  test("handles null id parameter", async () => {
+    users.findUserById.mockResolvedValue(null);
+    const res = await request(app).get("/api/users/null");
+    expect(res.status).toBe(404);
+  });
 });

--- a/backend/tests/apiModels.test.js
+++ b/backend/tests/apiModels.test.js
@@ -60,3 +60,22 @@ test("POST /api/models requires fields", async () => {
   const res = await request(app).post("/api/models").send({});
   expect(res.status).toBe(400);
 });
+
+test("POST /api/models returns 500 on db failure", async () => {
+  const body = { prompt: "oops", fileKey: "oops.glb" };
+  db.query.mockRejectedValueOnce(new Error("fail"));
+  const res = await request(app).post("/api/models").send(body);
+  expect(res.status).toBe(500);
+  expect(res.body).toEqual({ error: "Internal Server Error" });
+});
+
+test("POST /api/models validates fileKey", async () => {
+  const body = { prompt: "bad", fileKey: "bad key" };
+  const res = await request(app).post("/api/models").send(body);
+  expect(res.status).toBe(400);
+});
+
+test("POST /api/models rejects null payload", async () => {
+  const res = await request(app).post("/api/models").send(null);
+  expect(res.status).toBe(400);
+});

--- a/backend/tests/validateMiddleware.test.js
+++ b/backend/tests/validateMiddleware.test.js
@@ -22,4 +22,27 @@ describe("validate middleware", () => {
     expect(res.json.mock.calls[0][0]).toHaveProperty("error");
     expect(next).not.toHaveBeenCalled();
   });
+
+  test("calls next on non-Zod errors", () => {
+    const badSchema = {
+      parse: () => {
+        throw new Error("boom");
+      },
+    };
+    const req = { body: {} };
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    const next = jest.fn();
+    validate(badSchema)(req, res, next);
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  test("handles null body as invalid", () => {
+    const req = { body: null };
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    const next = jest.fn();
+    validate(schema)(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(next).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- expand users route tests for not found and null IDs
- cover validation middleware error paths
- add model route tests for DB failures and bad payloads

## Testing
- `npm run format` in `backend/`
- `npm test --silent` in `backend/`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_687635344dec832d89c3efcb509da8a0