### PR TITLE
Add granular ESLint diagnostics

### DIFF
--- a/backend/tests/detailedLint.test.js
+++ b/backend/tests/detailedLint.test.js
@@ -1,0 +1,44 @@
+const { execSync } = require("child_process");
+const path = require("path");
+
+function runEslint(cwd) {
+  try {
+    const out = execSync("npx eslint . -f json --max-warnings=0", {
+      cwd,
+      encoding: "utf8",
+    });
+    return JSON.parse(out);
+  } catch (err) {
+    if (err.stdout) {
+      try {
+        return JSON.parse(err.stdout);
+      } catch (_) {
+        console.error(err.stdout);
+      }
+    }
+    throw err;
+  }
+}
+
+describe("eslint detailed results", () => {
+  const repoRoot = path.join(__dirname, "..", "..");
+  const rootResults = runEslint(repoRoot);
+  const backendResults = runEslint(path.join(repoRoot, "backend"));
+
+  const all = [
+    ...rootResults.map((r) => ({ cwd: "root", ...r })),
+    ...backendResults.map((r) => ({ cwd: "backend", ...r })),
+  ];
+
+  all.forEach((file) => {
+    const relative = path.relative(repoRoot, file.filePath);
+    const messages = file.messages.filter((m) => m.severity >= 2);
+    const output = messages
+      .map((m) => `${m.line}:${m.column} ${m.message} (${m.ruleId})`)
+      .join("\n");
+    test(`${file.cwd} lint ${relative}`, () => {
+      if (output) console.error("\n" + output);
+      expect(messages).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add detailedLint.test.js to run ESLint per file and log errors for each file

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_6878f90c8468832da1748a6a45fc9d84