### PR TITLE
Fix coverage script help handling

### DIFF
--- a/backend/src/routes/models.js
+++ b/backend/src/routes/models.js
@@ -23,22 +23,18 @@ const createModelSchema = z.object({
 
 // expose schema for testing
 router.createModelSchema = createModelSchema;
-router.post(
-  "/api/models",
-  validate(createModelSchema),
-  async (req, res, next) => {
-    try {
-      const { prompt, fileKey } = req.body;
-      const url = `https://${process.env.CLOUDFRONT_DOMAIN}/${fileKey}`;
-      const result = await pool.query(
-        "INSERT INTO models (prompt, url) VALUES ($1, $2) RETURNING *",
-        [prompt, url],
-      );
-      res.status(201).json(result.rows[0]);
-    } catch (err) {
-      res.status(500).json({ error: "Internal Server Error" });
-    }
-  },
-);
+router.post("/api/models", validate(createModelSchema), async (req, res) => {
+  try {
+    const { prompt, fileKey } = req.body;
+    const url = `https://${process.env.CLOUDFRONT_DOMAIN}/${fileKey}`;
+    const result = await pool.query(
+      "INSERT INTO models (prompt, url) VALUES ($1, $2) RETURNING *",
+      [prompt, url],
+    );
+    res.status(201).json(result.rows[0]);
+  } catch (_err) {
+    res.status(500).json({ error: "Internal Server Error" });
+  }
+});
 
 module.exports = router;

--- a/backend/src/utils/incentives.js
+++ b/backend/src/utils/incentives.js
@@ -1,11 +1,11 @@
-function hasOrderedBefore(userId) {
+function hasOrderedBefore(_userId) {
   // placeholder DB call
   return true;
 }
 
-function firstOrderPrice(userId, basePrice) {
+function firstOrderPrice(_userId, basePrice) {
   // pretend you’ve wired up a `hasOrderedBefore` DB call
-  return hasOrderedBefore(userId) ? basePrice : Math.round(basePrice * 0.9);
+  return hasOrderedBefore(_userId) ? basePrice : Math.round(basePrice * 0.9);
 }
 
 function referralPrintPrice(referralCount, basePrice) {

--- a/backend/tests/frontend/bulkDiscount.test.js
+++ b/backend/tests/frontend/bulkDiscount.test.js
@@ -1,4 +1,9 @@
 /** @jest-environment node */
+/**
+ * Calculate bulk discount for a list of order items.
+ * @param {Array<{qty:number, material:string}>} items
+ * @returns {number}
+ */
 function computeBulkDiscount(items) {
   const TWO_PRINT_DISCOUNT = 700;
   const THIRD_PRINT_DISCOUNT = global.window.location.pathname.endsWith(

--- a/backend/tests/runCoverageScript.test.js
+++ b/backend/tests/runCoverageScript.test.js
@@ -47,12 +47,12 @@ describe("run-coverage script", () => {
       ),
     ).toBe(true);
   });
-  test("prints error when showing help", () => {
+  test("shows Jest help output", () => {
     const result = spawnSync(process.execPath, [script, "--help"], {
       env,
       encoding: "utf8",
     });
     expect(result.status).toBe(0);
-    expect(result.stderr + result.stdout).toMatch(/Failed to parse LCOV/);
+    expect(result.stderr + result.stdout).toMatch(/Usage: jest/);
   });
 });

--- a/scripts/run-coverage.js
+++ b/scripts/run-coverage.js
@@ -15,6 +15,18 @@ require("./check-node-version.js");
 require("./assert-setup.js");
 
 const extraArgs = process.argv.slice(2);
+if (extraArgs.includes("--help") || extraArgs.includes("-h")) {
+  const jestBin = path.join(
+    __dirname,
+    "..",
+    "backend",
+    "node_modules",
+    ".bin",
+    "jest",
+  );
+  const result = spawnSync(jestBin, extraArgs, { stdio: "inherit" });
+  process.exit(result.status || 0);
+}
 const jestArgs = [
   "--ci",
   "--coverage",

--- a/test/setupAuthMiddleware.js
+++ b/test/setupAuthMiddleware.js
@@ -1,7 +1,7 @@
 const express = require("express");
 /**
- *
- * @param app
+ * Setup auth middleware by adding a dummy user to each request.
+ * @param {import("express").Application} app Express app to attach middleware to. Defaults to `express.application`.
  */
 function setupAuth(app = express.application) {
   app.use((req, res, next) => {


### PR DESCRIPTION
## Summary
- fix lint errors in miscellaneous files
- ensure `run-coverage.js` exits cleanly when invoked with `--help`
- update the coverage script test

## Testing
- `npm test` (subset via runCoverageScript.test.js)
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68767869cc00832daf50b9c1b632c659