### PR TITLE
feat: add CI health check script

### DIFF
--- a/scripts/ci-health.js
+++ b/scripts/ci-health.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+const { execSync } = require("child_process");
+
+const requiredEnv = [
+  "DB_URL",
+  "STRIPE_SECRET_KEY",
+  "AWS_ACCESS_KEY_ID",
+  "AWS_SECRET_ACCESS_KEY",
+];
+
+for (const name of requiredEnv) {
+  if (!process.env[name]) {
+    console.error(`Missing required env var: ${name}`);
+    process.exit(1);
+  }
+}
+
+const services = [
+  process.env.DALLE_SERVER_URL,
+  process.env.SHIPPING_API_URL,
+  process.env.PRINTER_API_URL,
+].filter(Boolean);
+
+for (const url of services) {
+  try {
+    execSync(`curl -fsIL --max-time 5 ${url} -o /dev/null`, {
+      stdio: "ignore",
+    });
+  } catch {
+    console.error(`Service unreachable: ${url}`);
+    process.exit(1);
+  }
+}
+
+console.log("✅ CI environment healthy");

--- a/tests/ciHealthCheck.test.js
+++ b/tests/ciHealthCheck.test.js
@@ -1,0 +1,47 @@
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+describe("ci-health script", () => {
+  test("reports healthy when env vars set and services reachable", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "curl-"));
+    const fakeCurl = path.join(tmp, "curl");
+    fs.writeFileSync(fakeCurl, "#!/bin/sh\nexit 0");
+    fs.chmodSync(fakeCurl, 0o755);
+    const out = execFileSync("node", [path.join("scripts", "ci-health.js")], {
+      env: {
+        ...process.env,
+        PATH: `${tmp}:${process.env.PATH}`,
+        DB_URL: "postgres://user:pass@localhost/db",
+        STRIPE_SECRET_KEY: "sk_test",
+        AWS_ACCESS_KEY_ID: "id",
+        AWS_SECRET_ACCESS_KEY: "secret",
+        DALLE_SERVER_URL: "https://example.com",
+      },
+      encoding: "utf8",
+    });
+    expect(out).toContain("CI environment healthy");
+  });
+
+  test("fails when service unreachable", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "curl-"));
+    const fakeCurl = path.join(tmp, "curl");
+    fs.writeFileSync(fakeCurl, "#!/bin/sh\nexit 7");
+    fs.chmodSync(fakeCurl, 0o755);
+    expect(() => {
+      execFileSync("node", [path.join("scripts", "ci-health.js")], {
+        env: {
+          ...process.env,
+          PATH: `${tmp}:${process.env.PATH}`,
+          DB_URL: "postgres://user:pass@localhost/db",
+          STRIPE_SECRET_KEY: "sk_test",
+          AWS_ACCESS_KEY_ID: "id",
+          AWS_SECRET_ACCESS_KEY: "secret",
+          DALLE_SERVER_URL: "https://example.com",
+        },
+        encoding: "utf8",
+      });
+    }).toThrow(/Service unreachable/);
+  });
+});


### PR DESCRIPTION
## Summary
- add `scripts/ci-health.js` to check env vars and service connectivity
- cover success/failure scenarios in `ciHealthCheck.test.js`

## Testing
- `npm run format`
- `node scripts/run-jest.js tests/ciHealthCheck.test.js`


------
https://chatgpt.com/codex/tasks/task_e_687646898520832d8f331064391df261