### PR TITLE
Add coverage lint failure test

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,7 @@ For a quick end-to-end sanity check, run:
 ```bash
 npm run smoke
 ```
+
 If port 3000 is in use, stop the other process before running this.
 
 Run the backend unit tests alone:
@@ -565,12 +566,14 @@ CI=1 npx playwright install --with-deps
 This fetches the missing libraries via `apt` so the browsers can start correctly.
 
 ### Linting test output missing
+
 If `npm run coverage --prefix backend` fails with only LCOV data shown, run:
+
 ```bash
 npm run lint:debug
 ```
-to execute the linting test directly and view ESLint errors.
 
+to execute the linting test directly and view ESLint errors.
 
 ## Contributing
 

--- a/tests/runCoverageLintFailOutput.test.js
+++ b/tests/runCoverageLintFailOutput.test.js
@@ -1,0 +1,42 @@
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+const stub = path.join(__dirname, "..", "backend", "tests", "stubExecSync.js");
+
+function createBadFile() {
+  const tmpDir = path.join(__dirname, "..");
+  const file = path.join(tmpDir, `lint-fail-${Date.now()}.js`);
+  fs.writeFileSync(file, "var unused = 1\n");
+  return file;
+}
+
+describe("run-coverage lint failure output", () => {
+  test("reports eslint errors with file path", () => {
+    const badFile = createBadFile();
+    try {
+      execFileSync(
+        "node",
+        ["scripts/run-coverage.js", "tests/linting.test.js"],
+        {
+          cwd: path.join(__dirname, ".."),
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            SKIP_NET_CHECKS: "1",
+            SKIP_DB_CHECK: "1",
+            SKIP_PW_DEPS: "1",
+            NODE_OPTIONS: `--require ${stub}`,
+          },
+          stdio: "pipe",
+        },
+      );
+      throw new Error("coverage unexpectedly succeeded");
+    } catch (err) {
+      const output = (err.stdout || "") + (err.stderr || "");
+      expect(output).toContain(path.basename(badFile));
+      expect(err.status).not.toBe(0);
+    } finally {
+      fs.unlinkSync(badFile);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- run prettier on README
- test that run-coverage outputs ESLint errors

## Testing
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_6878f90c8468832da1748a6a45fc9d84