### PR TITLE
Fix logger dependency detection

### DIFF
--- a/scripts/ensure-root-deps.js
+++ b/scripts/ensure-root-deps.js
@@ -52,9 +52,16 @@ const playwrightPath = path.join(
   "playwright",
   "package.json",
 );
+const winstonPath = path.join(
+  __dirname,
+  "..",
+  "node_modules",
+  "winston",
+  "package.json",
+);
 
 const networkCheck = path.join(__dirname, "network-check.js");
-const requiredPaths = [pluginPath, expressPath, playwrightPath];
+const requiredPaths = [pluginPath, expressPath, playwrightPath, winstonPath];
 
 function cleanupNpmCache() {
   try {

--- a/tests/ensureRootDepsWinston.test.js
+++ b/tests/ensureRootDepsWinston.test.js
@@ -1,0 +1,32 @@
+const fs = require("fs");
+const child_process = require("child_process");
+const path = require("path");
+
+jest.mock("fs");
+jest.mock("child_process");
+
+describe("ensure-root-deps winston", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    fs.existsSync.mockReturnValue(true);
+    child_process.execSync.mockReset();
+    process.exit = jest.fn();
+  });
+
+  test("checks for winston package", () => {
+    const calls = [];
+    fs.existsSync.mockImplementation((p) => {
+      calls.push(p);
+      return true;
+    });
+    require("../scripts/ensure-root-deps.js");
+    const winstonPath = path.join(
+      __dirname,
+      "..",
+      "node_modules",
+      "winston",
+      "package.json",
+    );
+    expect(calls).toContain(winstonPath);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure winston is installed before running backend tests
- verify winston presence in ensure-root-deps

## Testing
- `npm run format`
- `npm test`
- `npm run smoke`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_6877e657ea90832da1efe881431d0e39