### PR TITLE
fix: validate backend deps in test runner

### DIFF
--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -16,6 +16,17 @@ if (!process.env.SKIP_ROOT_DEPS_CHECK) {
   }
 }
 
+try {
+  require.resolve("nodemailer", {
+    paths: [path.join(__dirname, "..", "backend")],
+  });
+} catch {
+  console.error(
+    "Missing backend dependencies. Run 'npm run setup' before running tests.",
+  );
+  process.exit(1);
+}
+
 function verifyFiles(args) {
   const repoRoot = path.resolve(__dirname, "..");
   let checking = false;

--- a/tests/runJestMissingDeps.test.js
+++ b/tests/runJestMissingDeps.test.js
@@ -32,3 +32,25 @@ test("run-jest exits when plugin missing and check skipped", () => {
     fs.renameSync(backupDir, pluginDir);
   }
 });
+
+const nodemailerDir = path.join(
+  __dirname,
+  "..",
+  "backend",
+  "node_modules",
+  "nodemailer",
+);
+const nodemailerBackup = nodemailerDir + ".bak";
+
+test("run-jest exits when nodemailer missing", () => {
+  if (!fs.existsSync(nodemailerDir)) return;
+  fs.renameSync(nodemailerDir, nodemailerBackup);
+  try {
+    const code = run("node", ["scripts/run-jest.js", "tests/dummy.test.js"], {
+      SKIP_ROOT_DEPS_CHECK: "1",
+    });
+    expect(code).not.toBe(0);
+  } finally {
+    fs.renameSync(nodemailerBackup, nodemailerDir);
+  }
+});


### PR DESCRIPTION
## Summary
- ensure `nodemailer` is present before running tests
- test that `run-jest` fails when `nodemailer` is missing

## Testing
- `node scripts/run-jest.js backend/src/__tests__/models.test.js --runInBand`
- `node scripts/run-jest.js tests/runJestMissingDeps.test.js --runInBand`


------
https://chatgpt.com/codex/tasks/task_e_68766de63ed0832dad37fae6e5847449