### PR TITLE
Fix run-jest test expectations

### DIFF
--- a/backend/tests/runJestScript.test.js
+++ b/backend/tests/runJestScript.test.js
@@ -23,7 +23,7 @@ test("uses backend jest when installed", () => {
   expect(child_process.spawnSync).toHaveBeenCalledWith(
     expect.stringContaining("backend/node_modules/.bin/jest"),
     expect.any(Array),
-    expect.objectContaining({ stdio: "inherit" }),
+    expect.objectContaining({ cwd: expect.stringContaining("backend") }),
   );
 });
 
@@ -33,6 +33,6 @@ test("falls back to npm test when jest missing", () => {
   expect(child_process.spawnSync).toHaveBeenCalledWith(
     "npm",
     expect.arrayContaining(["test", "--prefix", "backend"]),
-    expect.objectContaining({ stdio: "inherit" }),
+    expect.objectContaining({ cwd: expect.stringContaining("backend") }),
   );
 });


### PR DESCRIPTION
## Summary
- update `runJestScript` test expectations to match current behavior

## Testing
- `npm test` in `backend`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6877fc39f7c0832db7ba4b670e4b805a