### PR TITLE
Fix wait-on indefinite wait

### DIFF
--- a/.github/workflows/glb-tests.yml
+++ b/.github/workflows/glb-tests.yml
@@ -58,4 +58,4 @@ jobs:
         env:
           PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
         run: |
-          npx -y concurrently -k -s first "npm run serve" "npx wait-on http://localhost:3000 && npx playwright test e2e/*.test.js"
+          npx -y concurrently -k -s first "npm run serve" "npx wait-on http://localhost:3000 --timeout 300000 && npx playwright test e2e/*.test.js"

--- a/.github/workflows/pipeline-smoke.yml
+++ b/.github/workflows/pipeline-smoke.yml
@@ -47,7 +47,7 @@ jobs:
         shell: bash
 
       - name: Wait for backend
-        run: npx wait-on http://localhost:3000
+        run: npx wait-on http://localhost:3000 --timeout 300000
 
       - name: Test generate endpoint
         run: pnpm run test:generate


### PR DESCRIPTION
## Summary
- set a timeout on the wait-on steps so workflow fails quickly

## Testing
- `npm run format`
- `npm test`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_687929b25ca8832daa4e72d1aa2c5da4