### PR TITLE
Fix frontend test import handling

### DIFF
--- a/backend/tests/frontend/index.test.js
+++ b/backend/tests/frontend/index.test.js
@@ -23,12 +23,14 @@ describe("index validatePrompt", () => {
     global.document = dom.window.document;
     const shareSrc = fs
       .readFileSync(path.join(__dirname, "../../../js/share.js"), "utf8")
-      .replace(/^import[^\n]*\n/gm, "")
-      .replace(/export \{[^}]+\};?/, "");
+      .replace(/^import[^\n]*\r?\n/gm, "")
+      .replace(/export \{[^}]+\};?/, "")
+      .replace(/export\s+function/g, "function");
     dom.window.eval(shareSrc);
     let script = fs
       .readFileSync(path.join(__dirname, "../../../js/index.js"), "utf8")
-      .replace(/^import[^\n]*\n/gm, "")
+      .replace(/^import[^\n]*\r?\n/gm, "")
+      .replace(/export\s+function/g, "function")
 
       .replace(/window\.addEventListener\(['"]DOMContentLoaded['"][\s\S]+$/, "")
       .replace(/let savedProfile = null;\n?/, "");


### PR DESCRIPTION
## Summary
- update `index.test.js` to remove ES module syntax lines in JS fixtures

## Testing
- `node scripts/run-jest.js backend/tests/frontend/index.test.js`

------
https://chatgpt.com/codex/tasks/task_e_687660df0a7c832db30c02cf73cb4f9d