### PR TITLE
Fix env validation test stderr handling

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,1 @@
+../.env.example

--- a/backend/tests/envValidation.test.js
+++ b/backend/tests/envValidation.test.js
@@ -1,4 +1,4 @@
-const { execSync } = require("child_process");
+const { execSync, spawnSync } = require("child_process");
 const path = require("path");
 const fs = require("fs");
 
@@ -107,7 +107,7 @@ describe("validate-env script", () => {
   });
 
   test("fails when database unreachable", () => {
-    const output = execSync(`bash ${script}`, {
+    const { stdout, stderr } = spawnSync("bash", [script], {
       env: {
         ...process.env,
         ...baseEnv,
@@ -115,8 +115,9 @@ describe("validate-env script", () => {
         SKIP_NET_CHECKS: "1",
         SKIP_DB_CHECK: "",
       },
-      stdio: "pipe",
-    }).toString();
+      encoding: "utf8",
+    });
+    const output = `${stdout}${stderr}`;
     expect(output).toMatch(/Database connection check failed/);
     expect(output).toMatch(/environment OK/);
   });


### PR DESCRIPTION
## Summary
- add backend `.env.example` symlink so tests can move the example file
- read stderr in the unreachable DB test so it catches the failure message

## Testing
- `node scripts/run-jest.js backend/tests/envValidation.test.js --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_6876402a0bf0832dbe2a3c6708225f1b