### PR TITLE
Fix error handler when logger fails

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -15,7 +15,11 @@ app.use((err, req, res, _next) => {
     url: req.originalUrl,
     body: req.body,
   };
-  logger.error("Error handling request", context, err);
+  try {
+    logger.error("Error handling request", context, err);
+  } catch (_logErr) {
+    // ignore logging failures
+  }
   capture(err);
   res.status(500).json({ error: "Internal Server Error" });
 });


### PR DESCRIPTION
## Summary
- handle logger errors inside backend error middleware

## Testing
- `npm run format`
- `npx jest src/__tests__/models.test.js -t "POST /api/models" --runInBand --verbose --coverage=false`

------
https://chatgpt.com/codex/tasks/task_e_68766e957430832db388b3019889f5e1