### PR TITLE
Add missing stripe webhook secret in test setup

### DIFF
--- a/backend/tests/setupGlobals.js
+++ b/backend/tests/setupGlobals.js
@@ -66,6 +66,9 @@ if (!process.env.STRIPE_SECRET_KEY) {
 if (!process.env.STRIPE_PUBLISHABLE_KEY) {
   process.env.STRIPE_PUBLISHABLE_KEY = "pk_test";
 }
+if (!process.env.STRIPE_WEBHOOK_SECRET) {
+  process.env.STRIPE_WEBHOOK_SECRET = "whsec";
+}
 
 // Ensure any proxy environment variables do not interfere with HTTP mocking
 for (const key of [

--- a/backend/tests/stripeWebhook.test.js
+++ b/backend/tests/stripeWebhook.test.js
@@ -1,0 +1,5 @@
+const config = require("../config");
+
+test("test env provides STRIPE_WEBHOOK_SECRET", () => {
+  expect(config.stripeWebhook).toBe("whsec");
+});


### PR DESCRIPTION
## Summary
- default STRIPE_WEBHOOK_SECRET in backend test globals
- verify webhook secret is defined in tests

## Testing
- `npm run format`
- `node scripts/run-jest.js backend/tests/stripeWebhook.test.js`


------
https://chatgpt.com/codex/tasks/task_e_687656e9c920832d91bcc7923165e538