### PR TITLE
Fix npm test helper usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,9 +368,9 @@ To run Jest directly from the repository root, use:
 npm run jest -- --runInBand --silent
 ```
 
-If you encounter environment issues running backend tests, use the helper script
-below. It sets Node 20, validates the environment and saves output to
-`/tmp/test.log`:
+`npm test` uses the helper script below to ensure the environment is prepared.
+You can also invoke it directly to debug issues. It sets Node 20, validates the
+environment and saves output to `/tmp/test.log`:
 
 ```bash
 ./scripts/test-backend.sh

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "pretest": "node scripts/check-repo-root.js && node scripts/assert-setup.js",
     "jest": "node scripts/run-jest.js",
     "test:structure": "jest --runTestsByPath tests/projectStructure.test.js",
-    "test": "npm test --prefix backend",
+    "test": "bash scripts/test-backend.sh",
     "coverage": "npm run coverage --prefix backend",
     "typecheck": "tsc --noEmit",
     "i18n:lint": "node scripts/i18n-lint.js",

--- a/tests/testBackendScript.integration.test.js
+++ b/tests/testBackendScript.integration.test.js
@@ -1,0 +1,23 @@
+const { execFileSync } = require("child_process");
+const path = require("path");
+
+test("test-backend script runs a backend unit test", () => {
+  const script = path.join("scripts", "test-backend.sh");
+  const env = {
+    ...process.env,
+    HF_TOKEN: "x",
+    AWS_ACCESS_KEY_ID: "id",
+    AWS_SECRET_ACCESS_KEY: "secret",
+    DB_URL: "postgres://user:pass@localhost/db",
+    STRIPE_SECRET_KEY: "sk_test",
+    SKIP_NET_CHECKS: "1",
+    SKIP_PW_DEPS: "1",
+    SKIP_DB_CHECK: "1",
+  };
+  delete env.npm_config_http_proxy;
+  delete env.npm_config_https_proxy;
+  execFileSync("bash", [script, "backend/tests/envValidation.test.js"], {
+    stdio: "inherit",
+    env,
+  });
+});


### PR DESCRIPTION
## Summary
- use test-backend helper script for `npm test`
- add integration test covering the helper
- document that `npm test` runs `test-backend.sh`

## Testing
- `npm run format` in `backend/`
- `bash scripts/test-backend.sh backend/tests/envValidation.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6876788f3b04832dbcad28cbaf40f7b4