### PR TITLE
Fix prettier format script ignoring root config

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -12,7 +12,7 @@
     "seed": "node scripts/seed-db.js",
     "create-admin": "node scripts/create-admin.js",
     "preformat": "node ../scripts/ensure-root-deps.js",
-    "format": "node -e \"const path=require('path');process.chdir('..');require(path.join(process.cwd(),'scripts/ensure-root-deps.js'))\" && prettier --log-level warn --write \"**/*.{js,jsx,json,md}\"",
+    "format": "sh -c 'cd .. && node scripts/ensure-root-deps.js && prettier --log-level warn --write \"**/*.{js,jsx,json,md}\" --ignore-path .prettierignore'",
     "send-reminders": "node scripts/send-purchase-reminders.js",
     "send-abandoned-offers": "node scripts/send-abandoned-offers.js",
     "send-followups": "node scripts/send-post-purchase-followups.js",
@@ -35,7 +35,7 @@
     "send-ops-report": "node scripts/send-ops-report.js",
     "flag-overdue-printers": "node scripts/flag-overdue-procurement-orders.js",
     "pretest": "node scripts/ensure-deps.js",
-    "format:check": "prettier --log-level warn --check \"**/*.{js,jsx,json,md}\""
+    "format:check": "sh -c 'cd .. && prettier --log-level warn --check \"**/*.{js,jsx,json,md}\" --ignore-path .prettierignore'"
   },
   "keywords": [],
   "author": "",

--- a/backend/tests/formatScript.test.js
+++ b/backend/tests/formatScript.test.js
@@ -6,4 +6,14 @@ describe("format script", () => {
       execSync("npm run format --silent", { cwd: __dirname + "/.." });
     }).not.toThrow();
   });
+
+  test("does not modify ignored files", () => {
+    const fs = require("fs");
+    const path = require("path");
+    const file = path.join(__dirname, "..", "..", "scripts", "ci_watchdog.js");
+    const before = fs.readFileSync(file, "utf8");
+    execSync("npm run format --silent", { cwd: path.join(__dirname, "..") });
+    const after = fs.readFileSync(file, "utf8");
+    expect(after).toBe(before);
+  });
 });


### PR DESCRIPTION
## Summary
- ensure backend `npm run format` uses root .prettierignore
- add regression test for the formatting script

## Testing
- `npm run format`
- `npm test tests/formatScript.test.js`


------
https://chatgpt.com/codex/tasks/task_e_687687c67530832d855083cce960a1c8