### PR TITLE
Add ESLint isolation tests

### DIFF
--- a/backend/tests/lint-isolation-a1b2c3.test.js
+++ b/backend/tests/lint-isolation-a1b2c3.test.js
@@ -1,0 +1,13 @@
+const { spawnSync } = require("child_process");
+const path = require("path");
+
+test("server.js passes ESLint", () => {
+  const file = path.join(__dirname, "..", "server.js");
+  const result = spawnSync("npx", ["eslint", file], { encoding: "utf8" });
+  if (result.status !== 0) {
+    throw new Error(
+      `ESLint failed for ${file}:\n${result.stdout}${result.stderr}`,
+    );
+  }
+  expect(result.status).toBe(0);
+});

--- a/backend/tests/lint-isolation-d4e5f6.test.js
+++ b/backend/tests/lint-isolation-d4e5f6.test.js
@@ -1,0 +1,13 @@
+const { spawnSync } = require("child_process");
+const path = require("path");
+
+test("src/app.js passes ESLint", () => {
+  const file = path.join(__dirname, "..", "src", "app.js");
+  const result = spawnSync("npx", ["eslint", file], { encoding: "utf8" });
+  if (result.status !== 0) {
+    throw new Error(
+      `ESLint failed for ${file}:\n${result.stdout}${result.stderr}`,
+    );
+  }
+  expect(result.status).toBe(0);
+});

--- a/backend/tests/lint-isolation-g7h8i9.test.js
+++ b/backend/tests/lint-isolation-g7h8i9.test.js
@@ -1,0 +1,13 @@
+const { spawnSync } = require("child_process");
+const path = require("path");
+
+test("src/logger.js passes ESLint", () => {
+  const file = path.join(__dirname, "..", "src", "logger.js");
+  const result = spawnSync("npx", ["eslint", file], { encoding: "utf8" });
+  if (result.status !== 0) {
+    throw new Error(
+      `ESLint failed for ${file}:\n${result.stdout}${result.stderr}`,
+    );
+  }
+  expect(result.status).toBe(0);
+});

--- a/backend/tests/lint-isolation-j1k2l3.test.js
+++ b/backend/tests/lint-isolation-j1k2l3.test.js
@@ -1,0 +1,13 @@
+const { spawnSync } = require("child_process");
+const path = require("path");
+
+test("routes/models.js passes ESLint", () => {
+  const file = path.join(__dirname, "..", "routes", "models.js");
+  const result = spawnSync("npx", ["eslint", file], { encoding: "utf8" });
+  if (result.status !== 0) {
+    throw new Error(
+      `ESLint failed for ${file}:\n${result.stdout}${result.stderr}`,
+    );
+  }
+  expect(result.status).toBe(0);
+});

--- a/backend/tests/lint-isolation-m4n5o6.test.js
+++ b/backend/tests/lint-isolation-m4n5o6.test.js
@@ -1,0 +1,13 @@
+const { spawnSync } = require("child_process");
+const path = require("path");
+
+test("routes/users.js passes ESLint", () => {
+  const file = path.join(__dirname, "..", "routes", "users.js");
+  const result = spawnSync("npx", ["eslint", file], { encoding: "utf8" });
+  if (result.status !== 0) {
+    throw new Error(
+      `ESLint failed for ${file}:\n${result.stdout}${result.stderr}`,
+    );
+  }
+  expect(result.status).toBe(0);
+});

--- a/backend/tests/lint-isolation-p7q8r9.test.js
+++ b/backend/tests/lint-isolation-p7q8r9.test.js
@@ -1,0 +1,13 @@
+const { spawnSync } = require("child_process");
+const path = require("path");
+
+test("utils/getEnv.js passes ESLint", () => {
+  const file = path.join(__dirname, "..", "utils", "getEnv.js");
+  const result = spawnSync("npx", ["eslint", file], { encoding: "utf8" });
+  if (result.status !== 0) {
+    throw new Error(
+      `ESLint failed for ${file}:\n${result.stdout}${result.stderr}`,
+    );
+  }
+  expect(result.status).toBe(0);
+});

--- a/backend/tests/lint-isolation-s1t2u3.test.js
+++ b/backend/tests/lint-isolation-s1t2u3.test.js
@@ -1,0 +1,13 @@
+const { spawnSync } = require("child_process");
+const path = require("path");
+
+test("utils/generateShareCard.js passes ESLint", () => {
+  const file = path.join(__dirname, "..", "utils", "generateShareCard.js");
+  const result = spawnSync("npx", ["eslint", file], { encoding: "utf8" });
+  if (result.status !== 0) {
+    throw new Error(
+      `ESLint failed for ${file}:\n${result.stdout}${result.stderr}`,
+    );
+  }
+  expect(result.status).toBe(0);
+});

--- a/backend/tests/lint-isolation-v4w5x6.test.js
+++ b/backend/tests/lint-isolation-v4w5x6.test.js
@@ -1,0 +1,13 @@
+const { spawnSync } = require("child_process");
+const path = require("path");
+
+test("queue/jobQueue.js passes ESLint", () => {
+  const file = path.join(__dirname, "..", "queue", "jobQueue.js");
+  const result = spawnSync("npx", ["eslint", file], { encoding: "utf8" });
+  if (result.status !== 0) {
+    throw new Error(
+      `ESLint failed for ${file}:\n${result.stdout}${result.stderr}`,
+    );
+  }
+  expect(result.status).toBe(0);
+});


### PR DESCRIPTION
## Summary
- add new lint-isolation tests that run ESLint on single files

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_68792a6e321c832d86e6ee16307d8acc