### PR TITLE
Validate env before running coverage

### DIFF
--- a/scripts/run-coverage.js
+++ b/scripts/run-coverage.js
@@ -9,6 +9,11 @@ const repoRoot = path.join(__dirname, "..");
 // coverage run doesn't silently use a wrong version when mise wasn't activated.
 require("./check-node-version.js");
 
+// Validate environment variables and dependencies just like the test and CI
+// scripts do. This prevents confusing failures when `npm run coverage` is run
+// without first executing the setup script.
+require("./assert-setup.js");
+
 const extraArgs = process.argv.slice(2);
 const jestArgs = [
   "--ci",

--- a/tests/runCoverageScript.test.js
+++ b/tests/runCoverageScript.test.js
@@ -1,9 +1,13 @@
 const { execFileSync } = require("child_process");
 const fs = require("fs");
 const path = require("path");
+const os = require("os");
+
+const stub = path.join(__dirname, "..", "backend", "tests", "stubExecSync.js");
 
 describe("run-coverage script", () => {
-  test("generates lcov report", () => {
+  test("generates lcov report and runs setup", () => {
+    const logFile = path.join(os.tmpdir(), `coverage-${Date.now()}.log`);
     execFileSync(
       "node",
       ["scripts/run-coverage.js", "backend/tests/awsCredentials.test.ts"],
@@ -13,6 +17,8 @@ describe("run-coverage script", () => {
           SKIP_NET_CHECKS: "1",
           SKIP_DB_CHECK: "1",
           SKIP_PW_DEPS: "1",
+          EXEC_LOG_FILE: logFile,
+          NODE_OPTIONS: `--require ${stub}`,
         },
         encoding: "utf8",
       },
@@ -21,6 +27,8 @@ describe("run-coverage script", () => {
     const summary = path.join("backend", "coverage", "coverage-summary.json");
     expect(fs.existsSync(lcov)).toBe(true);
     expect(fs.existsSync(summary)).toBe(true);
+    const logs = fs.readFileSync(logFile, "utf8");
+    expect(logs).toMatch(/validate-env\.sh/);
   });
 
   test("fails when coverage cannot be parsed", () => {


### PR DESCRIPTION
## Summary
- ensure scripts/run-coverage.js validates the environment and dependencies
- update tests to confirm run-coverage invokes the setup logic

## Testing
- `npm run format`
- `node scripts/run-jest.js tests/runCoverageScript.test.js --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_687646521ee0832d93b205c9988ef58e