### PR TITLE
Add granular ESLint isolation tests

### DIFF
--- a/backend/tests/lint-isolation-a1b2c3.test.js
+++ b/backend/tests/lint-isolation-a1b2c3.test.js
@@ -1,0 +1,24 @@
+const { execSync } = require("child_process");
+const path = require("path");
+
+test("backend/src/lib/getEnv.js passes ESLint", () => {
+  const repo = path.resolve(__dirname, "..", "..");
+  const file = path.join(repo, "backend/src/lib/getEnv.js");
+  const eslint = path.join(repo, "node_modules", ".bin", "eslint");
+  let output = "";
+  let status = 0;
+  try {
+    execSync(`node --experimental-vm-modules ${eslint} "${file}"`, {
+      cwd: repo,
+      stdio: "pipe",
+      encoding: "utf8",
+    });
+  } catch (err) {
+    status = err.status ?? 1;
+    output = `${err.stdout || ""}${err.stderr || ""}`;
+  }
+  if (status !== 0) {
+    throw new Error(`ESLint failed for ${file}\n${output}`);
+  }
+  expect(status).toBe(0);
+});

--- a/backend/tests/lint-isolation-d4e5f6.test.js
+++ b/backend/tests/lint-isolation-d4e5f6.test.js
@@ -1,0 +1,24 @@
+const { execSync } = require("child_process");
+const path = require("path");
+
+test("backend/src/lib/logger.js passes ESLint", () => {
+  const repo = path.resolve(__dirname, "..", "..");
+  const file = path.join(repo, "backend/src/lib/logger.js");
+  const eslint = path.join(repo, "node_modules", ".bin", "eslint");
+  let output = "";
+  let status = 0;
+  try {
+    execSync(`node --experimental-vm-modules ${eslint} "${file}"`, {
+      cwd: repo,
+      stdio: "pipe",
+      encoding: "utf8",
+    });
+  } catch (err) {
+    status = err.status ?? 1;
+    output = `${err.stdout || ""}${err.stderr || ""}`;
+  }
+  if (status !== 0) {
+    throw new Error(`ESLint failed for ${file}\n${output}`);
+  }
+  expect(status).toBe(0);
+});

--- a/backend/tests/lint-isolation-g7h8i9.test.js
+++ b/backend/tests/lint-isolation-g7h8i9.test.js
@@ -1,0 +1,24 @@
+const { execSync } = require("child_process");
+const path = require("path");
+
+test("backend/src/lib/storeGlb.js passes ESLint", () => {
+  const repo = path.resolve(__dirname, "..", "..");
+  const file = path.join(repo, "backend/src/lib/storeGlb.js");
+  const eslint = path.join(repo, "node_modules", ".bin", "eslint");
+  let output = "";
+  let status = 0;
+  try {
+    execSync(`node --experimental-vm-modules ${eslint} "${file}"`, {
+      cwd: repo,
+      stdio: "pipe",
+      encoding: "utf8",
+    });
+  } catch (err) {
+    status = err.status ?? 1;
+    output = `${err.stdout || ""}${err.stderr || ""}`;
+  }
+  if (status !== 0) {
+    throw new Error(`ESLint failed for ${file}\n${output}`);
+  }
+  expect(status).toBe(0);
+});

--- a/backend/tests/lint-isolation-j1k2l3.test.js
+++ b/backend/tests/lint-isolation-j1k2l3.test.js
@@ -1,0 +1,24 @@
+const { execSync } = require("child_process");
+const path = require("path");
+
+test("backend/src/lib/uploadS3.js passes ESLint", () => {
+  const repo = path.resolve(__dirname, "..", "..");
+  const file = path.join(repo, "backend/src/lib/uploadS3.js");
+  const eslint = path.join(repo, "node_modules", ".bin", "eslint");
+  let output = "";
+  let status = 0;
+  try {
+    execSync(`node --experimental-vm-modules ${eslint} "${file}"`, {
+      cwd: repo,
+      stdio: "pipe",
+      encoding: "utf8",
+    });
+  } catch (err) {
+    status = err.status ?? 1;
+    output = `${err.stdout || ""}${err.stderr || ""}`;
+  }
+  if (status !== 0) {
+    throw new Error(`ESLint failed for ${file}\n${output}`);
+  }
+  expect(status).toBe(0);
+});

