### PR TITLE
fix: resolve env file path

### DIFF
--- a/backend/tests/envValidation.test.js
+++ b/backend/tests/envValidation.test.js
@@ -78,6 +78,18 @@ describe("validate-env script", () => {
     ).not.toThrow();
   });
 
+  test("uses repo root env file when run from backend directory", () => {
+    const env = { ...process.env, ...baseEnv };
+    delete env.DB_URL;
+    expect(() =>
+      execSync(`bash ${script}`, {
+        env,
+        stdio: "pipe",
+        cwd: path.join(__dirname, ".."),
+      }),
+    ).not.toThrow();
+  });
+
   test("fails when DB_URL missing and example file absent", () => {
     const env = { ...process.env, ...baseEnv };
     delete env.DB_URL;

--- a/scripts/validate-env.sh
+++ b/scripts/validate-env.sh
@@ -21,6 +21,9 @@ mise settings add idiomatic_version_file_enable_tools node --yes >/dev/null 2>&1
 if [ -f .mise.toml ]; then
   mise trust .mise.toml >/dev/null 2>&1 || true
 fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
 load_env_file() {
   local file="$1"
   while IFS='=' read -r key value; do
@@ -31,10 +34,10 @@ load_env_file() {
   done < "$file"
 }
 
-if [ -f .env ]; then
-  load_env_file .env
-elif [ -f .env.example ]; then
-  load_env_file .env.example
+if [ -f "$repo_root/.env" ]; then
+  load_env_file "$repo_root/.env"
+elif [ -f "$repo_root/.env.example" ]; then
+  load_env_file "$repo_root/.env.example"
 fi
 
 # Disable HTTP/2 for local testing to avoid client errors


### PR DESCRIPTION
## Summary
- resolve repository root when reading `.env` files
- test that `validate-env` works from backend directory

## Testing
- `npm run format` in `backend/`
```
tests/stubMissingDeps.js 1ms (unchanged)
...
utils/validateStl.js 1ms (unchanged)
```
- `npm test --silent` in `backend/`
```
Test Suites: 3 skipped, 31 passed, 31 of 34 total
Tests:       3 skipped, 65 passed, 68 total
Snapshots:   0 total
Time:        18.492 s
Ran all test suites.
```
- `SKIP_PW_DEPS=1 npm run ci` (partial)
```
  ✓  1 e2e/a11y.test.js:18:3 › a11y check /index.html (3.4s)
  ✓  2 e2e/a11y.test.js:18:3 › a11y check /login.html (951ms)
  ✓  3 e2e/a11y.test.js:18:3 › a11y check /signup.html (1.2s)
  ✓  4 e2e/a11y.test.js:18:3 › a11y check /payment.html (1.5s)

  4 passed (8.7s)
```

------
https://chatgpt.com/codex/tasks/task_e_687637a8a0e8832d86fcb772087a8b39