### PR TITLE
Fix test script paths

### DIFF
--- a/backend/tests/assertSetup.test.js
+++ b/backend/tests/assertSetup.test.js
@@ -3,7 +3,7 @@ const os = require("os");
 const path = require("path");
 const { spawnSync } = require("child_process");
 
-const script = path.join(__dirname, "..", "scripts", "assert-setup.js");
+const script = path.join(__dirname, "..", "..", "scripts", "assert-setup.js");
 const stub = path.join(__dirname, "stubExecSync.js");
 
 function runAssertSetup(nodeVersion, extraEnv = {}) {
@@ -29,9 +29,9 @@ function runAssertSetup(nodeVersion, extraEnv = {}) {
 
 describe("assert-setup script", () => {
   test("fails on Node <20", () => {
-    const res = runAssertSetup("18.0.0");
-    expect(res.status).not.toBe(0);
-    expect(res.stderr).toContain("Node 20 or newer is required");
+    const { result } = runAssertSetup("18.0.0");
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("Node 20 or newer is required");
   });
 
   test("succeeds on Node >=20", () => {

--- a/backend/tests/frontend/bulkDiscount.test.js
+++ b/backend/tests/frontend/bulkDiscount.test.js
@@ -16,10 +16,9 @@ function load() {
   });
   global.window = dom.window;
   global.document = dom.window.document;
-  let script = fs.readFileSync(
-    path.join(__dirname, "../../../js/payment.js"),
-    "utf8",
-  );
+  let script = fs
+    .readFileSync(path.join(__dirname, "../../../js/payment.js"), "utf8")
+    .replace(/import[^;]+;\n?/g, "");
   script += "\nwindow._computeBulkDiscount = computeBulkDiscount;";
   dom.window.eval(script);
   return dom;

--- a/backend/tests/frontend/flashBanner.test.js
+++ b/backend/tests/frontend/flashBanner.test.js
@@ -26,10 +26,9 @@ function setupDom() {
   dom.window.setInterval = setInterval;
   dom.window.clearInterval = clearInterval;
   dom.window.Date = Date;
-  const script = fs.readFileSync(
-    path.join(__dirname, "../../../js/payment.js"),
-    "utf8",
-  );
+  const script = fs
+    .readFileSync(path.join(__dirname, "../../../js/payment.js"), "utf8")
+    .replace(/import[^;]+;\n?/g, "");
   dom.window.eval(script);
   return dom;
 }

--- a/backend/tests/frontend/index.test.js
+++ b/backend/tests/frontend/index.test.js
@@ -27,8 +27,7 @@ describe("index validatePrompt", () => {
     dom.window.eval(shareSrc);
     let script = fs
       .readFileSync(path.join(__dirname, "../../../js/index.js"), "utf8")
-      .replace(/import { shareOn } from ['"]\.\/share.js['"];?/, "")
-
+      .replace(/import[^;]+;\n?/g, "")
       .replace(/window\.addEventListener\(['"]DOMContentLoaded['"][\s\S]+$/, "")
       .replace(/let savedProfile = null;\n?/, "");
 

--- a/backend/tests/frontend/quantityDefault.test.js
+++ b/backend/tests/frontend/quantityDefault.test.js
@@ -19,10 +19,9 @@ function loadDom() {
   });
   global.window = dom.window;
   global.document = dom.window.document;
-  const script = fs.readFileSync(
-    path.join(__dirname, "../../../js/payment.js"),
-    "utf8",
-  );
+  const script = fs
+    .readFileSync(path.join(__dirname, "../../../js/payment.js"), "utf8")
+    .replace(/import[^;]+;\n?/g, "");
   dom.window.eval(script);
   return dom;
 }

--- a/backend/tests/frontend/share.test.js
+++ b/backend/tests/frontend/share.test.js
@@ -14,7 +14,8 @@ describe("shareOn", () => {
     dom.window.navigator.share = undefined;
     const src = fs
       .readFileSync(path.join(__dirname, "../../../js/share.js"), "utf8")
-      .replace(/export \{[^}]+\};?/, "");
+      .replace(/export \{[^}]+\};?/, "")
+      .replace(/import[^;]+;\n?/g, "");
     dom.window.eval(src);
     return dom.window.shareOn;
   }

--- a/backend/tests/frontend/slotCount.test.js
+++ b/backend/tests/frontend/slotCount.test.js
@@ -47,10 +47,9 @@ describe("slot count", () => {
     dom.window.fetch = jest.fn(() =>
       Promise.resolve({ ok: true, json: () => ({ slots: 5 }) }),
     );
-    const scriptSrc = fs.readFileSync(
-      path.join(__dirname, "../../../js/payment.js"),
-      "utf8",
-    );
+    const scriptSrc = fs
+      .readFileSync(path.join(__dirname, "../../../js/payment.js"), "utf8")
+      .replace(/import[^;]+;\n?/g, "");
     dom.window.eval(scriptSrc);
     await new Promise((r) => setTimeout(r, 50));
     expect(dom.window.document.getElementById("slot-count").textContent).toBe(
@@ -73,10 +72,9 @@ describe("slot count", () => {
     dom.window.fetch = jest.fn(() =>
       Promise.resolve({ ok: true, json: () => ({ slots: 6 }) }),
     );
-    const scriptSrc = fs.readFileSync(
-      path.join(__dirname, "../../../js/payment.js"),
-      "utf8",
-    );
+    const scriptSrc = fs
+      .readFileSync(path.join(__dirname, "../../../js/payment.js"), "utf8")
+      .replace(/import[^;]+;\n?/g, "");
     dom.window.eval(scriptSrc);
     dom.window.localStorage.setItem("slotCycle", cycleKey());
     dom.window.localStorage.setItem("slotPurchases", "2");

--- a/backend/tests/frontend/viewerReady.test.js
+++ b/backend/tests/frontend/viewerReady.test.js
@@ -22,7 +22,7 @@ function setup() {
   global.document = dom.window.document;
   let script = fs
     .readFileSync(path.join(__dirname, "../../../js/index.js"), "utf8")
-    .replace(/import { shareOn } from ['"]\.\/share.js['"];?/, "")
+    .replace(/import[^;]+;\n?/g, "")
     .replace(/window\.addEventListener\(['"]DOMContentLoaded['"][\s\S]+$/, "")
     .replace(/let savedProfile = null;\n?/, "");
   script += "\nwindow._showModel = showModel;\nwindow._hideAll = hideAll;";

--- a/tests/assertSetup.test.js
+++ b/tests/assertSetup.test.js
@@ -28,7 +28,7 @@ describe("assert-setup script", () => {
     fs.readdirSync.mockReturnValue([]);
     child_process.execSync.mockImplementation(() => {});
 
-    expect(() => require("../scripts/assert-setup.js")).not.toThrow();
+    expect(() => require("../../scripts/assert-setup.js")).not.toThrow();
     expect(child_process.execSync).toHaveBeenCalledWith("CI=1 npm run setup", {
       stdio: "inherit",
       env: expect.any(Object),
@@ -40,7 +40,7 @@ describe("assert-setup script", () => {
     fs.existsSync.mockReturnValue(true);
     fs.readdirSync.mockReturnValue(["chromium"]);
 
-    expect(() => require("../scripts/assert-setup.js")).not.toThrow();
+    expect(() => require("../../scripts/assert-setup.js")).not.toThrow();
   });
 
   test("invokes validate-env when HF_TOKEN missing", () => {
@@ -53,7 +53,7 @@ describe("assert-setup script", () => {
 
     child_process.execSync.mockImplementation(() => {});
 
-    expect(() => require("../scripts/assert-setup.js")).not.toThrow();
+    expect(() => require("../../scripts/assert-setup.js")).not.toThrow();
     expect(child_process.execSync).toHaveBeenCalledWith(
       "SKIP_NET_CHECKS=1 bash scripts/validate-env.sh >/dev/null",
       { stdio: "inherit" },
@@ -66,7 +66,7 @@ describe("assert-setup script", () => {
     fs.existsSync.mockReturnValue(true);
     fs.readdirSync.mockReturnValue(["chromium"]);
     child_process.execSync.mockImplementation(() => {});
-    expect(() => require("../scripts/assert-setup.js")).not.toThrow();
+    expect(() => require("../../scripts/assert-setup.js")).not.toThrow();
     expect(child_process.execSync).toHaveBeenCalledWith(
       "SKIP_NET_CHECKS=1 bash scripts/validate-env.sh >/dev/null",
       { stdio: "inherit" },
@@ -84,7 +84,7 @@ describe("assert-setup script", () => {
     fs.readdirSync.mockReturnValue(["chromium"]);
 
     jest.isolateModules(() => {
-      require("../scripts/assert-setup.js");
+      require("../../scripts/assert-setup.js");
     });
 
     expect(ensureRootDeps).toHaveBeenCalled();
@@ -97,7 +97,7 @@ describe("assert-setup script", () => {
     child_process.execSync.mockImplementation(() => {});
 
     jest.isolateModules(() => {
-      require("../scripts/assert-setup.js");
+      require("../../scripts/assert-setup.js");
     });
 
     expect(child_process.execSync).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- fix script paths and imports in front-end tests

## Testing
- `npm run format`
- `npx jest tests/assertSetup.test.js --runInBand --reporters=default --colors`


------
https://chatgpt.com/codex/tasks/task_e_68765653b594832da9c887ccf776cba2