--- a/backend/tests/lint-isolation-m4n5o6.test.js
+++ b/backend/tests/lint-isolation-m4n5o6.test.js
@@ -1,0 +1,24 @@
+const { execSync } = require("child_process");
+const path = require("path");
+
+test("backend/src/utils/incentives.js passes ESLint", () => {
+  const repo = path.resolve(__dirname, "..", "..");
+  const file = path.join(repo, "backend/src/utils/incentives.js");
+  const eslint = path.join(repo, "node_modules", ".bin", "eslint");
+  let output = "";
+  let status = 0;
+  try {
+    execSync(`node --experimental-vm-modules ${eslint} "${file}"`, {
+      cwd: repo,
+      stdio: "pipe",
+      encoding: "utf8",
+    });
+  } catch (err) {
+    status = err.status ?? 1;
+    output = `${err.stdout || ""}${err.stderr || ""}`;
+  }
+  if (status !== 0) {
+    throw new Error(`ESLint failed for ${file}\n${output}`);
+  }
+  expect(status).toBe(0);
+});

--- a/backend/tests/lint-isolation-p7q8r9.test.js
+++ b/backend/tests/lint-isolation-p7q8r9.test.js
@@ -1,0 +1,24 @@
+const { execSync } = require("child_process");
+const path = require("path");
+
+test("backend/src/utils/stripAnsi.js passes ESLint", () => {
+  const repo = path.resolve(__dirname, "..", "..");
+  const file = path.join(repo, "backend/src/utils/stripAnsi.js");
+  const eslint = path.join(repo, "node_modules", ".bin", "eslint");
+  let output = "";
+  let status = 0;
+  try {
+    execSync(`node --experimental-vm-modules ${eslint} "${file}"`, {
+      cwd: repo,
+      stdio: "pipe",
+      encoding: "utf8",
+    });
+  } catch (err) {
+    status = err.status ?? 1;
+    output = `${err.stdout || ""}${err.stderr || ""}`;
+  }
+  if (status !== 0) {
+    throw new Error(`ESLint failed for ${file}\n${output}`);
+  }
+  expect(status).toBe(0);
+});

--- a/backend/tests/lint-isolation-s1t2u3.test.js
+++ b/backend/tests/lint-isolation-s1t2u3.test.js
@@ -1,0 +1,24 @@
+const { execSync } = require("child_process");
+const path = require("path");
+
+test("backend/src/pipeline/generateModel.js passes ESLint", () => {
+  const repo = path.resolve(__dirname, "..", "..");
+  const file = path.join(repo, "backend/src/pipeline/generateModel.js");
+  const eslint = path.join(repo, "node_modules", ".bin", "eslint");
+  let output = "";
+  let status = 0;
+  try {
+    execSync(`node --experimental-vm-modules ${eslint} "${file}"`, {
+      cwd: repo,
+      stdio: "pipe",
+      encoding: "utf8",
+    });
+  } catch (err) {
+    status = err.status ?? 1;
+    output = `${err.stdout || ""}${err.stderr || ""}`;
+  }
+  if (status !== 0) {
+    throw new Error(`ESLint failed for ${file}\n${output}`);
+  }
+  expect(status).toBe(0);
+});

--- a/backend/tests/lint-isolation-v4w5x6.test.js
+++ b/backend/tests/lint-isolation-v4w5x6.test.js
@@ -1,0 +1,24 @@
+const { execSync } = require("child_process");
+const path = require("path");
+
+test("backend/src/app.js passes ESLint", () => {
+  const repo = path.resolve(__dirname, "..", "..");
+  const file = path.join(repo, "backend/src/app.js");
+  const eslint = path.join(repo, "node_modules", ".bin", "eslint");
+  let output = "";
+  let status = 0;
+  try {
+    execSync(`node --experimental-vm-modules ${eslint} "${file}"`, {
+      cwd: repo,
+      stdio: "pipe",
+      encoding: "utf8",
+    });
+  } catch (err) {
+    status = err.status ?? 1;
+    output = `${err.stdout || ""}${err.stderr || ""}`;
+  }
+  if (status !== 0) {
+    throw new Error(`ESLint failed for ${file}\n${output}`);
+  }
+  expect(status).toBe(0);
+});


### PR DESCRIPTION
## Summary
- add eight Jest tests running ESLint on individual backend files

## Testing
- `node scripts/run-jest.js backend/tests/lint-isolation-a1b2c3.test.js`
- `SKIP_PW_DEPS=1 npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_68792a6e321c832d86e6ee16307d8acc