### PR TITLE
Improve smoke test diagnostics

### DIFF
--- a/backend/tests/runSmokeConcurrentlyFailure.test.ts
+++ b/backend/tests/runSmokeConcurrentlyFailure.test.ts
@@ -5,12 +5,11 @@ const { main } = require("../../scripts/run-smoke");
 
 /** Simulate failure when the concurrently step fails. */
 test("run-smoke reports diagnostics when concurrently step fails", () => {
-  child_process.execSync.mockImplementation((cmd) => {
+  child_process.spawnSync.mockImplementation((cmd) => {
     if (cmd.includes("concurrently")) {
-      const err = new Error("concurrently failed");
-      err.status = 1;
-      throw err;
+      return { status: 1, stderr: "concurrently failed" };
     }
+    return { status: 0 };
   });
   const errSpy = jest.spyOn(console, "error").mockImplementation(() => {});
   const exitSpy = jest.spyOn(process, "exit").mockImplementation(() => {

--- a/backend/tests/runSmokeConnectFailure.test.ts
+++ b/backend/tests/runSmokeConnectFailure.test.ts
@@ -6,12 +6,11 @@ const { main } = require("../../scripts/run-smoke");
 
 /** Simulate failure when the smoke script runs the wait-on step. */
 test("run-smoke reports diagnostics when wait-on fails", () => {
-  child_process.execSync.mockImplementation((cmd) => {
+  child_process.spawnSync.mockImplementation((cmd) => {
     if (cmd.includes("wait-on")) {
-      const err = new Error("wait-on failed");
-      err.status = 1;
-      throw err;
+      return { status: 1, stderr: "wait-on failed" };
     }
+    return { status: 0 };
   });
   const errSpy = jest.spyOn(console, "error").mockImplementation(() => {});
   const exitSpy = jest.spyOn(process, "exit").mockImplementation(() => {

--- a/backend/tests/runSmokeFailure.test.ts
+++ b/backend/tests/runSmokeFailure.test.ts
@@ -6,13 +6,11 @@ const { main } = require("../../scripts/run-smoke");
 
 describe("run-smoke failure handling", () => {
   beforeEach(() => {
-    child_process.execSync.mockReset();
+    child_process.spawnSync.mockReset();
   });
 
   test("exits with message when setup fails", () => {
-    child_process.execSync.mockImplementation(() => {
-      throw Object.assign(new Error("setup failed"), { status: 1 });
-    });
+    child_process.spawnSync.mockImplementation(() => ({ status: 1 }));
     const exitSpy = jest.spyOn(process, "exit").mockImplementation(() => {
       throw new Error("exit");
     });

--- a/backend/tests/runSmokeValidateEnvFailure.test.ts
+++ b/backend/tests/runSmokeValidateEnvFailure.test.ts
@@ -5,12 +5,11 @@ const { main } = require("../../scripts/run-smoke");
 
 /** Simulate failure when validate-env script fails. */
 test("run-smoke reports diagnostics when validate-env fails", () => {
-  child_process.execSync.mockImplementation((cmd) => {
+  child_process.spawnSync.mockImplementation((cmd) => {
     if (cmd.includes("validate-env")) {
-      const err = new Error("validate-env failed");
-      err.status = 1;
-      throw err;
+      return { status: 1, stderr: "validate-env failed" };
     }
+    return { status: 0 };
   });
   const errSpy = jest.spyOn(console, "error").mockImplementation(() => {});
   const exitSpy = jest.spyOn(process, "exit").mockImplementation(() => {

--- a/scripts/dev-server.js
+++ b/scripts/dev-server.js
@@ -30,9 +30,12 @@ function startDevServer(port = 3000) {
       console.log(`Dev server listening on http://localhost:${port}`);
     })
     .on("error", (err) => {
-      console.error("Dev server failed", err.message);
+      console.error("Dev server failed", err.stack || err.message);
       process.exit(1);
     });
+  server.on("close", () => {
+    console.log("Dev server closed");
+  });
   return server;
 }
 


### PR DESCRIPTION
## Summary
- log environment details and exit codes in `run-smoke.js`
- capture wait timeout and pipe `concurrently` output to log files
- report dev server shutdowns and stack traces
- update smoke failure tests for `spawnSync`

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687914ee9efc832d9035431cf51a6f8e