### PR TITLE
Add GLB workflow tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,18 @@ For a quick end-to-end sanity check, run:
 npm run smoke
 ```
 
+Run the backend unit tests alone:
+
+```bash
+npm run test:unit
+```
+
+Run the Playwright end-to-end suite:
+
+```bash
+npm run test:e2e
+```
+
 To run Jest directly from the repository root, use:
 
 ```bash

--- a/backend/__tests__/glbPrep.test.ts
+++ b/backend/__tests__/glbPrep.test.ts
@@ -1,0 +1,69 @@
+import fs from "fs";
+import path from "path";
+import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
+
+jest.mock("@aws-sdk/client-s3", () => ({
+  S3Client: jest.fn(),
+  PutObjectCommand: jest.fn(),
+}));
+
+const uploadModule = require("../src/lib/uploadS3");
+const { uploadFile } = uploadModule;
+import { prepareImage } from "../src/lib/prepareImage.ts";
+let mockedUpload: jest.SpyInstance;
+
+describe("glb prep helpers", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    process.env.AWS_REGION = "us-east-1";
+    process.env.S3_BUCKET = "bucket";
+    process.env.CLOUDFRONT_DOMAIN = "cdn.test";
+    process.env.AWS_ACCESS_KEY_ID = "id";
+    process.env.AWS_SECRET_ACCESS_KEY = "secret";
+    (S3Client as jest.Mock).mockImplementation(() => ({
+      send: jest.fn().mockResolvedValue({}),
+    }));
+    mockedUpload = jest.spyOn(uploadModule, "uploadFile");
+  });
+
+  afterEach(() => {
+    delete process.env.AWS_REGION;
+    delete process.env.S3_BUCKET;
+    delete process.env.CLOUDFRONT_DOMAIN;
+    delete process.env.AWS_ACCESS_KEY_ID;
+    delete process.env.AWS_SECRET_ACCESS_KEY;
+  });
+
+  test("uploadFile success returns cloudfront url", async () => {
+    const send = jest.fn().mockResolvedValue({});
+    (S3Client as jest.Mock).mockImplementation(() => ({ send }));
+    const tmp = path.join("/tmp", "t.glb");
+    fs.writeFileSync(tmp, "data");
+    const url = await uploadFile(tmp, "model/gltf-binary");
+    expect(send).toHaveBeenCalled();
+    expect(url).toMatch(/^https:\/\/cdn\.test\/images\//);
+    // leave tmp file for the mock stream
+  });
+
+  test("uploadFile propagates s3 errors", async () => {
+    const err = new Error("fail");
+    const send = jest.fn().mockRejectedValue(err);
+    (S3Client as jest.Mock).mockImplementation(() => ({ send }));
+    const tmp = path.join("/tmp", "t.glb");
+    fs.writeFileSync(tmp, "data");
+    await expect(uploadFile(tmp, "model/gltf-binary")).rejects.toThrow("fail");
+    // leave tmp file for the mock stream
+  });
+
+  test("prepareImage leaves http urls unchanged", async () => {
+    const url = await prepareImage("http://example.com/file.png");
+    expect(url).toBe("http://example.com/file.png");
+    expect(mockedUpload).not.toHaveBeenCalled();
+  });
+
+  test("prepareImage rejects traversal paths", async () => {
+    await expect(prepareImage("/etc/passwd")).rejects.toThrow(
+      "image file not found",
+    );
+  });
+});

--- a/e2e/model-upload.test.js
+++ b/e2e/model-upload.test.js
@@ -1,0 +1,80 @@
+const { test, expect } = require("@playwright/test");
+const path = require("path");
+
+// Simple HTML interface for uploading a .glb file and displaying it
+const PAGE_HTML = `
+<form id="u"><input id="file" type="file" /><button type="submit">Upload</button></form>
+<p id="msg"></p>
+<model-viewer id="viewer"></model-viewer>
+<script type="module">
+  const form = document.getElementById('u');
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const fd = new FormData();
+    fd.append('model', document.getElementById('file').files[0]);
+    const controller = new AbortController();
+    // fail if the request takes longer than 1s
+    const timeout = setTimeout(() => controller.abort(), 1000);
+    try {
+      const res = await fetch('/api/upload-model', { method: 'POST', body: fd, signal: controller.signal });
+      const data = await res.json();
+      document.getElementById('viewer').src = data.url;
+    } catch (err) {
+      document.getElementById('msg').textContent = err.message || 'Upload failed';
+    } finally {
+      clearTimeout(timeout);
+    }
+  });
+</script>`;
+
+test.describe("model upload workflow", () => {
+  const fixture = path.join(__dirname, "..", "models", "bag.glb");
+
+  test("valid glb uploads and renders", async ({ page }) => {
+    await page.route("/api/upload-model", async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ url: "https://s3.example.com/models/bag.glb" }),
+      });
+    });
+    await page.setContent(PAGE_HTML);
+    await page.setInputFiles("#file", fixture);
+    await page.click("button");
+    await expect(page.locator("model-viewer")).toHaveAttribute(
+      "src",
+      /bag\.glb/,
+    );
+    await expect(page.locator("#msg")).toHaveText("");
+  });
+
+  test("server rejects corrupted glb", async ({ page }) => {
+    await page.route("/api/upload-model", async (route) => {
+      await route.fulfill({
+        status: 400,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "Invalid GLB" }),
+      });
+    });
+    await page.setContent(PAGE_HTML);
+    await page.setInputFiles("#file", fixture);
+    await page.click("button");
+    await expect(page.locator("#msg")).toHaveText(/Invalid GLB/);
+  });
+
+  test("shows timeout message when backend is slow", async ({ page }) => {
+    await page.route("/api/upload-model", async (route) => {
+      // delay longer than the page's abort timeout
+      await new Promise((r) => setTimeout(r, 1500));
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ url: "https://s3.example.com/models/bag.glb" }),
+      });
+    });
+    await page.setContent(PAGE_HTML);
+    await page.setInputFiles("#file", fixture);
+    await page.click("button");
+    await expect(page.locator("#msg")).toHaveText(/AbortError/);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -52,6 +52,8 @@
     "validate-env": "bash scripts/validate-env.sh",
     "setup": "bash scripts/setup.sh",
     "e2e": "playwright test",
+    "test:e2e": "playwright test",
+    "test:unit": "npm test --prefix backend",
     "serve": "npm run build && node scripts/dev-server.js",
     "smoke": "node scripts/run-smoke.js",
     "build": "echo 'no build step'",


### PR DESCRIPTION
## Summary
- add Playwright tests for GLB upload page
- add unit tests for prepareImage and uploadFile helpers
- expose `test:e2e` and `test:unit` npm scripts
- document running the new test scripts

## Testing
- `npm run setup`
- `cd backend && npm run format`
- `cd backend && npm test`
- `SKIP_PW_DEPS=1 npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_6877abb2e0a4832d91d17e53ae191520