### PR TITLE
Fix apt fallback in env validation

### DIFF
--- a/scripts/validate-env.sh
+++ b/scripts/validate-env.sh
@@ -93,6 +93,13 @@ if [[ -n "${npm_config_http_proxy:-}" || -n "${npm_config_https_proxy:-}" ]]; th
 fi
 
 
+if [[ -z "${SKIP_PW_DEPS:-}" ]]; then
+  if ! node scripts/check-apt.js >/dev/null 2>&1; then
+    echo "APT repository check failed. Falling back to SKIP_PW_DEPS=1." >&2
+    export SKIP_PW_DEPS=1
+  fi
+fi
+
 if [[ -z "${SKIP_NET_CHECKS:-}" ]]; then
   network_output=$(node scripts/network-check.js 2>&1)
   net_status=$?
@@ -108,13 +115,6 @@ if [[ -z "${SKIP_NET_CHECKS:-}" ]]; then
       echo "Network check failed. Ensure access to the npm registry and Playwright CDN." >&2
       exit 1
     fi
-  fi
-fi
-
-if [[ -z "${SKIP_PW_DEPS:-}" ]]; then
-  if ! node scripts/check-apt.js >/dev/null 2>&1; then
-    echo "APT repository check failed. Falling back to SKIP_PW_DEPS=1." >&2
-    export SKIP_PW_DEPS=1
   fi
 fi
 

--- a/tests/validateEnvAptNetwork.test.js
+++ b/tests/validateEnvAptNetwork.test.js
@@ -1,0 +1,34 @@
+const { spawnSync } = require("child_process");
+
+function run(env) {
+  const result = spawnSync("bash", ["scripts/validate-env.sh"], {
+    env,
+    encoding: "utf8",
+  });
+  const output = (result.stdout || "") + (result.stderr || "");
+  if (result.status !== 0) {
+    const error = new Error(output);
+    error.code = result.status;
+    throw error;
+  }
+  return output;
+}
+
+describe("validate-env apt network", () => {
+  test("skips network failure for apt after fallback", () => {
+    const env = {
+      ...process.env,
+      HF_TOKEN: "tok",
+      AWS_ACCESS_KEY_ID: "id",
+      AWS_SECRET_ACCESS_KEY: "secret",
+      DB_URL: "postgres://user:pass@localhost/db",
+      STRIPE_SECRET_KEY: "sk_test",
+      CLOUDFRONT_MODEL_DOMAIN: "cdn.test",
+      APT_CHECK_URL: "http://127.0.0.1:9",
+      SKIP_NET_CHECKS: "",
+    };
+    const output = run(env);
+    expect(output).toContain("APT repository check failed");
+    expect(output).toContain("✅ environment OK");
+  });
+});


### PR DESCRIPTION
## Summary
- run apt repository check before network check in `validate-env.sh`
- add regression test ensuring network check succeeds when apt is unreachable

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_6877d9205c50832dba5ada1bdaaad9ad