### PR TITLE
Fix ensure-root-deps node version check

### DIFF
--- a/scripts/ensure-root-deps.js
+++ b/scripts/ensure-root-deps.js
@@ -5,9 +5,9 @@ const os = require("os");
 
 const requiredMajor = parseInt(process.env.REQUIRED_NODE_MAJOR || "20", 10);
 const currentMajor = parseInt(process.versions.node.split(".")[0], 10);
-if (currentMajor < requiredMajor) {
+if (currentMajor !== requiredMajor) {
   console.error(
-    `Node ${requiredMajor} or newer is required. Current version: ${process.versions.node}`,
+    `Node ${requiredMajor} is required. Current version: ${process.versions.node}`,
   );
   process.exit(1);
 }

--- a/tests/ensureRootDepsNodeVersionMismatch.test.js
+++ b/tests/ensureRootDepsNodeVersionMismatch.test.js
@@ -1,0 +1,25 @@
+const fs = require("fs");
+const child_process = require("child_process");
+
+jest.mock("fs");
+jest.mock("child_process");
+
+describe("ensure-root-deps node version mismatch", () => {
+  beforeEach(() => {
+    fs.existsSync.mockReturnValue(true);
+    child_process.execSync.mockReset();
+    process.exit = jest.fn();
+  });
+
+  test("fails when node version differs from required", () => {
+    const originalVersions = process.versions;
+    Object.defineProperty(process, "versions", {
+      value: { ...process.versions, node: "25.0.0" },
+    });
+    jest.isolateModules(() => {
+      require("../scripts/ensure-root-deps.js");
+    });
+    expect(process.exit).toHaveBeenCalledWith(1);
+    Object.defineProperty(process, "versions", { value: originalVersions });
+  });
+});


### PR DESCRIPTION
## Summary
- enforce exact Node version match in `ensure-root-deps.js`
- add unit test for version mismatch

## Testing
- `npm test`
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_6879333399f4832d93d28a62fb156934