### PR TITLE
Skip generate flow test when keys missing

### DIFF
--- a/e2e/smoke.test.js
+++ b/e2e/smoke.test.js
@@ -106,6 +106,10 @@ test('generate flow', async ({ page }) => {
     test.skip(true, 'modelviewer.dev unreachable');
   }
 
+  if (!process.env.SPARC3D_TOKEN || !process.env.STABILITY_KEY) {
+    test.skip(true, 'generation keys not set');
+  }
+
   await page.goto('/generate.html');
   // The form is rendered via React after scripts load, so wait for the prompt
   // field before interacting with it. Give the page up to 30s to load the


### PR DESCRIPTION
## Summary
- skip generate flow smoke test when SPARC3D or Stability keys aren't set

## Testing
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68779cb729fc832da40b66ac1e61aef2