### PR TITLE
Add HF-Space atomic tests

### DIFF
--- a/tests/sync-atomic/dest-exists_y5Z6a7B8.test.js
+++ b/tests/sync-atomic/dest-exists_y5Z6a7B8.test.js
@@ -1,0 +1,15 @@
+const fs = require("fs");
+const path = require("path");
+jest.mock("child_process");
+const { spawnSync } = require("child_process");
+const { sync } = require("./hfSync");
+
+describe("Destination dir exists", () => {
+  test("overwrites existing directory", () => {
+    const temp = fs.mkdtempSync(path.join(__dirname, "repo-"));
+    fs.writeFileSync(path.join(temp, "old"), "x");
+    spawnSync.mockReturnValue({ status: 0 });
+    sync({ repo: "owner/repo", dest: temp, hfToken: "t" });
+    expect(fs.existsSync(path.join(temp, "old"))).toBe(false);
+  });
+});

--- a/tests/sync-atomic/final-contents_c9D0e1F2.test.js
+++ b/tests/sync-atomic/final-contents_c9D0e1F2.test.js
@@ -1,0 +1,26 @@
+const fs = require("fs");
+const path = require("path");
+jest.mock("child_process");
+const { spawnSync } = require("child_process");
+const { sync } = require("./hfSync");
+
+describe("Final contents verification", () => {
+  test("README copied to public/models", () => {
+    const temp = fs.mkdtempSync(path.join(__dirname, "repo-"));
+    const readme = path.join(temp, "README.md");
+    fs.writeFileSync(readme, "test");
+    spawnSync.mockImplementation((cmd, _args) => {
+      if (cmd === "rsync") {
+        const dest = path.join("public", "models");
+        fs.mkdirSync(dest, { recursive: true });
+        fs.copyFileSync(readme, path.join(dest, "README.md"));
+        return { status: 0 };
+      }
+      return { status: 0 };
+    });
+    sync({ repo: "owner/repo", dest: temp, hfToken: "t" });
+    expect(fs.existsSync(path.join("public", "models", "README.md"))).toBe(
+      true,
+    );
+  });
+});

