### PR TITLE
Fix linting test output

### DIFF
--- a/backend/tests/linting.test.js
+++ b/backend/tests/linting.test.js
@@ -5,6 +5,10 @@ describe("linting", () => {
     const result = spawnSync("npm", ["run", "lint", "--silent"], {
       encoding: "utf8",
     });
+    if (result.status !== 0) {
+      // Print ESLint output to aid debugging
+      console.error(result.stdout + result.stderr);
+    }
     if (result.error) throw result.error;
     expect(result.status).toBe(0);
   });


### PR DESCRIPTION
## Summary
- show ESLint output on failure so lint test issues are easier to diagnose

## Testing
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6877d358c9e8832d9e92b13560bfb43a