### PR TITLE
Fix Sync HF Space workflow coverage

### DIFF
--- a/.github/workflows/sync-space.yml
+++ b/.github/workflows/sync-space.yml
@@ -40,7 +40,7 @@ jobs:
 
 
       - name: Run backend tests
-        run: npm test --prefix backend
+        run: npm run coverage --prefix backend
 
       - name: Run smoke tests
         run: npm run smoke


### PR DESCRIPTION
## Summary
- run `npm run coverage` in sync-space workflow instead of plain tests

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_6876cd1fb174832d9623fce78fff7591