### PR TITLE
Fix tests for restricted network environment

### DIFF
--- a/backend/tests/runJestScript.test.js
+++ b/backend/tests/runJestScript.test.js
@@ -4,17 +4,24 @@ const child_process = require("child_process");
 jest.mock("fs");
 jest.mock("child_process");
 
-const runJest = require("../../scripts/run-jest");
+let runJest;
 
 beforeEach(() => {
-  child_process.execSync.mockReset();
+  child_process.spawnSync.mockReset();
+  child_process.spawnSync.mockReturnValue({
+    status: 0,
+    stdout: "",
+    stderr: "",
+  });
+  runJest = require("../../scripts/run-jest");
 });
 
 test("uses backend jest when installed", () => {
   fs.existsSync.mockReturnValue(true);
   runJest(["--version"]);
-  expect(child_process.execSync).toHaveBeenCalledWith(
+  expect(child_process.spawnSync).toHaveBeenCalledWith(
     expect.stringContaining("backend/node_modules/.bin/jest"),
+    expect.any(Array),
     expect.objectContaining({ stdio: "inherit" }),
   );
 });
@@ -22,8 +29,9 @@ test("uses backend jest when installed", () => {
 test("falls back to npm test when jest missing", () => {
   fs.existsSync.mockReturnValue(false);
   runJest(["--help"]);
-  expect(child_process.execSync).toHaveBeenCalledWith(
-    expect.stringContaining("npm test --prefix backend"),
+  expect(child_process.spawnSync).toHaveBeenCalledWith(
+    "npm",
+    expect.arrayContaining(["test", "--prefix", "backend"]),
     expect.objectContaining({ stdio: "inherit" }),
   );
 });

--- a/backend/tests/stubExecSync.js
+++ b/backend/tests/stubExecSync.js
@@ -27,6 +27,48 @@ child_process.execSync = function (cmd, opts = {}) {
   return Buffer.from("");
 };
 
+child_process.spawnSync = function (cmd, args = [], opts = {}) {
+  const cwd = opts.cwd || process.cwd();
+  const prefix = `[cwd:${cwd}] `;
+  const joined = [cmd, ...(args || [])].join(" ");
+  if (logFile) {
+    try {
+      fs.appendFileSync(logFile, prefix + joined + "\n");
+    } catch (_err) {
+      /* ignore */
+    }
+  }
+  if (joined.includes("playwright install")) {
+    return {
+      status: 0,
+      stdout: "Playwright host dependencies already satisfied.",
+      stderr: "",
+    };
+  }
+  if (joined.includes("node_modules/.bin/jest")) {
+    const fsPath = require("path");
+    const summaryPath = fsPath.join(process.cwd(), "backend", "coverage");
+    try {
+      fs.mkdirSync(summaryPath, { recursive: true });
+      fs.writeFileSync(
+        fsPath.join(summaryPath, "coverage-summary.json"),
+        JSON.stringify({ total: {} }),
+      );
+    } catch (_) {
+      /* ignore */
+    }
+    return {
+      status: 0,
+      stdout: "TN:\nSF:/dev/null\nend_of_record\n",
+      stderr: "",
+    };
+  }
+  if (process.env.FAIL_ENSURE_DEPS && joined.includes("ensure-deps.js")) {
+    return { status: 1, stdout: "", stderr: "ensure-deps failed" };
+  }
+  return { status: 0, stdout: "", stderr: "" };
+};
+
 if (process.env.FAKE_NODE_MODULES_MISSING) {
   const origExists = fs.existsSync;
   fs.existsSync = (p) => {

--- a/backend/tests/stubMissingDeps.js
+++ b/backend/tests/stubMissingDeps.js
@@ -5,3 +5,15 @@ child_process.execSync = function (cmd) {
   }
   return Buffer.from("");
 };
+
+child_process.spawnSync = function (cmd, args = []) {
+  const joined = [cmd, ...(args || [])].join(" ");
+  if (joined.includes("playwright install --with-deps --dry-run")) {
+    return {
+      status: 0,
+      stdout: "Host system is missing dependencies",
+      stderr: "",
+    };
+  }
+  return { status: 0, stdout: "", stderr: "" };
+};


### PR DESCRIPTION
## Summary
- stub child_process.spawnSync in test helpers
- update runJestScript tests for spawnSync usage

## Testing
- `npm test --prefix backend`
- `npm run format --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_6877f8dfdfd8832d98fee28d7d7337cd