### PR TITLE
Fix Jest deletion warnings

### DIFF
--- a/scripts/jest-disable-deletion.js
+++ b/scripts/jest-disable-deletion.js
@@ -1,0 +1,1 @@
+global[Symbol.for("$$jest-deletion-mode")] = "off";

--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -89,7 +89,15 @@ function runJest(args) {
   const options = {
     stdio: "inherit",
     cwd: runFromRoot ? repoRoot : backendDir,
-    env,
+    env: {
+      ...env,
+      NODE_OPTIONS: [
+        env.NODE_OPTIONS,
+        `--require ${path.join(__dirname, "jest-disable-deletion.js")}`,
+      ]
+        .filter(Boolean)
+        .join(" "),
+    },
   };
 
   if (fs.existsSync(jestBin)) {

--- a/tests/jestDeletionMode.test.js
+++ b/tests/jestDeletionMode.test.js
@@ -1,0 +1,4 @@
+/** Ensure jest deletion warnings are disabled */
+test("jest deletion mode disabled", () => {
+  expect(global[Symbol.for("$$jest-deletion-mode")]).toBe("off");
+});


### PR DESCRIPTION
## Summary
- disable Jest global deletion warnings before tests run
- assert deletion warnings stay disabled

## Testing
- `node scripts/run-jest.js tests/jestDeletionMode.test.js --runInBand`
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_6877f1362f08832da701911c1c49f335