### PR TITLE
Fix smoke test network check

### DIFF
--- a/e2e/smoke.test.js
+++ b/e2e/smoke.test.js
@@ -17,9 +17,12 @@ if (process.env.JEST_WORKER_ID) {
 const { execSync } = require('child_process');
 function canFetchSync(url) {
   try {
-    execSync(`curl -fIs --max-time 5 --noproxy '*' ${url}`, {
-      stdio: 'ignore',
-    });
+    execSync(
+      `curl -fsSL --max-time 10 --noproxy '*' ${url} -o /dev/null`,
+      {
+        stdio: 'ignore',
+      },
+    );
     return true;
   } catch {
     return false;


### PR DESCRIPTION
## Summary
- avoid false positives in Playwright smoke test network checks

## Testing
- `mise exec node@20 -- npm run format`
- `cd backend && mise exec node@20 -- npm test --silent`
- `mise exec node@20 -- npm run ci`
- `mise exec node@20 -- npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68778e14105c832db17dd3b77aa00fee