### PR TITLE
Add ESLint isolation tests

### DIFF
--- a/backend/tests/lint-isolation-a1b2c3.test.js
+++ b/backend/tests/lint-isolation-a1b2c3.test.js
@@ -1,0 +1,12 @@
+const { execSync } = require("child_process");
+const path = require("path");
+
+test("app.js passes ESLint", () => {
+  const file = path.join(__dirname, "..", "src", "app.js");
+  try {
+    execSync(`npx eslint "${file}"`, { stdio: "pipe", encoding: "utf8" });
+  } catch (err) {
+    const output = `${err.stdout || ""}${err.stderr || ""}`;
+    throw new Error(`ESLint failed for ${file}\n${output}`);
+  }
+});

--- a/backend/tests/lint-isolation-d4e5f6.test.js
+++ b/backend/tests/lint-isolation-d4e5f6.test.js
@@ -1,0 +1,12 @@
+const { execSync } = require("child_process");
+const path = require("path");
+
+test("logger.js passes ESLint", () => {
+  const file = path.join(__dirname, "..", "src", "logger.js");
+  try {
+    execSync(`npx eslint "${file}"`, { stdio: "pipe", encoding: "utf8" });
+  } catch (err) {
+    const output = `${err.stdout || ""}${err.stderr || ""}`;
+    throw new Error(`ESLint failed for ${file}\n${output}`);
+  }
+});

--- a/backend/tests/lint-isolation-g7h8i9.test.js
+++ b/backend/tests/lint-isolation-g7h8i9.test.js
@@ -1,0 +1,12 @@
+const { execSync } = require("child_process");
+const path = require("path");
+
+test("routes/checkout.js passes ESLint", () => {
+  const file = path.join(__dirname, "..", "src", "routes", "checkout.js");
+  try {
+    execSync(`npx eslint "${file}"`, { stdio: "pipe", encoding: "utf8" });
+  } catch (err) {
+    const output = `${err.stdout || ""}${err.stderr || ""}`;
+    throw new Error(`ESLint failed for ${file}\n${output}`);
+  }
+});

--- a/backend/tests/lint-isolation-j0k1l2.test.js
+++ b/backend/tests/lint-isolation-j0k1l2.test.js
@@ -1,0 +1,12 @@
+const { execSync } = require("child_process");
+const path = require("path");
+
+test("routes/models.js passes ESLint", () => {
+  const file = path.join(__dirname, "..", "src", "routes", "models.js");
+  try {
+    execSync(`npx eslint "${file}"`, { stdio: "pipe", encoding: "utf8" });
+  } catch (err) {
+    const output = `${err.stdout || ""}${err.stderr || ""}`;
+    throw new Error(`ESLint failed for ${file}\n${output}`);
+  }
+});

--- a/backend/tests/lint-isolation-m3n4o5.test.js
+++ b/backend/tests/lint-isolation-m3n4o5.test.js
@@ -1,0 +1,12 @@
+const { execSync } = require("child_process");
+const path = require("path");
+
+test("lib/getEnv.js passes ESLint", () => {
+  const file = path.join(__dirname, "..", "src", "lib", "getEnv.js");
+  try {
+    execSync(`npx eslint "${file}"`, { stdio: "pipe", encoding: "utf8" });
+  } catch (err) {
+    const output = `${err.stdout || ""}${err.stderr || ""}`;
+    throw new Error(`ESLint failed for ${file}\n${output}`);
+  }
+});

--- a/backend/tests/lint-isolation-p6q7r8.test.js
+++ b/backend/tests/lint-isolation-p6q7r8.test.js
@@ -1,0 +1,12 @@
+const { execSync } = require("child_process");
+const path = require("path");
+
+test("lib/uploadS3.js passes ESLint", () => {
+  const file = path.join(__dirname, "..", "src", "lib", "uploadS3.js");
+  try {
+    execSync(`npx eslint "${file}"`, { stdio: "pipe", encoding: "utf8" });
+  } catch (err) {
+    const output = `${err.stdout || ""}${err.stderr || ""}`;
+    throw new Error(`ESLint failed for ${file}\n${output}`);
+  }
+});

--- a/backend/tests/lint-isolation-s9t0u1.test.js
+++ b/backend/tests/lint-isolation-s9t0u1.test.js
@@ -1,0 +1,12 @@
+const { execSync } = require("child_process");
+const path = require("path");
+
+test("utils/incentives.js passes ESLint", () => {
+  const file = path.join(__dirname, "..", "src", "utils", "incentives.js");
+  try {
+    execSync(`npx eslint "${file}"`, { stdio: "pipe", encoding: "utf8" });
+  } catch (err) {
+    const output = `${err.stdout || ""}${err.stderr || ""}`;
+    throw new Error(`ESLint failed for ${file}\n${output}`);
+  }
+});

--- a/backend/tests/lint-isolation-v2w3x4.test.js
+++ b/backend/tests/lint-isolation-v2w3x4.test.js
@@ -1,0 +1,18 @@
+const { execSync } = require("child_process");
+const path = require("path");
+
+test("pipeline/generateModel.js passes ESLint", () => {
+  const file = path.join(
+    __dirname,
+    "..",
+    "src",
+    "pipeline",
+    "generateModel.js",
+  );
+  try {
+    execSync(`npx eslint "${file}"`, { stdio: "pipe", encoding: "utf8" });
+  } catch (err) {
+    const output = `${err.stdout || ""}${err.stderr || ""}`;
+    throw new Error(`ESLint failed for ${file}\n${output}`);
+  }
+});


### PR DESCRIPTION
## Summary
- add granular ESLint tests that lint a single source file

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68792a6e321c832d86e6ee16307d8acc