### PR TITLE
Fix logger tests

### DIFF
--- a/backend/src/lib/logger.js
+++ b/backend/src/lib/logger.js
@@ -1,11 +1,16 @@
 const Sentry = require("@sentry/node");
-const dsn = process.env.SENTRY_DSN;
-if (dsn) {
-  Sentry.init({ dsn });
-}
+
+let initialized = false;
+
 function capture(error) {
+  const dsn = process.env.SENTRY_DSN;
   if (dsn) {
+    if (!initialized) {
+      Sentry.init({ dsn });
+      initialized = true;
+    }
     Sentry.captureException(error);
   }
 }
+
 module.exports = { capture };

--- a/backend/src/logger.ts
+++ b/backend/src/logger.ts
@@ -1,1 +1,4 @@
-export { default } from '../../src/logger.js';
+// Re-export the main logger so CommonJS consumers receive the logger object
+// instead of a `{ default: logger }` wrapper.
+const logger = require("../../src/logger.js");
+module.exports = logger;


### PR DESCRIPTION
## Summary
- keep Sentry logger dynamic after initialization
- export backend logger using CommonJS
- rewrite logger tests so the Sentry mock is always used and logger config matches the current NODE_ENV

## Testing
- `node scripts/run-jest.js backend/tests/logger.test.js`
- `npm run format --silent`

------
https://chatgpt.com/codex/tasks/task_e_6876489655a8832d93abf094e24d9e72