### PR TITLE
Add model schema validation tests

### DIFF
--- a/backend/src/__tests__/models.test.js
+++ b/backend/src/__tests__/models.test.js
@@ -45,3 +45,22 @@ test("POST /api/models returns 500 on db error", async () => {
   expect(res.status).toBe(500);
   expect(res.body.error).toBe("Internal Server Error");
 });
+
+test("POST /api/models rejects invalid fileKey", async () => {
+  const res = await request(app)
+    .post("/api/models")
+    .send({ prompt: "p", fileKey: "../bad" });
+  expect(res.status).toBe(400);
+});
+
+test("POST /api/models accepts hyphen and underscore", async () => {
+  const rows = [
+    { id: 2, prompt: "p", url: "https://cdn.example.com/my-file_1.glb" },
+  ];
+  mPool.query.mockResolvedValueOnce({ rows });
+  const res = await request(app)
+    .post("/api/models")
+    .send({ prompt: "p", fileKey: "my-file_1.glb" });
+  expect(res.status).toBe(201);
+  expect(res.body).toEqual(rows[0]);
+});

--- a/backend/tests/apiModels.test.js
+++ b/backend/tests/apiModels.test.js
@@ -61,6 +61,22 @@ test("POST /api/models requires fields", async () => {
   expect(res.status).toBe(400);
 });
 
+test("POST /api/models rejects invalid fileKey", async () => {
+  const res = await request(app)
+    .post("/api/models")
+    .send({ prompt: "a", fileKey: "../bad" });
+  expect(res.status).toBe(400);
+});
+
+test("POST /api/models accepts hyphen and underscore", async () => {
+  const body = { prompt: "a", fileKey: "my-file_1.glb" };
+  const url = `https://${process.env.CLOUDFRONT_MODEL_DOMAIN}/${body.fileKey}`;
+  db.query.mockResolvedValueOnce({ rows: [{ id: 3, ...body, url }] });
+  const res = await request(app).post("/api/models").send(body);
+  expect(res.status).toBe(201);
+  expect(res.body.url).toBe(url);
+});
+
 test("POST /api/models/:id/public toggles visibility", async () => {
   const jwt = require("jsonwebtoken");
   const token = jwt.sign({ id: "u1" }, "secret");


### PR DESCRIPTION
## Summary
- verify model schema accepts hyphen/underscore file names
- ensure invalid file keys return 400

## Testing
- `node scripts/run-jest.js backend/src/__tests__/models.test.js backend/tests/apiModels.test.js`
- `SKIP_PW_DEPS=1 npm run smoke`
- `npm run format` in `backend/`

------
https://chatgpt.com/codex/tasks/task_e_68764684fa30832d949755614027cfe0