### PR TITLE
Add frontend readiness integration test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,10 @@ jobs:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '0'
         run: npm run e2e
 
+      - name: Wait for frontend readiness
+        if: ${{ !secrets.PERCY_TOKEN }}
+        run: node e2e/wait-for-backend-a3f9X2.test.js
+
       - name: Run accessibility tests
         env:
           PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright

--- a/e2e/wait-for-backend-a3f9X2.test.js
+++ b/e2e/wait-for-backend-a3f9X2.test.js
@@ -1,0 +1,26 @@
+const { spawn } = require("child_process");
+const waitOn = require("wait-on");
+
+jest.setTimeout(180000); // allow up to 3 minutes for setup and teardown
+
+test("frontend becomes ready within 2 minutes", async () => {
+  const proc = spawn("npm", ["run", "serve"], {
+    env: { ...process.env, PORT: "3000" },
+    stdio: "inherit",
+  });
+
+  let succeeded = false;
+  try {
+    await waitOn({
+      resources: ["http://localhost:3000"],
+      timeout: 2 * 60 * 1000,
+    });
+    succeeded = true;
+  } finally {
+    proc.kill("SIGTERM");
+  }
+
+  if (!succeeded) {
+    throw new Error("Frontend never became ready within 2 minutes");
+  }
+});


### PR DESCRIPTION
## Summary
- add `wait-for-backend-a3f9X2.test.js` to ensure `npm run serve` becomes ready
- run the new test in CI smoke job

## Testing
- `npm test --prefix backend`
- `npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_687929b98044832db0e9706b6fe85d05