### PR TITLE
Fix frontend import errors in tests

### DIFF
--- a/backend/tests/frontend/bulkDiscount.test.js
+++ b/backend/tests/frontend/bulkDiscount.test.js
@@ -16,10 +16,9 @@ function load() {
   });
   global.window = dom.window;
   global.document = dom.window.document;
-  let script = fs.readFileSync(
-    path.join(__dirname, "../../../js/payment.js"),
-    "utf8",
-  );
+  let script = fs
+    .readFileSync(path.join(__dirname, "../../../js/payment.js"), "utf8")
+    .replace(/import { track } from ['"]\.\/analytics.js['"];?/, "");
   script += "\nwindow._computeBulkDiscount = computeBulkDiscount;";
   dom.window.eval(script);
   return dom;

--- a/backend/tests/frontend/flashBanner.test.js
+++ b/backend/tests/frontend/flashBanner.test.js
@@ -26,10 +26,9 @@ function setupDom() {
   dom.window.setInterval = setInterval;
   dom.window.clearInterval = clearInterval;
   dom.window.Date = Date;
-  const script = fs.readFileSync(
-    path.join(__dirname, "../../../js/payment.js"),
-    "utf8",
-  );
+  const script = fs
+    .readFileSync(path.join(__dirname, "../../../js/payment.js"), "utf8")
+    .replace(/import { track } from ['"]\.\/analytics.js['"];?/, "");
   dom.window.eval(script);
   return dom;
 }

--- a/backend/tests/frontend/index.test.js
+++ b/backend/tests/frontend/index.test.js
@@ -23,12 +23,13 @@ describe("index validatePrompt", () => {
     global.document = dom.window.document;
     const shareSrc = fs
       .readFileSync(path.join(__dirname, "../../../js/share.js"), "utf8")
-      .replace(/export \{[^}]+\};?/, "");
+      .replace(/export \{[^}]+\};?/, "")
+      .replace(/import { track } from ['"]\.\/analytics.js['"];?/, "");
     dom.window.eval(shareSrc);
     let script = fs
       .readFileSync(path.join(__dirname, "../../../js/index.js"), "utf8")
       .replace(/import { shareOn } from ['"]\.\/share.js['"];?/, "")
-
+      .replace(/import { track } from ['"]\.\/analytics.js['"];?/, "")
       .replace(/window\.addEventListener\(['"]DOMContentLoaded['"][\s\S]+$/, "")
       .replace(/let savedProfile = null;\n?/, "");
 
@@ -36,6 +37,14 @@ describe("index validatePrompt", () => {
     dom.window.eval(script);
     return dom;
   }
+
+  test("sanitizes imports", () => {
+    const script = fs
+      .readFileSync(path.join(__dirname, "../../../js/index.js"), "utf8")
+      .replace(/import { shareOn } from ['"]\.\/share.js['"];?/, "")
+      .replace(/import { track } from ['"]\.\/analytics.js['"];?/, "");
+    expect(script).not.toMatch(/import /);
+  });
 
   test("rejects short prompt", () => {
     const dom = setup();

--- a/backend/tests/frontend/paymentSanitize.test.js
+++ b/backend/tests/frontend/paymentSanitize.test.js
@@ -1,0 +1,10 @@
+/** @jest-environment node */
+const fs = require("fs");
+const path = require("path");
+
+test("payment script sanitized for node", () => {
+  const script = fs
+    .readFileSync(path.join(__dirname, "../../../js/payment.js"), "utf8")
+    .replace(/import { track } from ['"]\.\/analytics.js['"];?/, "");
+  expect(script).not.toMatch(/import /);
+});

--- a/backend/tests/frontend/quantityDefault.test.js
+++ b/backend/tests/frontend/quantityDefault.test.js
@@ -19,10 +19,9 @@ function loadDom() {
   });
   global.window = dom.window;
   global.document = dom.window.document;
-  const script = fs.readFileSync(
-    path.join(__dirname, "../../../js/payment.js"),
-    "utf8",
-  );
+  const script = fs
+    .readFileSync(path.join(__dirname, "../../../js/payment.js"), "utf8")
+    .replace(/import { track } from ['"]\.\/analytics.js['"];?/, "");
   dom.window.eval(script);
   return dom;
 }

--- a/backend/tests/frontend/share.test.js
+++ b/backend/tests/frontend/share.test.js
@@ -14,7 +14,8 @@ describe("shareOn", () => {
     dom.window.navigator.share = undefined;
     const src = fs
       .readFileSync(path.join(__dirname, "../../../js/share.js"), "utf8")
-      .replace(/export \{[^}]+\};?/, "");
+      .replace(/export \{[^}]+\};?/, "")
+      .replace(/import { track } from ['"]\.\/analytics.js['"];?/, "");
     dom.window.eval(src);
     return dom.window.shareOn;
   }

--- a/backend/tests/frontend/sharedModel.test.js
+++ b/backend/tests/frontend/sharedModel.test.js
@@ -12,7 +12,8 @@ function setup(url) {
   global.document = dom.window.document;
   const shareSrc = fs
     .readFileSync(path.join(__dirname, "../../../js/share.js"), "utf8")
-    .replace(/export \{[^}]+\};?/, "");
+    .replace(/export \{[^}]+\};?/, "")
+    .replace(/import { track } from ['"]\.\/analytics.js['"];?/, "");
   dom.window.eval(shareSrc);
   let script = fs
     .readFileSync(path.join(__dirname, "../../../js/sharedModel.js"), "utf8")

--- a/backend/tests/frontend/slotCount.test.js
+++ b/backend/tests/frontend/slotCount.test.js
@@ -47,10 +47,9 @@ describe("slot count", () => {
     dom.window.fetch = jest.fn(() =>
       Promise.resolve({ ok: true, json: () => ({ slots: 5 }) }),
     );
-    const scriptSrc = fs.readFileSync(
-      path.join(__dirname, "../../../js/payment.js"),
-      "utf8",
-    );
+    const scriptSrc = fs
+      .readFileSync(path.join(__dirname, "../../../js/payment.js"), "utf8")
+      .replace(/import { track } from ['"]\.\/analytics.js['"];?/, "");
     dom.window.eval(scriptSrc);
     await new Promise((r) => setTimeout(r, 50));
     expect(dom.window.document.getElementById("slot-count").textContent).toBe(
@@ -73,10 +72,9 @@ describe("slot count", () => {
     dom.window.fetch = jest.fn(() =>
       Promise.resolve({ ok: true, json: () => ({ slots: 6 }) }),
     );
-    const scriptSrc = fs.readFileSync(
-      path.join(__dirname, "../../../js/payment.js"),
-      "utf8",
-    );
+    const scriptSrc = fs
+      .readFileSync(path.join(__dirname, "../../../js/payment.js"), "utf8")
+      .replace(/import { track } from ['"]\.\/analytics.js['"];?/, "");
     dom.window.eval(scriptSrc);
     dom.window.localStorage.setItem("slotCycle", cycleKey());
     dom.window.localStorage.setItem("slotPurchases", "2");

--- a/backend/tests/frontend/viewerReady.test.js
+++ b/backend/tests/frontend/viewerReady.test.js
@@ -23,6 +23,8 @@ function setup() {
   let script = fs
     .readFileSync(path.join(__dirname, "../../../js/index.js"), "utf8")
     .replace(/import { shareOn } from ['"]\.\/share.js['"];?/, "")
+    .replace(/import { track } from ['"]\.\/analytics.js['"];?/, "")
+    .replace(/window\.shareOn = shareOn;\n?/, "")
     .replace(/window\.addEventListener\(['"]DOMContentLoaded['"][\s\S]+$/, "")
     .replace(/let savedProfile = null;\n?/, "");
   script += "\nwindow._showModel = showModel;\nwindow._hideAll = hideAll;";


### PR DESCRIPTION
## Summary
- sanitize frontend unit tests so imported scripts work with JSDOM
- add a new paymentSanitize test to prevent regressions

## Testing
- `node scripts/run-jest.js backend/tests/frontend/paymentSanitize.test.js`
- `npm run format --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_687657a6dba0832d9a2e1596707ec9a4