### PR TITLE
Update docs for dependency setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,9 @@ pull request:
 1. Install dependencies with `npm run setup` in the repository root.
 2. Run `npm run format` in `backend/`.
 3. Run `npm test` in `backend/` and include the results in the PR description.
+   If tests fail because Playwright or other dependencies are missing (for
+   example `assertSetupBackendDeps.test.js` fails), rerun `npm run setup` in the
+   repository root to install them before running tests again.
 
 4. Check your diff with `git status --short` to verify no unrelated files were
    modified.


### PR DESCRIPTION
## Summary
- remind codex agents to rerun `npm run setup` if tests fail for missing deps

## Testing
- `npm run format` in `backend/`
- `npm test` in `backend/`


------
https://chatgpt.com/codex/tasks/task_e_6877e649ce10832d93d57964bc55c30d