### PR TITLE
Fix assertSetup test path

### DIFF
--- a/backend/tests/assertSetup.test.js
+++ b/backend/tests/assertSetup.test.js
@@ -3,7 +3,7 @@ const os = require("os");
 const path = require("path");
 const { spawnSync } = require("child_process");
 
-const script = path.join(__dirname, "..", "scripts", "assert-setup.js");
+const script = path.join(__dirname, "..", "..", "scripts", "assert-setup.js");
 const stub = path.join(__dirname, "stubExecSync.js");
 
 function runAssertSetup(nodeVersion, extraEnv = {}) {
@@ -30,8 +30,8 @@ function runAssertSetup(nodeVersion, extraEnv = {}) {
 describe("assert-setup script", () => {
   test("fails on Node <20", () => {
     const res = runAssertSetup("18.0.0");
-    expect(res.status).not.toBe(0);
-    expect(res.stderr).toContain("Node 20 or newer is required");
+    expect(res.result.status).not.toBe(0);
+    expect(res.result.stderr).toContain("Node 20 or newer is required");
   });
 
   test("succeeds on Node >=20", () => {


### PR DESCRIPTION
## Summary
- update path to `assert-setup.js` in backend test
- check `result` object in test assertions

## Testing
- `npm run format`
- `node scripts/run-jest.js backend/tests/assertSetup.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6876486c6a48832dbc5bbc19bfc62920