### PR TITLE
Fix coverage collection and add safeguard test

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,7 @@
   "main": "server.js",
   "scripts": {
     "test": "jest",
-    "test-ci": "jest --ci --coverage --collectCoverageFrom=\"**/*.{js,jsx,ts,tsx}\" --maxWorkers=2 --forceExit",
+    "test-ci": "jest --ci --coverage --maxWorkers=2 --forceExit",
     "coverage": "node ../scripts/run-coverage.js",
     "start": "node server.js",
     "init-db": "node scripts/init-db.js",

--- a/backend/tests/testCiScript.test.js
+++ b/backend/tests/testCiScript.test.js
@@ -1,0 +1,9 @@
+const pkg = require("../package.json");
+
+describe("test-ci script", () => {
+  test("uses jest config coverage settings", () => {
+    expect(pkg.scripts["test-ci"]).toBe(
+      "jest --ci --coverage --maxWorkers=2 --forceExit",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- avoid passing collectCoverageFrom via `test-ci` script
- add regression test verifying `test-ci` uses jest config

## Testing
- `npm test tests/testCiScript.test.js`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68767858adbc832da9c8730462adcff7