### PR TITLE
Add deprecation warning test

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -307,6 +307,9 @@ app.post("/api/dalle", async (req, res) => {
  * Placeholder endpoint that returns a fake model id
  */
 app.post("/api/generate-model", (req, res) => {
+  console.warn(
+    "[DEPRECATED] /api/generate-model is deprecated; use /api/generate instead",
+  );
   const { prompt } = req.body || {};
   if (!prompt) return res.status(400).json({ error: "Prompt required" });
   res.json({ success: true, modelId: "placeholder-id" });

--- a/backend/tests/api.test.js
+++ b/backend/tests/api.test.js
@@ -921,11 +921,16 @@ test("POST /api/dalle requires prompt", async () => {
 });
 
 test("POST /api/generate-model returns placeholder", async () => {
+  const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
   const res = await request(app)
     .post("/api/generate-model")
     .send({ prompt: "cat" });
   expect(res.status).toBe(200);
   expect(res.body).toEqual({ success: true, modelId: "placeholder-id" });
+  expect(warn).toHaveBeenCalledWith(
+    expect.stringContaining("/api/generate-model is deprecated"),
+  );
+  warn.mockRestore();
 });
 
 test("POST /api/generate-model requires prompt", async () => {


### PR DESCRIPTION
## Summary
- warn when deprecated `/api/generate-model` endpoint is used
- verify warning with new test

## Testing
- `npm run format` in `backend/`
- `npm test -- -i` in `backend/`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_687635e297dc832dba29b6985daf61fa