### PR TITLE
Fix coverage deps test stubs

### DIFF
--- a/backend/tests/runJestScript.test.js
+++ b/backend/tests/runJestScript.test.js
@@ -8,13 +8,16 @@ const runJest = require("../../scripts/run-jest");
 
 beforeEach(() => {
   child_process.execSync.mockReset();
+  child_process.spawnSync.mockReset();
+  child_process.spawnSync.mockReturnValue({ status: 0 });
 });
 
 test("uses backend jest when installed", () => {
   fs.existsSync.mockReturnValue(true);
   runJest(["--version"]);
-  expect(child_process.execSync).toHaveBeenCalledWith(
+  expect(child_process.spawnSync).toHaveBeenCalledWith(
     expect.stringContaining("backend/node_modules/.bin/jest"),
+    expect.any(Array),
     expect.objectContaining({ stdio: "inherit" }),
   );
 });
@@ -22,8 +25,9 @@ test("uses backend jest when installed", () => {
 test("falls back to npm test when jest missing", () => {
   fs.existsSync.mockReturnValue(false);
   runJest(["--help"]);
-  expect(child_process.execSync).toHaveBeenCalledWith(
-    expect.stringContaining("npm test --prefix backend"),
+  expect(child_process.spawnSync).toHaveBeenCalledWith(
+    "npm",
+    expect.arrayContaining(["test", "--prefix", "backend"]),
     expect.objectContaining({ stdio: "inherit" }),
   );
 });

--- a/backend/tests/stubMissingDeps.js
+++ b/backend/tests/stubMissingDeps.js
@@ -1,7 +1,15 @@
 const child_process = require("child_process");
-child_process.execSync = function (cmd) {
+
+function fakeInstall(cmd) {
   if (cmd.includes("playwright install --with-deps --dry-run")) {
     return Buffer.from("Host system is missing dependencies");
   }
   return Buffer.from("");
-};
+}
+
+child_process.execSync = (cmd) => fakeInstall(cmd);
+child_process.spawnSync = (cmd, args = []) => ({
+  status: 0,
+  stdout: fakeInstall(`${cmd} ${args.join(" ")}`),
+  stderr: "",
+});

--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -3,7 +3,7 @@ const fs = require("fs");
 const { spawnSync } = require("child_process");
 const path = require("path");
 
-if (!process.env.SKIP_ROOT_DEPS_CHECK) {
+if (!process.env.SKIP_ROOT_DEPS_CHECK && process.env.NODE_ENV !== "test") {
   require("./ensure-root-deps.js");
 } else {
   try {


### PR DESCRIPTION
## Summary
- stub spawnSync in test helpers
- skip root dependency checks when run under Jest
- update runJestScript test expectations

## Testing
- `node ../scripts/run-jest.js backend/tests/runCoverageMissingDeps.test.js`
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_6877f8c32948832dac614582d28b416b