### PR TITLE
Add codeql script and test

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "diagnose": "bash scripts/diagnose.sh",
     "test:generate": "node scripts/test-generate.js",
     "test:webhook": "node scripts/test-webhook.js",
+    "codeql": "node scripts/check-code-scanning.js",
     "check:code-scanning": "node scripts/check-code-scanning.js",
     "commitlint": "commitlint --from=HEAD~1",
     "lint:md": "markdownlint-cli2 \"**/*.md\""

--- a/tests/codeqlScript.test.js
+++ b/tests/codeqlScript.test.js
@@ -1,0 +1,5 @@
+const pkg = require("../package.json");
+
+test("codeql script runs code scanning check", () => {
+  expect(pkg.scripts.codeql).toBe("node scripts/check-code-scanning.js");
+});


### PR DESCRIPTION
## Summary
- add a `codeql` npm script that runs the existing check-code-scanning script
- ensure the script exists with a new Jest test

## Testing
- `npm test --prefix backend`
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6877d90c58d8832db6ccf3c633a4bb6e