### PR TITLE
Refactor frontend tests to use DOM parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,7 +530,7 @@ The `npm run setup` script now performs this cleanup before and after installing
 dependencies, so new clones shouldn't hit this error. If you still encounter it,
 re-run `npm run setup` to ensure the cache directory is cleared.
 
-### TAR\_ENTRY\_ERROR or ENOENT during `npm ci`
+### TAR_ENTRY_ERROR or ENOENT during `npm ci`
 
 If `npm run format` exits with errors like `TAR_ENTRY_ERROR` or `ENOENT`, the
 package cache may be corrupted. Running `npm run setup` in the repository root

--- a/backend/tests/frontend/flashBanner.test.js
+++ b/backend/tests/frontend/flashBanner.test.js
@@ -5,15 +5,23 @@ const fs = require("fs");
 const path = require("path");
 const { JSDOM } = require("jsdom");
 
+function loadHtml(rel, extra = []) {
+  const raw = fs.readFileSync(path.join(__dirname, rel), "utf8");
+  const dom = new JSDOM(raw);
+  const { document } = dom.window;
+  document
+    .querySelectorAll('script[src^="http"], link[href^="http"]')
+    .forEach((el) => el.remove());
+  for (const sel of extra) {
+    document.querySelectorAll(sel).forEach((el) => el.remove());
+  }
+  return dom.serialize();
+}
+
 function setupDom() {
-  const html = fs
-    .readFileSync(path.join(__dirname, "../../../payment.html"), "utf8")
-    .replace(/<script[^>]+src="https?:\/\/[^"]+"[^>]*><\/script>/g, "")
-    .replace(/<link[^>]+href="https?:\/\/[^"]+[^>]*>/g, "")
-    .replace(
-      /<script[^>]+src="js\/modelViewerTouchFix.js"[^>]*><\/script>/,
-      "",
-    );
+  const html = loadHtml("../../../payment.html", [
+    'script[src$="modelViewerTouchFix.js"]',
+  ]);
   const dom = new JSDOM(html, {
     runScripts: "dangerously",
     resources: "usable",

--- a/backend/tests/frontend/index.test.js
+++ b/backend/tests/frontend/index.test.js
@@ -3,14 +3,25 @@ const fs = require("fs");
 const path = require("path");
 const { JSDOM } = require("jsdom");
 
-let html = fs.readFileSync(path.join(__dirname, "../../../index.html"), "utf8");
-html = html
-  .replace(/<script[^>]+src="https?:\/\/[^>]+><\/script>/g, "")
-  .replace(/<link[^>]+href="https?:\/\/[^>]+>/g, "")
-  .replace(
-    /<script[^>]+src="js\/(?:index|theme|subredditLanding|modelViewerTouchFix)\.js"[^>]*><\/script>/g,
-    "",
-  );
+function loadHtml(rel, extra = []) {
+  const raw = fs.readFileSync(path.join(__dirname, rel), "utf8");
+  const dom = new JSDOM(raw);
+  const { document } = dom.window;
+  document
+    .querySelectorAll('script[src^="http"], link[href^="http"]')
+    .forEach((el) => el.remove());
+  for (const sel of extra) {
+    document.querySelectorAll(sel).forEach((el) => el.remove());
+  }
+  return dom.serialize();
+}
+
+let html = loadHtml("../../../index.html", [
+  'script[src$="index.js"]',
+  'script[src$="theme.js"]',
+  'script[src$="subredditLanding.js"]',
+  'script[src$="modelViewerTouchFix.js"]',
+]);
 
 describe("index validatePrompt", () => {
   function setup() {

--- a/backend/tests/frontend/login.test.js
+++ b/backend/tests/frontend/login.test.js
@@ -3,10 +3,23 @@ const fs = require("fs");
 const path = require("path");
 const { JSDOM } = require("jsdom");
 
-let html = fs.readFileSync(path.join(__dirname, "../../../login.html"), "utf8");
-html = html
-  .replace(/<script[^>]+tailwind[^>]*><\/script>/, "")
-  .replace(/<link[^>]+font-awesome[^>]+>/, "");
+function loadHtml(rel, extra = []) {
+  const raw = fs.readFileSync(path.join(__dirname, rel), "utf8");
+  const dom = new JSDOM(raw);
+  const { document } = dom.window;
+  document
+    .querySelectorAll('script[src^="http"], link[href^="http"]')
+    .forEach((el) => el.remove());
+  for (const sel of extra) {
+    document.querySelectorAll(sel).forEach((el) => el.remove());
+  }
+  return dom.serialize();
+}
+
+let html = loadHtml("../../../login.html", [
+  'script[src*="tailwind"]',
+  'link[href*="font-awesome"]',
+]);
 
 describe("login form", () => {
   test("shows error on failed login", async () => {

--- a/backend/tests/frontend/quantityDefault.test.js
+++ b/backend/tests/frontend/quantityDefault.test.js
@@ -3,15 +3,23 @@ const fs = require("fs");
 const path = require("path");
 const { JSDOM } = require("jsdom");
 
+function loadHtml(rel, extra = []) {
+  const raw = fs.readFileSync(path.join(__dirname, rel), "utf8");
+  const dom = new JSDOM(raw);
+  const { document } = dom.window;
+  document
+    .querySelectorAll('script[src^="http"], link[href^="http"]')
+    .forEach((el) => el.remove());
+  for (const sel of extra) {
+    document.querySelectorAll(sel).forEach((el) => el.remove());
+  }
+  return dom.serialize();
+}
+
 function loadDom() {
-  const html = fs
-    .readFileSync(path.join(__dirname, "../../../payment.html"), "utf8")
-    .replace(/<script[^>]+src="https?:\/\/[^>]+><\/script>/g, "")
-    .replace(/<link[^>]+href="https?:\/\/[^>]+>/g, "")
-    .replace(
-      /<script[^>]+src="js\/modelViewerTouchFix.js"[^>]*><\/script>/,
-      "",
-    );
+  const html = loadHtml("../../../payment.html", [
+    'script[src$="modelViewerTouchFix.js"]',
+  ]);
   const dom = new JSDOM(html, {
     runScripts: "dangerously",
     resources: "usable",

--- a/backend/tests/frontend/signup.test.js
+++ b/backend/tests/frontend/signup.test.js
@@ -3,13 +3,23 @@ const fs = require("fs");
 const path = require("path");
 const { JSDOM } = require("jsdom");
 
-let html = fs.readFileSync(
-  path.join(__dirname, "../../../signup.html"),
-  "utf8",
-);
-html = html
-  .replace(/<script[^>]+tailwind[^>]*><\/script>/, "")
-  .replace(/<link[^>]+font-awesome[^>]+>/, "");
+function loadHtml(rel, extra = []) {
+  const raw = fs.readFileSync(path.join(__dirname, rel), "utf8");
+  const dom = new JSDOM(raw);
+  const { document } = dom.window;
+  document
+    .querySelectorAll('script[src^="http"], link[href^="http"]')
+    .forEach((el) => el.remove());
+  for (const sel of extra) {
+    document.querySelectorAll(sel).forEach((el) => el.remove());
+  }
+  return dom.serialize();
+}
+
+let html = loadHtml("../../../signup.html", [
+  'script[src*="tailwind"]',
+  'link[href*="font-awesome"]',
+]);
 
 describe("signup form", () => {
   test("shows error on failed signup", async () => {

--- a/backend/tests/frontend/slotCount.test.js
+++ b/backend/tests/frontend/slotCount.test.js
@@ -3,14 +3,20 @@ const fs = require("fs");
 const path = require("path");
 const { JSDOM } = require("jsdom");
 
-let html = fs.readFileSync(
-  path.join(__dirname, "../../../payment.html"),
-  "utf8",
-);
-html = html
-  .replace(/<script[^>]+src="https?:\/\/[^>]+><\/script>/g, "")
-  .replace(/<link[^>]+href="https?:\/\/[^>]+>/g, "")
-  .replace(/<script[^>]+src="js\/[^>]+><\/script>/g, "");
+function loadHtml(rel, extra = []) {
+  const raw = fs.readFileSync(path.join(__dirname, rel), "utf8");
+  const dom = new JSDOM(raw);
+  const { document } = dom.window;
+  document
+    .querySelectorAll('script[src^="http"], link[href^="http"]')
+    .forEach((el) => el.remove());
+  for (const sel of extra) {
+    document.querySelectorAll(sel).forEach((el) => el.remove());
+  }
+  return dom.serialize();
+}
+
+let html = loadHtml("../../../payment.html", ['script[src^="js/"]']);
 
 function cycleKey() {
   const tz = "America/New_York";

--- a/backend/tests/frontend/viewerReady.test.js
+++ b/backend/tests/frontend/viewerReady.test.js
@@ -3,14 +3,25 @@ const fs = require("fs");
 const path = require("path");
 const { JSDOM } = require("jsdom");
 
-let html = fs.readFileSync(path.join(__dirname, "../../../index.html"), "utf8");
-html = html
-  .replace(/<script[^>]+src="https?:\/\/[^>]+><\/script>/g, "")
-  .replace(/<link[^>]+href="https?:\/\/[^>]+>/g, "")
-  .replace(
-    /<script[^>]+src="js\/(?:index|theme|subredditLanding|modelViewerTouchFix)\.js"[^>]*><\/script>/g,
-    "",
-  );
+function loadHtml(rel, extra = []) {
+  const raw = fs.readFileSync(path.join(__dirname, rel), "utf8");
+  const dom = new JSDOM(raw);
+  const { document } = dom.window;
+  document
+    .querySelectorAll('script[src^="http"], link[href^="http"]')
+    .forEach((el) => el.remove());
+  for (const sel of extra) {
+    document.querySelectorAll(sel).forEach((el) => el.remove());
+  }
+  return dom.serialize();
+}
+
+let html = loadHtml("../../../index.html", [
+  'script[src$="index.js"]',
+  'script[src$="theme.js"]',
+  'script[src$="subredditLanding.js"]',
+  'script[src$="modelViewerTouchFix.js"]',
+]);
 
 function setup() {
   const dom = new JSDOM(html, {


### PR DESCRIPTION
## Summary
- parse HTML fixtures with JSDOM in frontend unit tests
- strip scripts and links via DOM methods instead of regex
- format README for prettier compliance

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_68779f077bc4832d92d86950e989b91e