### PR TITLE
Add regression test for assert-setup

### DIFF
--- a/backend/tests/assertSetupBackendDeps.test.js
+++ b/backend/tests/assertSetupBackendDeps.test.js
@@ -46,4 +46,13 @@ describe("assert-setup backend deps", () => {
       if (fs.existsSync(backup)) fs.renameSync(backup, nodeModules);
     }
   });
+
+  test("exits non-zero when ensure-deps fails", () => {
+    const { result } = runAssertSetup({
+      SKIP_NET_CHECKS: "1",
+      SKIP_PW_DEPS: "1",
+      FAIL_ENSURE_DEPS: "1",
+    });
+    expect(result.status).not.toBe(0);
+  });
 });

--- a/backend/tests/stubExecSync.js
+++ b/backend/tests/stubExecSync.js
@@ -15,6 +15,11 @@ child_process.execSync = function (cmd, opts = {}) {
   if (cmd.includes("playwright install")) {
     return Buffer.from("Playwright host dependencies already satisfied.");
   }
+  if (process.env.FAIL_ENSURE_DEPS && cmd.includes("ensure-deps.js")) {
+    const err = new Error("ensure-deps failed");
+    err.status = 1;
+    throw err;
+  }
   return Buffer.from("");
 };
 


### PR DESCRIPTION
## Summary
- simulate ensure-deps failure via stub
- verify assert-setup exits non-zero when ensure-deps fails

## Testing
- `node scripts/run-jest.js backend/tests/assertSetupBackendDeps.test.js`
- `npm run format`
- `npm run format` in backend

------
https://chatgpt.com/codex/tasks/task_e_687644d04170832da920586e3c19ea46