### PR TITLE
Fix ensure-root-deps mise trust

### DIFF
--- a/scripts/ensure-root-deps.js
+++ b/scripts/ensure-root-deps.js
@@ -12,6 +12,17 @@ if (currentMajor < requiredMajor) {
   process.exit(1);
 }
 
+try {
+  const repoRoot = path.join(__dirname, "..");
+  execSync(`mise trust ${repoRoot}`, { stdio: "ignore" });
+  const miseToml = path.join(repoRoot, ".mise.toml");
+  if (fs.existsSync(miseToml)) {
+    execSync(`mise trust ${miseToml}`, { stdio: "ignore" });
+  }
+} catch {
+  // ignore errors from mise trust to avoid masking real issues
+}
+
 function getEnv() {
   const env = { ...process.env };
   delete env.npm_config_http_proxy;

--- a/tests/ensureRootDepsTrust.test.js
+++ b/tests/ensureRootDepsTrust.test.js
@@ -1,0 +1,20 @@
+const fs = require("fs");
+const child_process = require("child_process");
+
+jest.mock("fs");
+
+describe("ensure-root-deps mise trust", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    fs.existsSync.mockReturnValue(true);
+    jest.spyOn(child_process, "execSync").mockReset();
+  });
+
+  test("calls mise trust on repo startup", () => {
+    require("../scripts/ensure-root-deps.js");
+    const call = child_process.execSync.mock.calls.find((c) =>
+      String(c[0]).includes("mise trust"),
+    );
+    expect(call).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- run `mise trust` in `ensure-root-deps.js` so new environments trust the repo config
- add test to verify `mise trust` is called

## Testing
- `npm run format`
- `npm run format --prefix backend`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876780582ec832db255db4c6da88146