### PR TITLE
Add atomic smoke pipeline tests

### DIFF
--- a/tests/smoke-atomic/apiEndpoint_1a2b3c4d.test.js
+++ b/tests/smoke-atomic/apiEndpoint_1a2b3c4d.test.js
@@ -1,0 +1,40 @@
+const { spawn } = require("child_process");
+const net = require("net");
+const path = require("path");
+const fetch = require("node-fetch");
+
+const repoRoot = path.resolve(__dirname, "..", "..");
+
+function waitPort(port, timeout = 5000) {
+  const start = Date.now();
+  return new Promise((resolve, reject) => {
+    (function check() {
+      const socket = net.connect(port, "127.0.0.1");
+      socket.once("error", () => {
+        socket.destroy();
+        if (Date.now() - start > timeout) return reject(new Error("timeout"));
+        setTimeout(check, 100);
+      });
+      socket.once("connect", () => {
+        socket.end();
+        resolve();
+      });
+    })();
+  });
+}
+
+test("api generate endpoint returns json", async () => {
+  const proc = spawn("npm", ["run", "serve"], {
+    cwd: repoRoot,
+    env: { ...process.env, PORT: "3000", SKIP_PW_DEPS: "1" },
+    stdio: "ignore",
+  });
+  await waitPort(3000);
+  const res = await fetch("http://localhost:3000/api/generate", {
+    method: "POST",
+  });
+  expect(res.status).toBe(200);
+  const body = await res.json();
+  expect(typeof body.glb_url).toBe("string");
+  proc.kill("SIGTERM");
+});

--- a/tests/smoke-atomic/envValidation_c4d2a3b9.test.js
+++ b/tests/smoke-atomic/envValidation_c4d2a3b9.test.js
@@ -1,0 +1,30 @@
+const { spawnSync } = require("child_process");
+const path = require("path");
+const { initEnv } = require("../../scripts/run-smoke.js");
+
+const repoRoot = path.resolve(__dirname, "..", "..");
+
+function run(env) {
+  return spawnSync("bash", ["scripts/validate-env.sh"], {
+    cwd: repoRoot,
+    env,
+    encoding: "utf8",
+  });
+}
+
+describe("validate-env script", () => {
+  const baseEnv = initEnv({ SKIP_NET_CHECKS: "1", SKIP_DB_CHECK: "1" });
+
+  test("fails when AWS_ACCESS_KEY_ID missing", () => {
+    const env = { ...baseEnv, AWS_ACCESS_KEY_ID: "" };
+    const res = run(env);
+    expect(res.status).not.toBe(0);
+    expect(res.stdout + res.stderr).toMatch(/AWS_ACCESS_KEY_ID must be set/);
+  });
+
+  test("succeeds with required vars", () => {
+    const res = run(baseEnv);
+    expect(res.status).toBe(0);
+    expect(res.stdout + res.stderr).toContain("environment OK");
+  });
+});

