### PR TITLE
Add testable analytics hooks

### DIFF
--- a/js/analytics.js
+++ b/js/analytics.js
@@ -1,0 +1,26 @@
+const API_BASE =
+  (typeof window !== "undefined" && window.API_ORIGIN
+    ? window.API_ORIGIN
+    : "") + "/api";
+
+export function track(event, data = {}) {
+  if (typeof window !== "undefined" && window.__TEST_HOOKS__?.trackEvent) {
+    try {
+      window.__TEST_HOOKS__.trackEvent(event, data);
+    } catch {}
+  } else if (global.__TEST_HOOKS__?.trackEvent) {
+    try {
+      global.__TEST_HOOKS__.trackEvent(event, data);
+    } catch {}
+  }
+  if (typeof fetch !== "function") return Promise.resolve();
+  return fetch(`${API_BASE}/track/${event}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+}
+
+if (typeof module !== "undefined") {
+  module.exports = { track };
+}

--- a/js/index.js
+++ b/js/index.js
@@ -1,5 +1,6 @@
 "use strict";
 import { shareOn } from "./share.js";
+import { track } from "./analytics.js";
 
 const API_BASE = (window.API_ORIGIN || "") + "/api";
 const TZ = "America/New_York";
@@ -39,16 +40,12 @@ const LOW_POLY_GLB = FALLBACK_GLB_LOW;
       localStorage.setItem("adSessionId", sessionId);
     }
     const subreddit = localStorage.getItem("adSubreddit");
-    fetch(`${API_BASE}/track/page`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        sessionId,
-        subreddit,
-        utmSource: localStorage.getItem("utm_source") || undefined,
-        utmMedium: localStorage.getItem("utm_medium") || undefined,
-        utmCampaign: localStorage.getItem("utm_campaign") || undefined,
-      }),
+    track("page", {
+      sessionId,
+      subreddit,
+      utmSource: localStorage.getItem("utm_source") || undefined,
+      utmMedium: localStorage.getItem("utm_medium") || undefined,
+      utmCampaign: localStorage.getItem("utm_campaign") || undefined,
     }).catch(() => {});
   } catch {
     /* ignore */
@@ -85,11 +82,7 @@ const LOW_POLY_GLB = FALLBACK_GLB_LOW;
         localStorage.setItem("adSessionId", sessionId);
       }
       localStorage.setItem("adSubreddit", sr);
-      fetch(`${API_BASE}/track/ad-click`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ subreddit: sr, sessionId }),
-      }).catch(() => {});
+      track("ad-click", { subreddit: sr, sessionId }).catch(() => {});
     }
   } catch {
     /* ignore errors */
@@ -1090,10 +1083,10 @@ async function init() {
     const sessionId = localStorage.getItem("adSessionId");
     const subreddit = localStorage.getItem("adSubreddit");
     if (sessionId && subreddit && item.jobId) {
-      fetch(`${API_BASE}/track/cart`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ sessionId, modelId: item.jobId, subreddit }),
+      track("cart", {
+        sessionId,
+        modelId: item.jobId,
+        subreddit,
       }).catch(() => {});
     }
     // Animation and sound handled in basket.js

--- a/js/payment.js
+++ b/js/payment.js
@@ -46,6 +46,7 @@ const PRINT_CLUB_ANNUAL_PRICE = Math.round(
 let selectedPrice = PRICES.multi;
 const SINGLE_BORDER_COLOR = "#60a5fa";
 const API_BASE = (window.API_ORIGIN || "") + "/api";
+import { track } from "./analytics.js";
 // Time zone used to reset local purchase counts at 1 AM Eastern
 const TZ = "America/New_York";
 let flashTimerId = null;
@@ -259,11 +260,9 @@ function recordPurchase() {
   const sessionId = localStorage.getItem("adSessionId");
   const subreddit = localStorage.getItem("adSubreddit");
   if (sessionId && subreddit) {
-    fetch(`${API_BASE}/track/checkout`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ sessionId, subreddit, step: "complete" }),
-    }).catch(() => {});
+    track("checkout", { sessionId, subreddit, step: "complete" }).catch(
+      () => {},
+    );
   }
 }
 
@@ -1464,11 +1463,9 @@ async function initPaymentPage() {
     const sessionId = localStorage.getItem("adSessionId");
     const subreddit = localStorage.getItem("adSubreddit");
     if (sessionId && subreddit) {
-      fetch(`${API_BASE}/track/checkout`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ sessionId, subreddit, step: "start" }),
-      }).catch(() => {});
+      track("checkout", { sessionId, subreddit, step: "start" }).catch(
+        () => {},
+      );
     }
     const qty = Math.max(
       1,

--- a/js/share.js
+++ b/js/share.js
@@ -1,4 +1,5 @@
 const API_BASE = (window.API_ORIGIN || "") + "/api";
+import { track } from "./analytics.js";
 
 async function captureSnapshot(glbUrl) {
   if (!glbUrl) return null;
@@ -60,11 +61,7 @@ async function shareOn(
         typeof localStorage !== "undefined"
           ? localStorage.getItem("shareId")
           : null;
-      await fetch(`${API_BASE}/track/share`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ shareId, network }),
-      });
+      await track("share", { shareId, network });
     } catch (err) {
       console.error("Failed to track share", err);
     }

--- a/tests/analyticsWrapper.test.js
+++ b/tests/analyticsWrapper.test.js
@@ -1,0 +1,45 @@
+const { track } = require("../js/analytics.js");
+
+beforeEach(() => {
+  global.fetch = jest.fn(() => Promise.resolve({ ok: true }));
+});
+
+afterEach(() => {
+  delete global.__TEST_HOOKS__;
+  delete global.window;
+  delete global.fetch;
+});
+
+test("track sends payload and invokes global hook", async () => {
+  global.__TEST_HOOKS__ = { trackEvent: jest.fn() };
+  await track("cart", { sessionId: "s1", modelId: "m1", subreddit: "funny" });
+  expect(global.fetch).toHaveBeenCalledWith(
+    expect.stringContaining("/api/track/cart"),
+    expect.objectContaining({
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        sessionId: "s1",
+        modelId: "m1",
+        subreddit: "funny",
+      }),
+    }),
+  );
+  expect(global.__TEST_HOOKS__.trackEvent).toHaveBeenCalledWith("cart", {
+    sessionId: "s1",
+    modelId: "m1",
+    subreddit: "funny",
+  });
+});
+
+test("track uses window hook when available", async () => {
+  global.window = { __TEST_HOOKS__: { trackEvent: jest.fn(), API_ORIGIN: "" } };
+  await track("share", { shareId: "sh1", network: "facebook" });
+  expect(global.window.__TEST_HOOKS__.trackEvent).toHaveBeenCalledWith(
+    "share",
+    {
+      shareId: "sh1",
+      network: "facebook",
+    },
+  );
+});


### PR DESCRIPTION
## Summary
- add analytics event helper with test hook support
- use the new helper in Share, Index and Payment scripts
- verify tracking via new analytics wrapper tests

## Testing
- `npm run format:check`
- `npm run test` in `backend/`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_687635df1f28832db1f39114ef345cd9