### PR TITLE
Add JSON summary step to coverage script

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,7 +13,7 @@ jobs:
       - run: SKIP_PW_DEPS=1 npm run setup
       - run: npm run coverage
       - name: Validate coverage-summary.json
-        run: node -e "JSON.parse(require('fs').readFileSync('backend/coverage/coverage-summary.json','utf-8')); console.log('✅ JSON ok')"
+        run: node -e "JSON.parse(require('fs').readFileSync('coverage/coverage-summary.json','utf-8')); console.log('✅ JSON ok')"
       - name: Check coverage thresholds
         run: node scripts/check-coverage.js
       - name: Validate LCOV report

--- a/backend/__tests__/coverageSummaryExists.test.js
+++ b/backend/__tests__/coverageSummaryExists.test.js
@@ -1,6 +1,6 @@
 const fs = require("fs");
 
-const summary = "backend/coverage/coverage-summary.json";
+const summary = "coverage/coverage-summary.json";
 
 (process.env.CI ? test : test.skip)("coverage summary exists", () => {
   expect(fs.existsSync(summary)).toBe(true);

--- a/scripts/run-coverage.js
+++ b/scripts/run-coverage.js
@@ -72,12 +72,17 @@ if (start === -1) {
 output = output.slice(start);
 fs.writeFileSync(lcovPath, output);
 console.log(`LCOV written to ${lcovPath}`);
-const summaryPath = path.join(
-  repoRoot,
-  "backend",
-  "coverage",
-  "coverage-summary.json",
+// Generate a repo root summary for CI badges and coverage checks.
+const nyc = spawnSync(
+  "npx",
+  ["-y", "nyc", "report", "--reporter=json-summary", "--report-dir=coverage"],
+  { cwd: repoRoot, stdio: "inherit" },
 );
+if (nyc.status) {
+  console.error(`nyc report failed with code ${nyc.status}`);
+  process.exit(nyc.status);
+}
+const summaryPath = path.join(repoRoot, "coverage", "coverage-summary.json");
 if (!fs.existsSync(summaryPath)) {
   console.error(`Missing coverage summary: ${summaryPath}`);
   process.exit(1);

--- a/tests/runCoverageScript.test.js
+++ b/tests/runCoverageScript.test.js
@@ -24,7 +24,7 @@ describe("run-coverage script", () => {
       },
     );
     const lcov = path.join("coverage", "lcov.info");
-    const summary = path.join("backend", "coverage", "coverage-summary.json");
+    const summary = path.join("coverage", "coverage-summary.json");
     expect(fs.existsSync(lcov)).toBe(true);
     expect(fs.existsSync(summary)).toBe(true);
     const logs = fs.readFileSync(logFile, "utf8");


### PR DESCRIPTION
## Summary
- ensure `coverage/coverage-summary.json` is generated
- update the CI workflow and tests to expect the root summary

## Testing
- `npm run format`
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_68768258e098832db29fde5a070171ef