### PR TITLE
Fix coverage script paths

### DIFF
--- a/scripts/check-coverage.js
+++ b/scripts/check-coverage.js
@@ -2,16 +2,10 @@ const fs = require("fs");
 
 const config = JSON.parse(fs.readFileSync(".nycrc", "utf8"));
 
-const possiblePaths = [
-  "backend/coverage/coverage-summary.json",
-  "coverage/coverage-summary.json",
-];
-const summaryPath = possiblePaths.find((p) => fs.existsSync(p));
-if (!summaryPath) {
+const summaryPath = "coverage/coverage-summary.json";
+if (!fs.existsSync(summaryPath)) {
   console.error(
-    `Missing coverage summary: ${possiblePaths.join(
-      " or ",
-    )}\nRun 'npm run coverage' first to generate it.`,
+    `Missing coverage summary: ${summaryPath}\nRun 'npm run coverage' first to generate it.`,
   );
   process.exit(1);
 }

--- a/scripts/run-coverage.js
+++ b/scripts/run-coverage.js
@@ -3,7 +3,7 @@ const { spawnSync } = require("child_process");
 const fs = require("fs");
 const path = require("path");
 
-const repoRoot = path.join(__dirname, "..");
+const repoRoot = path.resolve(__dirname, "..");
 
 // Ensure the active Node version matches the project's requirement so the
 // coverage run doesn't silently use a wrong version when mise wasn't activated.

--- a/tests/checkCoverageScript.test.js
+++ b/tests/checkCoverageScript.test.js
@@ -2,13 +2,7 @@ const { execFileSync } = require("child_process");
 const fs = require("fs");
 const path = require("path");
 
-const summary = path.join(
-  __dirname,
-  "..",
-  "backend",
-  "coverage",
-  "coverage-summary.json",
-);
+const summary = path.join(__dirname, "..", "coverage", "coverage-summary.json");
 const backup = summary + ".bak";
 const nycrc = path.join(__dirname, "..", ".nycrc");
 const nycBackup = nycrc + ".bak";


### PR DESCRIPTION
## Summary
- update coverage artifact paths
- check coverage summary only at repo root

## Testing
- `npm run format`
- `npm test ../tests/checkCoverageScript.test.js tests/runCoverageScript.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68768dd04bb8832dbc5b97708a6e699b