### PR TITLE
Add failing coverage test

### DIFF
--- a/tests/rootCoverageFailure.test.js
+++ b/tests/rootCoverageFailure.test.js
@@ -1,0 +1,50 @@
+const { execFileSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+const repoRoot = path.join(__dirname, "..");
+
+function clean() {
+  fs.rmSync(path.join(repoRoot, "coverage"), { recursive: true, force: true });
+  fs.rmSync(path.join(repoRoot, "backend", "coverage"), {
+    recursive: true,
+    force: true,
+  });
+}
+
+describe("npm run coverage", () => {
+  afterEach(() => {
+    clean();
+  });
+
+  test("reports missing coverage summary", () => {
+    const stub = path.resolve(__dirname, "stubMissingSummary.js");
+    const env = {
+      ...process.env,
+      HF_TOKEN: "x",
+      AWS_ACCESS_KEY_ID: "id",
+      AWS_SECRET_ACCESS_KEY: "secret",
+      DB_URL: "db",
+      STRIPE_SECRET_KEY: "sk",
+      SKIP_NET_CHECKS: "1",
+      SKIP_PW_DEPS: "1",
+      NODE_OPTIONS: `--require ${stub}`,
+    };
+    let output = "";
+    let status = 0;
+    try {
+      execFileSync("npm", ["run", "coverage", "--prefix", "backend"], {
+        cwd: repoRoot,
+        env,
+        encoding: "utf8",
+        stdio: "pipe",
+      });
+      throw new Error("coverage unexpectedly succeeded");
+    } catch (err) {
+      status = err.status;
+      output = (err.stdout || "") + (err.stderr || "");
+    }
+    expect(status).not.toBe(0);
+    expect(output).toMatch(/Missing coverage summary/);
+  });
+});

--- a/tests/stubMissingSummary.js
+++ b/tests/stubMissingSummary.js
@@ -1,0 +1,6 @@
+const fs = require("fs");
+const orig = fs.existsSync;
+fs.existsSync = function (p) {
+  if (String(p).includes("coverage-summary.json")) return false;
+  return orig.call(fs, p);
+};


### PR DESCRIPTION
## Summary
- add stubMissingSummary.js to simulate missing coverage-summary
- add rootCoverageFailure.test.js to reproduce `npm run coverage` failure when summary is missing

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_68790e802670832da18c6c0f6b3e001a