### PR TITLE
Add logger output format test

### DIFF
--- a/backend/tests/loggerFormat.test.js
+++ b/backend/tests/loggerFormat.test.js
@@ -1,0 +1,46 @@
+const path = require("path");
+const Transport = require("winston-transport");
+
+class MemoryTransport extends Transport {
+  constructor() {
+    super();
+    this.logs = [];
+  }
+  log(info, callback) {
+    this.logs.push(JSON.stringify(info));
+    callback();
+  }
+}
+
+describe("logger JSON format", () => {
+  let logger;
+  let memory;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env.NODE_ENV = "development";
+    logger = require(path.join(__dirname, "..", "..", "src", "logger.js"));
+    memory = new MemoryTransport();
+    logger.add(memory);
+  });
+
+  afterEach(() => {
+    logger.remove(memory);
+  });
+
+  test("startup log includes timestamp, level and code", () => {
+    logger.info("S000: startup complete");
+    const obj = JSON.parse(memory.logs[0]);
+    expect(obj.level).toBe("info");
+    expect(obj.message).toBe("S000: startup complete");
+    expect(obj.timestamp).toBeDefined();
+  });
+
+  test("error log includes timestamp, level and code", () => {
+    logger.error("E999: fatal error");
+    const obj = JSON.parse(memory.logs[0]);
+    expect(obj.level).toBe("error");
+    expect(obj.message).toBe("E999: fatal error");
+    expect(obj.timestamp).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add test capturing logger output and verify timestamp/level

## Testing
- `npm run format`
- `node ../scripts/run-jest.js backend/tests/loggerFormat.test.js`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_687646a34830832da872096febcb5bc9