### PR TITLE
Fix smoke test node version check

### DIFF
--- a/scripts/install-mise.sh
+++ b/scripts/install-mise.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if command -v mise >/dev/null 2>&1; then
-  exit 0
+if ! command -v mise >/dev/null 2>&1; then
+  curl -fsSL https://mise.run | bash
+  # mise installer adds ~/.local/bin to PATH but it may not be active yet
+  export PATH="$HOME/.local/bin:$PATH"
+  echo "mise installed"
 fi
 
-curl -fsSL https://mise.run | bash
-# mise installer adds ~/.local/bin to PATH but it may not be active yet
-export PATH="$HOME/.local/bin:$PATH"
-echo "mise installed"
+# Ensure Node 20 is available globally so subsequent scripts work even if the
+# container's default Node version differs.
+mise use -g node@20 >/dev/null 2>&1 || true

--- a/scripts/validate-env.sh
+++ b/scripts/validate-env.sh
@@ -79,9 +79,14 @@ fi
 required_node_major="${REQUIRED_NODE_MAJOR:-20}"
 current_major=$(node -v | sed -E "s/^v([0-9]+).*/\1/")
 if [ "$current_major" -ne "$required_node_major" ]; then
-  echo "Node $required_node_major is required. Current version: $current_major" >&2
-  echo "Run 'mise env node@$required_node_major' and retry." >&2
-  exit 1
+  echo "Installing Node $required_node_major via mise" >&2
+  mise use -g node@$required_node_major >/dev/null 2>&1 || true
+  eval "$(mise activate bash)"
+  current_major=$(node -v | sed -E "s/^v([0-9]+).*/\1/")
+  if [ "$current_major" -ne "$required_node_major" ]; then
+    echo "Node $required_node_major is required. Current version: $current_major" >&2
+    exit 1
+  fi
 fi
 
 

--- a/tests/validateEnvAutoInstallNode.test.js
+++ b/tests/validateEnvAutoInstallNode.test.js
@@ -1,0 +1,13 @@
+const fs = require("fs");
+const path = require("path");
+
+describe("validate-env auto install node", () => {
+  test("script installs required node when version mismatched", () => {
+    const content = fs.readFileSync(
+      path.join(__dirname, "..", "scripts", "validate-env.sh"),
+      "utf8",
+    );
+    expect(content).toMatch(/Installing Node \$required_node_major via mise/);
+    expect(content).toMatch(/mise use -g node@\$required_node_major/);
+  });
+});


### PR DESCRIPTION
## Summary
- install Node 20 automatically in install-mise script
- make validate-env auto-install required Node version
- add regression test for validate-env Node auto install

## Testing
- `npm run format`
- `(cd backend && npm test)`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_6878ff3cd720832da6275b1df007f25d