### PR TITLE
Fix run-jest for JS tests

### DIFF
--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -40,12 +40,18 @@ function runJest(args) {
   const backendDir = path.join(repoRoot, "backend");
   const jestBin = path.join(backendDir, "node_modules", ".bin", "jest");
 
-  const runFromRoot = args.some((arg) => {
+  const hasFileArgs = args.some((arg) => !arg.startsWith("-"));
+  let jestArgs = [...args];
+  if (hasFileArgs && !jestArgs.includes("--runTestsByPath")) {
+    jestArgs.unshift("--runTestsByPath");
+  }
+
+  const runFromRoot = jestArgs.some((arg) => {
     const abs = path.resolve(repoRoot, arg);
     return !abs.startsWith(backendDir);
   });
 
-  const cmdArgs = args.join(" ");
+  const cmdArgs = jestArgs.join(" ");
   const env = { ...process.env };
   if (runFromRoot) {
     env.NODE_PATH = [path.join(repoRoot, "node_modules"), env.NODE_PATH || ""]

--- a/tests/runJestBackendJs.test.js
+++ b/tests/runJestBackendJs.test.js
@@ -1,0 +1,24 @@
+const { execFileSync } = require("child_process");
+
+/** Ensure run-jest works with backend JS tests without explicit flag */
+test("run-jest executes backend JS test", () => {
+  const env = {
+    ...process.env,
+    HF_TOKEN: "x",
+    AWS_ACCESS_KEY_ID: "id",
+    AWS_SECRET_ACCESS_KEY: "secret",
+    DB_URL: "postgres://user:pass@localhost/db",
+    STRIPE_SECRET_KEY: "sk_test",
+    SKIP_NET_CHECKS: "1",
+    SKIP_DB_CHECK: "1",
+    SKIP_PW_DEPS: "1",
+  };
+  execFileSync(
+    "node",
+    ["scripts/run-jest.js", "backend/__tests__/health.test.js"],
+    {
+      stdio: "inherit",
+      env,
+    },
+  );
+});


### PR DESCRIPTION
## Summary
- support JS test files in `run-jest`
- add integration test that runs a backend JS test through the helper

## Testing
- `node scripts/run-jest.js tests/runJestBackendJs.test.js`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_687638d1d640832dbe9bebdd791cece1