### PR TITLE
Fix missing winston module check

### DIFF
--- a/scripts/ensure-root-deps.js
+++ b/scripts/ensure-root-deps.js
@@ -52,9 +52,16 @@ const playwrightPath = path.join(
   "playwright",
   "package.json",
 );
+const winstonPath = path.join(
+  __dirname,
+  "..",
+  "node_modules",
+  "winston",
+  "package.json",
+);
 
 const networkCheck = path.join(__dirname, "network-check.js");
-const requiredPaths = [pluginPath, expressPath, playwrightPath];
+const requiredPaths = [pluginPath, expressPath, playwrightPath, winstonPath];
 
 function cleanupNpmCache() {
   try {

--- a/tests/ensureRootDeps.test.js
+++ b/tests/ensureRootDeps.test.js
@@ -1,4 +1,5 @@
 const fs = require("fs");
+const path = require("path");
 const child_process = require("child_process");
 
 jest.mock("fs");
@@ -18,6 +19,10 @@ describe("ensure-root-deps", () => {
     });
     const calls = child_process.execSync.mock.calls.map((c) => c[0]);
     expect(calls).toContain("npm ci");
+    const winstonCheck = fs.existsSync.mock.calls.find((c) =>
+      String(c[0]).includes(path.join("node_modules", "winston")),
+    );
+    expect(winstonCheck).toBeTruthy();
   });
 
   test("retries on network failure", () => {


### PR DESCRIPTION
## Summary
- check `winston` in `ensure-root-deps`
- test for winston dependency

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6877e665d13c832d9ecb3811210c107d