### PR TITLE
Fix coverage missing deps test for Node >20

### DIFF
--- a/backend/tests/runCoverageMissingDeps.test.js
+++ b/backend/tests/runCoverageMissingDeps.test.js
@@ -44,6 +44,7 @@ describe("run-coverage missing deps", () => {
     const result = runCoverage({
       EXEC_LOG_FILE: logFile,
       FAKE_NODE_MODULES_MISSING: "1",
+      REQUIRED_NODE_MAJOR: process.versions.node.split(".")[0],
     });
     try {
       expect(result.status).toBe(0);


### PR DESCRIPTION
## Summary
- make runCoverageMissingDeps test adapt to the active Node version

## Testing
- `npm test backend/tests/runCoverageMissingDeps.test.js`
- `npm test`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6877dbfa2b94832d8ba8350e5813f971