### PR TITLE
Add frontend readiness integration test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,9 @@ jobs:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '0'
         run: npx percy exec -- npm run e2e
 
+      - name: Verify frontend readiness
+        run: node e2e/wait-for-backend-a3f9X2.test.js
+
       - name: Run smoke tests
         if: ${{ !secrets.PERCY_TOKEN }}
         env:

--- a/e2e/wait-for-backend-a3f9X2.test.js
+++ b/e2e/wait-for-backend-a3f9X2.test.js
@@ -1,0 +1,37 @@
+const { spawn } = require("child_process");
+const waitOn = require("wait-on");
+
+async function main() {
+  const server = spawn("npm", ["run", "serve"], {
+    stdio: "inherit",
+    shell: true,
+  });
+  let exited = false;
+  server.on("exit", () => {
+    exited = true;
+  });
+  try {
+    await waitOn({
+      resources: ["http://localhost:3000/healthz"],
+      timeout: 120000,
+    });
+    const res = await fetch("http://localhost:3000/healthz");
+    if (!res.ok) {
+      throw new Error(`Expected 200 from /healthz, got ${res.status}`);
+    }
+    console.log("Server responded within timeout");
+  } catch (err) {
+    console.error("Frontend failed to become ready within 2 minutes");
+    console.error(err.message || err);
+    server.kill("SIGTERM");
+    process.exit(1);
+  }
+  server.kill("SIGTERM");
+  if (!exited) {
+    await new Promise((resolve) => server.on("exit", resolve));
+  }
+}
+
+if (require.main === module) {
+  main();
+}


### PR DESCRIPTION
## Summary
- add a server readiness check test
- ensure the CI smoke job waits for the frontend

## Testing
- `node e2e/wait-for-backend-a3f9X2.test.js`
- `npm test`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_687929b98044832db0e9706b6fe85d05