### PR TITLE
Add atomic smoke pipeline tests

### DIFF
--- a/tests/smoke-atomic/apiGenerate_g5h6i7j8.test.js
+++ b/tests/smoke-atomic/apiGenerate_g5h6i7j8.test.js
@@ -1,0 +1,35 @@
+const { spawn } = require("child_process");
+const net = require("net");
+
+function waitForPort(port, timeout = 5000) {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    function tryConnect() {
+      const socket = net.connect(port, "127.0.0.1");
+      socket.on("connect", () => {
+        socket.end();
+        resolve();
+      });
+      socket.on("error", () => {
+        socket.destroy();
+        if (Date.now() - start > timeout) reject(new Error("timeout"));
+        else setTimeout(tryConnect, 100);
+      });
+    }
+    tryConnect();
+  });
+}
+
+test("api /api/generate returns json", async () => {
+  const port = 3200 + Math.floor(Math.random() * 5000);
+  const env = { ...process.env, PORT: String(port) };
+  const proc = spawn("npm", ["run", "serve"], { env });
+  await waitForPort(port);
+  const res = await fetch(`http://localhost:${port}/api/generate`, {
+    method: "POST",
+  });
+  const body = await res.json();
+  expect(res.status).toBe(200);
+  expect(body).toHaveProperty("glb_url");
+  proc.kill();
+});

--- a/tests/smoke-atomic/envValidation_a1b2c3d4.test.js
+++ b/tests/smoke-atomic/envValidation_a1b2c3d4.test.js
@@ -1,0 +1,36 @@
+const { spawnSync } = require("child_process");
+const path = require("path");
+
+test("validate-env fails without DB_URL and succeeds when present", () => {
+  const script = path.join(__dirname, "..", "..", "scripts", "validate-env.sh");
+  const missing = spawnSync("bash", [script], {
+    env: {
+      ...process.env,
+      AWS_ACCESS_KEY_ID: "id",
+      AWS_SECRET_ACCESS_KEY: "secret",
+      STRIPE_SECRET_KEY: "sk_test",
+      CLOUDFRONT_MODEL_DOMAIN: "cdn.test",
+      DB_URL: "",
+      SKIP_NET_CHECKS: "1",
+    },
+    encoding: "utf8",
+  });
+  expect(missing.status).not.toBe(0);
+  expect(missing.stdout + missing.stderr).toMatch(/DB_URL must be set/);
+
+  const ok = spawnSync("bash", [script], {
+    env: {
+      ...process.env,
+      AWS_ACCESS_KEY_ID: "id",
+      AWS_SECRET_ACCESS_KEY: "secret",
+      STRIPE_SECRET_KEY: "sk_test",
+      CLOUDFRONT_MODEL_DOMAIN: "cdn.test",
+      DB_URL: "postgres://user:pass@localhost/db",
+      SKIP_NET_CHECKS: "1",
+      SKIP_DB_CHECK: "1",
+    },
+    encoding: "utf8",
+  });
+  expect(ok.status).toBe(0);
+  expect(ok.stdout + ok.stderr).toMatch(/environment OK/);
+});

