### PR TITLE
Fix test setup stubs

### DIFF
--- a/backend/tests/runJestScript.test.js
+++ b/backend/tests/runJestScript.test.js
@@ -4,17 +4,25 @@ const child_process = require("child_process");
 jest.mock("fs");
 jest.mock("child_process");
 
+process.env.SKIP_ROOT_DEPS_CHECK = "1";
 const runJest = require("../../scripts/run-jest");
+
+afterAll(() => {
+  delete process.env.SKIP_ROOT_DEPS_CHECK;
+});
 
 beforeEach(() => {
   child_process.execSync.mockReset();
+  child_process.spawnSync.mockReset();
+  child_process.spawnSync.mockReturnValue({ status: 0 });
 });
 
 test("uses backend jest when installed", () => {
   fs.existsSync.mockReturnValue(true);
   runJest(["--version"]);
-  expect(child_process.execSync).toHaveBeenCalledWith(
+  expect(child_process.spawnSync).toHaveBeenCalledWith(
     expect.stringContaining("backend/node_modules/.bin/jest"),
+    expect.any(Array),
     expect.objectContaining({ stdio: "inherit" }),
   );
 });
@@ -22,8 +30,9 @@ test("uses backend jest when installed", () => {
 test("falls back to npm test when jest missing", () => {
   fs.existsSync.mockReturnValue(false);
   runJest(["--help"]);
-  expect(child_process.execSync).toHaveBeenCalledWith(
-    expect.stringContaining("npm test --prefix backend"),
+  expect(child_process.spawnSync).toHaveBeenCalledWith(
+    "npm",
+    expect.arrayContaining(["test", "--prefix", "backend"]),
     expect.objectContaining({ stdio: "inherit" }),
   );
 });

--- a/backend/tests/stubMissingDeps.js
+++ b/backend/tests/stubMissingDeps.js
@@ -5,3 +5,15 @@ child_process.execSync = function (cmd) {
   }
   return Buffer.from("");
 };
+
+child_process.spawnSync = function (cmd, args, _opts = {}) {
+  const full = `${cmd} ${Array.isArray(args) ? args.join(" ") : ""}`.trim();
+  if (full.includes("playwright install --with-deps --dry-run")) {
+    return {
+      status: 0,
+      stdout: "Host system is missing dependencies",
+      stderr: "",
+    };
+  }
+  return { status: 0, stdout: "", stderr: "" };
+};


### PR DESCRIPTION
## Summary
- stub `spawnSync` in test helpers to avoid running real commands
- update runJestScript test expectations
- intercept Playwright host dependency check output

## Testing
- `npm run lint`
- `SKIP_PW_DEPS=1 npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_6877f14dcdc8832d8f1c92e11742850a