### PR TITLE
Fix environment and frontend tests

### DIFF
--- a/backend/tests/assertSetup.test.js
+++ b/backend/tests/assertSetup.test.js
@@ -3,7 +3,7 @@ const os = require("os");
 const path = require("path");
 const { spawnSync } = require("child_process");
 
-const script = path.join(__dirname, "..", "scripts", "assert-setup.js");
+const script = path.join(__dirname, "..", "..", "scripts", "assert-setup.js");
 const stub = path.join(__dirname, "stubExecSync.js");
 
 function runAssertSetup(nodeVersion, extraEnv = {}) {
@@ -30,8 +30,8 @@ function runAssertSetup(nodeVersion, extraEnv = {}) {
 describe("assert-setup script", () => {
   test("fails on Node <20", () => {
     const res = runAssertSetup("18.0.0");
-    expect(res.status).not.toBe(0);
-    expect(res.stderr).toContain("Node 20 or newer is required");
+    expect(res.result.status).not.toBe(0);
+    expect(res.result.stderr).toContain("Node 20 or newer is required");
   });
 
   test("succeeds on Node >=20", () => {

--- a/backend/tests/envValidation.test.js
+++ b/backend/tests/envValidation.test.js
@@ -93,7 +93,7 @@ describe("validate-env script", () => {
   test("fails when DB_URL missing and example file absent", () => {
     const env = { ...process.env, ...baseEnv };
     delete env.DB_URL;
-    const example = path.resolve(process.cwd(), ".env.example");
+    const example = path.resolve(__dirname, "..", "..", ".env.example");
     const backup = `${example}.bak`;
     fs.renameSync(example, backup);
     let threw = false;

--- a/backend/tests/frontend/flashBanner.test.js
+++ b/backend/tests/frontend/flashBanner.test.js
@@ -26,10 +26,9 @@ function setupDom() {
   dom.window.setInterval = setInterval;
   dom.window.clearInterval = clearInterval;
   dom.window.Date = Date;
-  const script = fs.readFileSync(
-    path.join(__dirname, "../../../js/payment.js"),
-    "utf8",
-  );
+  const script = fs
+    .readFileSync(path.join(__dirname, "../../../js/payment.js"), "utf8")
+    .replace(/import [^;]+;?/, "");
   dom.window.eval(script);
   return dom;
 }

--- a/backend/tests/frontend/slotCount.test.js
+++ b/backend/tests/frontend/slotCount.test.js
@@ -47,10 +47,9 @@ describe("slot count", () => {
     dom.window.fetch = jest.fn(() =>
       Promise.resolve({ ok: true, json: () => ({ slots: 5 }) }),
     );
-    const scriptSrc = fs.readFileSync(
-      path.join(__dirname, "../../../js/payment.js"),
-      "utf8",
-    );
+    const scriptSrc = fs
+      .readFileSync(path.join(__dirname, "../../../js/payment.js"), "utf8")
+      .replace(/import [^;]+;?/, "");
     dom.window.eval(scriptSrc);
     await new Promise((r) => setTimeout(r, 50));
     expect(dom.window.document.getElementById("slot-count").textContent).toBe(
@@ -73,10 +72,9 @@ describe("slot count", () => {
     dom.window.fetch = jest.fn(() =>
       Promise.resolve({ ok: true, json: () => ({ slots: 6 }) }),
     );
-    const scriptSrc = fs.readFileSync(
-      path.join(__dirname, "../../../js/payment.js"),
-      "utf8",
-    );
+    const scriptSrc = fs
+      .readFileSync(path.join(__dirname, "../../../js/payment.js"), "utf8")
+      .replace(/import [^;]+;?/, "");
     dom.window.eval(scriptSrc);
     dom.window.localStorage.setItem("slotCycle", cycleKey());
     dom.window.localStorage.setItem("slotPurchases", "2");


### PR DESCRIPTION
## Summary
- update env validation test to use repo root example file
- remove ESM imports when loading payment.js in browser tests
- fix slot count frontend test setup
- correct assertSetup script path and expectations

## Testing
- `node scripts/run-jest.js backend/tests/envValidation.test.js`
- `node scripts/run-jest.js backend/tests/frontend/flashBanner.test.js backend/tests/frontend/slotCount.test.js`
- `node scripts/run-jest.js backend/tests/assertSetup.test.js`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_687646dc41e8832d8508d775db15697f