### PR TITLE
Fix npm ci failure in codeql workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,7 +28,7 @@ jobs:
           languages: javascript-typescript
       - name: Build
         run: |
-          npm ci
+          node scripts/run-npm-ci.js
           npm run build
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3.29.2

--- a/tests/codeqlWorkflow.test.js
+++ b/tests/codeqlWorkflow.test.js
@@ -33,4 +33,18 @@ describe("codeql workflow", () => {
     );
     expect(hasCheck).toBe(true);
   });
+
+  test("uses run-npm-ci helper in build step", () => {
+    const file = path.join(
+      __dirname,
+      "..",
+      ".github",
+      "workflows",
+      "codeql.yml",
+    );
+    const yml = YAML.parse(fs.readFileSync(file, "utf8"));
+    const steps = yml.jobs.analyze.steps.map((s) => s.run || "");
+    const hasHelper = steps.some((cmd) => cmd.includes("run-npm-ci.js"));
+    expect(hasHelper).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- run fallback `npm ci` script in `codeql.yml`
- check `codeql` workflow uses the helper

## Testing
- `npm run format`
- `npm test --prefix backend` *(output truncated due to long lines)*

------
https://chatgpt.com/codex/tasks/task_e_6876b46463e0832da5504ebadab8731b