### PR TITLE
Add env configuration tests

### DIFF
--- a/backend/tests/config.test.js
+++ b/backend/tests/config.test.js
@@ -19,3 +19,50 @@ test("loads when CLOUDFRONT_MODEL_DOMAIN restored", () => {
     expect(cfg.cloudfrontModelDomain).toBe(original);
   });
 });
+
+test("warns when required vars are missing", () => {
+  jest.isolateModules(() => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    delete process.env.DB_URL;
+    delete process.env.STRIPE_SECRET_KEY;
+    delete process.env.STRIPE_WEBHOOK_SECRET;
+    require("../config");
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Missing required env vars: DB_URL, STRIPE_SECRET_KEY, STRIPE_WEBHOOK_SECRET",
+      ),
+    );
+    warn.mockRestore();
+  });
+});
+
+test("warns when optional GLB vars are missing", () => {
+  jest.isolateModules(() => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    delete process.env.CLOUDFRONT_MODEL_DOMAIN;
+    delete process.env.SPARC3D_ENDPOINT;
+    delete process.env.SPARC3D_TOKEN;
+    require("../config");
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Missing optional GLB env vars: CLOUDFRONT_MODEL_DOMAIN, SPARC3D_ENDPOINT, SPARC3D_TOKEN",
+      ),
+    );
+    warn.mockRestore();
+  });
+});
+
+test("no warnings when all vars present", () => {
+  jest.isolateModules(() => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    process.env.DB_URL = "postgres://user:pass@localhost/db";
+    process.env.STRIPE_SECRET_KEY = "test";
+    process.env.STRIPE_WEBHOOK_SECRET = "whsec";
+    process.env.CLOUDFRONT_MODEL_DOMAIN = original;
+    process.env.SPARC3D_ENDPOINT = "http://endpoint";
+    process.env.SPARC3D_TOKEN = "tok";
+    require("../config");
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});

--- a/tests/runSmoke.malformed-env.test.js
+++ b/tests/runSmoke.malformed-env.test.js
@@ -1,0 +1,39 @@
+const fs = require("fs");
+const path = require("path");
+
+const envFile = path.join(__dirname, "..", ".env");
+
+function withTempEnv(content, fn) {
+  const exists = fs.existsSync(envFile);
+  const backup = exists ? fs.readFileSync(envFile, "utf8") : null;
+  fs.writeFileSync(envFile, content);
+  try {
+    fn();
+  } finally {
+    if (exists) {
+      fs.writeFileSync(envFile, backup);
+    } else {
+      fs.unlinkSync(envFile);
+    }
+  }
+}
+
+test("initEnv ignores malformed lines", () => {
+  const lines = [
+    "GOOD=value",
+    "BADLINE",
+    "SPACED = 'a value'",
+    "=NOVAR",
+    "EMPTY=",
+  ].join("\n");
+  withTempEnv(lines, () => {
+    jest.isolateModules(() => {
+      const { env } = require("../scripts/run-smoke.js");
+      expect(env.GOOD).toBe("value");
+      expect(env.SPACED).toBe("a value");
+      expect(env.EMPTY).toBe("");
+      expect(env.BADLINE).toBeUndefined();
+      expect(env.NOVAR).toBeUndefined();
+    });
+  });
+});

--- a/tests/validateEnvConflict.test.js
+++ b/tests/validateEnvConflict.test.js
@@ -1,0 +1,31 @@
+const { spawnSync } = require("child_process");
+
+function run(env) {
+  return spawnSync(
+    "bash",
+    [
+      "-c",
+      'source scripts/validate-env.sh >/dev/null && echo -n "$HF_API_KEY $S3_BUCKET_NAME"',
+    ],
+    {
+      env: { SKIP_NET_CHECKS: "1", SKIP_DB_CHECK: "1", ...env },
+      encoding: "utf8",
+    },
+  );
+}
+
+test("does not override conflicting variables", () => {
+  const res = run({
+    HF_TOKEN: "tok1",
+    HF_API_KEY: "tok2",
+    AWS_ACCESS_KEY_ID: "id",
+    AWS_SECRET_ACCESS_KEY: "secret",
+    DB_URL: "postgres://user:pass@localhost/db",
+    STRIPE_SECRET_KEY: "sk_test",
+    CLOUDFRONT_MODEL_DOMAIN: "cdn.test",
+    S3_BUCKET: "bucket",
+    S3_BUCKET_NAME: "name",
+  });
+  expect(res.status).toBe(0);
+  expect(res.stdout).toBe("tok2 name");
+});


### PR DESCRIPTION
## Summary
- extend backend config tests for missing env vars
- test run-smoke env parsing with malformed lines
- ensure validate-env.sh respects conflicting HF_TOKEN/HF_API_KEY

## Testing
- `npm run format`
- `npm test` (backend)
- `node scripts/run-jest.js backend/tests/config.test.js tests/runSmoke.malformed-env.test.js tests/validateEnvConflict.test.js`
- `SKIP_PW_DEPS=1 npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_6876353c8b68832d9ce0b8b7b1fd903d