### PR TITLE
Add smoke pipeline failure tests

### DIFF
--- a/backend/tests/runSmokeConcurrentlyFailure.test.ts
+++ b/backend/tests/runSmokeConcurrentlyFailure.test.ts
@@ -1,0 +1,26 @@
+const child_process = require("child_process");
+
+jest.mock("child_process");
+const { main } = require("../../scripts/run-smoke");
+
+/** Simulate failure when the concurrently step fails. */
+test("run-smoke reports diagnostics when concurrently step fails", () => {
+  child_process.execSync.mockImplementation((cmd) => {
+    if (cmd.includes("concurrently")) {
+      const err = new Error("concurrently failed");
+      err.status = 1;
+      throw err;
+    }
+  });
+  const errSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  const exitSpy = jest.spyOn(process, "exit").mockImplementation(() => {
+    throw new Error("exit");
+  });
+  expect(() => main()).toThrow("exit");
+  const messages = errSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+  expect(messages).toMatch(/Smoke test failed/);
+  expect(messages).toMatch(/concurrently/);
+  expect(exitSpy).toHaveBeenCalledWith(1);
+  errSpy.mockRestore();
+  exitSpy.mockRestore();
+});

--- a/backend/tests/runSmokeValidateEnvFailure.test.ts
+++ b/backend/tests/runSmokeValidateEnvFailure.test.ts
@@ -1,0 +1,26 @@
+const child_process = require("child_process");
+
+jest.mock("child_process");
+const { main } = require("../../scripts/run-smoke");
+
+/** Simulate failure when validate-env script fails. */
+test("run-smoke reports diagnostics when validate-env fails", () => {
+  child_process.execSync.mockImplementation((cmd) => {
+    if (cmd.includes("validate-env")) {
+      const err = new Error("validate-env failed");
+      err.status = 1;
+      throw err;
+    }
+  });
+  const errSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  const exitSpy = jest.spyOn(process, "exit").mockImplementation(() => {
+    throw new Error("exit");
+  });
+  expect(() => main()).toThrow("exit");
+  const messages = errSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+  expect(messages).toMatch(/Smoke test failed/);
+  expect(messages).toMatch(/validate-env/);
+  expect(exitSpy).toHaveBeenCalledWith(1);
+  errSpy.mockRestore();
+  exitSpy.mockRestore();
+});

--- a/tests/runSmoke.commandOrder.test.js
+++ b/tests/runSmoke.commandOrder.test.js
@@ -1,0 +1,28 @@
+const child_process = require("child_process");
+
+beforeEach(() => {
+  jest.resetModules();
+  jest.spyOn(child_process, "execSync").mockImplementation(() => {});
+  process.env.SKIP_SETUP = "1";
+  process.env.SKIP_PW_DEPS = "1";
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+  delete process.env.SKIP_SETUP;
+  delete process.env.SKIP_PW_DEPS;
+});
+
+test("run-smoke executes commands in expected order", () => {
+  const { main } = require("../scripts/run-smoke.js");
+  main();
+  const commands = child_process.execSync.mock.calls.map((c) => c[0]);
+  expect(commands[0]).toBe("npm run validate-env");
+  expect(commands).not.toContain("npm run setup");
+  expect(commands).toContain('pkill -f "node scripts/dev-server.js"');
+  const killPortIdx = commands.indexOf("npx -y kill-port 3000");
+  expect(killPortIdx).toBeGreaterThan(-1);
+  const concurrentCmd = commands.find((c) => c.includes("concurrently"));
+  expect(concurrentCmd).toMatch(/wait-on/);
+  expect(commands.indexOf(concurrentCmd)).toBe(commands.length - 1);
+});


### PR DESCRIPTION
## Summary
- expand smoke test coverage to capture pipeline failures
- verify command order in smoke script

## Testing
- `npm run format` in `backend/`
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6878f8b10d80832d933c09a36bcb61f4