### PR TITLE
Fix env validation and frontend test imports

### DIFF
--- a/backend/tests/assertSetup.test.js
+++ b/backend/tests/assertSetup.test.js
@@ -29,9 +29,9 @@ function runAssertSetup(nodeVersion, extraEnv = {}) {
 
 describe("assert-setup script", () => {
   test("fails on Node <20", () => {
-    const res = runAssertSetup("18.0.0");
-    expect(res.status).not.toBe(0);
-    expect(res.stderr).toContain("Node 20 or newer is required");
+    const { result } = runAssertSetup("18.0.0");
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("Node 20 or newer is required");
   });
 
   test("succeeds on Node >=20", () => {

--- a/backend/tests/envValidation.test.js
+++ b/backend/tests/envValidation.test.js
@@ -93,7 +93,7 @@ describe("validate-env script", () => {
   test("fails when DB_URL missing and example file absent", () => {
     const env = { ...process.env, ...baseEnv };
     delete env.DB_URL;
-    const example = path.resolve(process.cwd(), ".env.example");
+    const example = path.resolve(__dirname, "../../.env.example");
     const backup = `${example}.bak`;
     fs.renameSync(example, backup);
     let threw = false;

--- a/backend/tests/frontend/bulkDiscount.test.js
+++ b/backend/tests/frontend/bulkDiscount.test.js
@@ -16,10 +16,9 @@ function load() {
   });
   global.window = dom.window;
   global.document = dom.window.document;
-  let script = fs.readFileSync(
-    path.join(__dirname, "../../../js/payment.js"),
-    "utf8",
-  );
+  let script = fs
+    .readFileSync(path.join(__dirname, "../../../js/payment.js"), "utf8")
+    .replace(/import[^;]+;\n/, "");
   script += "\nwindow._computeBulkDiscount = computeBulkDiscount;";
   dom.window.eval(script);
   return dom;

--- a/backend/tests/frontend/flashBanner.test.js
+++ b/backend/tests/frontend/flashBanner.test.js
@@ -26,10 +26,9 @@ function setupDom() {
   dom.window.setInterval = setInterval;
   dom.window.clearInterval = clearInterval;
   dom.window.Date = Date;
-  const script = fs.readFileSync(
-    path.join(__dirname, "../../../js/payment.js"),
-    "utf8",
-  );
+  const script = fs
+    .readFileSync(path.join(__dirname, "../../../js/payment.js"), "utf8")
+    .replace(/import[^;]+;\n/, "");
   dom.window.eval(script);
   return dom;
 }

--- a/backend/tests/frontend/index.test.js
+++ b/backend/tests/frontend/index.test.js
@@ -28,6 +28,7 @@ describe("index validatePrompt", () => {
     let script = fs
       .readFileSync(path.join(__dirname, "../../../js/index.js"), "utf8")
       .replace(/import { shareOn } from ['"]\.\/share.js['"];?/, "")
+      .replace(/import { track } from ['"]\.\/analytics.js['"];?/, "")
 
       .replace(/window\.addEventListener\(['"]DOMContentLoaded['"][\s\S]+$/, "")
       .replace(/let savedProfile = null;\n?/, "");

--- a/backend/tests/frontend/quantityDefault.test.js
+++ b/backend/tests/frontend/quantityDefault.test.js
@@ -19,10 +19,9 @@ function loadDom() {
   });
   global.window = dom.window;
   global.document = dom.window.document;
-  const script = fs.readFileSync(
-    path.join(__dirname, "../../../js/payment.js"),
-    "utf8",
-  );
+  const script = fs
+    .readFileSync(path.join(__dirname, "../../../js/payment.js"), "utf8")
+    .replace(/import[^;]+;\n/, "");
   dom.window.eval(script);
   return dom;
 }

--- a/backend/tests/frontend/slotCount.test.js
+++ b/backend/tests/frontend/slotCount.test.js
@@ -47,10 +47,9 @@ describe("slot count", () => {
     dom.window.fetch = jest.fn(() =>
       Promise.resolve({ ok: true, json: () => ({ slots: 5 }) }),
     );
-    const scriptSrc = fs.readFileSync(
-      path.join(__dirname, "../../../js/payment.js"),
-      "utf8",
-    );
+    const scriptSrc = fs
+      .readFileSync(path.join(__dirname, "../../../js/payment.js"), "utf8")
+      .replace(/import[^;]+;\n/, "");
     dom.window.eval(scriptSrc);
     await new Promise((r) => setTimeout(r, 50));
     expect(dom.window.document.getElementById("slot-count").textContent).toBe(
@@ -73,10 +72,9 @@ describe("slot count", () => {
     dom.window.fetch = jest.fn(() =>
       Promise.resolve({ ok: true, json: () => ({ slots: 6 }) }),
     );
-    const scriptSrc = fs.readFileSync(
-      path.join(__dirname, "../../../js/payment.js"),
-      "utf8",
-    );
+    const scriptSrc = fs
+      .readFileSync(path.join(__dirname, "../../../js/payment.js"), "utf8")
+      .replace(/import[^;]+;\n/, "");
     dom.window.eval(scriptSrc);
     dom.window.localStorage.setItem("slotCycle", cycleKey());
     dom.window.localStorage.setItem("slotPurchases", "2");

--- a/backend/tests/frontend/viewerReady.test.js
+++ b/backend/tests/frontend/viewerReady.test.js
@@ -23,6 +23,7 @@ function setup() {
   let script = fs
     .readFileSync(path.join(__dirname, "../../../js/index.js"), "utf8")
     .replace(/import { shareOn } from ['"]\.\/share.js['"];?/, "")
+    .replace(/import { track } from ['"]\.\/analytics.js['"];?/, "")
     .replace(/window\.addEventListener\(['"]DOMContentLoaded['"][\s\S]+$/, "")
     .replace(/let savedProfile = null;\n?/, "");
   script += "\nwindow._showModel = showModel;\nwindow._hideAll = hideAll;";

--- a/backend/tests/logger.test.js
+++ b/backend/tests/logger.test.js
@@ -1,6 +1,6 @@
 const Sentry = require("@sentry/node");
 const { capture } = require("../src/lib/logger");
-const logger = require("../src/logger");
+const logger = require("../src/logger").default || require("../src/logger");
 const { transports } = require("winston");
 
 describe("capture", () => {
@@ -10,8 +10,11 @@ describe("capture", () => {
   });
 
   test("does not throw without DSN", () => {
+    const spy = jest
+      .spyOn(Sentry, "captureException")
+      .mockImplementation(() => {});
     expect(() => capture(new Error("boom"))).not.toThrow();
-    expect(Sentry.captureException).not.toHaveBeenCalled();
+    expect(spy).not.toHaveBeenCalled();
   });
 
   test("forwards errors to Sentry when DSN is set", () => {


### PR DESCRIPTION
## Summary
- fix env example path in envValidation test
- strip analytics imports in frontend tests
- adapt assertSetup and logger tests for current modules

## Testing
- `npm run format` in backend
- `node scripts/run-jest.js backend/tests/envValidation.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68764455aa00832d9710272f4700eecf