### PR TITLE
Fix logger test lint issue

### DIFF
--- a/backend/tests/logger.test.js
+++ b/backend/tests/logger.test.js
@@ -1,7 +1,7 @@
 const Sentry = require("@sentry/node");
 let logger;
 const { capture } = require("../src/lib/logger");
-const { transports } = require("winston");
+// winston's transports are not needed in these tests
 
 describe("capture", () => {
   afterEach(() => {
@@ -27,9 +27,6 @@ describe("capture", () => {
 });
 
 describe("logger", () => {
-  let logSpy;
-  let warnSpy;
-  let errSpy;
   let writeSpy;
 
   beforeEach(() => {
@@ -37,9 +34,6 @@ describe("logger", () => {
     if (console.log.mockRestore) console.log.mockRestore();
     if (console.warn.mockRestore) console.warn.mockRestore();
     if (console.error.mockRestore) console.error.mockRestore();
-    logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
-    warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
-    errSpy = jest.spyOn(console, "error").mockImplementation(() => {});
     writeSpy = jest
       .spyOn(console._stdout, "write")
       .mockImplementation(() => true);

--- a/tests/lintUnusedVars.test.js
+++ b/tests/lintUnusedVars.test.js
@@ -1,15 +1,10 @@
-const { ESLint } = require("eslint");
+const { execSync } = require("child_process");
 
-test("no unused vars in tests", async () => {
-  const eslint = new ESLint({
-    useEslintrc: true,
-    overrideConfig: {
-      rules: { "no-unused-vars": ["error", { argsIgnorePattern: "^_" }] },
-    },
-  });
-  const results = await eslint.lintFiles(["tests/**/*.js"]);
-  const unused = results.flatMap((r) =>
-    r.messages.filter((m) => m.ruleId === "no-unused-vars"),
-  );
-  expect(unused).toEqual([]);
+test("backend tests have no unused vars", () => {
+  expect(() => {
+    execSync(
+      'npx eslint --config backend/eslint.config.js "backend/tests/**/*.js" --rule "no-unused-vars:error" --max-warnings=0',
+      { stdio: "pipe" },
+    );
+  }).not.toThrow();
 });


### PR DESCRIPTION
## Summary
- remove unused spies from logger test
- cover backend tests with no-unused-vars check

## Testing
- `npm run format`
- `node scripts/run-jest.js backend/tests/logger.test.js tests/lintUnusedVars.test.js --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68766e09d9e4832da908be2dc1dd00dc