### PR TITLE
Fix failing backend tests

### DIFF
--- a/backend/tests/assertSetup.test.js
+++ b/backend/tests/assertSetup.test.js
@@ -29,9 +29,9 @@ function runAssertSetup(nodeVersion, extraEnv = {}) {
 
 describe("assert-setup script", () => {
   test("fails on Node <20", () => {
-    const res = runAssertSetup("18.0.0");
-    expect(res.status).not.toBe(0);
-    expect(res.stderr).toContain("Node 20 or newer is required");
+    const { result } = runAssertSetup("18.0.0");
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("Node 20 or newer is required");
   });
 
   test("succeeds on Node >=20", () => {

--- a/backend/tests/envValidation.test.js
+++ b/backend/tests/envValidation.test.js
@@ -93,6 +93,8 @@ describe("validate-env script", () => {
   test("fails when DB_URL missing and example file absent", () => {
     const env = { ...process.env, ...baseEnv };
     delete env.DB_URL;
+    const prevDbUrl = process.env.DB_URL;
+    delete process.env.DB_URL;
     const example = path.resolve(process.cwd(), ".env.example");
     const backup = `${example}.bak`;
     fs.renameSync(example, backup);
@@ -103,6 +105,7 @@ describe("validate-env script", () => {
       threw = true;
     }
     fs.renameSync(backup, example);
+    if (prevDbUrl) process.env.DB_URL = prevDbUrl;
     expect(threw).toBe(true);
   });
 

--- a/backend/tests/frontend/flashBanner.test.js
+++ b/backend/tests/frontend/flashBanner.test.js
@@ -26,10 +26,9 @@ function setupDom() {
   dom.window.setInterval = setInterval;
   dom.window.clearInterval = clearInterval;
   dom.window.Date = Date;
-  const script = fs.readFileSync(
-    path.join(__dirname, "../../../js/payment.js"),
-    "utf8",
-  );
+  const script = fs
+    .readFileSync(path.join(__dirname, "../../../js/payment.js"), "utf8")
+    .replace(/import { track } from ['"]\.\/analytics.js['"];?/, "");
   dom.window.eval(script);
   return dom;
 }

--- a/backend/tests/frontend/index.test.js
+++ b/backend/tests/frontend/index.test.js
@@ -23,12 +23,13 @@ describe("index validatePrompt", () => {
     global.document = dom.window.document;
     const shareSrc = fs
       .readFileSync(path.join(__dirname, "../../../js/share.js"), "utf8")
+      .replace(/import { track } from ['"]\.\/analytics.js['"];?/, "")
       .replace(/export \{[^}]+\};?/, "");
     dom.window.eval(shareSrc);
     let script = fs
       .readFileSync(path.join(__dirname, "../../../js/index.js"), "utf8")
       .replace(/import { shareOn } from ['"]\.\/share.js['"];?/, "")
-
+      .replace(/import { track } from ['"]\.\/analytics.js['"];?/, "")
       .replace(/window\.addEventListener\(['"]DOMContentLoaded['"][\s\S]+$/, "")
       .replace(/let savedProfile = null;\n?/, "");
 

--- a/backend/tests/frontend/slotCount.test.js
+++ b/backend/tests/frontend/slotCount.test.js
@@ -47,10 +47,9 @@ describe("slot count", () => {
     dom.window.fetch = jest.fn(() =>
       Promise.resolve({ ok: true, json: () => ({ slots: 5 }) }),
     );
-    const scriptSrc = fs.readFileSync(
-      path.join(__dirname, "../../../js/payment.js"),
-      "utf8",
-    );
+    const scriptSrc = fs
+      .readFileSync(path.join(__dirname, "../../../js/payment.js"), "utf8")
+      .replace(/import { track } from ['"]\.\/analytics.js['"];?/, "");
     dom.window.eval(scriptSrc);
     await new Promise((r) => setTimeout(r, 50));
     expect(dom.window.document.getElementById("slot-count").textContent).toBe(
@@ -73,10 +72,9 @@ describe("slot count", () => {
     dom.window.fetch = jest.fn(() =>
       Promise.resolve({ ok: true, json: () => ({ slots: 6 }) }),
     );
-    const scriptSrc = fs.readFileSync(
-      path.join(__dirname, "../../../js/payment.js"),
-      "utf8",
-    );
+    const scriptSrc = fs
+      .readFileSync(path.join(__dirname, "../../../js/payment.js"), "utf8")
+      .replace(/import { track } from ['"]\.\/analytics.js['"];?/, "");
     dom.window.eval(scriptSrc);
     dom.window.localStorage.setItem("slotCycle", cycleKey());
     dom.window.localStorage.setItem("slotPurchases", "2");

--- a/backend/tests/frontend/viewerReady.test.js
+++ b/backend/tests/frontend/viewerReady.test.js
@@ -20,9 +20,14 @@ function setup() {
   });
   global.window = dom.window;
   global.document = dom.window.document;
+  const shareSrc = fs
+    .readFileSync(path.join(__dirname, "../../../js/share.js"), "utf8")
+    .replace(/import { track } from ['"]\.\/analytics.js['"];?/, "");
+  dom.window.eval(shareSrc);
   let script = fs
     .readFileSync(path.join(__dirname, "../../../js/index.js"), "utf8")
     .replace(/import { shareOn } from ['"]\.\/share.js['"];?/, "")
+    .replace(/import { track } from ['"]\.\/analytics.js['"];?/, "")
     .replace(/window\.addEventListener\(['"]DOMContentLoaded['"][\s\S]+$/, "")
     .replace(/let savedProfile = null;\n?/, "");
   script += "\nwindow._showModel = showModel;\nwindow._hideAll = hideAll;";

--- a/backend/tests/logger.test.js
+++ b/backend/tests/logger.test.js
@@ -1,9 +1,12 @@
 const Sentry = require("@sentry/node");
 const { capture } = require("../src/lib/logger");
-const logger = require("../src/logger");
+const logger = require("../src/logger").default;
 const { transports } = require("winston");
 
 describe("capture", () => {
+  beforeEach(() => {
+    jest.spyOn(Sentry, "captureException").mockImplementation(() => {});
+  });
   afterEach(() => {
     delete process.env.SENTRY_DSN;
     jest.restoreAllMocks();
@@ -16,9 +19,7 @@ describe("capture", () => {
 
   test("forwards errors to Sentry when DSN is set", () => {
     process.env.SENTRY_DSN = "abc";
-    const spy = jest
-      .spyOn(Sentry, "captureException")
-      .mockImplementation(() => {});
+    const spy = Sentry.captureException;
     const err = new Error("boom");
     capture(err);
     expect(spy).toHaveBeenCalledWith(err);

--- a/backend/tests/serverLint.test.js
+++ b/backend/tests/serverLint.test.js
@@ -1,7 +1,9 @@
 const { execSync } = require("child_process");
+const path = require("path");
 
 test("backend/server.js passes eslint", () => {
   expect(() => {
-    execSync("npx eslint backend/server.js", { stdio: "pipe" });
+    const serverPath = path.join(__dirname, "../server.js");
+    execSync(`npx eslint ${serverPath}`, { stdio: "pipe" });
   }).not.toThrow();
 });


### PR DESCRIPTION
## Summary
- remove leftover ES module imports when evaluating frontend scripts in tests
- stub Sentry in logger tests and load exported logger correctly
- handle temporary DB_URL in envValidation tests
- fix assertSetup test return handling
- resolve ESLint path for server.js

## Testing
- `npm run format`
- `node scripts/run-jest.js backend/tests/serverLint.test.js`

------
https://chatgpt.com/codex/tasks/task_e_687655f00328832d850b66467d2b7e90