### PR TITLE
Fix jsdoc lint for jest environment tag

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -32,6 +32,13 @@ module.exports = [
       "upload",
       "src",
     ],
+    settings: {
+      jsdoc: {
+        tagNamePreference: {
+          "jest-environment": false,
+        },
+      },
+    },
   },
   {
     languageOptions: {

--- a/tests/checkoutForm.react.test.js
+++ b/tests/checkoutForm.react.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsdoc/check-tag-names */
 /**
  * @jest-environment jsdom
  */


### PR DESCRIPTION
## Summary
- recognize `@jest-environment` via ESLint settings
- silence jsdoc rule in the CheckoutForm test

## Testing
- `npm run format`
- `npm test`
- `npm run lint`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6876d4d5e898832d835057e5604edfc5