### PR TITLE
Ensure Node 20 for validation

### DIFF
--- a/scripts/validate-env.sh
+++ b/scripts/validate-env.sh
@@ -78,8 +78,9 @@ if [[ -z "${SKIP_DB_CHECK:-}" && "${DB_URL}" == "$placeholder_db" ]]; then
 fi
 required_node_major="${REQUIRED_NODE_MAJOR:-20}"
 current_major=$(node -v | sed -E "s/^v([0-9]+).*/\1/")
-if [ "$current_major" -lt "$required_node_major" ]; then
-  echo "Node $required_node_major or newer is required. Current version: $current_major" >&2
+if [ "$current_major" -ne "$required_node_major" ]; then
+  echo "Node $required_node_major is required. Current version: $current_major" >&2
+  echo "Run 'mise env node@$required_node_major' and retry." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- verify that the `validate-env` script checks for Node 20 specifically
- show instructions to activate Node 20 when the version is different

## Testing
- `npm test` in `backend`
- `npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68779f1ec7e0832d9c212bc0e5da05bf