### PR TITLE
Add schema and STL validator tests

### DIFF
--- a/backend/routes/models.js
+++ b/backend/routes/models.js
@@ -15,6 +15,9 @@ const createModelSchema = z.object({
   fileKey: z.string().regex(/^[A-Za-z0-9._-]+$/, "invalid fileKey"),
 });
 
+// expose schema for testing
+router.createModelSchema = createModelSchema;
+
 router.post("/", validate(createModelSchema), async (req, res, next) => {
   try {
     const { prompt, fileKey } = req.body;

--- a/backend/src/routes/models.js
+++ b/backend/src/routes/models.js
@@ -20,6 +20,9 @@ const createModelSchema = z.object({
   prompt: z.string().min(1, "prompt is required"),
   fileKey: z.string().regex(/^[A-Za-z0-9._-]+$/, "invalid fileKey"),
 });
+
+// expose schema for testing
+router.createModelSchema = createModelSchema;
 router.post(
   "/api/models",
   validate(createModelSchema),

--- a/backend/tests/modelsSchema.test.js
+++ b/backend/tests/modelsSchema.test.js
@@ -1,0 +1,28 @@
+const router = require("../routes/models");
+const { z } = require("zod");
+
+const schema = router.createModelSchema;
+
+describe("createModelSchema", () => {
+  test("accepts valid input", () => {
+    const data = { prompt: "hello", fileKey: "foo.glb" };
+    expect(schema.parse(data)).toEqual(data);
+  });
+
+  test("rejects empty prompt", () => {
+    expect(() => schema.parse({ prompt: "", fileKey: "file" })).toThrow(
+      z.ZodError,
+    );
+  });
+
+  test("rejects invalid fileKey characters", () => {
+    expect(() => schema.parse({ prompt: "ok", fileKey: "../evil" })).toThrow(
+      z.ZodError,
+    );
+  });
+
+  test("allows hyphen and underscore in fileKey", () => {
+    const data = { prompt: "a", fileKey: "my-file_1.glb" };
+    expect(schema.parse(data)).toEqual(data);
+  });
+});

--- a/backend/tests/utils/validateStl.test.js
+++ b/backend/tests/utils/validateStl.test.js
@@ -31,6 +31,29 @@ describe("validateStl", () => {
     expect(validateStl(file)).toBe(false);
   });
 
+  test("fails when ASCII STL missing end marker", () => {
+    const file = path.join(tmpDir, "no_end.stl");
+    const ascii = "solid test";
+    fs.writeFileSync(file, ascii);
+    expect(validateStl(file)).toBe(false);
+  });
+
+  test("fails for binary STL with zero triangles", () => {
+    const file = path.join(tmpDir, "zero_tris.stl");
+    const buf = Buffer.alloc(84);
+    buf.write("BIN", 0, "ascii");
+    buf.writeUInt32LE(0, 80);
+    fs.writeFileSync(file, buf);
+    expect(validateStl(file)).toBe(false);
+  });
+
+  test("fails when binary file too short", () => {
+    const file = path.join(tmpDir, "short.stl");
+    const buf = Buffer.alloc(10);
+    fs.writeFileSync(file, buf);
+    expect(validateStl(file)).toBe(false);
+  });
+
   test("returns false when file missing", () => {
     const file = path.join(tmpDir, "missing.stl");
     expect(validateStl(file)).toBe(false);


### PR DESCRIPTION
## Summary
- expose `createModelSchema` from models routes
- expand STL validator test cases
- add tests for the model creation schema

## Testing
- `npm run format` in `backend/`
- `node scripts/run-jest.js --runTestsByPath backend/tests/modelsSchema.test.js backend/tests/utils/validateStl.test.js`

------
https://chatgpt.com/codex/tasks/task_e_687635440bb8832dbbed170e6293f8c6