### PR TITLE
Fix frontend test imports

### DIFF
--- a/backend/tests/frontend/bulkDiscount.test.js
+++ b/backend/tests/frontend/bulkDiscount.test.js
@@ -1,6 +1,7 @@
 /** @jest-environment node */
 const fs = require("fs");
 const path = require("path");
+const { loadScript } = require("../helpers");
 const { JSDOM } = require("jsdom");
 
 function load() {
@@ -16,10 +17,7 @@ function load() {
   });
   global.window = dom.window;
   global.document = dom.window.document;
-  let script = fs.readFileSync(
-    path.join(__dirname, "../../../js/payment.js"),
-    "utf8",
-  );
+  let script = loadScript("js/payment.js");
   script += "\nwindow._computeBulkDiscount = computeBulkDiscount;";
   dom.window.eval(script);
   return dom;

--- a/backend/tests/frontend/flashBanner.test.js
+++ b/backend/tests/frontend/flashBanner.test.js
@@ -3,6 +3,7 @@ jest.useFakeTimers();
 
 const fs = require("fs");
 const path = require("path");
+const { loadScript } = require("../helpers");
 const { JSDOM } = require("jsdom");
 
 function setupDom() {
@@ -26,10 +27,7 @@ function setupDom() {
   dom.window.setInterval = setInterval;
   dom.window.clearInterval = clearInterval;
   dom.window.Date = Date;
-  const script = fs.readFileSync(
-    path.join(__dirname, "../../../js/payment.js"),
-    "utf8",
-  );
+  let script = loadScript("js/payment.js");
   dom.window.eval(script);
   return dom;
 }

--- a/backend/tests/frontend/index.test.js
+++ b/backend/tests/frontend/index.test.js
@@ -2,6 +2,7 @@
 const fs = require("fs");
 const path = require("path");
 const { JSDOM } = require("jsdom");
+const { loadScript } = require("../helpers");
 
 let html = fs.readFileSync(path.join(__dirname, "../../../index.html"), "utf8");
 html = html
@@ -21,14 +22,12 @@ describe("index validatePrompt", () => {
     });
     global.window = dom.window;
     global.document = dom.window.document;
-    const shareSrc = fs
-      .readFileSync(path.join(__dirname, "../../../js/share.js"), "utf8")
-      .replace(/export \{[^}]+\};?/, "");
+    const shareSrc = loadScript("js/share.js").replace(
+      /export \{[^}]+\};?/,
+      "",
+    );
     dom.window.eval(shareSrc);
