### PR TITLE
Fix frontend test regressions

### DIFF
--- a/backend/src/__tests__/models.test.js
+++ b/backend/src/__tests__/models.test.js
@@ -9,7 +9,13 @@ const mPool = { query: jest.fn() };
 Pool.mockImplementation(() => mPool);
 
 const request = require("supertest");
-const app = require("../app");
+let app;
+
+beforeEach(() => {
+  jest.isolateModules(() => {
+    app = require("../app");
+  });
+});
 
 afterEach(() => {
   jest.clearAllMocks();

--- a/backend/tests/frontend/components/CheckoutForm.test.js
+++ b/backend/tests/frontend/components/CheckoutForm.test.js
@@ -18,6 +18,7 @@ const src = fs.readFileSync(
   "utf8",
 );
 const { code } = babel.transformSync(src, {
+  filename: "CheckoutForm.js",
   presets: [["@babel/preset-react", { runtime: "automatic" }]],
   plugins: [
     ["@babel/plugin-syntax-typescript", { isTSX: true }],

--- a/backend/tests/frontend/viewerReady.test.js
+++ b/backend/tests/frontend/viewerReady.test.js
@@ -25,8 +25,13 @@ function setup() {
     .readFileSync(path.join(__dirname, "../../../js/index.js"), "utf8")
     .replace(/^import[^\n]*\n/gm, "")
     .replace(/window\.addEventListener\(['"]DOMContentLoaded['"][\s\S]+$/, "")
-    .replace(/let savedProfile = null;\n?/, "");
-  script += "\nwindow._showModel = showModel;\nwindow._hideAll = hideAll;";
+    .replace(/let savedProfile = null;\n?/, "")
+    .replace(
+      /await ensureModelViewerLoaded\(\)/,
+      "await window.ensureModelViewerLoaded()",
+    );
+  script +=
+    "\nwindow._showModel = showModel;\nwindow._hideAll = hideAll;\nwindow.ensureModelViewerLoaded = ensureModelViewerLoaded;";
   dom.window.eval(script);
   return dom;
 }

--- a/js/index.js
+++ b/js/index.js
@@ -876,8 +876,12 @@ async function init() {
     if (globalThis.document) {
       document.body.dataset.viewerReady = "error";
     }
+    return;
   }
-  if (window.customElements?.whenDefined) {
+  if (
+    window.customElements?.whenDefined &&
+    window.customElements.get?.("model-viewer")
+  ) {
     try {
       await customElements.whenDefined("model-viewer");
     } catch {}


### PR DESCRIPTION
## Summary
- provide filename to Babel for CheckoutForm test
- patch viewerReady test to override module loading
- reload app per test in models test
- avoid hang in init when model-viewer fails

## Testing
- `node scripts/run-jest.js backend/tests/frontend/viewerReady.test.js`
- `node scripts/run-jest.js backend/tests/frontend/components/CheckoutForm.test.js`
- `node scripts/run-jest.js backend/src/__tests__/models.test.js`
- `node scripts/run-jest.js tests/runCoverageScript.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68766e822250832dbbbb80282409cae6