### PR TITLE
Add node version guidance

### DIFF
--- a/scripts/assert-setup.js
+++ b/scripts/assert-setup.js
@@ -57,6 +57,7 @@ if (currentMajor < requiredMajor) {
   console.error(
     `Node ${requiredMajor} or newer is required. Current version: ${process.versions.node}`,
   );
+  console.error(`Run 'mise env node@${requiredMajor}' and retry.`);
   process.exit(1);
 }
 

--- a/tests/assertSetupNodeVersion.test.js
+++ b/tests/assertSetupNodeVersion.test.js
@@ -1,0 +1,28 @@
+const { spawnSync } = require("child_process");
+const path = require("path");
+
+describe("assert-setup node version check", () => {
+  test("fails with helpful message when node too old", () => {
+    const env = {
+      ...process.env,
+      HF_TOKEN: "x",
+      AWS_ACCESS_KEY_ID: "id",
+      AWS_SECRET_ACCESS_KEY: "secret",
+      SKIP_NET_CHECKS: "1",
+    };
+    const node18 = path.join(
+      process.env.HOME,
+      ".local/share/mise/installs/node/18.20.8/bin/node",
+    );
+    const result = spawnSync(
+      node18,
+      [path.resolve(__dirname, "../scripts/assert-setup.js")],
+      {
+        env,
+        encoding: "utf8",
+      },
+    );
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("Run 'mise env node@20' and retry.");
+  });
+});


### PR DESCRIPTION
## Summary
- clarify assert-setup node version error
- test helpful message when node version is too old

## Testing
- `npm test tests/assertSetupNodeVersion.test.js`
- `npm run format --silent`

------
https://chatgpt.com/codex/tasks/task_e_6878ff2cbc54832dad701fa55850da3c