### PR TITLE
Remove unused readFileSync

### DIFF
--- a/backend/src/lib/uploadS3.ts
+++ b/backend/src/lib/uploadS3.ts
@@ -34,7 +34,6 @@ export async function uploadFile(
   if (!accessKey || !secretKey) throw new Error("AWS credentials are not set");
   const client = new S3Client({ region });
   const key = `images/${Date.now()}-${path.basename(filePath)}`;
-  const body = fs.readFileSync(filePath);
   await client.send(
     new PutObjectCommand({
       Bucket: bucket,


### PR DESCRIPTION
## Summary
- remove unused buffer from S3 upload helper

## Testing
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68779f29f7f4832db245e32c31be97ff