### PR TITLE
Fix apt-check hang and add timeout test

### DIFF
--- a/scripts/check-apt.js
+++ b/scripts/check-apt.js
@@ -47,10 +47,12 @@ if (!aptUtilsInstalled()) {
 }
 
 for (let i = 1; i <= 3; i++) {
-  const update = spawnSync("sudo", ["apt-get", "update"], {
+  const spawnOpts = {
     encoding: "utf8",
     env: { ...process.env, DEBIAN_FRONTEND: "noninteractive" },
-  });
+    timeout: 15000,
+  };
+  const update = spawnSync("sudo", ["apt-get", "update"], spawnOpts);
   if (update.status === 0) {
     const install = spawnSync(
       "sudo",
@@ -62,10 +64,7 @@ for (let i = 1; i <= 3; i++) {
         "install",
         "ca-certificates",
       ],
-      {
-        encoding: "utf8",
-        env: { ...process.env, DEBIAN_FRONTEND: "noninteractive" },
-      },
+      spawnOpts,
     );
     if (install.status === 0) {
       console.log("✅ apt update and install check succeeded");

--- a/tests/aptCheckScriptTimeout.test.js
+++ b/tests/aptCheckScriptTimeout.test.js
@@ -1,0 +1,16 @@
+const { execFileSync } = require("child_process");
+const path = require("path");
+
+const binDir = path.join(__dirname, "bin-apt-timeout");
+
+describe("apt-check timeout", () => {
+  test("times out when apt-get hangs", () => {
+    const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}` };
+    expect(() => {
+      execFileSync("node", [path.join("scripts", "check-apt.js")], {
+        env,
+        encoding: "utf8",
+      });
+    }).toThrow(/apt-get update failed/);
+  });
+});

--- a/tests/bin-apt-timeout/apt-get
+++ b/tests/bin-apt-timeout/apt-get
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+sleep 30
+exit 1

--- a/tests/bin-apt-timeout/sudo
+++ b/tests/bin-apt-timeout/sudo
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+if [[ "$1" == "apt-get" ]]; then
+  shift
+  apt-get "$@"
+else
+  command sudo "$@"
+fi

--- a/tests/fullPipelineScript.test.js
+++ b/tests/fullPipelineScript.test.js
@@ -57,6 +57,8 @@ describe("test-full-pipeline script", () => {
       DB_URL: "postgres://user:password@localhost:5432/your_database",
     };
     const output = execFileSync("node", [script], { encoding: "utf8", env });
-    expect(output).toMatch(/Skipping \/api\/generate test due to SKIP_DB_CHECK/);
+    expect(output).toMatch(
+      /Skipping \/api\/generate test due to SKIP_DB_CHECK/,
+    );
   });
 });


### PR DESCRIPTION
## Summary
- avoid long `apt-get` hangs in `check-apt.js` by adding a timeout
- test that hanging `apt-get` exits quickly

## Testing
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`
- `SKIP_PW_DEPS=1 npm run diagnose`


------
https://chatgpt.com/codex/tasks/task_e_6878ff4d34c0832d99fd75de66045219