### PR TITLE
Fix coverage script to show failing output

### DIFF
--- a/scripts/run-coverage.js
+++ b/scripts/run-coverage.js
@@ -91,6 +91,10 @@ fs.mkdirSync(path.dirname(summaryPath), { recursive: true });
 const summaryData = fs.readFileSync(backendSummary);
 fs.writeFileSync(summaryPath, summaryData);
 if (result.status) {
+  if (result.stdout) {
+    console.error("\n\u26d4 Jest output:\n");
+    console.error(result.stdout);
+  }
   console.error(`Jest exited with code ${result.status}`);
   process.exit(result.status);
 }


### PR DESCRIPTION
## Summary
- print Jest output when coverage fails so lint errors are visible

## Testing
- `npm run format`
- `npm test --silent --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(truncated)*
- `SKIP_PW_DEPS=1 npm run smoke` *(truncated)*

------
https://chatgpt.com/codex/tasks/task_e_6878d3aa6434832d9bf21480c7beef50