-    let script = fs
-      .readFileSync(path.join(__dirname, "../../../js/index.js"), "utf8")
-      .replace(/import { shareOn } from ['"]\.\/share.js['"];?/, "")
-
+    let script = loadScript("js/index.js")
       .replace(/window\.addEventListener\(['"]DOMContentLoaded['"][\s\S]+$/, "")
       .replace(/let savedProfile = null;\n?/, "");
 

--- a/backend/tests/frontend/quantityDefault.test.js
+++ b/backend/tests/frontend/quantityDefault.test.js
@@ -1,6 +1,7 @@
 /** @jest-environment node */
 const fs = require("fs");
 const path = require("path");
+const { loadScript } = require("../helpers");
 const { JSDOM } = require("jsdom");
 
 function loadDom() {
@@ -19,10 +20,7 @@ function loadDom() {
   });
   global.window = dom.window;
   global.document = dom.window.document;
-  const script = fs.readFileSync(
-    path.join(__dirname, "../../../js/payment.js"),
-    "utf8",
-  );
+  let script = loadScript("js/payment.js");
   dom.window.eval(script);
   return dom;
 }

--- a/backend/tests/frontend/share.test.js
+++ b/backend/tests/frontend/share.test.js
@@ -2,6 +2,7 @@
 const fs = require("fs");
 const path = require("path");
 const { JSDOM } = require("jsdom");
+const { loadScript } = require("../helpers");
 
 describe("shareOn", () => {
   function load() {
@@ -12,9 +13,7 @@ describe("shareOn", () => {
     global.window = dom.window;
     global.document = dom.window.document;
     dom.window.navigator.share = undefined;
-    const src = fs
-      .readFileSync(path.join(__dirname, "../../../js/share.js"), "utf8")
-      .replace(/export \{[^}]+\};?/, "");
+    const src = loadScript("js/share.js").replace(/export \{[^}]+\};?/, "");
     dom.window.eval(src);
     return dom.window.shareOn;
   }

--- a/backend/tests/frontend/sharedModel.test.js
+++ b/backend/tests/frontend/sharedModel.test.js
@@ -1,6 +1,7 @@
 /** @jest-environment node */
 const fs = require("fs");
 const path = require("path");
+const { loadScript } = require("../helpers");
 const { JSDOM } = require("jsdom");
 
 function setup(url) {
@@ -10,13 +11,12 @@ function setup(url) {
   });
   global.window = dom.window;
   global.document = dom.window.document;
-  const shareSrc = fs
-    .readFileSync(path.join(__dirname, "../../../js/share.js"), "utf8")
-    .replace(/export \{[^}]+\};?/, "");
+  const shareSrc = loadScript("js/share.js").replace(/export \{[^}]+\};?/, "");
   dom.window.eval(shareSrc);
-  let script = fs
-    .readFileSync(path.join(__dirname, "../../../js/sharedModel.js"), "utf8")
-    .replace(/import { shareOn } from ['"]\.\/share.js['"];?/, "");
+  let script = loadScript("js/sharedModel.js").replace(
+    /import { shareOn } from ['"]\.\/share.js['"];?/,
+    "",
+  );
   dom.window.eval(script);
   return dom;
 }

--- a/backend/tests/frontend/slotCount.test.js
+++ b/backend/tests/frontend/slotCount.test.js
@@ -1,6 +1,7 @@
 /** @jest-environment node */
 const fs = require("fs");
 const path = require("path");
+const { loadScript } = require("../helpers");
 const { JSDOM } = require("jsdom");
 
 let html = fs.readFileSync(
@@ -47,10 +48,7 @@ describe("slot count", () => {
     dom.window.fetch = jest.fn(() =>
       Promise.resolve({ ok: true, json: () => ({ slots: 5 }) }),
     );
-    const scriptSrc = fs.readFileSync(
-      path.join(__dirname, "../../../js/payment.js"),
-      "utf8",
-    );
+    let scriptSrc = loadScript("js/payment.js");
     dom.window.eval(scriptSrc);
     await new Promise((r) => setTimeout(r, 50));
     expect(dom.window.document.getElementById("slot-count").textContent).toBe(
@@ -73,10 +71,7 @@ describe("slot count", () => {
     dom.window.fetch = jest.fn(() =>
       Promise.resolve({ ok: true, json: () => ({ slots: 6 }) }),
     );
-    const scriptSrc = fs.readFileSync(
-      path.join(__dirname, "../../../js/payment.js"),
-      "utf8",
-    );
+    let scriptSrc = loadScript("js/payment.js");
     dom.window.eval(scriptSrc);
     dom.window.localStorage.setItem("slotCycle", cycleKey());
     dom.window.localStorage.setItem("slotPurchases", "2");

--- a/backend/tests/frontend/viewerReady.test.js
+++ b/backend/tests/frontend/viewerReady.test.js
@@ -2,6 +2,7 @@
 const fs = require("fs");
 const path = require("path");
 const { JSDOM } = require("jsdom");
+const { loadScript } = require("../helpers");
 
 let html = fs.readFileSync(path.join(__dirname, "../../../index.html"), "utf8");
 html = html
@@ -20,9 +21,8 @@ function setup() {
   });
   global.window = dom.window;
   global.document = dom.window.document;
-  let script = fs
-    .readFileSync(path.join(__dirname, "../../../js/index.js"), "utf8")
-    .replace(/import { shareOn } from ['"]\.\/share.js['"];?/, "")
+  dom.window.shareOn = () => {};
+  let script = loadScript("js/index.js")
     .replace(/window\.addEventListener\(['"]DOMContentLoaded['"][\s\S]+$/, "")
     .replace(/let savedProfile = null;\n?/, "");
   script += "\nwindow._showModel = showModel;\nwindow._hideAll = hideAll;";

--- a/backend/tests/helpers.js
+++ b/backend/tests/helpers.js
@@ -1,0 +1,9 @@
+const fs = require("fs");
+const path = require("path");
+
+function loadScript(file) {
+  const src = fs.readFileSync(path.join(__dirname, "..", "..", file), "utf8");
+  return src.replace(/^import[^;]+;\n?/gm, "");
+}
+
+module.exports = { loadScript };

--- a/backend/tests/utils/stripImportsFunction.test.js
+++ b/backend/tests/utils/stripImportsFunction.test.js
@@ -1,0 +1,15 @@
+const { loadScript } = require("../helpers");
+
+test("loadScript removes ES module imports", () => {
+  const src = "import foo from './bar.js';\nconst x = 1;";
+  const fs = require("fs");
+  const tmp = require("os").tmpdir();
+  const path = require("path");
+  const file = path.join(tmp, `tmp-${Date.now()}.js`);
+  fs.writeFileSync(file, src);
+  const repoRoot = path.join(__dirname, "..", "..");
+  const rel = path.relative(repoRoot, file);
+  const cleaned = loadScript(rel);
+  fs.unlinkSync(file);
+  expect(cleaned).toBe("const x = 1;");
+});


### PR DESCRIPTION
## Summary
- sanitize imported scripts for jsdom-based frontend tests
- add helper to strip ESM imports
- verify helper works with unit test

## Testing
- `npm run format`
- `node scripts/run-jest.js backend/tests/frontend/flashBanner.test.js`
- `node scripts/run-jest.js backend/tests/frontend/bulkDiscount.test.js`
- `node scripts/run-jest.js backend/tests/frontend/slotCount.test.js`
- `node scripts/run-jest.js backend/tests/frontend/quantityDefault.test.js`
- `node scripts/run-jest.js backend/tests/frontend/share.test.js`
- `node scripts/run-jest.js backend/tests/frontend/sharedModel.test.js`
- `node scripts/run-jest.js backend/tests/utils/stripImportsFunction.test.js`
- `npm test --silent` *(fails: envValidation.test.js, runCoverageScript.test.js, serverLint.test.js, logger.test.js, assertSetup.test.js, checkout.env.test.js, setupValidation.test.js, utils/dailyPrints.test.js, viewerReady.test.js, linting.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_687657bc9388832daadf29e5fcbf0ad2