### PR TITLE
Implement first-order discount

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -2850,11 +2850,12 @@ app.post("/api/create-order", authOptional, async (req, res) => {
     }
 
     if (req.user) {
-      const { rows: paid } = await db.query(
-        "SELECT 1 FROM orders WHERE user_id=$1 AND status=$2 LIMIT 1",
-        [req.user.id, "paid"],
+      const { rows: counts } = await db.query(
+        "SELECT COUNT(*) FROM orders WHERE user_id=$1",
+        [req.user.id],
       );
-      if (paid.length === 0) {
+      const orderCount = parseInt(counts[0].count, 10) || 0;
+      if (orderCount === 0) {
         const firstDisc = Math.round((price || 0) * (qty || 1) * 0.1);
         totalDiscount += firstDisc;
         await db.query("INSERT INTO incentives(user_id, type) VALUES($1,$2)", [

--- a/backend/tests/api.test.js
+++ b/backend/tests/api.test.js
@@ -199,7 +199,7 @@ test("create-order quantity discount", async () => {
 test("create-order applies first-order discount", async () => {
   db.query
     .mockResolvedValueOnce({ rows: [{ job_id: "1", user_id: "u1" }] })
-    .mockResolvedValueOnce({ rows: [] })
+    .mockResolvedValueOnce({ rows: [{ count: "0" }] })
     .mockResolvedValueOnce({})
     .mockResolvedValueOnce({});
   const token = jwt.sign({ id: "u1" }, "secret");
@@ -766,7 +766,7 @@ test("POST /api/create-order saves UTM params", async () => {
 test("create-order inserts commission for marketplace sale", async () => {
   db.query
     .mockResolvedValueOnce({ rows: [{ job_id: "1", user_id: "seller" }] })
-    .mockResolvedValueOnce({ rows: [1] })
+    .mockResolvedValueOnce({ rows: [{ count: "1" }] })
     .mockResolvedValueOnce({});
   db.insertCommission.mockResolvedValueOnce({});
   const token = jwt.sign({ id: "buyer" }, "secret");

--- a/backend/tests/api.test.ts
+++ b/backend/tests/api.test.ts
@@ -199,7 +199,7 @@ test("create-order quantity discount", async () => {
 test("create-order applies first-order discount", async () => {
   db.query
     .mockResolvedValueOnce({ rows: [{ job_id: "1", user_id: "u1" }] })
-    .mockResolvedValueOnce({ rows: [] })
+    .mockResolvedValueOnce({ rows: [{ count: "0" }] })
     .mockResolvedValueOnce({})
     .mockResolvedValueOnce({});
   const token = jwt.sign({ id: "u1" }, "secret");
@@ -766,7 +766,7 @@ test("POST /api/create-order saves UTM params", async () => {
 test("create-order inserts commission for marketplace sale", async () => {
   db.query
     .mockResolvedValueOnce({ rows: [{ job_id: "1", user_id: "seller" }] })
-    .mockResolvedValueOnce({ rows: [1] })
+    .mockResolvedValueOnce({ rows: [{ count: "1" }] })
     .mockResolvedValueOnce({});
   db.insertCommission.mockResolvedValueOnce({});
   const token = jwt.sign({ id: "buyer" }, "secret");


### PR DESCRIPTION
## Summary
- apply 10% discount for first-time orders in `server.js`
- update unit tests to expect order count query

## Testing
- `npm test` in `backend/`
- `SKIP_PW_DEPS=1 npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_687667d7d164832d9a4093fbd8de28fa