### PR TITLE
Fix apt-utils install loop

### DIFF
--- a/scripts/check-apt.js
+++ b/scripts/check-apt.js
@@ -13,20 +13,6 @@ function aptUtilsInstalled() {
   return res.status === 0 && /install ok installed/.test(res.stdout);
 }
 
-function installAptUtils() {
-  console.log("Installing apt-utils package...");
-  const res = spawnSync("sudo", ["apt-get", "-y", "install", "apt-utils"], {
-    encoding: "utf8",
-    env: { ...process.env, DEBIAN_FRONTEND: "noninteractive" },
-  });
-  if (res.status !== 0) {
-    process.stderr.write(res.stderr || "");
-    process.stdout.write(res.stdout || "");
-    console.error("Failed to install apt-utils package.");
-    process.exit(res.status || 1);
-  }
-}
-
 if (process.env.SKIP_PW_DEPS) {
   console.log("Skipping apt check due to SKIP_PW_DEPS");
   process.exit(0);
@@ -43,7 +29,10 @@ if (!commandExists("sudo")) {
 }
 
 if (!aptUtilsInstalled()) {
-  installAptUtils();
+  console.error(
+    "apt-utils package is missing. Set SKIP_PW_DEPS=1 to skip Playwright dependencies.",
+  );
+  process.exit(1);
 }
 
 for (let i = 1; i <= 3; i++) {

--- a/tests/aptCheckInstallAptUtils.test.js
+++ b/tests/aptCheckInstallAptUtils.test.js
@@ -3,20 +3,22 @@ const path = require("path");
 const os = require("os");
 const fs = require("fs");
 
-describe("apt-check installs apt-utils when missing", () => {
-  test("installs apt-utils package", () => {
+describe("apt-check when apt-utils is missing", () => {
+  test("fails without attempting installation", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "aptlog-"));
     const log = path.join(tmp, "log");
     const binDir = path.join(__dirname, "bin-dpkg-no-utils");
-    execFileSync("node", [path.join("scripts", "check-apt.js")], {
-      env: {
-        ...process.env,
-        PATH: `${binDir}:${process.env.PATH}`,
-        LOG_FILE: log,
-      },
-      encoding: "utf8",
-    });
-    const output = fs.readFileSync(log, "utf8");
-    expect(output).toMatch(/install apt-utils/);
+    expect(() => {
+      execFileSync("node", [path.join("scripts", "check-apt.js")], {
+        env: {
+          ...process.env,
+          PATH: `${binDir}:${process.env.PATH}`,
+          LOG_FILE: log,
+        },
+        encoding: "utf8",
+      });
+    }).toThrow(/apt-utils package is missing/);
+    const output = fs.existsSync(log) ? fs.readFileSync(log, "utf8") : "";
+    expect(output).toBe("");
   });
 });


### PR DESCRIPTION
## Summary
- skip apt-utils install when checking apt repositories
- update apt-check test

## Testing
- `npm run format --silent --prefix backend`
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_6878ff1f6328832d92f09ef436544351