### PR TITLE
Fix backend server lint path

### DIFF
--- a/backend/tests/serverLint.test.js
+++ b/backend/tests/serverLint.test.js
@@ -1,7 +1,12 @@
 const { execSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
 
-test("backend/server.js passes eslint", () => {
+test("server.js passes eslint", () => {
+  const serverFile = path.join(__dirname, "..", "server.js");
+  // Ensure the file exists to prevent path errors from masking lint failures
+  expect(fs.existsSync(serverFile)).toBe(true);
   expect(() => {
-    execSync("npx eslint backend/server.js", { stdio: "pipe" });
+    execSync(`npx eslint ${serverFile}`, { stdio: "pipe" });
   }).not.toThrow();
 });


### PR DESCRIPTION
## Summary
- correct path to `server.js` in `serverLint.test.js`
- verify the file exists before running ESLint

## Testing
- `npm run format` in `backend/`
- `npm test tests/serverLint.test.js`

------
https://chatgpt.com/codex/tasks/task_e_687655fbb4d4832d978383e1cc875658