### PR TITLE
Fix lcov test gating

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Check coverage thresholds
         run: node scripts/check-coverage.js
       - name: Validate LCOV report
-        run: node scripts/run-jest.js backend/__tests__/lcovExists.test.js
+        run: CHECK_LCOV=1 node scripts/run-jest.js backend/__tests__/lcovExists.test.js
       - name: Verify coverage summary
         run: node scripts/run-jest.js backend/__tests__/coverageSummaryExists.test.js
       - run: cat coverage/lcov.info | npx coveralls

--- a/backend/__tests__/lcovExists.test.js
+++ b/backend/__tests__/lcovExists.test.js
@@ -3,7 +3,8 @@ const path = require("path");
 
 const lcov = path.join(__dirname, "..", "..", "coverage", "lcov.info");
 
-(process.env.CI ? test : test.skip)("lcov.info exists and is valid", () => {
+const shouldCheck = process.env.CHECK_LCOV === "1";
+(shouldCheck ? test : test.skip)("lcov.info exists and is valid", () => {
   expect(fs.existsSync(lcov)).toBe(true);
   const content = fs.readFileSync(lcov, "utf8");
   expect(/^(TN|SF):/m.test(content)).toBe(true);


### PR DESCRIPTION
## Summary
- require `CHECK_LCOV=1` for the LCOV existence test
- set the env var in the coverage workflow

## Testing
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `node scripts/run-jest.js backend/__tests__/lcovExists.test.js`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6876d4cde2f4832da06cf8f232a6b7e9