### PR TITLE
Fix run-jest path handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "pretest": "node scripts/check-repo-root.js && node scripts/assert-setup.js",
     "jest": "node scripts/run-jest.js",
     "test:structure": "jest --runTestsByPath tests/projectStructure.test.js",
-    "test": "npm test --prefix backend",
+    "test": "node scripts/run-jest.js",
     "coverage": "npm run coverage --prefix backend",
     "typecheck": "tsc --noEmit",
     "i18n:lint": "node scripts/i18n-lint.js",

--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -57,10 +57,21 @@ function runJest(args) {
     jestArgs.unshift("--runTestsByPath");
   }
 
-  const runFromRoot = jestArgs.some((arg) => {
+  const fileArgs = jestArgs.filter(
+    (arg) => arg !== "--runTestsByPath" && !arg.startsWith("-"),
+  );
+  const runFromRoot = fileArgs.some((arg) => {
     const abs = path.resolve(repoRoot, arg);
     return !abs.startsWith(backendDir);
   });
+
+  if (!runFromRoot) {
+    jestArgs = jestArgs.map((arg) => {
+      if (arg === "--runTestsByPath" || arg.startsWith("-")) return arg;
+      const abs = path.resolve(repoRoot, arg);
+      return path.relative(backendDir, abs);
+    });
+  }
 
   const cmdArgs = jestArgs.join(" ");
   const env = { ...process.env };


### PR DESCRIPTION
## Summary
- use run-jest for the root test script
- handle file paths correctly in run-jest

## Testing
- `node scripts/run-jest.js tests/dummy.test.js --runInBand`
- `npm run format --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_687677183784832d8a2fc89308fabbd5