### PR TITLE
Fix coverage output paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
       "text",
       "json-summary"
     ],
+    "report-dir": "coverage",
     "check-coverage": false,
     "branches": 0,
     "functions": 0,

--- a/scripts/run-coverage.js
+++ b/scripts/run-coverage.js
@@ -89,7 +89,8 @@ if (!fs.existsSync(backendSummary)) {
 }
 const summaryPath = path.join(repoRoot, "coverage", "coverage-summary.json");
 fs.mkdirSync(path.dirname(summaryPath), { recursive: true });
-fs.copyFileSync(backendSummary, summaryPath);
+const summaryData = fs.readFileSync(backendSummary);
+fs.writeFileSync(summaryPath, summaryData);
 if (result.status) {
   console.error(`Jest exited with code ${result.status}`);
   process.exit(result.status);


### PR DESCRIPTION
## Summary
- configure nyc to emit files in `coverage/`
- write coverage summary JSON explicitly in `run-coverage.js`

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_6876be3d5510832d947eec5506d3d315