### PR TITLE
Fix backend tests

### DIFF
--- a/backend/tests/stubExecSync.js
+++ b/backend/tests/stubExecSync.js
@@ -27,6 +27,34 @@ child_process.execSync = function (cmd, opts = {}) {
   return Buffer.from("");
 };
 
+child_process.spawnSync = function (cmd, args, _opts = {}) {
+  const fullCmd = Array.isArray(args) ? [cmd, ...args].join(" ") : cmd;
+  if (/jest/.test(fullCmd)) {
+    const repoRoot = path.join(__dirname, "..", "..");
+    const covDir = path.join(repoRoot, "coverage");
+    const backendDir = path.join(repoRoot, "backend", "coverage");
+    fs.mkdirSync(covDir, { recursive: true });
+    fs.mkdirSync(backendDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(backendDir, "coverage-summary.json"),
+      JSON.stringify({ total: { lines: { pct: 100 } } }),
+    );
+    return {
+      status: 0,
+      stdout: "TN:\nSF:file.js\nend_of_record\n",
+      stderr: "",
+    };
+  }
+  if (fullCmd.includes("playwright install")) {
+    return {
+      status: 0,
+      stdout: "Playwright host dependencies already satisfied.",
+      stderr: "",
+    };
+  }
+  return { status: 0, stdout: "", stderr: "" };
+};
+
 if (process.env.FAKE_NODE_MODULES_MISSING) {
   const origExists = fs.existsSync;
   fs.existsSync = (p) => {

--- a/backend/tests/stubMissingDeps.js
+++ b/backend/tests/stubMissingDeps.js
@@ -5,3 +5,15 @@ child_process.execSync = function (cmd) {
   }
   return Buffer.from("");
 };
+
+child_process.spawnSync = function (cmd, args) {
+  const fullCmd = Array.isArray(args) ? [cmd, ...args].join(" ") : cmd;
+  if (fullCmd.includes("playwright install --with-deps --dry-run")) {
+    return {
+      status: 0,
+      stdout: "Host system is missing dependencies",
+      stderr: "",
+    };
+  }
+  return { status: 0, stdout: "", stderr: "" };
+};


### PR DESCRIPTION
## Summary
- support spawnSync in test stubs
- align runJestScript tests with spawnSync implementation

## Testing
- `npm run format`
- `npm test`
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_6877f935052c832d83e4cae24c12138e