### PR TITLE
Add extra pipeline failure tests

### DIFF
--- a/tests/fullPipelineScript.test.js
+++ b/tests/fullPipelineScript.test.js
@@ -24,4 +24,39 @@ describe("test-full-pipeline script", () => {
     const content = fs.readFileSync(script, "utf8");
     expect(content).toMatch(/SKIP_DB_CHECK/);
   });
+
+  test("fails when required env var missing", () => {
+    const env = {
+      ...process.env,
+      SPARC3D_ENDPOINT: "http://test",
+      HF_API_KEY: "",
+      AWS_ACCESS_KEY_ID: "id",
+      AWS_SECRET_ACCESS_KEY: "secret",
+      S3_BUCKET_NAME: "bucket",
+      CLOUDFRONT_MODEL_DOMAIN: "domain",
+    };
+    try {
+      execFileSync("node", [script], { encoding: "utf8", env });
+    } catch (err) {
+      const output = (err.stdout || "") + (err.stderr || "");
+      expect(output).toMatch(/Missing required env var: HF_API_KEY/);
+      return;
+    }
+    throw new Error("script should have failed");
+  });
+
+  test("skips when DB_URL is placeholder", () => {
+    const env = {
+      ...process.env,
+      SPARC3D_ENDPOINT: "http://test",
+      HF_API_KEY: "1",
+      AWS_ACCESS_KEY_ID: "id",
+      AWS_SECRET_ACCESS_KEY: "secret",
+      S3_BUCKET_NAME: "bucket",
+      CLOUDFRONT_MODEL_DOMAIN: "domain",
+      DB_URL: "postgres://user:password@localhost:5432/your_database",
+    };
+    const output = execFileSync("node", [script], { encoding: "utf8", env });
+    expect(output).toMatch(/Skipping \/api\/generate test due to SKIP_DB_CHECK/);
+  });
 });


### PR DESCRIPTION
## Summary
- expand `test-full-pipeline` suite with failure cases for missing env vars and placeholder DB

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 SKIP_NET_CHECKS=1 npm run setup`
- `npm test --prefix backend` *(fails: installing apt-utils)*
- `npm run ci` *(fails to complete)*
- `npm run smoke` *(fails to complete)*
- `npm run diagnose` *(fails to complete)*

------
https://chatgpt.com/codex/tasks/task_e_6878f8b10d80832d933c09a36bcb61f4