### PR TITLE
Fix failing coverage tests

### DIFF
--- a/backend/tests/additionalApi.test.js
+++ b/backend/tests/additionalApi.test.js
@@ -53,7 +53,7 @@ beforeEach(() => {
 
 test("GET /api/my/models returns models", async () => {
   db.query.mockResolvedValueOnce({ rows: [{ job_id: "j1" }] });
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .get("/api/my/models")
     .set("authorization", `Bearer ${token}`);
@@ -65,7 +65,7 @@ test("GET /api/my/models includes snapshot", async () => {
   db.query.mockResolvedValueOnce({
     rows: [{ job_id: "j1", snapshot: "snap.png" }],
   });
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .get("/api/my/models")
     .set("authorization", `Bearer ${token}`);
@@ -80,7 +80,7 @@ test("GET /api/my/models requires auth", async () => {
 
 test("GET /api/my/models ordered by date", async () => {
   db.query.mockResolvedValueOnce({ rows: [] });
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   await request(app)
     .get("/api/my/models")
     .set("authorization", `Bearer ${token}`);
@@ -92,7 +92,7 @@ test("GET /api/my/models ordered by date", async () => {
 
 test("GET /api/my/models supports pagination", async () => {
   db.query.mockResolvedValueOnce({ rows: [] });
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   await request(app)
     .get("/api/my/models?limit=5&offset=2")
     .set("authorization", `Bearer ${token}`);
@@ -108,7 +108,7 @@ test("GET /api/my/models returns models sorted by date", async () => {
     { job_id: "j1", created_at: "2024-01-01" },
   ];
   db.query.mockResolvedValueOnce({ rows });
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .get("/api/my/models")
     .set("authorization", `Bearer ${token}`);
@@ -118,7 +118,7 @@ test("GET /api/my/models returns models sorted by date", async () => {
 
 test("GET /api/profile returns profile", async () => {
   db.query.mockResolvedValueOnce({ rows: [{ display_name: "A" }] });
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .get("/api/profile")
     .set("authorization", `Bearer ${token}`);
@@ -128,7 +128,7 @@ test("GET /api/profile returns profile", async () => {
 
 test("GET /api/profile 404 when missing", async () => {
   db.query.mockResolvedValueOnce({ rows: [] });
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .get("/api/profile")
     .set("authorization", `Bearer ${token}`);
@@ -191,7 +191,7 @@ test("POST /api/models/:id/like adds like", async () => {
     .mockResolvedValueOnce({ rows: [] })
     .mockResolvedValueOnce({})
     .mockResolvedValueOnce({ rows: [{ count: "1" }] });
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .post("/api/models/j1/like")
     .set("authorization", `Bearer ${token}`)
@@ -205,7 +205,7 @@ test("POST /api/models/:id/like removes like", async () => {
     .mockResolvedValueOnce({ rows: [{}] })
     .mockResolvedValueOnce({})
     .mockResolvedValueOnce({ rows: [{ count: "0" }] });
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .post("/api/models/j1/like")
     .set("authorization", `Bearer ${token}`)
@@ -222,7 +222,7 @@ test("POST /api/models/:id/like requires auth", async () => {
 test("POST /api/models/:id/public updates flag", async () => {
   db.query.mockResolvedValueOnce({ rows: [{ is_public: true }] });
 
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .post("/api/models/j1/public")
     .set("authorization", `Bearer ${token}`)
@@ -236,7 +236,7 @@ test("POST /api/models/:id/public updates flag", async () => {
 });
 
 test("POST /api/models/:id/public requires boolean", async () => {
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .post("/api/models/j1/public")
     .set("authorization", `Bearer ${token}`)
@@ -249,7 +249,7 @@ test("DELETE /api/models/:id deletes model", async () => {
     .mockResolvedValueOnce({ rows: [{ job_id: "j1" }] })
     .mockResolvedValueOnce({})
     .mockResolvedValueOnce({});
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .delete("/api/models/j1")
     .set("authorization", `Bearer ${token}`);
@@ -260,7 +260,7 @@ test("DELETE /api/models/:id deletes model", async () => {
 
 test("DELETE /api/models/:id 404 when missing", async () => {
   db.query.mockResolvedValueOnce({ rows: [] });
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .delete("/api/models/bad")
     .set("authorization", `Bearer ${token}`);
@@ -269,7 +269,7 @@ test("DELETE /api/models/:id 404 when missing", async () => {
 
 test("DELETE /api/community/:id deletes creation", async () => {
   db.query.mockResolvedValueOnce({ rows: [{ id: "c1" }] });
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .delete("/api/community/c1")
     .set("authorization", `Bearer ${token}`);
@@ -280,7 +280,7 @@ test("DELETE /api/community/:id deletes creation", async () => {
 
 test("DELETE /api/community/:id 404 when missing", async () => {
   db.query.mockResolvedValueOnce({ rows: [] });
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .delete("/api/community/bad")
     .set("authorization", `Bearer ${token}`);
@@ -317,7 +317,7 @@ test("GET /api/community/model/:id returns model", async () => {
 
 test("GET /api/community/mine returns creations", async () => {
   db.getUserCreations.mockResolvedValueOnce([]);
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .get("/api/community/mine")
     .set("authorization", `Bearer ${token}`);
@@ -327,7 +327,7 @@ test("GET /api/community/mine returns creations", async () => {
 
 test("POST /api/community/:id/comment adds comment", async () => {
   db.insertCommunityComment.mockResolvedValueOnce({ id: "x", text: "t" });
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .post("/api/community/c1/comment")
     .set("authorization", `Bearer ${token}`)
@@ -431,7 +431,7 @@ test("POST /api/competitions/:id/comments requires auth", async () => {
 
 test("POST /api/competitions/:id/comments", async () => {
   db.query.mockResolvedValueOnce({ rows: [{ id: "c1", text: "hello" }] });
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .post("/api/competitions/5/comments")
     .set("authorization", `Bearer ${token}`)
@@ -446,7 +446,7 @@ test("POST /api/competitions/:id/comments", async () => {
 
 test("POST /api/competitions/:id/enter", async () => {
   db.query.mockResolvedValueOnce({});
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .post("/api/competitions/5/enter")
     .set("authorization", `Bearer ${token}`)
@@ -471,7 +471,7 @@ test("POST /api/competitions/:id/enter rejects unauthenticated user", async () =
 
 test("POST /api/competitions/:id/enter prevents duplicate", async () => {
   db.query.mockResolvedValueOnce({});
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   await request(app)
     .post("/api/competitions/5/enter")
     .set("authorization", `Bearer ${token}`)
@@ -484,7 +484,7 @@ test("POST /api/competitions/:id/enter prevents duplicate", async () => {
 
 test("POST /api/competitions/:id/enter allows repeat submission without error", async () => {
   db.query.mockResolvedValue({});
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const first = await request(app)
     .post("/api/competitions/5/enter")
     .set("authorization", `Bearer ${token}`)
@@ -506,7 +506,7 @@ test("POST /api/competitions/:id/discount returns code", async () => {
   db.query
     .mockResolvedValueOnce({ rows: [{}] })
     .mockResolvedValueOnce({ rows: [{ code: "X1" }] });
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .post("/api/competitions/5/discount")
     .set("authorization", `Bearer ${token}`)
@@ -521,7 +521,7 @@ test("POST /api/competitions/:id/discount returns code", async () => {
 
 test("POST /api/competitions/:id/discount requires entry", async () => {
   db.query.mockResolvedValueOnce({ rows: [] });
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .post("/api/competitions/5/discount")
     .set("authorization", `Bearer ${token}`)
@@ -533,7 +533,7 @@ test("POST /api/competitions/:id/vote stores vote", async () => {
   db.query
     .mockResolvedValueOnce({})
     .mockResolvedValueOnce({ rows: [{ count: "1" }] });
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .post("/api/competitions/5/vote")
     .set("authorization", `Bearer ${token}`)
@@ -543,7 +543,7 @@ test("POST /api/competitions/:id/vote stores vote", async () => {
 });
 
 test("POST /api/competitions/:id/vote requires modelId", async () => {
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .post("/api/competitions/5/vote")
     .set("authorization", `Bearer ${token}`)
@@ -685,7 +685,7 @@ test("GET /api/init-data returns slots, stats, and profile", async () => {
   const { _setDailyPrintsSold } = require("../utils/dailyPrints");
   _setDailyPrintsSold(10);
   db.query.mockResolvedValueOnce({ rows: [{ display_name: "A" }] });
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .get("/api/init-data")
     .set("authorization", `Bearer ${token}`);
@@ -701,7 +701,7 @@ test("GET /api/payment-init bundles payment data", async () => {
     .mockResolvedValueOnce({
       rows: [{ display_name: "B", shipping_info: { name: "J" } }],
     });
-  const token = jwt.sign({ id: "u2" }, "secret");
+  const token = jwt.sign({ id: "u2" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .get("/api/payment-init")
     .set("authorization", `Bearer ${token}`);

--- a/backend/tests/api.test.js
+++ b/backend/tests/api.test.js
@@ -202,7 +202,7 @@ test("create-order applies first-order discount", async () => {
     .mockResolvedValueOnce({ rows: [{ count: "0" }] })
     .mockResolvedValueOnce({})
     .mockResolvedValueOnce({});
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   await request(app)
     .post("/api/create-order")
     .set("authorization", `Bearer ${token}`)
@@ -417,7 +417,7 @@ test("POST /api/generate accepts image upload", async () => {
 test("POST /api/community submits model", async () => {
   db.query.mockResolvedValueOnce({ rows: [{ generated_title: "Auto" }] });
   db.query.mockResolvedValueOnce({});
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .post("/api/community")
     .set("authorization", `Bearer ${token}`)
@@ -435,7 +435,7 @@ test("POST /api/community uses BLIP caption for title", async () => {
   generateCaption.mockResolvedValueOnce(caption);
   db.query.mockResolvedValueOnce({ rows: [{ generated_title: caption }] });
   db.query.mockResolvedValueOnce({});
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .post("/api/community")
     .set("authorization", `Bearer ${token}`)
@@ -449,7 +449,7 @@ test("POST /api/community uses BLIP caption for title", async () => {
 });
 
 test("POST /api/community requires jobId", async () => {
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .post("/api/community")
     .set("authorization", `Bearer ${token}`)
@@ -497,7 +497,7 @@ test("GET /api/community/recent pagination and category", async () => {
 
 test("GET /api/community/mine returns creations", async () => {
   db.getUserCreations.mockResolvedValueOnce([]);
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   await request(app)
     .get("/api/community/mine")
     .set("authorization", `Bearer ${token}`);
@@ -513,7 +513,7 @@ test("POST /api/community/:id/comment requires auth", async () => {
 
 test("POST /api/community/:id/comment", async () => {
   db.insertCommunityComment.mockResolvedValueOnce({ id: "c1", text: "hi" });
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .post("/api/community/5/comment")
     .set("authorization", `Bearer ${token}`)
@@ -619,7 +619,7 @@ test("/api/generate falls back on server failure", async () => {
 
 test("/api/generate saves authenticated user id", async () => {
   generateModel.mockResolvedValueOnce("/m.glb");
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   await request(app)
     .post("/api/generate")
     .set("authorization", `Bearer ${token}`)
@@ -674,7 +674,7 @@ test("GET /api/users/:username/profile 404 when missing", async () => {
 });
 
 test("GET /api/profile returns profile", async () => {
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   db.query.mockResolvedValueOnce({
     rows: [
       {
@@ -694,7 +694,7 @@ test("GET /api/profile returns profile", async () => {
 });
 
 test("POST /api/profile saves details", async () => {
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   db.query.mockResolvedValueOnce({});
   const res = await request(app)
     .post("/api/profile")
@@ -716,7 +716,7 @@ test("POST /api/create-order saves user id", async () => {
     .mockResolvedValueOnce({ rows: [{ job_id: "1", user_id: "u1" }] })
     .mockResolvedValueOnce({ rows: [{ id: "o1" }] })
     .mockResolvedValueOnce({});
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   await request(app)
     .post("/api/create-order")
     .set("authorization", `Bearer ${token}`)
@@ -768,7 +768,7 @@ test("create-order inserts commission for marketplace sale", async () => {
     .mockResolvedValueOnce({ rows: [{ count: "1" }] })
     .mockResolvedValueOnce({});
   db.insertCommission.mockResolvedValueOnce({});
-  const token = jwt.sign({ id: "buyer" }, "secret");
+  const token = jwt.sign({ id: "buyer" }, process.env.AUTH_SECRET || "secret");
   await request(app)
     .post("/api/create-order")
     .set("authorization", `Bearer ${token}`)
@@ -791,7 +791,7 @@ test("create-order using credit deducts balance", async () => {
     total_credits: 2,
     used_credits: 1,
   });
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .post("/api/create-order")
     .set("authorization", `Bearer ${token}`)
@@ -808,7 +808,7 @@ test("create-order using credit rejects odd quantity", async () => {
     total_credits: 2,
     used_credits: 0,
   });
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .post("/api/create-order")
     .set("authorization", `Bearer ${token}`)
@@ -820,7 +820,7 @@ test("GET /api/my/orders returns orders", async () => {
   db.query.mockResolvedValueOnce({
     rows: [{ session_id: "s1", snapshot: "img", prompt: "p" }],
   });
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .get("/api/my/orders")
     .set("authorization", `Bearer ${token}`);
@@ -938,7 +938,7 @@ test("POST /api/generate-model requires prompt", async () => {
 });
 
 test("GET /api/dashboard returns aggregated info", async () => {
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   db.query
     .mockResolvedValueOnce({
       rows: [{ id: "u1", username: "alice", email: "a@e.com" }],

--- a/backend/tests/api.test.ts
+++ b/backend/tests/api.test.ts
@@ -202,7 +202,7 @@ test("create-order applies first-order discount", async () => {
     .mockResolvedValueOnce({ rows: [{ count: "0" }] })
     .mockResolvedValueOnce({})
     .mockResolvedValueOnce({});
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   await request(app)
     .post("/api/create-order")
     .set("authorization", `Bearer ${token}`)
@@ -419,7 +419,7 @@ test("POST /api/generate accepts image upload", async () => {
 test("POST /api/community submits model", async () => {
   db.query.mockResolvedValueOnce({ rows: [{ generated_title: "Auto" }] });
   db.query.mockResolvedValueOnce({});
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .post("/api/community")
     .set("authorization", `Bearer ${token}`)
@@ -437,7 +437,7 @@ test("POST /api/community uses BLIP caption for title", async () => {
   generateCaption.mockResolvedValueOnce(caption);
   db.query.mockResolvedValueOnce({ rows: [{ generated_title: caption }] });
   db.query.mockResolvedValueOnce({});
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .post("/api/community")
     .set("authorization", `Bearer ${token}`)
@@ -451,7 +451,7 @@ test("POST /api/community uses BLIP caption for title", async () => {
 });
 
 test("POST /api/community requires jobId", async () => {
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .post("/api/community")
     .set("authorization", `Bearer ${token}`)
@@ -499,7 +499,7 @@ test("GET /api/community/recent pagination and category", async () => {
 
 test("GET /api/community/mine returns creations", async () => {
   db.getUserCreations.mockResolvedValueOnce([]);
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   await request(app)
     .get("/api/community/mine")
     .set("authorization", `Bearer ${token}`);
@@ -515,7 +515,7 @@ test("POST /api/community/:id/comment requires auth", async () => {
 
 test("POST /api/community/:id/comment", async () => {
   db.insertCommunityComment.mockResolvedValueOnce({ id: "c1", text: "hi" });
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .post("/api/community/5/comment")
     .set("authorization", `Bearer ${token}`)
@@ -621,7 +621,7 @@ test("/api/generate falls back on server failure", async () => {
 
 test("/api/generate saves authenticated user id", async () => {
   generateModel.mockResolvedValueOnce("/m.glb");
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   await request(app)
     .post("/api/generate")
     .set("authorization", `Bearer ${token}`)
@@ -676,7 +676,7 @@ test("GET /api/users/:username/profile 404 when missing", async () => {
 });
 
 test("GET /api/profile returns profile", async () => {
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   db.query.mockResolvedValueOnce({
     rows: [
       {
@@ -696,7 +696,7 @@ test("GET /api/profile returns profile", async () => {
 });
 
 test("POST /api/profile saves details", async () => {
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   db.query.mockResolvedValueOnce({});
   const res = await request(app)
     .post("/api/profile")
@@ -718,7 +718,7 @@ test("POST /api/create-order saves user id", async () => {
     .mockResolvedValueOnce({ rows: [{ job_id: "1", user_id: "u1" }] })
     .mockResolvedValueOnce({ rows: [{ id: "o1" }] })
     .mockResolvedValueOnce({});
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   await request(app)
     .post("/api/create-order")
     .set("authorization", `Bearer ${token}`)
@@ -770,7 +770,7 @@ test("create-order inserts commission for marketplace sale", async () => {
     .mockResolvedValueOnce({ rows: [{ count: "1" }] })
     .mockResolvedValueOnce({});
   db.insertCommission.mockResolvedValueOnce({});
-  const token = jwt.sign({ id: "buyer" }, "secret");
+  const token = jwt.sign({ id: "buyer" }, process.env.AUTH_SECRET || "secret");
   await request(app)
     .post("/api/create-order")
     .set("authorization", `Bearer ${token}`)
@@ -793,7 +793,7 @@ test("create-order using credit deducts balance", async () => {
     total_credits: 2,
     used_credits: 1,
   });
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .post("/api/create-order")
     .set("authorization", `Bearer ${token}`)
@@ -810,7 +810,7 @@ test("create-order using credit rejects odd quantity", async () => {
     total_credits: 2,
     used_credits: 0,
   });
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .post("/api/create-order")
     .set("authorization", `Bearer ${token}`)
@@ -822,7 +822,7 @@ test("GET /api/my/orders returns orders", async () => {
   db.query.mockResolvedValueOnce({
     rows: [{ session_id: "s1", snapshot: "img", prompt: "p" }],
   });
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .get("/api/my/orders")
     .set("authorization", `Bearer ${token}`);
@@ -935,7 +935,7 @@ test("POST /api/generate-model requires prompt", async () => {
 });
 
 test("GET /api/dashboard returns aggregated info", async () => {
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   db.query
     .mockResolvedValueOnce({
       rows: [{ id: "u1", username: "alice", email: "a@e.com" }],

--- a/backend/tests/apiModels.test.js
+++ b/backend/tests/apiModels.test.js
@@ -79,7 +79,7 @@ test("POST /api/models accepts hyphen and underscore", async () => {
 
 test("POST /api/models/:id/public toggles visibility", async () => {
   const jwt = require("jsonwebtoken");
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   db.query.mockResolvedValueOnce({ rows: [{ is_public: true }] });
   const res = await request(app)
     .post("/api/models/5/public")
@@ -95,7 +95,7 @@ test("POST /api/models/:id/public toggles visibility", async () => {
 
 test("DELETE /api/models/:id removes model", async () => {
   const jwt = require("jsonwebtoken");
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   db.query.mockResolvedValueOnce({ rows: [{ job_id: "5" }] });
   db.query.mockResolvedValueOnce({});
   db.query.mockResolvedValueOnce({});

--- a/backend/tests/assertSetup.test.js
+++ b/backend/tests/assertSetup.test.js
@@ -3,7 +3,6 @@ const os = require("os");
 const path = require("path");
 const { spawnSync } = require("child_process");
 
-
 process.env.HF_TOKEN = process.env.HF_TOKEN || "token";
 process.env.AWS_ACCESS_KEY_ID = process.env.AWS_ACCESS_KEY_ID || "key";
 process.env.AWS_SECRET_ACCESS_KEY =

--- a/backend/tests/cart.test.js
+++ b/backend/tests/cart.test.js
@@ -27,7 +27,7 @@ const app = require("../server");
 const jwt = require("jsonwebtoken");
 
 test("POST /api/cart/items adds item", async () => {
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   db.insertCartItem.mockResolvedValueOnce({ id: 1 });
   const res = await request(app)
     .post("/api/cart/items")
@@ -38,7 +38,7 @@ test("POST /api/cart/items adds item", async () => {
 });
 
 test("PATCH /api/cart/items/:id updates item", async () => {
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   db.updateCartItem.mockResolvedValueOnce({ id: 1, quantity: 3 });
   const res = await request(app)
     .patch("/api/cart/items/1")
@@ -49,7 +49,7 @@ test("PATCH /api/cart/items/:id updates item", async () => {
 });
 
 test("DELETE /api/cart/items/:id removes item", async () => {
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .delete("/api/cart/items/1")
     .set("authorization", `Bearer ${token}`);
@@ -58,7 +58,7 @@ test("DELETE /api/cart/items/:id removes item", async () => {
 });
 
 test("GET /api/cart returns items", async () => {
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   db.getCartItems.mockResolvedValueOnce([{ id: 1 }]);
   const res = await request(app)
     .get("/api/cart")
@@ -68,7 +68,7 @@ test("GET /api/cart returns items", async () => {
 });
 
 test("POST /api/cart/checkout creates session", async () => {
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   db.getCartItems.mockResolvedValueOnce([{ id: 1, job_id: "j1", quantity: 1 }]);
   const res = await request(app)
     .post("/api/cart/checkout")

--- a/backend/tests/commissions.test.js
+++ b/backend/tests/commissions.test.js
@@ -30,7 +30,7 @@ test("GET /api/commissions returns totals", async () => {
       { id: "c2", commission_cents: 50, status: "paid" },
     ],
   });
-  const token = jwt.sign({ id: "seller" }, "secret");
+  const token = jwt.sign({ id: "seller" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .get("/api/commissions")
     .set("authorization", `Bearer ${token}`);

--- a/backend/tests/createOrder.additional.test.js
+++ b/backend/tests/createOrder.additional.test.js
@@ -36,7 +36,7 @@ describe("create-order extras", () => {
       .mockResolvedValueOnce({ rows: [{ count: "2" }] })
       .mockResolvedValueOnce({})
       .mockResolvedValueOnce({});
-    const token = jwt.sign({ id: "u1" }, "secret");
+    const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
     await request(app)
       .post("/api/create-order")
       .set("authorization", `Bearer ${token}`)

--- a/backend/tests/engagement.test.js
+++ b/backend/tests/engagement.test.js
@@ -32,7 +32,7 @@ test("GET /api/achievements requires auth", async () => {
 
 test("GET /api/achievements returns list", async () => {
   db.getAchievements.mockResolvedValue([{ name: "First Print" }]);
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .get("/api/achievements")
     .set("authorization", `Bearer ${token}`);

--- a/backend/tests/payouts.test.js
+++ b/backend/tests/payouts.test.js
@@ -37,7 +37,7 @@ test("POST /api/payouts requires auth", async () => {
 
 test("POST /api/payouts 400 without account", async () => {
   db.query.mockResolvedValueOnce({ rows: [{ stripe_account_id: null }] });
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .post("/api/payouts")
     .set("authorization", `Bearer ${token}`);
@@ -52,7 +52,7 @@ test("POST /api/payouts transfers funds", async () => {
     })
     .mockResolvedValueOnce({});
   stripeMock.transfers.create.mockResolvedValue({ id: "tr_1" });
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .post("/api/payouts")
     .set("authorization", `Bearer ${token}`);
@@ -77,7 +77,7 @@ test("POST /api/stripe/connect creates link", async () => {
     .mockResolvedValueOnce({});
   stripeMock.accounts.create.mockResolvedValue({ id: "acct_2" });
   stripeMock.accountLinks.create.mockResolvedValue({ url: "https://connect" });
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .post("/api/stripe/connect")
     .set("authorization", `Bearer ${token}`)

--- a/backend/tests/referralPost.test.js
+++ b/backend/tests/referralPost.test.js
@@ -17,7 +17,7 @@ const app = require("../server");
 
 test("POST /api/referral-post returns code when verified", async () => {
   verifyTag.mockResolvedValue(true);
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .post("/api/referral-post")
     .set("authorization", `Bearer ${token}`)
@@ -29,7 +29,7 @@ test("POST /api/referral-post returns code when verified", async () => {
 
 test("POST /api/referral-post rejects invalid tag", async () => {
   verifyTag.mockResolvedValue(false);
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .post("/api/referral-post")
     .set("authorization", `Bearer ${token}`)

--- a/backend/tests/rewards.test.js
+++ b/backend/tests/rewards.test.js
@@ -31,7 +31,7 @@ beforeEach(() => {
 
 test("GET /api/referral-link returns code", async () => {
   db.getOrCreateReferralLink.mockResolvedValue("abc123");
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .get("/api/referral-link")
     .set("authorization", `Bearer ${token}`);
@@ -42,7 +42,7 @@ test("GET /api/referral-link returns code", async () => {
 
 test("GET /api/rewards returns points", async () => {
   db.getRewardPoints.mockResolvedValue(42);
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .get("/api/rewards")
     .set("authorization", `Bearer ${token}`);
@@ -54,7 +54,7 @@ test("GET /api/rewards returns points", async () => {
 test("POST /api/rewards/redeem returns code", async () => {
   db.getRewardPoints.mockResolvedValue(150);
   db.getRewardOption.mockResolvedValue({ amount_cents: 500 });
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .post("/api/rewards/redeem")
     .set("authorization", `Bearer ${token}`)
@@ -104,7 +104,7 @@ test("POST /api/referral-signup grants codes", async () => {
 test("GET /api/orders/:id/referral-link returns code", async () => {
   db.query.mockResolvedValueOnce({ rows: [{ user_id: "u1" }] });
   db.getOrCreateOrderReferralLink.mockResolvedValue("orderabc");
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .get("/api/orders/o1/referral-link")
     .set("authorization", `Bearer ${token}`);
@@ -116,7 +116,7 @@ test("GET /api/orders/:id/referral-link returns code", async () => {
 test("GET /api/orders/:id/referral-qr returns png", async () => {
   db.query.mockResolvedValueOnce({ rows: [{ user_id: "u1" }] });
   db.getOrCreateOrderReferralLink.mockResolvedValue("orderabc");
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .get("/api/orders/o1/referral-qr")
     .set("authorization", `Bearer ${token}`);

--- a/backend/tests/saleCredits.test.js
+++ b/backend/tests/saleCredits.test.js
@@ -97,7 +97,7 @@ test("Stripe webhook awards seller credit", async () => {
 test("POST /api/credits/redeem deducts credit", async () => {
   db.getSaleCredit.mockResolvedValue(600);
   db.adjustSaleCredit.mockResolvedValue(100);
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .post("/api/credits/redeem")
     .set("authorization", `Bearer ${token}`)
@@ -109,7 +109,7 @@ test("POST /api/credits/redeem deducts credit", async () => {
 
 test("GET /api/credits returns credit balance", async () => {
   db.getSaleCredit.mockResolvedValue(800);
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .get("/api/credits")
     .set("authorization", `Bearer ${token}`);

--- a/backend/tests/socialShares.test.js
+++ b/backend/tests/socialShares.test.js
@@ -26,7 +26,7 @@ beforeEach(() => {
 
 test("POST /api/social-shares stores submission", async () => {
   db.insertSocialShare.mockResolvedValue({ id: 1, verified: false });
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .post("/api/social-shares")
     .set("authorization", `Bearer ${token}`)

--- a/backend/tests/subscriptions.test.js
+++ b/backend/tests/subscriptions.test.js
@@ -45,7 +45,7 @@ beforeEach(() => {
 });
 
 test("GET /api/subscription returns subscription", async () => {
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .get("/api/subscription")
     .set("authorization", `Bearer ${token}`);
@@ -54,7 +54,7 @@ test("GET /api/subscription returns subscription", async () => {
 });
 
 test("POST /api/subscription creates record", async () => {
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .post("/api/subscription")
     .set("authorization", `Bearer ${token}`)
@@ -64,7 +64,7 @@ test("POST /api/subscription creates record", async () => {
 });
 
 test("GET /api/subscription/credits returns remaining", async () => {
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .get("/api/subscription/credits")
     .set("authorization", `Bearer ${token}`);
@@ -73,7 +73,7 @@ test("GET /api/subscription/credits returns remaining", async () => {
 });
 
 test("GET /api/subscription/summary returns subscription and credits", async () => {
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .get("/api/subscription/summary")
     .set("authorization", `Bearer ${token}`);
@@ -85,7 +85,7 @@ test("GET /api/subscription/summary returns subscription and credits", async () 
 test("POST /api/subscription/portal returns url", async () => {
   db.getSubscription.mockResolvedValueOnce({ stripe_customer_id: "cus_1" });
   stripeMock.billingPortal.sessions.create.mockResolvedValueOnce({ url: "u" });
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .post("/api/subscription/portal")
     .set("authorization", `Bearer ${token}`);
@@ -96,7 +96,7 @@ test("POST /api/subscription/portal returns url", async () => {
 
 test("POST /api/subscription/portal 404 without customer", async () => {
   db.getSubscription.mockResolvedValueOnce(null);
-  const token = jwt.sign({ id: "u1" }, "secret");
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .post("/api/subscription/portal")
     .set("authorization", `Bearer ${token}`);

--- a/backend/tests/validateMiddleware.test.js
+++ b/backend/tests/validateMiddleware.test.js
@@ -23,12 +23,10 @@ describe("validate middleware", () => {
     expect(next).not.toHaveBeenCalled();
   });
 
-
   test("calls next on non-Zod errors", () => {
     const badSchema = {
       parse: () => {
         throw new Error("boom");
-
       },
     };
     const req = { body: {} };


### PR DESCRIPTION
## Summary
- sign JWT tokens using the AUTH_SECRET env

## Testing
- `npm test --prefix backend`
- `node scripts/run-coverage.js`

------
https://chatgpt.com/codex/tasks/task_e_6876c5b3d488832d9eaeebf39eec8544