### PR TITLE
Fix NODE_PATH for root tests

### DIFF
--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -79,7 +79,11 @@ function runJest(args) {
   const cmdArgs = jestArgs.join(" ");
   const env = { ...process.env };
   if (runFromRoot) {
-    env.NODE_PATH = [path.join(repoRoot, "node_modules"), env.NODE_PATH || ""]
+    env.NODE_PATH = [
+      path.join(repoRoot, "node_modules"),
+      path.join(backendDir, "node_modules"),
+      env.NODE_PATH || "",
+    ]
       .filter(Boolean)
       .join(path.delimiter);
   }

--- a/tests/dummyBackendDeps.test.js
+++ b/tests/dummyBackendDeps.test.js
@@ -1,0 +1,9 @@
+const axios = require("axios");
+const dotenv = require("dotenv");
+const forwarded = require("forwarded");
+
+test("backend deps resolve", () => {
+  expect(typeof axios).toBe("function");
+  expect(typeof dotenv.config).toBe("function");
+  expect(typeof forwarded).toBe("function");
+});

--- a/tests/runJestBackendDepsResolution.test.js
+++ b/tests/runJestBackendDepsResolution.test.js
@@ -1,0 +1,26 @@
+const { execFileSync } = require("child_process");
+const path = require("path");
+
+const repoRoot = path.resolve(__dirname, "..");
+const script = path.join("scripts", "run-jest.js");
+
+const env = {
+  ...process.env,
+  HF_TOKEN: "test",
+  AWS_ACCESS_KEY_ID: "id",
+  AWS_SECRET_ACCESS_KEY: "secret",
+  SKIP_NET_CHECKS: "1",
+};
+
+delete env.npm_config_http_proxy;
+delete env.npm_config_https_proxy;
+
+test("run-jest resolves backend node_modules for root tests", () => {
+  expect(() =>
+    execFileSync("node", [script, "tests/dummyBackendDeps.test.js"], {
+      cwd: repoRoot,
+      stdio: "inherit",
+      env,
+    }),
+  ).not.toThrow();
+});


### PR DESCRIPTION
## Summary
- ensure run-jest includes backend `node_modules`
- add regression test confirming backend deps resolve

## Testing
- `npm run format`
- `node scripts/run-jest.js tests/runJestBackendDepsResolution.test.js`

------
https://chatgpt.com/codex/tasks/task_e_687687ea8ff8832d9b612b4409706d7d