### PR TITLE
Add migration dry-run test

### DIFF
--- a/backend/tests/migrationsDryRun.test.js
+++ b/backend/tests/migrationsDryRun.test.js
@@ -1,0 +1,32 @@
+const fs = require("fs");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+const script = path.join(__dirname, "..", "scripts", "run-migrations.js");
+const logFile = path.join(__dirname, "..", "pg-mock.log");
+
+const env = {
+  ...process.env,
+  NODE_OPTIONS: `--require ${path.resolve(__dirname, "stubPg.js")}`,
+  PG_MOCK_LOG: logFile,
+  DB_URL: "postgres://user:pass@localhost/db",
+};
+
+afterEach(() => {
+  if (fs.existsSync(logFile)) fs.unlinkSync(logFile);
+});
+
+test("migrations run without errors in dry-run mode", () => {
+  const result = spawnSync(process.execPath, [script], { env });
+  expect(result.status).toBe(0);
+  const queries = JSON.parse(fs.readFileSync(logFile, "utf8"));
+  const migrationDir = path.join(__dirname, "..", "migrations");
+  const files = fs
+    .readdirSync(migrationDir)
+    .filter((f) => f.endsWith(".sql"))
+    .sort();
+  const contents = files.map((f) =>
+    fs.readFileSync(path.join(migrationDir, f), "utf8"),
+  );
+  expect(queries).toEqual(contents);
+});

--- a/backend/tests/stubPg.js
+++ b/backend/tests/stubPg.js
@@ -1,0 +1,30 @@
+const fs = require("fs");
+const path = require("path");
+const Module = require("module");
+const logFile =
+  process.env.PG_MOCK_LOG || path.join(process.cwd(), "pg-mock.log");
+
+class MockClient {
+  constructor() {
+    this.log = [];
+  }
+  connect() {
+    return Promise.resolve();
+  }
+  query(sql) {
+    this.log.push(sql);
+    return Promise.resolve();
+  }
+  end() {
+    fs.writeFileSync(logFile, JSON.stringify(this.log));
+    return Promise.resolve();
+  }
+}
+
+const originalLoad = Module._load;
+Module._load = function (request, parent, isMain) {
+  if (request === "pg") {
+    return { Client: MockClient };
+  }
+  return originalLoad(request, parent, isMain);
+};


### PR DESCRIPTION
## Summary
- ensure migrations run without hitting the DB by mocking `pg`
- record executed SQL in a log file and verify all migrations run

## Testing
- `npm run format`
- `node scripts/run-jest.js backend/tests/migrationsDryRun.test.js`


------
https://chatgpt.com/codex/tasks/task_e_687646910494832d9bf60dc56c4ce1b0