### PR TITLE
Fix jest script test failure

### DIFF
--- a/backend/tests/runJestScript.js
+++ b/backend/tests/runJestScript.js
@@ -11,7 +11,7 @@ function runJest(args = []) {
     "backend",
     "node_modules",
     ".bin",
-    "jest"
+    "jest",
   );
 
   // always run inside the backend folder
@@ -27,11 +27,7 @@ function runJest(args = []) {
     child_process.spawnSync(jestBin, args, options);
   } else {
     // fallback to `npm test`
-    child_process.spawnSync(
-      "npm",
-      ["test", "--prefix", "backend"],
-      options
-    );
+    child_process.spawnSync("npm", ["test", "--prefix", "backend"], options);
   }
 }
 


### PR DESCRIPTION
## Summary
- rename `backend/tests/runJestScript.test.js` to remove `.test` suffix

## Testing
- `npm --prefix backend run format`
- `npm --prefix backend test`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6877f917a554832dae8668051242e098