### PR TITLE
Fix frontend test imports

### DIFF
--- a/backend/tests/frontend/index.test.js
+++ b/backend/tests/frontend/index.test.js
@@ -23,13 +23,13 @@ describe("index validatePrompt", () => {
     global.document = dom.window.document;
     const shareSrc = fs
       .readFileSync(path.join(__dirname, "../../../js/share.js"), "utf8")
-      .replace(/^import[^\n]*\r?\n/gm, "")
+      .replace(/^\s*import[^\n]*\r?\n/gm, "")
       .replace(/export \{[^}]+\};?/, "")
       .replace(/export\s+function/g, "function");
     dom.window.eval(shareSrc);
     let script = fs
       .readFileSync(path.join(__dirname, "../../../js/index.js"), "utf8")
-      .replace(/^import[^\n]*\r?\n/gm, "")
+      .replace(/^\s*import[^\n]*\r?\n/gm, "")
       .replace(/export\s+function/g, "function")
 
       .replace(/window\.addEventListener\(['"]DOMContentLoaded['"][\s\S]+$/, "")


### PR DESCRIPTION
## Summary
- update regex in `index.test.js` to strip imports robustly

## Testing
- `npm test -- -i backend/tests/frontend/index.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68766ef04aac832da441aad115266546