### PR TITLE
Add ESLint diagnostic tests

### DIFF
--- a/backend/tests/linting-diagnostics-9b3adf.test.js
+++ b/backend/tests/linting-diagnostics-9b3adf.test.js
@@ -1,0 +1,81 @@
+const { spawnSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+const repoRoot = path.join(__dirname, "..", "..");
+const backendDir = path.join(repoRoot, "backend");
+
+function runEslint(cwd, args = [], env = {}) {
+  return spawnSync("pnpm", ["exec", "eslint", ".", ...args], {
+    cwd,
+    encoding: "utf8",
+    env: { ...process.env, ...env },
+  });
+}
+
+test("root eslint exits 0", () => {
+  const res = runEslint(repoRoot);
+  console.log("root exit", res.status);
+  if (res.stderr) console.log(res.stderr);
+  expect(res.status).toBe(0);
+});
+
+test("backend eslint exits 0", () => {
+  const res = runEslint(backendDir);
+  console.log("backend exit", res.status);
+  if (res.stderr) console.log(res.stderr);
+  expect(res.status).toBe(0);
+});
+
+test("root has no warnings", () => {
+  const res = runEslint(repoRoot, ["-f", "json"]);
+  const results = JSON.parse(res.stdout || "[]");
+  const warnings = results.flatMap((r) =>
+    r.messages.filter((m) => m.severity === 1),
+  );
+  if (warnings.length) {
+    console.log("warnings:", warnings.map((w) => w.ruleId).join(","));
+  }
+  expect(warnings.length).toBe(0);
+});
+
+test("root has no errors", () => {
+  const res = runEslint(repoRoot, ["-f", "json"]);
+  const results = JSON.parse(res.stdout || "[]");
+  const errors = results.flatMap((r) =>
+    r.messages.filter((m) => m.severity === 2),
+  );
+  if (errors.length) {
+    console.log("errors:", errors.map((e) => e.ruleId).join(","));
+  }
+  expect(errors.length).toBe(0);
+});
+
+test("eslint config resolves", () => {
+  const cfg = path.join(repoRoot, "eslint.config.js");
+  console.log("config path", cfg);
+  expect(() => require.resolve(cfg)).not.toThrow();
+});
+
+test("root and backend exit codes match", () => {
+  const rootRes = runEslint(repoRoot);
+  const backRes = runEslint(backendDir);
+  console.log("root", rootRes.status, "backend", backRes.status);
+  expect(rootRes.status).toBe(backRes.status);
+});
+
+test("eslint writes log file", () => {
+  const log = path.join(repoRoot, "eslint-diagnostic.log");
+  if (fs.existsSync(log)) fs.unlinkSync(log);
+  runEslint(repoRoot, ["-o", log]);
+  const exists = fs.existsSync(log);
+  console.log("log exists", exists);
+  expect(exists).toBe(true);
+});
+
+test("CI flag does not change exit code", () => {
+  const normal = runEslint(repoRoot);
+  const ci = runEslint(repoRoot, [], { CI: "true" });
+  console.log("normal", normal.status, "ci", ci.status);
+  expect(ci.status).toBe(normal.status);
+});


### PR DESCRIPTION
## Summary
- add new diagnostic test file to surface ESLint failures and environment issues

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_68792c95d998832da8347754582454bc