### PR TITLE
Fix network dependency checks in tests

### DIFF
--- a/scripts/check-host-deps.js
+++ b/scripts/check-host-deps.js
@@ -55,15 +55,15 @@ function hostDepsInstalled() {
   }
 }
 
-if (hostDepsInstalled()) {
-  console.log("Playwright host dependencies already satisfied.");
-  process.exit(0);
-}
-
 if (process.env.SKIP_PW_DEPS) {
   console.warn(
     "SKIP_PW_DEPS is set but Playwright host dependencies are missing. Skipping installation...",
   );
+  process.exit(0);
+}
+
+if (hostDepsInstalled()) {
+  console.log("Playwright host dependencies already satisfied.");
   process.exit(0);
 }
 

--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 const fs = require("fs");
-const { spawnSync } = require("child_process");
+const { execSync } = require("child_process");
 const path = require("path");
 
-if (!process.env.SKIP_ROOT_DEPS_CHECK) {
+if (!process.env.SKIP_ROOT_DEPS_CHECK && !process.env.JEST_WORKER_ID) {
   require("./ensure-root-deps.js");
 } else {
   try {
@@ -93,15 +93,9 @@ function runJest(args) {
   };
 
   if (fs.existsSync(jestBin)) {
-    const r = spawnSync(jestBin, jestArgs, options);
-    if (r.status !== 0) process.exit(r.status || 1);
+    execSync(`${jestBin} ${jestArgs.join(" ")}`, options);
   } else {
-    const r = spawnSync(
-      "npm",
-      ["test", "--prefix", "backend", "--", ...jestArgs],
-      options,
-    );
-    if (r.status !== 0) process.exit(r.status || 1);
+    execSync(`npm test --prefix backend -- ${jestArgs.join(" ")}`, options);
   }
 }
 


### PR DESCRIPTION
## Summary
- avoid Playwright host deps when SKIP_PW_DEPS is set
- skip network checks when requested and use execSync for npm installs
- adjust run-jest to skip dependency checks under Jest and use execSync

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6877f8a456a0832da9aaa66208f31098