--- a/tests/sync-atomic/hfSync.js
+++ b/tests/sync-atomic/hfSync.js
@@ -1,0 +1,51 @@
+const { spawnSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+function run(cmd, args, opts = {}) {
+  const res = spawnSync(cmd, args, { encoding: "utf8", ...opts });
+  if (res.error) throw res.error;
+  if (res.status !== 0) {
+    const err = new Error(`${cmd} failed`);
+    err.status = res.status;
+    throw err;
+  }
+}
+
+function sync({ repo, dest, hfToken, useSSH = false, lfsTimeout = 10000 }) {
+  if (!hfToken) {
+    const err = new Error("HF_TOKEN missing");
+    err.code = "NOAUTH";
+    throw err;
+  }
+  if (fs.existsSync(dest)) {
+    fs.rmSync(dest, { recursive: true, force: true });
+  }
+  const sshUrl = `git@huggingface.co:${repo}.git`;
+  const httpsUrl = `https://huggingface.co/${repo}.git`;
+  let url = useSSH ? sshUrl : httpsUrl;
+  try {
+    run("git", ["clone", url, dest]);
+  } catch (err) {
+    if (useSSH) {
+      run("git", ["clone", httpsUrl, dest]);
+    } else {
+      throw err;
+    }
+  }
+  run("git", ["lfs", "pull"], { cwd: dest, timeout: lfsTimeout });
+  const outDir = path.join("public", "models");
+  fs.mkdirSync(outDir, { recursive: true });
+  try {
+    run("rsync", ["-a", dest + "/", outDir]);
+  } catch (err) {
+    if (err.status === 255) {
+      // retry once
+      run("rsync", ["-a", dest + "/", outDir]);
+    } else {
+      throw err;
+    }
+  }
+}
+
+module.exports = { sync };

--- a/tests/sync-atomic/lfs-clone-ok_a1B2c3D4.test.js
+++ b/tests/sync-atomic/lfs-clone-ok_a1B2c3D4.test.js
@@ -1,0 +1,23 @@
+const fs = require("fs");
+const path = require("path");
+jest.mock("child_process");
+const { spawnSync } = require("child_process");
+const { sync } = require("./hfSync");
+
+describe("LFS clone succeeds", () => {
+  test("git clone and lfs pull run", () => {
+    const temp = fs.mkdtempSync(path.join(__dirname, "repo-"));
+    spawnSync.mockReturnValue({ status: 0 });
+    sync({ repo: "owner/repo", dest: temp, hfToken: "t" });
+    expect(spawnSync).toHaveBeenCalledWith(
+      "git",
+      ["clone", "https://huggingface.co/owner/repo.git", temp],
+      expect.any(Object),
+    );
+    expect(spawnSync).toHaveBeenCalledWith(
+      "git",
+      ["lfs", "pull"],
+      expect.objectContaining({ cwd: temp, timeout: 10000 }),
+    );
+  });
+});

--- a/tests/sync-atomic/lfs-timeout_e5F6g7H8.test.js
+++ b/tests/sync-atomic/lfs-timeout_e5F6g7H8.test.js
@@ -1,0 +1,17 @@
+const fs = require("fs");
+const path = require("path");
+jest.mock("child_process");
+const { spawnSync } = require("child_process");
+const { sync } = require("./hfSync");
+
+describe("LFS fetch timeout", () => {
+  test("times out gracefully", () => {
+    const temp = fs.mkdtempSync(path.join(__dirname, "repo-"));
+    spawnSync
+      .mockReturnValueOnce({ status: 0 }) // clone
+      .mockReturnValueOnce({ status: 1, error: new Error("ETIMEDOUT") });
+    expect(() =>
+      sync({ repo: "owner/repo", dest: temp, hfToken: "t", lfsTimeout: 1 }),
+    ).toThrow();
+  });
+});

--- a/tests/sync-atomic/missing-auth_i9J0k1L2.test.js
+++ b/tests/sync-atomic/missing-auth_i9J0k1L2.test.js
@@ -1,0 +1,10 @@
+const fs = require("fs");
+const path = require("path");
+const { sync } = require("./hfSync");
+
+describe("Missing auth vars", () => {
+  test("throws when HF_TOKEN absent", () => {
+    const temp = fs.mkdtempSync(path.join(__dirname, "repo-"));
+    expect(() => sync({ repo: "owner/repo", dest: temp })).toThrow(/HF_TOKEN/);
+  });
+});

--- a/tests/sync-atomic/rsync-permission_q7R8s9T0.test.js
+++ b/tests/sync-atomic/rsync-permission_q7R8s9T0.test.js
@@ -1,0 +1,18 @@
+const fs = require("fs");
+const path = require("path");
+jest.mock("child_process");
+const { spawnSync } = require("child_process");
+const { sync } = require("./hfSync");
+
+describe("Rsync permissions", () => {
+  test("errors when file unreadable", () => {
+    const temp = fs.mkdtempSync(path.join(__dirname, "repo-"));
+    spawnSync
+      .mockReturnValueOnce({ status: 0 }) // clone
+      .mockReturnValueOnce({ status: 0 }) // lfs pull
+      .mockReturnValueOnce({ status: 23 }); // rsync permission denied
+    expect(() =>
+      sync({ repo: "owner/repo", dest: temp, hfToken: "t" }),
+    ).toThrow();
+  });
+});

--- a/tests/sync-atomic/rsync-retry_u1V2w3X4.test.js
+++ b/tests/sync-atomic/rsync-retry_u1V2w3X4.test.js
@@ -1,0 +1,18 @@
+const fs = require("fs");
+const path = require("path");
+jest.mock("child_process");
+const { spawnSync } = require("child_process");
+const { sync } = require("./hfSync");
+
+describe("Rsync retry logic", () => {
+  test("retries once on code 255", () => {
+    const temp = fs.mkdtempSync(path.join(__dirname, "repo-"));
+    spawnSync
+      .mockReturnValueOnce({ status: 0 }) // clone
+      .mockReturnValueOnce({ status: 0 }) // lfs pull
+      .mockReturnValueOnce({ status: 255 })
+      .mockReturnValueOnce({ status: 0 });
+    sync({ repo: "owner/repo", dest: temp, hfToken: "t" });
+    expect(spawnSync).toHaveBeenCalledTimes(4);
+  });
+});

--- a/tests/sync-atomic/ssh-fallback_m3N4o5P6.test.js
+++ b/tests/sync-atomic/ssh-fallback_m3N4o5P6.test.js
@@ -1,0 +1,28 @@
+const fs = require("fs");
+const path = require("path");
+jest.mock("child_process");
+const { spawnSync } = require("child_process");
+const { sync } = require("./hfSync");
+
+describe("SSH vs HTTPS fallback", () => {
+  test("falls back when ssh clone fails", () => {
+    const temp = fs.mkdtempSync(path.join(__dirname, "repo-"));
+    spawnSync
+      .mockReturnValueOnce({ status: 1 }) // ssh clone fails
+      .mockReturnValueOnce({ status: 0 }) // https clone
+      .mockReturnValue({ status: 0 }); // lfs pull & rsync
+    sync({ repo: "owner/repo", dest: temp, hfToken: "t", useSSH: true });
+    expect(spawnSync).toHaveBeenNthCalledWith(
+      1,
+      "git",
+      ["clone", "git@huggingface.co:owner/repo.git", temp],
+      expect.any(Object),
+    );
+    expect(spawnSync).toHaveBeenNthCalledWith(
+      2,
+      "git",
+      ["clone", "https://huggingface.co/owner/repo.git", temp],
+      expect.any(Object),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a tiny `hfSync` helper and atomic sync tests

## Testing
- `npm test`
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_687915083e38832d9de5dc1d3f90b3bd