--- a/tests/smoke-atomic/frontendBuild_c9d0e1f2.test.js
+++ b/tests/smoke-atomic/frontendBuild_c9d0e1f2.test.js
@@ -1,0 +1,12 @@
+const { spawnSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+test("npm run build succeeds and js folder exists", () => {
+  const result = spawnSync("npm", ["run", "build"], { encoding: "utf8" });
+  expect(result.status).toBe(0);
+  const jsDir = path.join(__dirname, "..", "..", "js");
+  expect(fs.existsSync(jsDir)).toBe(true);
+  const files = fs.readdirSync(jsDir);
+  expect(files.length).toBeGreaterThan(0);
+});

--- a/tests/smoke-atomic/httpHealthCheck_e7f8g9h0.test.js
+++ b/tests/smoke-atomic/httpHealthCheck_e7f8g9h0.test.js
@@ -1,0 +1,23 @@
+const { spawn } = require("child_process");
+
+function wait(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+test("root endpoint responds with 200", async () => {
+  const proc = spawn("npm", ["run", "serve"], { env: process.env });
+  for (let i = 0; i < 50; i++) {
+    try {
+      const res = await fetch("http://localhost:3000/");
+      if (res.status === 200) {
+        proc.kill();
+        return;
+      }
+    } catch {
+      /* empty */
+    }
+    await wait(100);
+  }
+  proc.kill();
+  throw new Error("server did not respond");
+});

--- a/tests/smoke-atomic/runHelper_h9i0j1k2.test.js
+++ b/tests/smoke-atomic/runHelper_h9i0j1k2.test.js
@@ -1,0 +1,20 @@
+const child_process = require("child_process");
+
+test("run helper invokes execSync and propagates errors", () => {
+  jest.spyOn(child_process, "execSync").mockImplementation((cmd) => {
+    if (cmd === "fail") {
+      const err = new Error("boom");
+      err.status = 1;
+      throw err;
+    }
+  });
+  jest.isolateModules(() => {
+    const { run } = require("../../scripts/run-smoke.js");
+    run("ok");
+    expect(child_process.execSync).toHaveBeenCalledWith("ok", {
+      stdio: "inherit",
+      env: expect.any(Object),
+    });
+    expect(() => run("fail")).toThrow("boom");
+  });
+});

--- a/tests/smoke-atomic/serveStartup_d3e4f5g6.test.js
+++ b/tests/smoke-atomic/serveStartup_d3e4f5g6.test.js
@@ -1,0 +1,30 @@
+const { spawn } = require("child_process");
+const net = require("net");
+
+function waitForPort(port, timeout = 5000) {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    function tryConnect() {
+      const socket = net.connect(port, "127.0.0.1");
+      socket.on("connect", () => {
+        socket.end();
+        resolve();
+      });
+      socket.on("error", () => {
+        socket.destroy();
+        if (Date.now() - start > timeout) {
+          reject(new Error("timeout"));
+        } else {
+          setTimeout(tryConnect, 100);
+        }
+      });
+    }
+    tryConnect();
+  });
+}
+
+test("npm run serve starts server on port 3000", async () => {
+  const proc = spawn("npm", ["run", "serve"], { env: process.env });
+  await waitForPort(3000);
+  proc.kill();
+});

--- a/tests/smoke-atomic/setupIdempotent_b5c6d7e8.test.js
+++ b/tests/smoke-atomic/setupIdempotent_b5c6d7e8.test.js
@@ -1,0 +1,11 @@
+const { spawnSync } = require("child_process");
+const path = require("path");
+
+test("setup script can run twice without error", () => {
+  const script = path.join(__dirname, "..", "..", "scripts", "setup.sh");
+  const env = { ...process.env, SKIP_PW_DEPS: "1", SKIP_NET_CHECKS: "1" };
+  const first = spawnSync("bash", [script], { env, encoding: "utf8" });
+  expect(first.status).toBe(0);
+  const second = spawnSync("bash", [script], { env, encoding: "utf8" });
+  expect(second.status).toBe(0);
+});

--- a/tests/smoke-atomic/viewerReady_f1g2h3i4.test.js
+++ b/tests/smoke-atomic/viewerReady_f1g2h3i4.test.js
@@ -1,0 +1,34 @@
+const { test, expect } = require("@playwright/test");
+const { spawn } = require("child_process");
+const net = require("net");
+
+function waitForPort(port, timeout = 5000) {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    function tryConnect() {
+      const socket = net.connect(port, "127.0.0.1");
+      socket.on("connect", () => {
+        socket.end();
+        resolve();
+      });
+      socket.on("error", () => {
+        socket.destroy();
+        if (Date.now() - start > timeout) reject(new Error("timeout"));
+        else setTimeout(tryConnect, 100);
+      });
+    }
+    tryConnect();
+  });
+}
+
+test("viewerReady flag present on homepage", async ({ page }) => {
+  const port = 3100 + Math.floor(Math.random() * 5000);
+  const env = { ...process.env, PORT: String(port) };
+  const proc = spawn("npm", ["run", "serve"], { env });
+  await waitForPort(port);
+  await page.goto(`http://localhost:${port}/`);
+  await page.waitForFunction('document.body.dataset.viewerReady === "true"');
+  const ready = await page.evaluate("document.body.dataset.viewerReady");
+  expect(ready).toBe("true");
+  proc.kill();
+});


### PR DESCRIPTION
## Summary
- break smoke pipeline into atomic Jest/Playwright tests
- new tests cover env validation, setup idempotency, build output, server startup, health check, viewer readiness, API response and run helper logic

## Testing
- `npm run format --prefix backend`
- `SKIP_PW_DEPS=1 npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_687914f273ac832da03c05326d12bbad