### PR TITLE
Fix npm audit test

### DIFF
--- a/scripts/check-vulns.js
+++ b/scripts/check-vulns.js
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+const { spawnSync } = require("child_process");
+
+const proc = spawnSync("npm", ["audit", "--json", "--omit=dev"], {
+  encoding: "utf8",
+});
+const output = proc.stdout || proc.stderr;
+let report;
+try {
+  report = JSON.parse(output);
+} catch (_err) {
+  console.error("Failed to parse npm audit JSON");
+  console.error(output);
+  process.exit(1);
+}
+let vulns = report.metadata && report.metadata.vulnerabilities;
+if (!vulns && report.vulnerabilities) {
+  vulns = {};
+  for (const v of Object.values(report.vulnerabilities)) {
+    const severity = v.severity;
+    if (severity) vulns[severity] = (vulns[severity] || 0) + 1;
+  }
+}
+const high = (vulns && vulns.high) || 0;
+const critical = (vulns && vulns.critical) || 0;
+if (high > 0 || critical > 0) {
+  console.error(
+    `High/critical vulnerabilities detected: high=${high} critical=${critical}`,
+  );
+  process.exit(1);
+}
+process.exit(0);

--- a/tests/vulnerability.test.js
+++ b/tests/vulnerability.test.js
@@ -1,0 +1,12 @@
+const { spawnSync } = require("child_process");
+
+test("No high or critical npm vulnerabilities", () => {
+  const proc = spawnSync("node", ["scripts/check-vulns.js"], {
+    encoding: "utf8",
+  });
+  if (proc.status !== 0) {
+    console.error(proc.stdout);
+    console.error(proc.stderr);
+  }
+  expect(proc.status).toBe(0);
+});


### PR DESCRIPTION
## Summary
- add check-vulns script to parse npm audit json output
- add Jest test for high/critical vulnerabilities

## Testing
- `npm test` in `backend/`
- `node scripts/run-jest.js tests/vulnerability.test.js`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68793e093620832db5a0b9a8895195f0