### PR TITLE
Fix Stripe key fallback in checkout route

### DIFF
--- a/backend/src/routes/checkout.ts
+++ b/backend/src/routes/checkout.ts
@@ -1,7 +1,7 @@
-import express from 'express';
-import Stripe from 'stripe';
-import { PRODUCT } from '../pricing';
-import { sendMail } from '../../mail';
+import express from "express";
+import Stripe from "stripe";
+import { PRODUCT } from "../pricing";
+import { sendMail } from "../../mail";
 
 export interface Order {
   slug: string;
@@ -11,25 +11,26 @@ export interface Order {
 
 export const orders = new Map<string, Order>();
 
-const secretKey = process.env.NODE_ENV === 'production'
-  ? process.env.STRIPE_LIVE_KEY
-  : process.env.STRIPE_TEST_KEY;
+const secretKey =
+  process.env.NODE_ENV === "production"
+    ? process.env.STRIPE_LIVE_KEY || process.env.STRIPE_SECRET_KEY
+    : process.env.STRIPE_TEST_KEY || process.env.STRIPE_SECRET_KEY;
 if (!secretKey) {
-  throw new Error('Stripe key not configured');
+  throw new Error("Stripe key not configured");
 }
 const stripe = new Stripe(secretKey);
 
 const router = express.Router();
 (router as any).orders = orders;
 
-router.post('/api/checkout', async (req, res, next) => {
+router.post("/api/checkout", async (req, res, next) => {
   try {
     const { slug, email } = req.body as Order;
     if (!slug || !email) {
-      return res.status(400).json({ error: 'missing fields' });
+      return res.status(400).json({ error: "missing fields" });
     }
     const session = await stripe.checkout.sessions.create({
-      mode: 'payment',
+      mode: "payment",
       line_items: [
         {
           price_data: {
@@ -52,29 +53,29 @@ router.post('/api/checkout', async (req, res, next) => {
 });
 
 router.post(
-  '/api/stripe/webhook',
-  express.raw({ type: 'application/json' }),
+  "/api/stripe/webhook",
+  express.raw({ type: "application/json" }),
   async (req, res, next) => {
     try {
-      const sig = req.headers['stripe-signature'] as string;
+      const sig = req.headers["stripe-signature"] as string;
       const event = stripe.webhooks.constructEvent(
         req.body,
         sig,
-        process.env.STRIPE_WEBHOOK_SECRET || '',
+        process.env.STRIPE_WEBHOOK_SECRET || "",
       );
-      if (event.type === 'checkout.session.completed') {
+      if (event.type === "checkout.session.completed") {
         const session = event.data.object as Stripe.Checkout.Session;
         const order = orders.get(session.id);
         if (order && !order.paid) {
           order.paid = true;
           const link = `https://huggingface.co/spaces/print2/Sparc3D/resolve/main/output/${order.slug}.glb`;
-          await sendMail(order.email, 'Your model is ready', link);
+          await sendMail(order.email, "Your model is ready", link);
         }
       }
       res.sendStatus(200);
     } catch (err) {
       // signature errors should return 400
-      if (err instanceof Error && err.message.includes('Webhook Error')) {
+      if (err instanceof Error && err.message.includes("Webhook Error")) {
         return res.sendStatus(400);
       }
       next(err);

--- a/backend/tests/checkout.env.test.js
+++ b/backend/tests/checkout.env.test.js
@@ -18,6 +18,16 @@ describe("checkout env validation", () => {
       jest.isolateModules(() => require("../src/routes/checkout"));
     }).not.toThrow();
   });
+  test("throws when all stripe keys are missing", () => {
+    const secret = process.env.STRIPE_SECRET_KEY;
+    delete process.env.STRIPE_TEST_KEY;
+    delete process.env.STRIPE_LIVE_KEY;
+    delete process.env.STRIPE_SECRET_KEY;
+    expect(() => {
+      jest.isolateModules(() => require("../src/routes/checkout"));
+    }).toThrow("Stripe key not configured");
+    process.env.STRIPE_SECRET_KEY = secret;
+  });
   test("router exposes orders map", () => {
     process.env.STRIPE_TEST_KEY = "sk_test";
     jest.isolateModules(() => {


### PR DESCRIPTION
## Summary
- load fallback Stripe secret key from `STRIPE_SECRET_KEY`
- verify fallback behavior in checkout env tests

## Testing
- `npm test`
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_687677c9776c832d8b77225df31504e5