### PR TITLE
Add env parsing tests

### DIFF
--- a/backend/tests/config.test.js
+++ b/backend/tests/config.test.js
@@ -19,3 +19,27 @@ test("loads when CLOUDFRONT_MODEL_DOMAIN restored", () => {
     expect(cfg.cloudfrontModelDomain).toBe(original);
   });
 });
+
+test("warns when required vars missing", () => {
+  const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+  jest.isolateModules(() => {
+    delete process.env.DB_URL;
+    delete process.env.STRIPE_SECRET_KEY;
+    delete process.env.STRIPE_WEBHOOK_SECRET;
+    require("../config");
+  });
+  expect(warn).toHaveBeenCalledWith(
+    expect.stringContaining("Missing required env vars"),
+  );
+  warn.mockRestore();
+});
+
+test("returns malformed DB_URL without throwing", () => {
+  jest.isolateModules(() => {
+    process.env.DB_URL = "not a url";
+    process.env.STRIPE_SECRET_KEY = "key";
+    process.env.STRIPE_WEBHOOK_SECRET = "wh";
+    const cfg = require("../config");
+    expect(cfg.dbUrl).toBe("not a url");
+  });
+});

--- a/tests/envParsing.test.js
+++ b/tests/envParsing.test.js
@@ -1,0 +1,50 @@
+const { spawnSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+describe("load_env_file handling", () => {
+  const root = path.resolve(__dirname, "..");
+  const envFile = path.join(root, ".env");
+  const baseEnv = {
+    AWS_ACCESS_KEY_ID: "id",
+    AWS_SECRET_ACCESS_KEY: "secret",
+    DB_URL: "postgres://user:pass@localhost/db",
+    STRIPE_SECRET_KEY: "sk",
+    CLOUDFRONT_MODEL_DOMAIN: "cdn",
+    SKIP_DB_CHECK: "1",
+    SKIP_NET_CHECKS: "1",
+  };
+
+  afterEach(() => {
+    if (fs.existsSync(envFile)) fs.unlinkSync(envFile);
+  });
+
+  test("first duplicate wins", () => {
+    fs.writeFileSync(envFile, "FOO=first\nFOO=second\n");
+    const result = spawnSync(
+      "bash",
+      ["-c", "source scripts/check-env.sh >/dev/null && echo -n $FOO"],
+      {
+        cwd: root,
+        env: { ...process.env, ...baseEnv },
+        encoding: "utf8",
+      },
+    );
+    expect(result.stdout).toBe("first");
+  });
+
+  test("existing env vars are not overwritten", () => {
+    fs.writeFileSync(envFile, "BAR=fromfile\n");
+    const result = spawnSync(
+      "bash",
+      ["-c", "BAR=pre source scripts/check-env.sh >/dev/null && echo -n $BAR"],
+      {
+        cwd: root,
+        env: { ...process.env, ...baseEnv },
+        encoding: "utf8",
+        shell: "/bin/bash",
+      },
+    );
+    expect(result.stdout).toBe("pre");
+  });
+});


### PR DESCRIPTION
## Summary
- extend backend config tests for missing and malformed env vars
- add env file parsing tests for duplicate handling

## Testing
- `npm run format`
- `npm test` in `backend/`
- `SKIP_PW_DEPS=1 npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_687635b67ba4832d9c4b647f3345fc3d