### PR TITLE
Apply first order discount

### DIFF
--- a/backend/src/routes/stripe/create-checkout-session.ts
+++ b/backend/src/routes/stripe/create-checkout-session.ts
@@ -1,24 +1,51 @@
-import { Router } from 'express';
-import Stripe from 'stripe';
-import db from '../../db';
+import { Router } from "express";
+import Stripe from "stripe";
+import db from "../../db";
 
 const router = Router();
-const stripe = new Stripe(process.env.STRIPE_KEY as string, { apiVersion: '2022-11-15' });
+const stripe = new Stripe(process.env.STRIPE_KEY as string, {
+  apiVersion: "2022-11-15",
+});
 
-router.post('/api/create-checkout-session', async (req, res, next) => {
+router.post("/api/create-checkout-session", async (req, res, next) => {
   try {
-    const { price, qty = 1, metadata = {} } = req.body;
-    const session = await stripe.checkout.sessions.create({
-      mode: 'payment',
-      payment_method_types: ['card'],
+    const { price, qty = 1, metadata = {}, userId } = req.body;
+
+    let unitAmount = price;
+    if (userId) {
+      const { rows } = await db.query(
+        "SELECT COUNT(*) FROM orders WHERE user_id=$1",
+        [userId],
+      );
+      const orderCount = parseInt(rows[0].count, 10) || 0;
+      if (orderCount === 0) {
+        unitAmount = Math.floor(unitAmount * 0.9);
+      }
+    }
+
+    const sessionParams = {
+      mode: "payment",
+      payment_method_types: ["card"],
       line_items: [
-        { price_data: { currency: 'usd', unit_amount: price, product_data: { name: 'Print Job' } }, quantity: qty },
+        {
+          price_data: {
+            currency: "usd",
+            unit_amount: unitAmount,
+            product_data: { name: "Print Job" },
+          },
+          quantity: qty,
+        },
       ],
       metadata,
-      success_url: 'https://example.com/success',
-      cancel_url: 'https://example.com/cancel',
-    });
-    await db.query('INSERT INTO orders(session_id,status) VALUES($1,$2)', [session.id, 'created']);
+      success_url: "https://example.com/success",
+      cancel_url: "https://example.com/cancel",
+    };
+
+    const session = await stripe.checkout.sessions.create(sessionParams);
+    await db.query("INSERT INTO orders(session_id,status) VALUES($1,$2)", [
+      session.id,
+      "created",
+    ]);
     res.json({ id: session.id, url: session.url });
   } catch (err: any) {
     next(err);

--- a/backend/tests/api.test.ts
+++ b/backend/tests/api.test.ts
@@ -208,7 +208,9 @@ test("create-order applies first-order discount", async () => {
     .set("authorization", `Bearer ${token}`)
     .send({ jobId: "1", price: 100, qty: 1, productType: "single" });
   const createCall = stripeMock.checkout.sessions.create.mock.calls.pop()[0];
-  expect(createCall.line_items[0].price_data.unit_amount).toBe(90);
+  expect(createCall.line_items[0].price_data.unit_amount).toBe(
+    Math.floor(100 * 0.9),
+  );
   const orderInsert = db.query.mock.calls.find((c) =>
     c[0].includes("INSERT INTO orders"),
   );


### PR DESCRIPTION
## Summary
- add first-order discount logic in create-checkout-session
- test that first order gets 10% off

## Testing
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` (partial output due to Prettier)
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6876824f6440832dbc505769f4298141