### PR TITLE
Fix health check test environment

### DIFF
--- a/backend/tests/health.test.js
+++ b/backend/tests/health.test.js
@@ -3,6 +3,8 @@ process.env.STRIPE_WEBHOOK_SECRET = "whsec";
 process.env.DB_URL = "postgres://user:pass@localhost/db";
 process.env.AWS_REGION = "us-east-1";
 process.env.S3_BUCKET = "bucket";
+const originalNodeEnv = process.env.NODE_ENV;
+process.env.NODE_ENV = "production";
 
 jest.mock("../db", () => ({
   query: jest.fn(),
@@ -22,6 +24,10 @@ const app = require("../server");
 
 beforeEach(() => {
   db.query.mockClear();
+});
+
+afterAll(() => {
+  process.env.NODE_ENV = originalNodeEnv;
 });
 
 test("GET /api/health returns ok", async () => {


### PR DESCRIPTION
## Summary
- ensure the health check test runs with NODE_ENV set to production
- restore NODE_ENV after tests

## Testing
- `npm test --silent -- --runInBand` (backend)
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68763797686c832db7b5dab94e18e1b5