### PR TITLE
Implement free print after referrals

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -580,7 +580,7 @@ app.get("/api/status/:jobId", async (req, res) => {
       req.params.jobId,
     ]);
     if (rows.length === 0) {
-      return res.status(404).json({ error: "Job not found" });
+      return res.status(404).json({ error: "Not found" });
     }
     const job = rows[0];
     res.json({
@@ -2734,7 +2734,7 @@ app.post("/api/create-order", authOptional, async (req, res) => {
       [jobId],
     );
     if (job.rows.length === 0) {
-      return res.status(404).json({ error: "Job not found" });
+      return res.status(404).json({ error: "Not found" });
     }
 
     let totalDiscount = discount || 0;
@@ -2784,6 +2784,8 @@ app.post("/api/create-order", authOptional, async (req, res) => {
         );
         const referralCount = parseInt(counts[0].count, 10) || 0;
         if (referralCount >= 3) {
+          totalDiscount = Math.round((price || 0) * (qty || 1));
+        } else {
           const { rows: existing } = await db.query(
             "SELECT 1 FROM incentives WHERE user_id=$1 AND type LIKE 'free_%' LIMIT 1",
             [referrerId],

--- a/backend/src/routes/models.js
+++ b/backend/src/routes/models.js
@@ -36,7 +36,7 @@ router.post(
       );
       res.status(201).json(result.rows[0]);
     } catch (err) {
-      next(err);
+      res.status(500).json({ error: "Internal Server Error" });
     }
   },
 );

--- a/backend/tests/api.test.js
+++ b/backend/tests/api.test.js
@@ -222,8 +222,6 @@ test("create-order grants free print after three referrals", async () => {
     .mockResolvedValueOnce({ rows: [{ code: "REF123" }] })
     .mockResolvedValueOnce({})
     .mockResolvedValueOnce({ rows: [{ count: "3" }] })
-    .mockResolvedValueOnce({ rows: [] })
-    .mockResolvedValueOnce({ rows: [{ code: "FREE1" }] })
     .mockResolvedValueOnce({});
   db.getUserIdForReferral.mockResolvedValue("u2");
 
@@ -235,11 +233,12 @@ test("create-order grants free print after three referrals", async () => {
   });
 
   expect(res.status).toBe(200);
+  const createCall = stripeMock.checkout.sessions.create.mock.calls.pop()[0];
+  expect(createCall.line_items[0].price_data.unit_amount).toBe(0);
   const incentiveCalls = db.query.mock.calls.filter((c) =>
     c[0].includes("INSERT INTO incentives"),
   );
-  expect(incentiveCalls).toHaveLength(2);
-  expect(incentiveCalls[1][1][1]).toMatch(/^free_/);
+  expect(incentiveCalls).toHaveLength(1);
   expect(db.insertReferredOrder).toHaveBeenCalled();
   expect(db.getUserIdForReferral).toHaveBeenCalledWith("REFCODE");
 });

--- a/backend/tests/api.test.ts
+++ b/backend/tests/api.test.ts
@@ -222,8 +222,6 @@ test("create-order grants free print after three referrals", async () => {
     .mockResolvedValueOnce({ rows: [{ code: "REF123" }] })
     .mockResolvedValueOnce({})
     .mockResolvedValueOnce({ rows: [{ count: "3" }] })
-    .mockResolvedValueOnce({ rows: [] })
-    .mockResolvedValueOnce({ rows: [{ code: "FREE1" }] })
     .mockResolvedValueOnce({});
   db.getUserIdForReferral.mockResolvedValue("u2");
 
@@ -235,11 +233,12 @@ test("create-order grants free print after three referrals", async () => {
   });
 
   expect(res.status).toBe(200);
+  const createCall = stripeMock.checkout.sessions.create.mock.calls.pop()[0];
+  expect(createCall.line_items[0].price_data.unit_amount).toBe(0);
   const incentiveCalls = db.query.mock.calls.filter((c) =>
     c[0].includes("INSERT INTO incentives"),
   );
-  expect(incentiveCalls).toHaveLength(2);
-  expect(incentiveCalls[1][1][1]).toMatch(/^free_/);
+  expect(incentiveCalls).toHaveLength(1);
   expect(db.insertReferredOrder).toHaveBeenCalled();
   expect(db.getUserIdForReferral).toHaveBeenCalledWith("REFCODE");
 });


### PR DESCRIPTION
## Summary
- ensure `/api/models` returns error body on DB failure
- change job not found message to generic 404
- grant free print when a referral has 3 uses
- update API tests for new free print logic

## Testing
- `node scripts/run-jest.js backend/tests/api.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_687667da9fc4832d990827e2357e844f