### PR TITLE
Fix smoke-test job setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,4 +185,6 @@ jobs:
       - name: Run smoke tests with fallback env
         env:
           STRIPE_TEST_KEY: dummy
-        run: npm run smoke
+        run: |
+          npm run setup
+          npm run smoke


### PR DESCRIPTION
## Summary
- ensure `smoke-fallback` job installs deps before smoke tests

## Testing
- `npm run format`
- `npm test`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68783bd2a97c832d9bc27e78601795f7