### PR TITLE
Fix coverage script output

### DIFF
--- a/scripts/run-coverage.js
+++ b/scripts/run-coverage.js
@@ -37,7 +37,10 @@ const jestArgs = [
   "--coverageReporters=json-summary",
   "--coverageReporters=lcov",
   "--coverageThreshold={}",
-  "--silent",
+  // Run Jest silently by default so coverage runs aren't noisy, but allow
+  // verbose output when COVERAGE_VERBOSE is set. This helps debug failures
+  // like ESLint warnings that would otherwise be hidden.
+  ...(process.env.COVERAGE_VERBOSE ? [] : ["--silent"]),
   "--config",
   path.join(__dirname, "..", "backend", "jest.config.js"),
   ...(extraArgs.length ? ["--runTestsByPath", ...extraArgs] : []),


### PR DESCRIPTION
## Summary
- allow verbose mode for `npm run coverage`

## Testing
- `npm run format -- scripts/run-coverage.js`
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_6878d3aa6434832d9bf21480c7beef50