### PR TITLE
Add error path coverage test

### DIFF
--- a/scripts/find-untested-error-paths.js
+++ b/scripts/find-untested-error-paths.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+const fs = require("fs");
+const path = require("path");
+
+function getArg(prefix, fallback) {
+  const arg = process.argv.find((a) => a.startsWith(prefix));
+  return arg ? arg.slice(prefix.length) : fallback;
+}
+
+const srcDir = getArg("--src=", path.join(__dirname, "..", "backend", "src"));
+const testsDir = getArg(
+  "--tests=",
+  path.join(__dirname, "..", "backend", "tests"),
+);
+
+function collectFiles(dir) {
+  let res = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      res.push(...collectFiles(full));
+    } else if (/\.(js|ts)$/.test(entry.name)) {
+      res.push(full);
+    }
+  }
+  return res;
+}
+
+const srcFiles = collectFiles(srcDir);
+const testFiles = collectFiles(testsDir);
+
+const testContent = testFiles.map((f) => fs.readFileSync(f, "utf8")).join("\n");
+
+const errorRegex = /throw new Error\((`|"|')(.*?)\1\)/gs;
+let untested = [];
+
+for (const file of srcFiles) {
+  const content = fs.readFileSync(file, "utf8");
+  let match;
+  while ((match = errorRegex.exec(content))) {
+    const msg = match[2];
+    if (!testContent.includes(msg)) {
+      untested.push(`${file}: ${msg}`);
+    }
+  }
+}
+
+if (untested.length) {
+  for (const line of untested) {
+    console.log(line);
+  }
+  process.exit(1);
+}
+process.exit(0);

--- a/tests/errorPathCoverage.test.js
+++ b/tests/errorPathCoverage.test.js
@@ -1,0 +1,18 @@
+// Jest integration test that fails if any error path is untested.
+
+test("All API error paths are tested", () => {
+  const { spawnSync } = require("child_process");
+  const proc = spawnSync(
+    "node",
+    [
+      "scripts/find-untested-error-paths.js",
+      "--src=backend/src",
+      "--tests=backend/tests",
+    ],
+    { encoding: "utf8" },
+  );
+  if (proc.status !== 0) {
+    console.error(proc.stdout);
+  }
+  expect(proc.status).toBe(0);
+});


### PR DESCRIPTION
## Summary
- add integration test that verifies every thrown error is exercised by tests
- introduce `find-untested-error-paths.js` script to scan backend sources and check for untested error paths

## Testing
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68793e026c04832dbf252dec27e2832c