### PR TITLE
Add lint debugging guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,6 +564,14 @@ CI=1 npx playwright install --with-deps
 
 This fetches the missing libraries via `apt` so the browsers can start correctly.
 
+### Linting test output missing
+If `npm run coverage --prefix backend` fails with only LCOV data shown, run:
+```bash
+npm run lint:debug
+```
+to execute the linting test directly and view ESLint errors.
+
+
 ## Contributing
 
 ⚠️ **Note:** this project uses OpenAI Codex to generate PRs;

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "format:check": "prettier --log-level warn --check \"**/*.{js,jsx,json,md,html}\"",
     "lint": "npm run check-conflicts && eslint . --max-warnings=0 && npm run lint --prefix backend",
     "lint:fix": "eslint . --fix",
+    "lint:debug": "node scripts/run-jest.js backend/tests/linting.test.js",
     "check-conflicts": "! grep -R --include=*.js --include=*.jsx --include=*.ts --include=*.tsx '^(<{7}|={7}|>{7})' .",
     "check-root": "node scripts/check-repo-root.js",
     "pretest": "node scripts/check-repo-root.js && node scripts/assert-setup.js",


### PR DESCRIPTION
## Summary
- add a script to run the linting test directly
- document how to debug coverage failures when only LCOV data prints

## Testing
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run smoke`
- `npm run format --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_6878e46fa830832d86029025322a749f