### PR TITLE
Add diagnostic test for smoke failures

### DIFF
--- a/tests/runSmoke.diagnostics.test.js
+++ b/tests/runSmoke.diagnostics.test.js
@@ -1,0 +1,40 @@
+const child_process = require("child_process");
+
+beforeEach(() => {
+  jest.resetModules();
+});
+
+afterEach(() => {
+  delete process.env.SKIP_SETUP;
+  delete process.env.SKIP_PW_DEPS;
+});
+
+test("run-smoke logs diagnostics on failure", () => {
+  const exec = jest
+    .spyOn(child_process, "execSync")
+    .mockImplementation((cmd) => {
+      if (cmd.includes("wait-on")) {
+        const err = new Error("fail");
+        err.status = 1;
+        throw err;
+      }
+    });
+  const errors = [];
+  const errSpy = jest
+    .spyOn(console, "error")
+    .mockImplementation((msg) => errors.push(msg));
+  const exit = jest.spyOn(process, "exit").mockImplementation((code) => {
+    throw new Error(`exit:${code}`);
+  });
+  process.env.SKIP_SETUP = "1";
+  process.env.SKIP_PW_DEPS = "1";
+  expect(() => {
+    require("../scripts/run-smoke.js").main();
+  }).toThrow(/exit:1/);
+  exec.mockRestore();
+  errSpy.mockRestore();
+  exit.mockRestore();
+  const output = errors.join("\n");
+  expect(output).toMatch(/Environment keys:/);
+  expect(output).toMatch(/Command:/);
+});


### PR DESCRIPTION
## Summary
- extend smoke test coverage with diagnostics check

## Testing
- `npm run format`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_6878f8b10d80832d933c09a36bcb61f4