### PR TITLE
Fix script imports in frontend tests

### DIFF
--- a/backend/tests/frontend/quantityDefault.test.js
+++ b/backend/tests/frontend/quantityDefault.test.js
@@ -19,10 +19,9 @@ function loadDom() {
   });
   global.window = dom.window;
   global.document = dom.window.document;
-  const script = fs.readFileSync(
-    path.join(__dirname, "../../../js/payment.js"),
-    "utf8",
-  );
+  const script = fs
+    .readFileSync(path.join(__dirname, "../../../js/payment.js"), "utf8")
+    .replace(/^import[^\n]*\n/gm, "");
   dom.window.eval(script);
   return dom;
 }

--- a/backend/tests/frontend/share.test.js
+++ b/backend/tests/frontend/share.test.js
@@ -14,6 +14,7 @@ describe("shareOn", () => {
     dom.window.navigator.share = undefined;
     const src = fs
       .readFileSync(path.join(__dirname, "../../../js/share.js"), "utf8")
+      .replace(/^import[^\n]*\n/gm, "")
       .replace(/export \{[^}]+\};?/, "");
     dom.window.eval(src);
     return dom.window.shareOn;

--- a/backend/tests/setupGlobals.js
+++ b/backend/tests/setupGlobals.js
@@ -63,6 +63,9 @@ if (!process.env.DB_URL) {
 if (!process.env.STRIPE_SECRET_KEY) {
   process.env.STRIPE_SECRET_KEY = "sk_test";
 }
+if (!process.env.STRIPE_TEST_KEY) {
+  process.env.STRIPE_TEST_KEY = process.env.STRIPE_SECRET_KEY;
+}
 if (!process.env.STRIPE_PUBLISHABLE_KEY) {
   process.env.STRIPE_PUBLISHABLE_KEY = "pk_test";
 }


### PR DESCRIPTION
## Summary
- strip ES module imports before evaluating `share.js` and `payment.js` in unit tests
- set a fallback `STRIPE_TEST_KEY` for backend tests

## Testing
- `node scripts/run-jest.js backend/tests/frontend/share.test.js`
- `node scripts/run-jest.js backend/tests/frontend/quantityDefault.test.js`
- `node scripts/run-jest.js backend/tests/checkout.env.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68765817596c832dace78ecea0c61a64