### PR TITLE
Fix JS import issues in frontend tests

### DIFF
--- a/backend/tests/frontend/flashBanner.test.js
+++ b/backend/tests/frontend/flashBanner.test.js
@@ -26,10 +26,9 @@ function setupDom() {
   dom.window.setInterval = setInterval;
   dom.window.clearInterval = clearInterval;
   dom.window.Date = Date;
-  const script = fs.readFileSync(
-    path.join(__dirname, "../../../js/payment.js"),
-    "utf8",
-  );
+  const script = fs
+    .readFileSync(path.join(__dirname, "../../../js/payment.js"), "utf8")
+    .replace(/^import[^\n]*\n/gm, "");
   dom.window.eval(script);
   return dom;
 }

--- a/backend/tests/frontend/index.test.js
+++ b/backend/tests/frontend/index.test.js
@@ -23,11 +23,12 @@ describe("index validatePrompt", () => {
     global.document = dom.window.document;
     const shareSrc = fs
       .readFileSync(path.join(__dirname, "../../../js/share.js"), "utf8")
+      .replace(/^import[^\n]*\n/gm, "")
       .replace(/export \{[^}]+\};?/, "");
     dom.window.eval(shareSrc);
     let script = fs
       .readFileSync(path.join(__dirname, "../../../js/index.js"), "utf8")
-      .replace(/import { shareOn } from ['"]\.\/share.js['"];?/, "")
+      .replace(/^import[^\n]*\n/gm, "")
 
       .replace(/window\.addEventListener\(['"]DOMContentLoaded['"][\s\S]+$/, "")
       .replace(/let savedProfile = null;\n?/, "");

--- a/backend/tests/frontend/sanitizedScripts.test.js
+++ b/backend/tests/frontend/sanitizedScripts.test.js
@@ -1,0 +1,26 @@
+const fs = require("fs");
+const path = require("path");
+
+function sanitize(src) {
+  return src.replace(/^import[^\n]*\n/gm, "").replace(/export \{[^}]+\};?/, "");
+}
+
+describe("script sanitization", () => {
+  test("share.js has imports removed", () => {
+    const src = fs.readFileSync(
+      path.join(__dirname, "../../../js/share.js"),
+      "utf8",
+    );
+    const sanitized = sanitize(src);
+    expect(sanitized).not.toMatch(/\bimport\b/);
+  });
+
+  test("payment.js has imports removed", () => {
+    const src = fs.readFileSync(
+      path.join(__dirname, "../../../js/payment.js"),
+      "utf8",
+    );
+    const sanitized = sanitize(src);
+    expect(sanitized).not.toMatch(/\bimport\b/);
+  });
+});

--- a/backend/tests/frontend/sharedModel.test.js
+++ b/backend/tests/frontend/sharedModel.test.js
@@ -12,11 +12,12 @@ function setup(url) {
   global.document = dom.window.document;
   const shareSrc = fs
     .readFileSync(path.join(__dirname, "../../../js/share.js"), "utf8")
+    .replace(/^import[^\n]*\n/gm, "")
     .replace(/export \{[^}]+\};?/, "");
   dom.window.eval(shareSrc);
   let script = fs
     .readFileSync(path.join(__dirname, "../../../js/sharedModel.js"), "utf8")
-    .replace(/import { shareOn } from ['"]\.\/share.js['"];?/, "");
+    .replace(/^import[^\n]*\n/gm, "");
   dom.window.eval(script);
   return dom;
 }

--- a/backend/tests/frontend/slotCount.test.js
+++ b/backend/tests/frontend/slotCount.test.js
@@ -47,10 +47,9 @@ describe("slot count", () => {
     dom.window.fetch = jest.fn(() =>
       Promise.resolve({ ok: true, json: () => ({ slots: 5 }) }),
     );
-    const scriptSrc = fs.readFileSync(
-      path.join(__dirname, "../../../js/payment.js"),
-      "utf8",
-    );
+    const scriptSrc = fs
+      .readFileSync(path.join(__dirname, "../../../js/payment.js"), "utf8")
+      .replace(/^import[^\n]*\n/gm, "");
     dom.window.eval(scriptSrc);
     await new Promise((r) => setTimeout(r, 50));
     expect(dom.window.document.getElementById("slot-count").textContent).toBe(
@@ -73,10 +72,9 @@ describe("slot count", () => {
     dom.window.fetch = jest.fn(() =>
       Promise.resolve({ ok: true, json: () => ({ slots: 6 }) }),
     );
-    const scriptSrc = fs.readFileSync(
-      path.join(__dirname, "../../../js/payment.js"),
-      "utf8",
-    );
+    const scriptSrc = fs
+      .readFileSync(path.join(__dirname, "../../../js/payment.js"), "utf8")
+      .replace(/^import[^\n]*\n/gm, "");
     dom.window.eval(scriptSrc);
     dom.window.localStorage.setItem("slotCycle", cycleKey());
     dom.window.localStorage.setItem("slotPurchases", "2");

--- a/backend/tests/frontend/viewerReady.test.js
+++ b/backend/tests/frontend/viewerReady.test.js
@@ -20,9 +20,10 @@ function setup() {
   });
   global.window = dom.window;
   global.document = dom.window.document;
+  dom.window.shareOn = () => {};
   let script = fs
     .readFileSync(path.join(__dirname, "../../../js/index.js"), "utf8")
-    .replace(/import { shareOn } from ['"]\.\/share.js['"];?/, "")
+    .replace(/^import[^\n]*\n/gm, "")
     .replace(/window\.addEventListener\(['"]DOMContentLoaded['"][\s\S]+$/, "")
     .replace(/let savedProfile = null;\n?/, "");
   script += "\nwindow._showModel = showModel;\nwindow._hideAll = hideAll;";


### PR DESCRIPTION
## Summary
- sanitize frontend scripts before eval
- add test ensuring scripts are sanitized
- stub `shareOn` in viewerReady tests

## Testing
- `npm run format`
- `node scripts/run-jest.js backend/tests/frontend/index.test.js backend/tests/frontend/flashBanner.test.js backend/tests/frontend/slotCount.test.js backend/tests/frontend/sharedModel.test.js backend/tests/frontend/sanitizedScripts.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6876452255f4832db7aa993195c167e3