### PR TITLE
Update coverage step to skip PW deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
         run: npm run ci
 
       - name: Run coverage
-        run: npm run coverage
+        run: SKIP_PW_DEPS=1 npm run coverage
 
       - name: Sanitize coverage for Coveralls
         run: |


### PR DESCRIPTION
## Summary
- skip Playwright deps during coverage in CI to avoid network hangs

## Testing
- `npm test` in `backend/`
- `npm run format` in `backend/`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68783be11c50832d91e6f6bfa0092b3f