### PR TITLE
Fix codeql script detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "test:webhook": "node scripts/test-webhook.js",
     "codeql": "node scripts/check-code-scanning.js",
     "check:code-scanning": "node scripts/check-code-scanning.js",
-    "codeql": "node scripts/check-code-scanning.js",
     "commitlint": "commitlint --from=HEAD~1",
     "lint:md": "markdownlint-cli2 \"**/*.md\""
   },

--- a/tests/codeqlScriptExec.test.js
+++ b/tests/codeqlScriptExec.test.js
@@ -1,0 +1,9 @@
+const { execSync } = require("child_process");
+
+// Ensure the codeql script runs without error. It should exit with code 0
+// even when GITHUB_TOKEN is missing, as the script skips the check.
+test("npm run codeql executes successfully", () => {
+  expect(() => {
+    execSync("npm run codeql", { stdio: "pipe" });
+  }).not.toThrow();
+});


### PR DESCRIPTION
## Summary
- remove duplicate `codeql` entry in `package.json`
- add test to run `npm run codeql`

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `node scripts/run-jest.js tests/codeqlScriptExec.test.js`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6877e638a18c832dbaebc8a12c4cca0d