### PR TITLE
Add test for run-jest dependency install

### DIFF
--- a/tests/backendNpmTestMissingDeps.test.js
+++ b/tests/backendNpmTestMissingDeps.test.js
@@ -1,0 +1,55 @@
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+const pluginDir = path.join(
+  __dirname,
+  "..",
+  "node_modules",
+  "@babel",
+  "plugin-syntax-typescript",
+);
+const backupDir = pluginDir + ".bak";
+
+function run(env) {
+  return execFileSync(
+    "node",
+    [
+      "scripts/run-jest.js",
+      "backend/tests/generateModel.test.ts",
+      "--runInBand",
+    ],
+    {
+      env,
+      stdio: "pipe",
+    },
+  ).toString();
+}
+
+describe("backend npm test missing deps", () => {
+  beforeAll(() => {
+    if (fs.existsSync(pluginDir)) fs.renameSync(pluginDir, backupDir);
+  });
+
+  afterAll(() => {
+    if (fs.existsSync(backupDir)) fs.renameSync(backupDir, pluginDir);
+  });
+
+  test("installs root dependencies when missing", () => {
+    const env = {
+      ...process.env,
+      HF_TOKEN: "test",
+      AWS_ACCESS_KEY_ID: "id",
+      AWS_SECRET_ACCESS_KEY: "secret",
+      DB_URL: "postgres://user:pass@localhost/db",
+      STRIPE_SECRET_KEY: "sk_test",
+      SKIP_NET_CHECKS: "1",
+      SKIP_PW_DEPS: "1",
+      SKIP_DB_CHECK: "1",
+      REAL_NPM: execFileSync("sh", ["-c", "command -v npm"]).toString().trim(),
+      PATH: path.join(__dirname, "bin-noop") + ":" + process.env.PATH,
+    };
+    const output = run(env);
+    expect(output).toMatch(/Dependencies missing/);
+  });
+});


### PR DESCRIPTION
## Summary
- add `backendNpmTestMissingDeps.test.js` to ensure `run-jest` installs root deps

## Testing
- `npm --prefix backend run format`
- `npm --prefix backend test`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6876376fac40832db1e14fa0fa12c3c9