### PR TITLE
Add GLB tests workflow

### DIFF
--- a/.github/workflows/glb-tests.yml
+++ b/.github/workflows/glb-tests.yml
@@ -1,0 +1,51 @@
+name: GLB Tests
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: 'backend/package-lock.json'
+      - name: Install dependencies
+        run: npm ci --prefix backend
+      - name: Run unit tests
+        run: npm run test:unit --prefix backend
+
+  e2e-tests:
+    needs: unit-tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: 'package-lock.json'
+      - name: Install dependencies
+        run: |
+          npm ci
+          npm ci --prefix backend
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+      - name: Install Playwright browsers
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
+        run: npx playwright install --with-deps
+      - name: Start server and run e2e tests
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
+        run: |
+          npx -y concurrently -k -s first "npm run serve" "npx wait-on http://localhost:3000 && npx playwright test e2e/*.test.js"


### PR DESCRIPTION
## Summary
- add new workflow `glb-tests.yml` with unit and e2e jobs

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_6877abb99498832db483072b6968e21a