### PR TITLE
Add ensure-root-deps failure test

### DIFF
--- a/tests/ensureRootDepsFailure.test.js
+++ b/tests/ensureRootDepsFailure.test.js
@@ -1,0 +1,31 @@
+const fs = require("fs");
+const child_process = require("child_process");
+
+jest.mock("fs");
+jest.mock("child_process");
+
+describe("ensure-root-deps failure", () => {
+  beforeEach(() => {
+    fs.existsSync.mockReset();
+    child_process.execSync.mockReset();
+    process.exit = jest.fn();
+    console.error = jest.fn();
+    console.warn = jest.fn();
+  });
+
+  test("exits after repeated install failures", () => {
+    fs.existsSync.mockReturnValue(false);
+    child_process.execSync.mockImplementation(() => {
+      const err = new Error("network error");
+      throw err;
+    });
+    jest.isolateModules(() => {
+      require("../scripts/ensure-root-deps.js");
+    });
+    expect(child_process.execSync).toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalledWith(
+      "Failed to install dependencies after multiple attempts.",
+    );
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+});


### PR DESCRIPTION
## Summary
- test ensure-root-deps exits after repeated failures

## Testing
- `npm run format`
- `npm test -- tests/ensureRootDepsFailure.test.js`
- `npm test`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_6877d900a35c832d86f3ae982c0c7b89