### PR TITLE
Fix Node version mismatch in workflows

### DIFF
--- a/.github/workflows/ci-watchdog.yml
+++ b/.github/workflows/ci-watchdog.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 25
+          node-version: 20
       - run: npm install --no-audit --no-fund
       - run: node scripts/ci_watchdog.js
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-      node-version: 25
+      node-version: 20
           cache: 'npm'
       - run: npm install --no-audit --no-fund
       - run: npm audit --audit-level=high
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-      node-version: 25
+      node-version: 20
           cache: 'npm'
       - name: Clean npm proxy settings
         run: |
@@ -168,7 +168,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-      node-version: 25
+      node-version: 20
           cache: 'npm'
       - run: npm install --no-audit --no-fund
       - run: npm run a11y
@@ -181,7 +181,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-      node-version: 25
+      node-version: 20
           cache: 'npm'
       - run: npm install --no-audit --no-fund
       - name: Run smoke tests with fallback env

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4.2.2
       - uses: actions/setup-node@v4.4.0
         with:
-          node-version: 25
+          node-version: 20
           cache: 'npm'
       - name: Verify code scanning enabled
         run: node scripts/check-code-scanning.js

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@v4.2.2
       - uses: actions/setup-node@v4.4.0
         with:
-          node-version: 25
+          node-version: 20
       - run: SKIP_PW_DEPS=1 npm run setup
       - run: SKIP_PW_DEPS=1 npm run coverage
       - name: Validate coverage-summary.json

--- a/.github/workflows/glb-tests.yml
+++ b/.github/workflows/glb-tests.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 25
+          node-version: 20
           cache: 'npm'
           cache-dependency-path: 'backend/package-lock.json'
       - name: Install dependencies
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 25
+          node-version: 20
           cache: 'npm'
           cache-dependency-path: 'package-lock.json'
       - name: Install dependencies

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 25
+          node-version: 20
           cache: 'npm'
       - run: npm install --no-audit --no-fund
       - name: Run Lighthouse CI

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 25
+          node-version: 20
           cache: 'npm'
       - run: npm install --no-audit --no-fund
       - run: npm run load -- -o artillery-report.json

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        node-version: 25
+        node-version: 20
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/openapi-lint.yml
+++ b/.github/workflows/openapi-lint.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 25
+          node-version: 20
       - run: npm install --no-audit --no-fund
       - run: npm run lint:md
       - run: npx @ibm/openapi-validator docs/openapi.yaml

--- a/.github/workflows/ops-report.yml
+++ b/.github/workflows/ops-report.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 25
+          node-version: 20
           cache: 'npm'
           cache-dependency-path: 'backend/package-lock.json'
       - run: npm install --no-audit --no-fund

--- a/.github/workflows/pipeline-smoke.yml
+++ b/.github/workflows/pipeline-smoke.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 25
+          node-version: 20
 
       - name: Install pnpm
         run: npm install -g pnpm

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 25
+          node-version: 20
           cache: "npm"
       - run: npm install --no-audit --no-fund
       - run: npm install --no-audit --no-fund --prefix backend

--- a/.github/workflows/printclub-reminders.yml
+++ b/.github/workflows/printclub-reminders.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 25
+          node-version: 20
           cache: 'npm'
           cache-dependency-path: 'backend/package-lock.json'
       - run: npm install --no-audit --no-fund

--- a/.github/workflows/reset-credits.yml
+++ b/.github/workflows/reset-credits.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 25
+          node-version: 20
           cache: 'npm'
           cache-dependency-path: 'backend/package-lock.json'
       - run: npm install --no-audit --no-fund

--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 25
+          node-version: 20
       - run: npm install -g pnpm
       - run: pnpm install
       - run: pnpm run smoke

--- a/.github/workflows/verify-lockfile.yml
+++ b/.github/workflows/verify-lockfile.yml
@@ -25,7 +25,7 @@ jobs:
       # Setup Node.js 20.x (>=16 required)
       - uses: actions/setup-node@v4
         with:
-          node-version: 25
+          node-version: 20
 
       # Install dependencies without auditing and without funding messages
       - run: npm install --no-audit --no-fund

--- a/backend/tests/workflowsNodeVersion.test.js
+++ b/backend/tests/workflowsNodeVersion.test.js
@@ -1,0 +1,13 @@
+const fs = require("fs");
+const path = require("path");
+
+describe("workflow Node versions", () => {
+  test("no workflow uses Node 25", () => {
+    const dir = path.resolve(__dirname, "..", "..", ".github", "workflows");
+    for (const file of fs.readdirSync(dir)) {
+      if (!file.endsWith(".yml")) continue;
+      const content = fs.readFileSync(path.join(dir, file), "utf8");
+      expect(content).not.toMatch(/node-version:\s*25/);
+    }
+  });
+});

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   "author": "",
   "license": "ISC",
   "engines": {
-    "node": ">=25"
+    "node": ">=20"
   },
   "type": "commonjs",
   "prettier": {},


### PR DESCRIPTION
## Summary
- pin Node.js version 20 in GitHub Actions
- relax engines field to allow Node 20
- add a regression test ensuring workflows avoid Node 25

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_6877cc93927c832dba25b10bf02dd23c