### PR TITLE
Add ESLint diagnostics tests

### DIFF
--- a/backend/tests/lintingDetailed.test.js
+++ b/backend/tests/lintingDetailed.test.js
@@ -1,9 +1,15 @@
 const { execSync } = require("child_process");
 const path = require("path");
+const fs = require("fs");
 
 const backendDir = path.join(__dirname, "..");
 
 test("detailed backend ESLint report", () => {
+  // eslint 9.x errors if an ignored directory is missing. The coverage
+  // directory is gitignored and may not exist in fresh clones, so ensure it
+  // is present before invoking ESLint.
+  const coverageDir = path.join(backendDir, "coverage");
+  if (!fs.existsSync(coverageDir)) fs.mkdirSync(coverageDir);
   const output = execSync(`npx eslint -f json .`, {
     cwd: backendDir,
     encoding: "utf8",

--- a/tests/eslintDiagnostics.test.js
+++ b/tests/eslintDiagnostics.test.js
@@ -1,0 +1,64 @@
+const { spawnSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+const repoRoot = path.resolve(__dirname, "..");
+const backendDir = path.join(repoRoot, "backend");
+
+function run(cmd, args, cwd, env = {}) {
+  return spawnSync(cmd, args, {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: "utf8",
+  });
+}
+
+describe("eslint diagnostics", () => {
+  test("pnpm exec eslint . exits 0 at repo root", () => {
+    const result = run("pnpm", ["exec", "eslint", "."], repoRoot);
+    if (result.status !== 0) console.error(result.stdout || result.stderr);
+    expect(result.status).toBe(0);
+  });
+
+  test("pnpm exec eslint . exits 0 in backend", () => {
+    const result = run("pnpm", ["exec", "eslint", "."], backendDir);
+    if (result.status !== 0) console.error(result.stdout || result.stderr);
+    expect(result.status).toBe(0);
+  });
+
+  test("no warnings with --max-warnings=0", () => {
+    const result = run(
+      "pnpm",
+      ["exec", "eslint", ".", "--max-warnings=0"],
+      repoRoot,
+    );
+    if (result.status !== 0) console.error(result.stdout || result.stderr);
+    expect(result.status).toBe(0);
+  });
+
+  test("no error messages in json output", () => {
+    const outFile = path.join(repoRoot, "tmp_eslint.json");
+    const result = run(
+      "pnpm",
+      ["exec", "eslint", ".", "-f", "json", "--output-file", outFile],
+      repoRoot,
+    );
+    if (result.status !== 0) console.error(result.stdout || result.stderr);
+    const output = JSON.parse(fs.readFileSync(outFile, "utf8"));
+    fs.unlinkSync(outFile);
+    const errors = output.flatMap((r) =>
+      r.messages.filter((m) => m.severity === 2),
+    );
+    expect(errors).toEqual([]);
+  });
+
+  test("print-config resolves for server.js", () => {
+    const result = run(
+      "pnpm",
+      ["exec", "eslint", "--print-config", "server.js"],
+      backendDir,
+    );
+    if (result.status !== 0) console.error(result.stdout || result.stderr);
+    expect(result.status).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure backend ESLint test creates the coverage directory
- add new jest test suite checking ESLint CLI behavior

## Testing
- `npm run format` in `backend/`
- `node scripts/run-jest.js tests/eslintDiagnostics.test.js backend/tests/lintingDetailed.test.js`
- `SKIP_PW_DEPS=1 npm test` in `backend/`

------
https://chatgpt.com/codex/tasks/task_e_6879330c9bf8832d9c6a2c60f8433af9