### PR TITLE
Ensure backend deps installed by assert-setup

### DIFF
--- a/backend/tests/assertSetupBackendDeps.test.js
+++ b/backend/tests/assertSetupBackendDeps.test.js
@@ -1,0 +1,49 @@
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+const script = path.join(__dirname, "..", "..", "scripts", "assert-setup.js");
+const stub = path.join(__dirname, "stubExecSync.js");
+
+function runAssertSetup(extraEnv = {}) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "pw-"));
+  fs.mkdirSync(path.join(tmpDir, "chromium"), { recursive: true });
+  const env = {
+    ...process.env,
+    NODE_OPTIONS: `--require ${stub}`,
+    PLAYWRIGHT_BROWSERS_PATH: tmpDir,
+    HF_TOKEN: "x",
+    AWS_ACCESS_KEY_ID: "id",
+    AWS_SECRET_ACCESS_KEY: "secret",
+    CLOUDFRONT_MODEL_DOMAIN: "cdn.test",
+    ...extraEnv,
+  };
+  const result = spawnSync(process.execPath, [script], {
+    env,
+    encoding: "utf8",
+  });
+  return { result, tmpDir };
+}
+
+describe("assert-setup backend deps", () => {
+  test("installs backend dependencies when missing", () => {
+    const logFile = path.join(os.tmpdir(), `log-${Date.now()}`);
+    const nodeModules = path.join(__dirname, "..", "node_modules");
+    const backup = nodeModules + ".bak";
+    if (fs.existsSync(nodeModules)) fs.renameSync(nodeModules, backup);
+    try {
+      const { result } = runAssertSetup({
+        EXEC_LOG_FILE: logFile,
+        SKIP_NET_CHECKS: "1",
+        SKIP_PW_DEPS: "1",
+      });
+      expect(result.status).toBe(0);
+      const logs = fs.readFileSync(logFile, "utf8");
+      expect(logs).toMatch(/ensure-deps\.js/);
+    } finally {
+      fs.unlinkSync(logFile);
+      if (fs.existsSync(backup)) fs.renameSync(backup, nodeModules);
+    }
+  });
+});

--- a/backend/tests/stubExecSync.js
+++ b/backend/tests/stubExecSync.js
@@ -2,10 +2,12 @@ const fs = require("fs");
 const child_process = require("child_process");
 
 let logFile = process.env.EXEC_LOG_FILE;
-child_process.execSync = function (cmd, _opts) {
+child_process.execSync = function (cmd, opts = {}) {
+  const cwd = opts.cwd || process.cwd();
+  const prefix = `[cwd:${cwd}] `;
   if (logFile) {
     try {
-      fs.appendFileSync(logFile, cmd + "\n");
+      fs.appendFileSync(logFile, prefix + cmd + "\n");
     } catch (_err) {
       // ignore logging errors
     }

--- a/scripts/assert-setup.js
+++ b/scripts/assert-setup.js
@@ -201,3 +201,26 @@ if (!jestInstalled() || !pluginInstalled()) {
     process.exit(1);
   }
 }
+
+// Ensure backend dependencies are present
+try {
+  const ensureEnv = { ...process.env };
+  if (process.env.EXEC_LOG_FILE)
+    ensureEnv.EXEC_LOG_FILE = process.env.EXEC_LOG_FILE;
+  let cmd = "node";
+  const match =
+    process.env.NODE_OPTIONS &&
+    process.env.NODE_OPTIONS.match(/--require\s+(\S+)/);
+  if (match) {
+    cmd += ` -r ${match[1]}`;
+  }
+  cmd += " scripts/ensure-deps.js";
+  child_process.execSync(cmd, {
+    stdio: "inherit",
+    cwd: path.join(repoRoot, "backend"),
+    env: ensureEnv,
+  });
+} catch (err) {
+  console.error("Failed to verify backend dependencies:", err.message);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- ensure `assert-setup.js` verifies backend dependencies by calling the backend ensure script with proper environment
- enhance `stubExecSync` to log command working directories
- add `assertSetupBackendDeps` test verifying backend dependency installation

## Testing
- `npm run format --prefix backend`
- `SKIP_NET_CHECKS=1 SKIP_PW_DEPS=1 npm test --prefix backend -- -w=1`
- `node scripts/run-jest.js --runTestsByPath backend/tests/assertSetupBackendDeps.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6876367fb570832dab9b5a31526688fe