### PR TITLE
Add generated checkout order tests

### DIFF
--- a/tests/generated_routes_a1b2c3d4.test.js
+++ b/tests/generated_routes_a1b2c3d4.test.js
@@ -1,0 +1,23 @@
+const checkout = require("../backend/src/routes/checkout.js");
+
+describe("checkout orders map store/get", () => {
+  for (let i = 0; i < 100; i++) {
+    test(`store and retrieve order ${i}`, () => {
+      checkout.orders.clear();
+      const id = "id" + i;
+      const data = { slug: "slug" + i, email: "email" + i };
+      checkout.orders.set(id, data);
+      expect(checkout.orders.get(id)).toEqual(data);
+    });
+  }
+});
+
+describe("checkout orders map clear", () => {
+  for (let i = 0; i < 100; i++) {
+    test(`clear orders ${i}`, () => {
+      checkout.orders.set("foo", { slug: "s", email: "e" });
+      checkout.orders.clear();
+      expect(checkout.orders.size).toBe(0);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add ~200 generated tests for checkout orders map

## Testing
- `npm run format`
- `npm test` *(fails: linting-diagnostics-9b3adf.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68795dadd5a0832dac776f0cd9d4be23