### PR TITLE
Fix logger JSON output

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -4,23 +4,54 @@ const isTest = process.env.NODE_ENV === "test";
 const level = process.env.LOG_LEVEL || (isTest ? "error" : "info");
 const consoleTransport = new transports.Console({ silent: isTest });
 
-const logger = createLogger({
+const baseLogger = createLogger({
   level,
   format: format.combine(format.timestamp(), format.json()),
   transports: [consoleTransport],
 });
 
-// During tests, avoid writing to console to prevent Jest spies from failing
-// when logger methods are invoked. The logger transport is already silenced
-// in test mode, so we skip the console wrapper entirely.
-if (!isTest) {
-  ["info", "warn", "error"].forEach((method) => {
-    const orig = logger[method].bind(logger);
-    logger[method] = (...args) => {
-      console[method](...args);
-      return orig(...args);
-    };
+// Format a log entry and send to console in JSON form
+function output(level, msg, meta = {}) {
+  const { code, ...rest } = meta;
+  const entry = {
+    timestamp: new Date().toISOString(),
+    level,
+    message: msg,
+    ...(code ? { code } : {}),
+    ...rest,
+  };
+  const str = JSON.stringify(entry);
+  if (level === "error") {
+    console.error(str);
+  } else {
+    console.log(str);
+  }
+  baseLogger.log({
+    level,
+    message: msg,
+    ...(code ? { code } : {}),
+    ...rest,
+    timestamp: entry.timestamp,
   });
 }
+
+const logger = {
+  info: (msg, meta) => {
+    if (isTest) return baseLogger.info(msg, meta);
+    output("info", msg, meta);
+  },
+  warn: (msg, meta) => {
+    if (isTest) return baseLogger.warn(msg, meta);
+    output("warn", msg, meta);
+  },
+  error: (msg, meta) => {
+    if (isTest) return baseLogger.error(msg, meta);
+    output("error", msg, meta);
+  },
+  add: (...args) => baseLogger.add(...args),
+  remove: (...args) => baseLogger.remove(...args),
+  transports: baseLogger.transports,
+  level: baseLogger.level,
+};
 
 module.exports = logger;


### PR DESCRIPTION
## Summary
- output structured logs for console messages

## Testing
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_6876be43f8ac832d835c76e67f15125a