### PR TITLE
Fix smoke env

### DIFF
--- a/scripts/run-smoke.js
+++ b/scripts/run-smoke.js
@@ -3,9 +3,9 @@ const { execSync } = require("child_process");
 const fs = require("fs");
 const path = require("path");
 
-function freePort(port) {
+function freePort(port, envVars = process.env) {
   try {
-    execSync(`npx -y kill-port ${port}`, { stdio: "inherit" });
+    execSync(`npx -y kill-port ${port}`, { stdio: "inherit", env: envVars });
   } catch (err) {
     console.warn(`kill-port ${port} failed`, err.message);
   }
@@ -13,6 +13,8 @@ function freePort(port) {
 
 function initEnv(baseEnv = process.env) {
   const env = { ...baseEnv };
+  delete env.npm_config_http_proxy;
+  delete env.npm_config_https_proxy;
 
   function loadEnvFile(file) {
     if (!fs.existsSync(file)) return;
@@ -98,7 +100,7 @@ function dumpDiagnostics(err) {
 function main() {
   try {
     run("npm run validate-env");
-    freePort(process.env.PORT || 3000);
+    freePort(process.env.PORT || 3000, env);
     if (!process.env.SKIP_SETUP && !fs.existsSync(".setup-complete")) {
       run("npm run setup");
     } else {


### PR DESCRIPTION
## Summary
- clear npm proxy vars in run-smoke before invoking setup

## Testing
- `npm run format --prefix backend`
- `SKIP_PW_DEPS=1 npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_6876e61559bc832dbcf3a6b64bd89cab