### PR TITLE
Fix CodeQL alerts #3014

### DIFF
--- a/backend/tests/procurement.test.js
+++ b/backend/tests/procurement.test.js
@@ -19,7 +19,9 @@ const order = {
   ],
 };
 
-const outPath = path.join(__dirname, "test_po.pdf");
+// Use a unique output path to avoid conflicts when both the JS and TS
+// versions of this test run in parallel.
+const outPath = path.join(__dirname, "test_po_js.pdf");
 
 afterEach(() => {
   if (fs.existsSync(outPath)) fs.unlinkSync(outPath);

--- a/backend/tests/procurement.test.ts
+++ b/backend/tests/procurement.test.ts
@@ -19,7 +19,9 @@ const order = {
   ],
 };
 
-const outPath = path.join(__dirname, "test_po.pdf");
+// Use a unique output path to avoid conflicts when both the JS and TS
+// versions of this test run in parallel.
+const outPath = path.join(__dirname, "test_po_ts.pdf");
 
 afterEach(() => {
   if (fs.existsSync(outPath)) fs.unlinkSync(outPath);


### PR DESCRIPTION
## Summary
- isolate JS and TS procurement tests to avoid output conflicts

## Testing
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_6877ead4fe5c832d8d3c93be64c2134f