### PR TITLE
Fix path checks for uploads

### DIFF
--- a/backend/src/lib/prepareImage.ts
+++ b/backend/src/lib/prepareImage.ts
@@ -24,12 +24,13 @@ export async function prepareImage(image: string): Promise<string> {
     await fs.promises.writeFile(filePath, Buffer.from(base64, "base64"));
     cleanup = true;
   } else {
-    const resolved = path.resolve(filePath);
+    const normalized = path.normalize(filePath);
+    const resolved = path.resolve(normalized);
     const uploadsDir = path.resolve("uploads");
-    if (!fs.existsSync(resolved)) {
+    if (!resolved.startsWith("/tmp") && !resolved.startsWith(uploadsDir)) {
       throw new Error("image file not found");
     }
-    if (!resolved.startsWith("/tmp") && !resolved.startsWith(uploadsDir)) {
+    if (!fs.existsSync(resolved)) {
       throw new Error("image file not found");
     }
     filePath = resolved;

--- a/backend/src/lib/uploadS3.ts
+++ b/backend/src/lib/uploadS3.ts
@@ -12,12 +12,13 @@ export async function uploadFile(
   filePath: string,
   contentType: string,
 ): Promise<string> {
-  const resolved = path.resolve(filePath);
+  const normalized = path.normalize(filePath);
+  const resolved = path.resolve(normalized);
   const uploadsDir = path.resolve("uploads");
-  if (!fs.existsSync(resolved)) {
+  if (!resolved.startsWith("/tmp") && !resolved.startsWith(uploadsDir)) {
     throw new Error("file not found");
   }
-  if (!resolved.startsWith("/tmp") && !resolved.startsWith(uploadsDir)) {
+  if (!fs.existsSync(resolved)) {
     throw new Error("file not found");
   }
   filePath = resolved;

--- a/backend/tests/prepareImage.test.ts
+++ b/backend/tests/prepareImage.test.ts
@@ -49,4 +49,16 @@ describe("prepareImage", () => {
       "image file not found",
     );
   });
+
+  test("rejects paths outside allowed dirs", async () => {
+    await expect(prepareImage("/etc/passwd")).rejects.toThrow(
+      "image file not found",
+    );
+    await expect(prepareImage("/tmp/../etc/passwd")).rejects.toThrow(
+      "image file not found",
+    );
+    await expect(prepareImage("uploads/../secret.png")).rejects.toThrow(
+      "image file not found",
+    );
+  });
 });

--- a/backend/tests/uploadS3.test.ts
+++ b/backend/tests/uploadS3.test.ts
@@ -33,4 +33,13 @@ describe("uploadFile env validation", () => {
       "AWS credentials",
     );
   });
+
+  test("rejects paths outside allowed dirs", async () => {
+    await expect(uploadFile("/etc/passwd", "image/png")).rejects.toThrow(
+      "file not found",
+    );
+    await expect(uploadFile("/tmp/../etc/passwd", "image/png")).rejects.toThrow(
+      "file not found",
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- sanitize input paths for prepareImage and uploadFile
- ensure unauthorized paths throw errors
- test path traversal attempts

## Testing
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68779efbd91c832da038a5b24d5525c4