### PR TITLE
Fix env tests and flash banner setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,7 +530,7 @@ The `npm run setup` script now performs this cleanup before and after installing
 dependencies, so new clones shouldn't hit this error. If you still encounter it,
 re-run `npm run setup` to ensure the cache directory is cleared.
 
-### TAR\_ENTRY\_ERROR or ENOENT during `npm ci`
+### TAR_ENTRY_ERROR or ENOENT during `npm ci`
 
 If `npm run format` exits with errors like `TAR_ENTRY_ERROR` or `ENOENT`, the
 package cache may be corrupted. Running `npm run setup` in the repository root

--- a/backend/scripts/ensure-deps.js
+++ b/backend/scripts/ensure-deps.js
@@ -109,7 +109,6 @@ function runSetup() {
   }
   try {
     execSync("npm run setup", { stdio: "inherit", cwd: repoRoot, env });
-
   } catch {
     if (env.SKIP_PW_DEPS) {
       console.warn(

--- a/backend/tests/envValidation.test.js
+++ b/backend/tests/envValidation.test.js
@@ -93,7 +93,8 @@ describe("validate-env script", () => {
   test("fails when DB_URL missing and example file absent", () => {
     const env = { ...process.env, ...baseEnv };
     delete env.DB_URL;
-    const example = path.resolve(process.cwd(), ".env.example");
+    const repoRoot = path.resolve(__dirname, "..", "..");
+    const example = path.join(repoRoot, ".env.example");
     const backup = `${example}.bak`;
     fs.renameSync(example, backup);
     let threw = false;
@@ -107,7 +108,7 @@ describe("validate-env script", () => {
   });
 
   test("fails when database unreachable", () => {
-    const output = execSync(`bash ${script}`, {
+    const output = execSync(`bash ${script} 2>&1`, {
       env: {
         ...process.env,
         ...baseEnv,

--- a/backend/tests/frontend/flashBanner.test.js
+++ b/backend/tests/frontend/flashBanner.test.js
@@ -26,10 +26,12 @@ function setupDom() {
   dom.window.setInterval = setInterval;
   dom.window.clearInterval = clearInterval;
   dom.window.Date = Date;
-  const script = fs.readFileSync(
+  dom.window.track = () => {};
+  let script = fs.readFileSync(
     path.join(__dirname, "../../../js/payment.js"),
     "utf8",
   );
+  script = script.replace(/^\s*import[^\n]+\n/m, "");
   dom.window.eval(script);
   return dom;
 }

--- a/backend/tests/validateMiddleware.test.js
+++ b/backend/tests/validateMiddleware.test.js
@@ -23,12 +23,10 @@ describe("validate middleware", () => {
     expect(next).not.toHaveBeenCalled();
   });
 
-
   test("calls next on non-Zod errors", () => {
     const badSchema = {
       parse: () => {
         throw new Error("boom");
-
       },
     };
     const req = { body: {} };


### PR DESCRIPTION
## Summary
- fix missing path handling in envValidation.test.js
- capture stderr output to check DB errors
- stub analytics import in flashBanner tests

## Testing
- `npm run format --prefix backend`
- `node scripts/run-jest.js backend/tests/envValidation.test.js backend/tests/frontend/flashBanner.test.js`

------
https://chatgpt.com/codex/tasks/task_e_687644088ee0832daadb2189232dfc09