### PR TITLE
Fix stripeWebhook test env isolation

### DIFF
--- a/backend/tests/stripeWebhook.test.js
+++ b/backend/tests/stripeWebhook.test.js
@@ -1,9 +1,10 @@
 test("test env provides STRIPE_WEBHOOK_SECRET", () => {
   const original = process.env.STRIPE_WEBHOOK_SECRET;
   process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
-  jest.resetModules();
-  const config = require("../config");
-  expect(config.stripeWebhook).toBe("whsec");
+  jest.isolateModules(() => {
+    const config = require("../config");
+    expect(config.stripeWebhook).toBe("whsec");
+  });
   if (original === undefined) {
     delete process.env.STRIPE_WEBHOOK_SECRET;
   } else {


### PR DESCRIPTION
## Summary
- isolate config module in `stripeWebhook.test.js` to avoid picking up CI secrets

## Testing
- `npm run format` in `backend/`
- `node scripts/run-jest.js backend/tests/stripeWebhook.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68768dda5270832da195d7272da21a4e