### PR TITLE
Add coverage tests for create-order and incentives utils

### DIFF
--- a/backend/tests/createOrder.additional.test.js
+++ b/backend/tests/createOrder.additional.test.js
@@ -1,0 +1,57 @@
+process.env.STRIPE_SECRET_KEY = "test";
+process.env.DB_URL = "postgres://user:pass@localhost/db";
+
+jest.mock("../db", () => ({
+  query: jest.fn(),
+  getUserIdForReferral: jest.fn(),
+  insertReferredOrder: jest.fn(),
+  getSubscription: jest.fn(),
+  ensureCurrentWeekCredits: jest.fn(),
+  getCurrentWeekCredits: jest.fn(),
+  incrementCreditsUsed: jest.fn(),
+}));
+const db = require("../db");
+
+jest.mock("stripe");
+const Stripe = require("stripe");
+const stripeMock = {
+  checkout: {
+    sessions: { create: jest.fn().mockResolvedValue({ id: "cs", url: "url" }) },
+  },
+};
+Stripe.mockImplementation(() => stripeMock);
+
+const request = require("supertest");
+const app = require("../server");
+const jwt = require("jsonwebtoken");
+
+describe("create-order extras", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("repeat customer does not get first order discount", async () => {
+    db.query
+      .mockResolvedValueOnce({ rows: [{ job_id: "1", user_id: "u1" }] })
+      .mockResolvedValueOnce({ rows: [{ count: "2" }] })
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({});
+    const token = jwt.sign({ id: "u1" }, "secret");
+    await request(app)
+      .post("/api/create-order")
+      .set("authorization", `Bearer ${token}`)
+      .send({ jobId: "1", price: 100, qty: 1, productType: "single" });
+    const createCall = stripeMock.checkout.sessions.create.mock.calls.pop()[0];
+    expect(createCall.line_items[0].price_data.unit_amount).toBe(100);
+    const incentive = db.query.mock.calls.find(
+      (c) =>
+        c[0].includes("INSERT INTO incentives") && c[1][1] === "first_order",
+    );
+    expect(incentive).toBeUndefined();
+    const orderInsert = db.query.mock.calls.find((c) =>
+      c[0].includes("INSERT INTO orders"),
+    );
+    expect(orderInsert[1][3]).toBe(100);
+    expect(orderInsert[1][7]).toBe(0);
+  });
+});

--- a/backend/tests/utils/incentives.test.js
+++ b/backend/tests/utils/incentives.test.js
@@ -1,0 +1,15 @@
+const incentives = require("../../src/utils/incentives");
+
+describe("incentives utilities", () => {
+  test("firstOrderPrice leaves price unchanged when user ordered before", () => {
+    expect(incentives.firstOrderPrice("u1", 100)).toBe(100);
+  });
+
+  test("referralPrintPrice returns base price below threshold", () => {
+    expect(incentives.referralPrintPrice(2, 120)).toBe(120);
+  });
+
+  test("referralPrintPrice is free after three referrals", () => {
+    expect(incentives.referralPrintPrice(3, 50)).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add regression tests for repeating customer checkout
- cover referral/incentive helpers

## Testing
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68769ef35980832d93a5d125c360430b