### PR TITLE
Add detailed ESLint diagnostics tests

### DIFF
--- a/backend/tests/lintingDetailed.test.js
+++ b/backend/tests/lintingDetailed.test.js
@@ -1,0 +1,22 @@
+const { execSync } = require("child_process");
+const path = require("path");
+
+const backendDir = path.join(__dirname, "..");
+
+test("detailed backend ESLint report", () => {
+  const output = execSync(`npx eslint ${backendDir} -f json`, {
+    encoding: "utf8",
+  });
+  const results = JSON.parse(output);
+  const errors = results
+    .flatMap((r) => r.messages.map((m) => ({ ...m, file: r.filePath })))
+    .filter((m) => m.severity === 2);
+  if (errors.length) {
+    const snippet = errors
+      .slice(0, 10)
+      .map((e) => `${e.file}:${e.line}:${e.column} ${e.ruleId}`)
+      .join("\n");
+    console.error("\n⛔ ESLint errors:\n" + snippet + "\n");
+  }
+  expect(errors).toEqual([]);
+});

--- a/tests/lintingDetailed.test.js
+++ b/tests/lintingDetailed.test.js
@@ -1,0 +1,17 @@
+const { execSync } = require("child_process");
+
+test("detailed ESLint report", () => {
+  const output = execSync("npx eslint . -f json", { encoding: "utf8" });
+  const results = JSON.parse(output);
+  const errors = results
+    .flatMap((r) => r.messages.map((m) => ({ ...m, file: r.filePath })))
+    .filter((m) => m.severity === 2);
+  if (errors.length) {
+    const snippet = errors
+      .slice(0, 10)
+      .map((e) => `${e.file}:${e.line}:${e.column} ${e.ruleId}`)
+      .join("\n");
+    console.error("\n⛔ ESLint errors:\n" + snippet + "\n");
+  }
+  expect(errors).toEqual([]);
+});


### PR DESCRIPTION
## Summary
- expand lint test coverage with detailed diagnostics
- add backend variant for lint diagnostics

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6878f90c8468832da1748a6a45fc9d84