### PR TITLE
Fix env validation test path

### DIFF
--- a/backend/tests/envValidation.test.js
+++ b/backend/tests/envValidation.test.js
@@ -93,7 +93,7 @@ describe("validate-env script", () => {
   test("fails when DB_URL missing and example file absent", () => {
     const env = { ...process.env, ...baseEnv };
     delete env.DB_URL;
-    const example = path.resolve(process.cwd(), ".env.example");
+    const example = path.resolve(__dirname, "..", "..", ".env.example");
     const backup = `${example}.bak`;
     fs.renameSync(example, backup);
     let threw = false;


### PR DESCRIPTION
## Summary
- fix path to `.env.example` when moved in tests

## Testing
- `node scripts/run-jest.js backend/tests/envValidation.test.js`


------
https://chatgpt.com/codex/tasks/task_e_687657099e74832d8448125f527db077