### PR TITLE
Add wait-on integration test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,10 @@ jobs:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '0'
         run: npm run e2e
 
+      - name: Wait for frontend readiness
+        if: ${{ !secrets.PERCY_TOKEN }}
+        run: node scripts/run-jest.js e2e/wait-for-backend-a3f9X2.test.js
+
       - name: Run accessibility tests
         env:
           PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright

--- a/e2e/wait-for-backend-a3f9X2.test.js
+++ b/e2e/wait-for-backend-a3f9X2.test.js
@@ -1,0 +1,29 @@
+const { spawn } = require("child_process");
+const waitOn = require("wait-on");
+
+if (require.main === module) {
+  console.error(
+    'This file is a Jest test. Run it with "npm test e2e/wait-for-backend-a3f9X2.test.js".',
+  );
+  process.exit(1);
+}
+
+jest.setTimeout(180000); // allow up to 3 minutes for the test
+
+test("frontend becomes ready within 2 minutes", async () => {
+  const server = spawn("npm", ["run", "serve"], {
+    stdio: "inherit",
+    shell: true,
+  });
+  let error;
+  try {
+    await waitOn({ resources: ["http://localhost:3000"], timeout: 120000 });
+  } catch (err) {
+    error = err;
+  } finally {
+    server.kill("SIGTERM");
+  }
+  if (error) {
+    throw new Error("Frontend failed to start within 2 minutes");
+  }
+});


### PR DESCRIPTION
## Summary
- add `wait-for-backend-a3f9X2.test.js` to ensure the frontend server becomes responsive
- run the new test as part of CI smoke workflow

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`
- `node scripts/run-jest.js e2e/wait-for-backend-a3f9X2.test.js`


------
https://chatgpt.com/codex/tasks/task_e_687929b98044832db0e9706b6fe85d05