### PR TITLE
Fix logger tests and env validation

### DIFF
--- a/backend/src/lib/logger.js
+++ b/backend/src/lib/logger.js
@@ -1,10 +1,12 @@
 const Sentry = require("@sentry/node");
-const dsn = process.env.SENTRY_DSN;
-if (dsn) {
-  Sentry.init({ dsn });
-}
+let initialized = false;
 function capture(error) {
+  const dsn = process.env.SENTRY_DSN;
   if (dsn) {
+    if (!initialized) {
+      Sentry.init({ dsn });
+      initialized = true;
+    }
     Sentry.captureException(error);
   }
 }

--- a/backend/src/lib/logger.ts
+++ b/backend/src/lib/logger.ts
@@ -1,1 +1,2 @@
-export * from './logger.js';
+// Re-export CommonJS implementation for compatibility with Jest
+module.exports = require("./logger.js");

--- a/backend/src/logger.ts
+++ b/backend/src/logger.ts
@@ -1,1 +1,2 @@
-export { default } from '../../src/logger.js';
+// Re-export the root logger using CommonJS to avoid ESM parsing issues in Jest
+module.exports = require("../../src/logger.js");

--- a/backend/tests/envValidation.test.js
+++ b/backend/tests/envValidation.test.js
@@ -93,7 +93,7 @@ describe("validate-env script", () => {
   test("fails when DB_URL missing and example file absent", () => {
     const env = { ...process.env, ...baseEnv };
     delete env.DB_URL;
-    const example = path.resolve(process.cwd(), ".env.example");
+    const example = path.resolve(__dirname, "..", "..", ".env.example");
     const backup = `${example}.bak`;
     fs.renameSync(example, backup);
     let threw = false;
@@ -107,7 +107,8 @@ describe("validate-env script", () => {
   });
 
   test("fails when database unreachable", () => {
-    const output = execSync(`bash ${script}`, {
+    const { spawnSync } = require("child_process");
+    const result = spawnSync("bash", [script], {
       env: {
         ...process.env,
         ...baseEnv,
@@ -115,8 +116,9 @@ describe("validate-env script", () => {
         SKIP_NET_CHECKS: "1",
         SKIP_DB_CHECK: "",
       },
-      stdio: "pipe",
-    }).toString();
+      encoding: "utf8",
+    });
+    const output = result.stdout + result.stderr;
     expect(output).toMatch(/Database connection check failed/);
     expect(output).toMatch(/environment OK/);
   });


### PR DESCRIPTION
## Summary
- use CommonJS for backend logger modules
- dynamically init Sentry inside `capture`
- adjust env validation tests to handle stderr
- stabilize logger tests for NODE_ENV quirks

## Testing
- `node scripts/run-jest.js backend/tests/envValidation.test.js backend/tests/logger.test.js --runInBand --no-cache`
- `npm run format --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_6876445e5700832d9ef7a630a606fe15