### PR TITLE
Fix Node activation in setup script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ These guidelines apply to all automated agents (e.g. the Codex agent) working on
 1. **Go to the repository root** – run `cd "$(git rev-parse --show-toplevel)"` after opening a shell to ensure paths resolve correctly.
 2. **Trust mise config** – execute `mise trust` in the repository root to prevent repeated `"config files not trusted"` warnings.
 3. **Unset proxy variables** – before running any `npm` commands, **and whenever you start a new shell session**, execute `unset npm_config_http_proxy npm_config_https_proxy` to silence `http-proxy` warnings.
-4. **Ensure Node 20** – run `mise use -g node@20` (or `mise install`) so the required Node version is active before running setup.
+4. **Ensure Node 20** – run `mise use -g node@20` (or `mise install`) and then `eval \"$(mise activate bash)\"` so the required Node version is active before running setup.
 5. **Validate the environment** – run `npm run validate-env` to ensure required variables are set and proxy vars remain unset.
 6. **Check network access** – ensure the environment can reach both
    `https://registry.npmjs.org` and `https://cdn.playwright.dev`. The setup

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -4,6 +4,11 @@ set -e
 # Ensure mise is available for toolchain management
 "$(dirname "$0")/install-mise.sh" >/dev/null
 
+# Activate the configured Node version so npm commands use Node 20 even when the
+# shell hasn't sourced mise's hook. This prevents "Node 20 is required" errors
+# from the preinstall script when the global Node version is different.
+eval "$(mise activate bash)"
+
 cleanup_npm_cache() {
   npm cache clean --force >/dev/null 2>&1 || true
   for dir in "$(npm config get cache)/_cacache" "$HOME/.npm/_cacache"; do

--- a/tests/setupScript.test.js
+++ b/tests/setupScript.test.js
@@ -20,4 +20,12 @@ describe("setup script", () => {
     );
     expect(content).toMatch(/check-host-deps\.js/);
   });
+
+  test("setup.sh activates mise for node", () => {
+    const content = fs.readFileSync(
+      path.join(__dirname, "..", "scripts", "setup.sh"),
+      "utf8",
+    );
+    expect(content).toMatch(/mise activate bash/);
+  });
 });


### PR DESCRIPTION
## Summary
- activate mise in setup script to ensure Node 20
- document activation step in AGENTS guidelines
- test that setup.sh activates mise

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6877bdd8ee24832da987db1885345725