### PR TITLE
Add test auth middleware setup

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   setupFiles: ["<rootDir>/backend/tests/setupGlobals.js"],
+  setupFilesAfterEnv: ["<rootDir>/test/setupAuthMiddleware.js"],
   coverageThreshold: {
     global: {
       branches: 55,

--- a/test/setupAuthMiddleware.js
+++ b/test/setupAuthMiddleware.js
@@ -1,0 +1,17 @@
+const express = require("express");
+/**
+ *
+ * @param app
+ */
+function setupAuth(app = express.application) {
+  app.use((req, res, next) => {
+    // in CI/tests, we pretend every request is from user "u1"
+    req.user = { id: process.env.TEST_USER_ID || "u1", username: "alice" };
+    next();
+  });
+}
+
+// apply middleware to all Express apps by default
+setupAuth();
+
+module.exports = setupAuth;


### PR DESCRIPTION
## Summary
- add `test/setupAuthMiddleware.js` that injects a fake user
- register new setup in Jest config

## Testing
- `npm run format`
- `npm run format --prefix backend`
- `node scripts/run-jest.js --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_687670dcc258832d91e74f5695b6e574