--- a/tests/smoke-atomic/frontendBuild_b7e9c0d3.test.js
+++ b/tests/smoke-atomic/frontendBuild_b7e9c0d3.test.js
@@ -1,0 +1,18 @@
+const { spawnSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+const repoRoot = path.resolve(__dirname, "..", "..");
+
+test("frontend build succeeds and outputs files", () => {
+  const res = spawnSync("npm", ["run", "build"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+  expect(res.status).toBe(0);
+  const distDir = fs.existsSync(path.join(repoRoot, "dist"))
+    ? path.join(repoRoot, "dist")
+    : repoRoot;
+  const entries = fs.readdirSync(distDir).filter((f) => !f.startsWith("."));
+  expect(entries.length).toBeGreaterThan(0);
+});

--- a/tests/smoke-atomic/httpHealth_b3d8e7f6.test.js
+++ b/tests/smoke-atomic/httpHealth_b3d8e7f6.test.js
@@ -1,0 +1,36 @@
+const { spawn } = require("child_process");
+const net = require("net");
+const path = require("path");
+const fetch = require("node-fetch");
+
+const repoRoot = path.resolve(__dirname, "..", "..");
+
+function waitPort(port, timeout = 5000) {
+  const start = Date.now();
+  return new Promise((resolve, reject) => {
+    (function check() {
+      const socket = net.connect(port, "127.0.0.1");
+      socket.once("error", () => {
+        socket.destroy();
+        if (Date.now() - start > timeout) return reject(new Error("timeout"));
+        setTimeout(check, 100);
+      });
+      socket.once("connect", () => {
+        socket.end();
+        resolve();
+      });
+    })();
+  });
+}
+
+test("GET / responds with 200", async () => {
+  const proc = spawn("npm", ["run", "serve"], {
+    cwd: repoRoot,
+    env: { ...process.env, PORT: "3000", SKIP_PW_DEPS: "1" },
+    stdio: "ignore",
+  });
+  await waitPort(3000);
+  const res = await fetch("http://localhost:3000/");
+  expect(res.status).toBe(200);
+  proc.kill("SIGTERM");
+});

--- a/tests/smoke-atomic/playwrightReady_a4b5c6d7.test.js
+++ b/tests/smoke-atomic/playwrightReady_a4b5c6d7.test.js
@@ -1,0 +1,49 @@
+/* eslint-env node, browser */
+const { spawn } = require("child_process");
+const net = require("net");
+const path = require("path");
+const { chromium } = require("playwright");
+
+jest.setTimeout(120000);
+
+const repoRoot = path.resolve(__dirname, "..", "..");
+
+function waitPort(port, timeout = 5000) {
+  const start = Date.now();
+  return new Promise((resolve, reject) => {
+    (function check() {
+      const socket = net.connect(port, "127.0.0.1");
+      socket.once("error", () => {
+        socket.destroy();
+        if (Date.now() - start > timeout) return reject(new Error("timeout"));
+        setTimeout(check, 100);
+      });
+      socket.once("connect", () => {
+        socket.end();
+        resolve();
+      });
+    })();
+  });
+}
+
+test("viewerReady dataset becomes true", async () => {
+  const proc = spawn("npm", ["run", "serve"], {
+    cwd: repoRoot,
+    env: { ...process.env, PORT: "3000", SKIP_PW_DEPS: "1" },
+    stdio: "ignore",
+  });
+  await waitPort(3000);
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  await page.goto("http://localhost:3000/");
+  await page.waitForFunction("document.body.dataset.viewerReady", {
+    timeout: 60000,
+  });
+  const ready = await page.evaluate("document.body.dataset.viewerReady");
+  expect(ready).toBeTruthy();
+  await browser.close();
+  await new Promise((resolve) => {
+    proc.once("close", resolve);
+    proc.kill("SIGTERM");
+  });
+});

--- a/tests/smoke-atomic/runSmokeHelper_f3e2d1c4.test.js
+++ b/tests/smoke-atomic/runSmokeHelper_f3e2d1c4.test.js
@@ -1,0 +1,28 @@
+const child_process = require("child_process");
+
+beforeEach(() => {
+  jest.resetModules();
+  jest.restoreAllMocks();
+});
+
+test("run executes command with env", () => {
+  const spy = jest
+    .spyOn(child_process, "execSync")
+    .mockReturnValue(Buffer.from(""));
+  const { run } = require("../../scripts/run-smoke.js");
+  run("echo hi");
+  expect(spy).toHaveBeenCalledWith("echo hi", {
+    stdio: "inherit",
+    env: expect.any(Object),
+  });
+});
+
+test("run throws on failure", () => {
+  const err = new Error("fail");
+  err.status = 1;
+  jest.spyOn(child_process, "execSync").mockImplementation(() => {
+    throw err;
+  });
+  const { run } = require("../../scripts/run-smoke.js");
+  expect(() => run("bad")).toThrow(err);
+});

--- a/tests/smoke-atomic/serveStartup_f9a1b2c3.test.js
+++ b/tests/smoke-atomic/serveStartup_f9a1b2c3.test.js
@@ -1,0 +1,33 @@
+const { spawn } = require("child_process");
+const net = require("net");
+const path = require("path");
+
+const repoRoot = path.resolve(__dirname, "..", "..");
+
+function waitPort(port, timeout = 5000) {
+  const start = Date.now();
+  return new Promise((resolve, reject) => {
+    (function check() {
+      const socket = net.connect(port, "127.0.0.1");
+      socket.once("error", () => {
+        socket.destroy();
+        if (Date.now() - start > timeout) return reject(new Error("timeout"));
+        setTimeout(check, 100);
+      });
+      socket.once("connect", () => {
+        socket.end();
+        resolve();
+      });
+    })();
+  });
+}
+
+test("npm run serve starts on port 3000", async () => {
+  const proc = spawn("npm", ["run", "serve"], {
+    cwd: repoRoot,
+    env: { ...process.env, PORT: "3000", SKIP_PW_DEPS: "1" },
+    stdio: "ignore",
+  });
+  await waitPort(3000);
+  proc.kill("SIGTERM");
+});

--- a/tests/smoke-atomic/setupIdempotent_e8f6g1h2.test.js
+++ b/tests/smoke-atomic/setupIdempotent_e8f6g1h2.test.js
@@ -1,0 +1,21 @@
+const { spawnSync } = require("child_process");
+const path = require("path");
+
+const repoRoot = path.resolve(__dirname, "..", "..");
+
+function runSetup() {
+  return spawnSync("bash", ["scripts/setup.sh"], {
+    cwd: repoRoot,
+    env: { ...process.env, SKIP_PW_DEPS: "1", SKIP_NET_CHECKS: "1" },
+    encoding: "utf8",
+  });
+}
+
+test("setup script is idempotent", () => {
+  for (let i = 0; i < 2; i++) {
+    const res = runSetup();
+    expect(res.status).toBe(0);
+  }
+  const flag = path.join(repoRoot, ".setup-complete");
+  expect(require("fs").existsSync(flag)).toBe(true);
+});


### PR DESCRIPTION
## Summary
- add new `tests/smoke-atomic` suite breaking out smoke pipeline
- cover env validation, setup idempotency, build, serve, health checks and API
- add minimal Playwright readiness test
- unit test run-smoke helper

## Testing
- `npm run format`
- `node scripts/run-jest.js tests/smoke-atomic/*.test.js`

------
https://chatgpt.com/codex/tasks/task_e_687914f273ac832da03c05326d12bbad