### PR TITLE
Add coverage threshold unit tests

### DIFF
--- a/scripts/run-coverage.js
+++ b/scripts/run-coverage.js
@@ -5,17 +5,65 @@ const path = require("path");
 
 const repoRoot = path.resolve(__dirname, "..");
 
-// Ensure the active Node version matches the project's requirement so the
-// coverage run doesn't silently use a wrong version when mise wasn't activated.
-require("./check-node-version.js");
+// Helper to check coverage summary against configured thresholds.
 
-// Validate environment variables and dependencies just like the test and CI
-// scripts do. This prevents confusing failures when `npm run coverage` is run
-// without first executing the setup script.
-require("./assert-setup.js");
+function checkCoverageThresholds(
+  summaryPath = path.join(repoRoot, "coverage", "coverage-summary.json"),
+) {
+  if (!fs.existsSync(summaryPath)) {
+    throw new Error(`Missing coverage summary: ${summaryPath}`);
+  }
+  const summary = JSON.parse(fs.readFileSync(summaryPath, "utf8"));
+  const thresholds = require("../jest.config.js").coverageThreshold.global;
+  const metrics = ["branches", "functions", "lines", "statements"];
+  for (const m of metrics) {
+    const actual = summary.total[m].pct;
+    const required = thresholds[m];
+    if (typeof required === "number" && actual < required) {
+      throw new Error(
+        `Coverage for ${m} ${actual}% does not meet threshold ${required}%`,
+      );
+    }
+  }
+  return true;
+}
 
