### PR TITLE
Add CheckoutForm React tests

### DIFF
--- a/tests/checkoutForm.react.test.js
+++ b/tests/checkoutForm.react.test.js
@@ -1,0 +1,44 @@
+/**
+ * @jest-environment jsdom
+ */
+const React = require("react");
+const { render, fireEvent, screen } = require("@testing-library/react");
+
+jest.mock("react-places-autocomplete", () => {
+  return ({ value, onChange, children }) =>
+    React.createElement(
+      "div",
+      {},
+      children({
+        getInputProps: (props) => ({
+          ...props,
+          value,
+          onChange: (e) => onChange(e.target.value),
+        }),
+        suggestions: [],
+        getSuggestionItemProps: () => ({}),
+        loading: false,
+      }),
+    );
+});
+
+const CheckoutForm = require("../src/components/CheckoutForm.js").default;
+
+test("manual entry fields appear when link clicked", () => {
+  render(React.createElement(CheckoutForm));
+  expect(screen.queryByLabelText(/Street/i)).toBeNull();
+  fireEvent.click(screen.getByText(/Enter it manually/));
+  expect(screen.getByLabelText(/Street/i)).toBeInTheDocument();
+  expect(screen.getByLabelText(/City/i)).toBeInTheDocument();
+  expect(screen.getByLabelText(/ZIP/i)).toBeInTheDocument();
+  expect(screen.getByLabelText(/Country/i)).toBeInTheDocument();
+});
+
+test("hidden inputs mirror manual values", () => {
+  render(React.createElement(CheckoutForm));
+  fireEvent.click(screen.getByText(/Enter it manually/));
+  fireEvent.change(screen.getByLabelText(/Street/i), {
+    target: { value: "1 Main" },
+  });
+  expect(screen.getAllByDisplayValue("1 Main").length).toBe(2);
+});


### PR DESCRIPTION
## Summary
- add new React Testing Library tests for CheckoutForm

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6876cee457c8832daf599191852b11dc