### PR TITLE
Fix test script to run jest in-band

### DIFF
--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -56,6 +56,9 @@ function runJest(args) {
   if (hasFileArgs && !jestArgs.includes("--runTestsByPath")) {
     jestArgs.unshift("--runTestsByPath");
   }
+  if (!jestArgs.includes("--runInBand")) {
+    jestArgs.push("--runInBand");
+  }
 
   const fileArgs = jestArgs.filter(
     (arg) => arg !== "--runTestsByPath" && !arg.startsWith("-"),

--- a/tests/testScript.test.js
+++ b/tests/testScript.test.js
@@ -1,0 +1,7 @@
+const pkg = require("../package.json");
+
+describe("package.json test script", () => {
+  test("uses run-jest.js", () => {
+    expect(pkg.scripts.test).toBe("node scripts/run-jest.js");
+  });
+});


### PR DESCRIPTION
## Summary
- run jest in-band via `scripts/run-jest.js`
- check test script is wired correctly

## Testing
- `npm run format --prefix backend`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687677ac5570832da6b98bcb4f63b2f0