### PR TITLE
Fix first order discount logic

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -2864,8 +2864,8 @@ app.post("/api/create-order", authOptional, async (req, res, next) => {
         [req.user.id],
       );
       const orderCount = parseInt(counts[0].count, 10) || 0;
-      if (orderCount === 0) {
-        const firstDisc = Math.round((price || 0) * (qty || 1) * 0.1);
+      if (orderCount === 0 && (qty || 1) === 1) {
+        const firstDisc = Math.round((price || 0) * 0.1);
         totalDiscount += firstDisc;
         await db.query("INSERT INTO incentives(user_id, type) VALUES($1,$2)", [
           req.user.id,


### PR DESCRIPTION
## Summary
- handle first-order discount only for single prints

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876be405f5c832d9e2c9ee137bc0070