### PR TITLE
Update coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,7 +11,7 @@ jobs:
         with:
           node-version: "20"
       - run: SKIP_PW_DEPS=1 npm run setup
-      - run: npm run coverage
+      - run: SKIP_PW_DEPS=1 npm run coverage
       - name: Validate coverage-summary.json
         run: node -e "JSON.parse(require('fs').readFileSync('coverage/coverage-summary.json','utf-8')); console.log('✅ JSON ok')"
       - name: Check coverage thresholds


### PR DESCRIPTION
## Summary
- skip Playwright CDN when running coverage on CI

## Testing
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `npm run smoke`
- `SKIP_PW_DEPS=1 npm run coverage`

------
https://chatgpt.com/codex/tasks/task_e_6876dc1ef6a4832db2df1020928d10e9