### PR TITLE
fix: ensure smoke test passes

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,7 @@ For a quick end-to-end sanity check, run:
 ```bash
 npm run smoke
 ```
+If port 3000 is in use, stop the other process before running this.
 
 Run the backend unit tests alone:
 


### PR DESCRIPTION
## Summary
- clarify README about port 3000 requirements for smoke tests

## Testing
- `npm run setup`
- `SKIP_PW_DEPS=1 npm run smoke`
- `node scripts/run-jest.js`
- `SKIP_PW_DEPS=1 npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_687827620264832daf08175aea4dadb2