### PR TITLE
Fix smoke test port conflicts

### DIFF
--- a/scripts/run-smoke.js
+++ b/scripts/run-smoke.js
@@ -98,6 +98,7 @@ function dumpDiagnostics(err) {
 function main() {
   try {
     run("npm run validate-env");
+    freePort(process.env.PORT || 3000);
     if (!process.env.SKIP_SETUP && !fs.existsSync(".setup-complete")) {
       run("npm run setup");
     } else {

--- a/tests/runSmoke.killPort.test.js
+++ b/tests/runSmoke.killPort.test.js
@@ -1,0 +1,20 @@
+const child_process = require("child_process");
+
+beforeEach(() => {
+  jest.resetModules();
+  jest.spyOn(child_process, "execSync").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  delete process.env.SKIP_SETUP;
+  delete process.env.SKIP_PW_DEPS;
+});
+
+test("run-smoke frees port before starting server", () => {
+  process.env.SKIP_SETUP = "1";
+  process.env.SKIP_PW_DEPS = "1";
+  const { main } = require("../scripts/run-smoke.js");
+  main();
+  const commands = child_process.execSync.mock.calls.map((c) => c[0]);
+  expect(commands).toContain("npx -y kill-port 3000");
+});


### PR DESCRIPTION
## Summary
- free port 3000 before starting the smoke test server
- add unit test ensuring port release

## Testing
- `npm run format`
- `node scripts/run-jest.js tests/runSmoke.killPort.test.js`
- `npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_687677d604a4832db84d2c169a1c8966