### PR TITLE
Fix path traversal checks and add tests

### DIFF
--- a/backend/src/lib/fileUtils.ts
+++ b/backend/src/lib/fileUtils.ts
@@ -1,0 +1,17 @@
+import fs from "fs";
+import path from "path";
+
+export function resolveLocalFile(
+  filePath: string,
+  allowedDirs: string[],
+  errMsg = "file not found",
+): string {
+  const resolved = path.resolve(filePath);
+  for (const dir of allowedDirs.map((d) => path.resolve(d))) {
+    if (resolved === dir || resolved.startsWith(dir + path.sep)) {
+      if (fs.existsSync(resolved)) return resolved;
+      break;
+    }
+  }
+  throw new Error(errMsg);
+}

--- a/backend/src/lib/prepareImage.ts
+++ b/backend/src/lib/prepareImage.ts
@@ -1,6 +1,7 @@
 import fs from "fs";
 import path from "path";
 import { uploadFile } from "./uploadS3";
+import { resolveLocalFile } from "./fileUtils";
 
 /**
  * Ensure an image is available via HTTP and return the URL.
@@ -24,16 +25,11 @@ export async function prepareImage(image: string): Promise<string> {
     await fs.promises.writeFile(filePath, Buffer.from(base64, "base64"));
     cleanup = true;
   } else {
-    const normalized = path.normalize(filePath);
-    const resolved = path.resolve(normalized);
-    const uploadsDir = path.resolve("uploads");
-    if (!resolved.startsWith("/tmp") && !resolved.startsWith(uploadsDir)) {
-      throw new Error("image file not found");
-    }
-    if (!fs.existsSync(resolved)) {
-      throw new Error("image file not found");
-    }
-    filePath = resolved;
+    filePath = resolveLocalFile(
+      filePath,
+      ["/tmp", "uploads"],
+      "image file not found",
+    );
   }
 
   try {

--- a/backend/src/lib/uploadS3.ts
+++ b/backend/src/lib/uploadS3.ts
@@ -1,6 +1,7 @@
 import fs from "fs";
 import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
 import path from "path";
+import { resolveLocalFile } from "./fileUtils";
 
 /**
  * Upload a file to S3 and return its public CloudFront URL
@@ -12,16 +13,7 @@ export async function uploadFile(
   filePath: string,
   contentType: string,
 ): Promise<string> {
-  const normalized = path.normalize(filePath);
-  const resolved = path.resolve(normalized);
-  const uploadsDir = path.resolve("uploads");
-  if (!resolved.startsWith("/tmp") && !resolved.startsWith(uploadsDir)) {
-    throw new Error("file not found");
-  }
-  if (!fs.existsSync(resolved)) {
-    throw new Error("file not found");
-  }
-  filePath = resolved;
+  filePath = resolveLocalFile(filePath, ["/tmp", "uploads"], "file not found");
   const region = process.env.AWS_REGION;
   const bucket = process.env.S3_BUCKET;
   const domain =

--- a/backend/tests/prepareImage.test.ts
+++ b/backend/tests/prepareImage.test.ts
@@ -60,5 +60,11 @@ describe("prepareImage", () => {
     await expect(prepareImage("uploads/../secret.png")).rejects.toThrow(
       "image file not found",
     );
+    await expect(prepareImage("/tmpstuff/evil.png")).rejects.toThrow(
+      "image file not found",
+    );
+    await expect(prepareImage("uploadsbad/evil.png")).rejects.toThrow(
+      "image file not found",
+    );
   });
 });

--- a/backend/tests/uploadS3.test.ts
+++ b/backend/tests/uploadS3.test.ts
@@ -41,5 +41,8 @@ describe("uploadFile env validation", () => {
     await expect(uploadFile("/tmp/../etc/passwd", "image/png")).rejects.toThrow(
       "file not found",
     );
+    await expect(uploadFile("/tmpstuff/evil.png", "image/png")).rejects.toThrow(
+      "file not found",
+    );
   });
 });


### PR DESCRIPTION
## Summary
- centralize safe path resolution
- use helper in prepareImage and uploadS3
- extend unit tests for edge cases

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6877bdf8d07c832d90eb1a917378acbd