### PR TITLE
Fix bulk discount test

### DIFF
--- a/backend/tests/frontend/bulkDiscount.test.js
+++ b/backend/tests/frontend/bulkDiscount.test.js
@@ -16,10 +16,9 @@ function load() {
   });
   global.window = dom.window;
   global.document = dom.window.document;
-  let script = fs.readFileSync(
-    path.join(__dirname, "../../../js/payment.js"),
-    "utf8",
-  );
+  let script = fs
+    .readFileSync(path.join(__dirname, "../../../js/payment.js"), "utf8")
+    .replace(/^import[^\n]*\n/gm, "");
   script += "\nwindow._computeBulkDiscount = computeBulkDiscount;";
   dom.window.eval(script);
   return dom;


### PR DESCRIPTION
## Summary
- strip ES module import when loading `payment.js` in bulkDiscount test

## Testing
- `npm run format`
- `node scripts/run-jest.js --runInBand --reporters=default`

------
https://chatgpt.com/codex/tasks/task_e_68766e664af4832dac664a33fd399dae