### PR TITLE
Fix failing share test with jsdom import

### DIFF
--- a/backend/tests/frontend/share.test.js
+++ b/backend/tests/frontend/share.test.js
@@ -12,9 +12,19 @@ describe("shareOn", () => {
     global.window = dom.window;
     global.document = dom.window.document;
     dom.window.navigator.share = undefined;
-    const src = fs
-      .readFileSync(path.join(__dirname, "../../../js/share.js"), "utf8")
-      .replace(/export \{[^}]+\};?/, "");
+    let src = fs.readFileSync(
+      path.join(__dirname, "../../../js/share.js"),
+      "utf8",
+    );
+    src = src
+      // strip the ESM export so the code can run in the JSDOM context
+      .replace(/export \{[^}]+\};?/, "")
+      // replace the analytics import with a stubbed function to avoid
+      // "import" syntax errors under Node's CommonJS environment
+      .replace(
+        /import\s+\{[^}]+\}\s+from\s+"\.\/analytics.js";?/,
+        "const track = () => {};",
+      );
     dom.window.eval(src);
     return dom.window.shareOn;
   }

--- a/tests/validateEnv.test.js
+++ b/tests/validateEnv.test.js
@@ -77,6 +77,9 @@ describe("validate-env script", () => {
     };
     const example = path.resolve(__dirname, "..", ".env.example");
     const backup = `${example}.bak`;
+    if (!fs.existsSync(example)) {
+      fs.writeFileSync(example, "# test\n");
+    }
     fs.renameSync(example, backup);
     try {
       const output = run(env);


### PR DESCRIPTION
## Summary
- stub the analytics import when loading `share.js` in jsdom
- ensure `validate-env` test creates `.env.example` when missing

## Testing
- `node scripts/run-jest.js backend/tests/frontend/share.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68765862f47c832da28c38b6a7e4dcb3