### PR TITLE
Add test for missing frontend dirs

### DIFF
--- a/tests/projectStructure.test.js
+++ b/tests/projectStructure.test.js
@@ -8,4 +8,14 @@ describe("project structure", () => {
     const pkg = path.join(repoRoot, "backend", "package.json");
     expect(fs.existsSync(pkg)).toBe(true);
   });
+
+  test("frontend utils directory does not exist", () => {
+    const utilsDir = path.join(repoRoot, "frontend", "utils");
+    expect(fs.existsSync(utilsDir)).toBe(false);
+  });
+
+  test("frontend helpers directory does not exist", () => {
+    const helpersDir = path.join(repoRoot, "frontend", "helpers");
+    expect(fs.existsSync(helpersDir)).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- add assertions verifying that nonexistent frontend utilities directories are absent

## Testing
- `npm test --prefix backend`
- `npm run format --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_687636ebba48832d849df885be688610