### PR TITLE
Fix CodeQL npm install

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,7 +28,7 @@ jobs:
           languages: javascript-typescript
       - name: Build
         run: |
-          npm ci
+          node scripts/run-npm-ci.js
           npm run build
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3.29.2

--- a/tests/codeqlWorkflow.test.js
+++ b/tests/codeqlWorkflow.test.js
@@ -33,4 +33,20 @@ describe("codeql workflow", () => {
     );
     expect(hasCheck).toBe(true);
   });
+
+  test("uses run-npm-ci.js for installs", () => {
+    const file = path.join(
+      __dirname,
+      "..",
+      ".github",
+      "workflows",
+      "codeql.yml",
+    );
+    const yml = YAML.parse(fs.readFileSync(file, "utf8"));
+    const steps = yml.jobs.analyze.steps.map((s) => s.run || "");
+    const hasScript = steps.some((cmd) =>
+      cmd.trim().startsWith("node scripts/run-npm-ci.js"),
+    );
+    expect(hasScript).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- use run-npm-ci.js in the CodeQL workflow
- check CodeQL workflow for the new install step

## Testing
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6876b46463e0832da5504ebadab8731b