-const extraArgs = process.argv.slice(2);
-if (extraArgs.includes("--help") || extraArgs.includes("-h")) {
+function runCoverage(extraArgs = process.argv.slice(2)) {
+  // Ensure the active Node version matches the project's requirement so the
+  // coverage run doesn't silently use a wrong version when mise wasn't activated.
+  require("./check-node-version.js");
+
+  // Validate environment variables and dependencies just like the test and CI
+  // scripts do. This prevents confusing failures when `npm run coverage` is run
+  // without first executing the setup script.
+  require("./assert-setup.js");
+  if (extraArgs.includes("--help") || extraArgs.includes("-h")) {
+    const jestBin = path.join(
+      __dirname,
+      "..",
+      "backend",
+      "node_modules",
+      ".bin",
+      "jest",
+    );
+    const result = spawnSync(jestBin, extraArgs, { stdio: "inherit" });
+    process.exit(result.status || 0);
+  }
+  const jestArgs = [
+    "--ci",
+    "--coverage",
+    "--maxWorkers=2",
+    "--detectOpenHandles",
+    "--forceExit",
+    "--coverageReporters=text-lcov",
+    "--coverageReporters=json-summary",
+    "--coverageReporters=lcov",
+    "--coverageThreshold={}",
+    "--config",
+    path.join(__dirname, "..", "backend", "jest.config.js"),
+    ...(extraArgs.length ? ["--runTestsByPath", ...extraArgs] : []),
+  ];
+
   const jestBin = path.join(
     __dirname,
     "..",
@@ -24,94 +72,78 @@ if (extraArgs.includes("--help") || extraArgs.includes("-h")) {
     ".bin",
     "jest",
   );
-  const result = spawnSync(jestBin, extraArgs, { stdio: "inherit" });
-  process.exit(result.status || 0);
-}
-const jestArgs = [
-  "--ci",
-  "--coverage",
-  "--maxWorkers=2",
-  "--detectOpenHandles",
-  "--forceExit",
-  "--coverageReporters=text-lcov",
-  "--coverageReporters=json-summary",
-  "--coverageReporters=lcov",
-  "--coverageThreshold={}",
-  "--config",
-  path.join(__dirname, "..", "backend", "jest.config.js"),
-  ...(extraArgs.length ? ["--runTestsByPath", ...extraArgs] : []),
-];
+  const result = spawnSync(jestBin, jestArgs, {
+    encoding: "utf8",
+    stdio: ["inherit", "pipe", "inherit"],
+    cwd: path.join(__dirname, ".."),
+    env: {
+      ...process.env,
+      NODE_PATH: path.join(__dirname, "..", "node_modules"),
+    },
+  });
 
-const jestBin = path.join(
-  __dirname,
-  "..",
-  "backend",
-  "node_modules",
-  ".bin",
-  "jest",
-);
-const result = spawnSync(jestBin, jestArgs, {
-  encoding: "utf8",
-  stdio: ["inherit", "pipe", "inherit"],
-  cwd: path.join(__dirname, ".."),
-  env: {
-    ...process.env,
-    NODE_PATH: path.join(__dirname, "..", "node_modules"),
-  },
-});
-
-const lcovPath = path.join(repoRoot, "coverage", "lcov.info");
-fs.mkdirSync(path.dirname(lcovPath), { recursive: true });
-let output = result.stdout || "";
-const start = output.indexOf("TN:");
-if (start === -1) {
-  console.error("Failed to parse LCOV from jest output");
-  process.exit(result.status || 1);
-}
-output = output.slice(start);
-fs.writeFileSync(lcovPath, output);
-
-const backendLcov = path.join(repoRoot, "backend", "coverage", "lcov.info");
-fs.mkdirSync(path.dirname(backendLcov), { recursive: true });
-fs.writeFileSync(backendLcov, output);
-console.log(`LCOV written to ${lcovPath}`);
-// Copy coverage summary produced by Jest to the repo root for CI checks.
-const backendSummary = path.join(
-  repoRoot,
-  "backend",
-  "coverage",
-  "coverage-summary.json",
-);
-if (!fs.existsSync(backendSummary)) {
-  console.error(`Missing coverage summary: ${backendSummary}`);
-  process.exit(1);
-}
-const summaryPath = path.join(repoRoot, "coverage", "coverage-summary.json");
-fs.mkdirSync(path.dirname(summaryPath), { recursive: true });
-const summaryData = fs.readFileSync(backendSummary);
-fs.writeFileSync(summaryPath, summaryData);
-if (result.status) {
-  if (result.stdout) {
-    const lines = result.stdout.trim().split("\n");
-    const snippet = lines.slice(-50).join("\n");
-    console.error("\n\u26d4 Jest output (last 50 lines):\n");
-    console.error(snippet);
-    try {
-      const failLog = path.join(repoRoot, "coverage", "failed.log");
-      fs.mkdirSync(path.dirname(failLog), { recursive: true });
-      fs.writeFileSync(failLog, result.stdout);
-      console.error(`Full output written to ${failLog}`);
-    } catch {
-      // ignore errors writing the log
-    }
+  const lcovPath = path.join(repoRoot, "coverage", "lcov.info");
+  fs.mkdirSync(path.dirname(lcovPath), { recursive: true });
+  let output = result.stdout || "";
+  const start = output.indexOf("TN:");
+  if (start === -1) {
+    console.error("Failed to parse LCOV from jest output");
+    process.exit(result.status || 1);
   }
-  console.error(`Jest exited with code ${result.status}`);
-  process.exit(result.status);
+  output = output.slice(start);
+  fs.writeFileSync(lcovPath, output);
+
+  const backendLcov = path.join(repoRoot, "backend", "coverage", "lcov.info");
+  fs.mkdirSync(path.dirname(backendLcov), { recursive: true });
+  fs.writeFileSync(backendLcov, output);
+  console.log(`LCOV written to ${lcovPath}`);
+  // Copy coverage summary produced by Jest to the repo root for CI checks.
+  const backendSummary = path.join(
+    repoRoot,
+    "backend",
+    "coverage",
+    "coverage-summary.json",
+  );
+  if (!fs.existsSync(backendSummary)) {
+    console.error(`Missing coverage summary: ${backendSummary}`);
+    process.exit(1);
+  }
+  const summaryPath = path.join(repoRoot, "coverage", "coverage-summary.json");
+  fs.mkdirSync(path.dirname(summaryPath), { recursive: true });
+  const summaryData = fs.readFileSync(backendSummary);
+  fs.writeFileSync(summaryPath, summaryData);
+  if (result.status) {
+    if (result.stdout) {
+      const lines = result.stdout.trim().split("\n");
+      const snippet = lines.slice(-50).join("\n");
+      console.error("\n\u26d4 Jest output (last 50 lines):\n");
+      console.error(snippet);
+      try {
+        const failLog = path.join(repoRoot, "coverage", "failed.log");
+        fs.mkdirSync(path.dirname(failLog), { recursive: true });
+        fs.writeFileSync(failLog, result.stdout);
+        console.error(`Full output written to ${failLog}`);
+      } catch {
+        // ignore errors writing the log
+      }
+    }
+    console.error(`Jest exited with code ${result.status}`);
+    process.exit(result.status);
+  }
+  const validContent = fs.readFileSync(lcovPath, "utf8");
+  if (/^(TN|SF):/m.test(validContent)) {
+    console.log("\u2705 lcov.info written successfully");
+  } else {
+    console.error("Generated lcov.info is invalid");
+    process.exit(1);
+  }
 }
-const validContent = fs.readFileSync(lcovPath, "utf8");
-if (/^(TN|SF):/m.test(validContent)) {
-  console.log("\u2705 lcov.info written successfully");
-} else {
-  console.error("Generated lcov.info is invalid");
-  process.exit(1);
+
+if (require.main === module) {
+  runCoverage();
 }
+
+module.exports = {
+  runCoverage,
+  checkCoverageThresholds,
+};

--- a/tests/runCoverageThreshold.test.js
+++ b/tests/runCoverageThreshold.test.js
@@ -1,0 +1,45 @@
+const fs = require("fs");
+const path = require("path");
+const { checkCoverageThresholds } = require("../scripts/run-coverage.js");
+const jestConfig = require("../jest.config.js");
+
+jest.mock("fs");
+
+describe("checkCoverageThresholds", () => {
+  const summaryPath = path.join("coverage", "coverage-summary.json");
+  const base = jestConfig.coverageThreshold.global;
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test("passes when all metrics meet thresholds", () => {
+    fs.existsSync.mockReturnValue(true);
+    fs.readFileSync.mockReturnValue(
+      JSON.stringify({
+        total: {
+          branches: { pct: base.branches + 10 },
+          functions: { pct: base.functions + 10 },
+          lines: { pct: base.lines + 10 },
+          statements: { pct: base.statements + 10 },
+        },
+      }),
+    );
+    expect(() => checkCoverageThresholds(summaryPath)).not.toThrow();
+  });
+
+  test("fails when a metric is below threshold", () => {
+    fs.existsSync.mockReturnValue(true);
+    fs.readFileSync.mockReturnValue(
+      JSON.stringify({
+        total: {
+          branches: { pct: base.branches - 5 },
+          functions: { pct: base.functions + 10 },
+          lines: { pct: base.lines + 10 },
+          statements: { pct: base.statements + 10 },
+        },
+      }),
+    );
+    expect(() => checkCoverageThresholds(summaryPath)).toThrow(/branches/);
+  });
+});


### PR DESCRIPTION
## Summary
- export a `checkCoverageThresholds` function from `scripts/run-coverage.js`
- wrap run-coverage logic in `runCoverage` and export it
- add new unit tests in `tests/runCoverageThreshold.test.js`

## Testing
- `node scripts/run-jest.js tests/runCoverageThreshold.test.js`
- `npm test` in `backend/`


------
https://chatgpt.com/codex/tasks/task_e_6879031d23f0832db010ca36f9eb7114