### PR TITLE
Add generated incentive tests

### DIFF
--- a/tests/generated_utils_f2a1e6d8.test.js
+++ b/tests/generated_utils_f2a1e6d8.test.js
@@ -1,0 +1,23 @@
+const {
+  firstOrderPrice,
+  referralPrintPrice,
+} = require("../backend/src/utils/incentives.js");
+
+describe("firstOrderPrice always returns base price", () => {
+  for (let i = 0; i < 100; i++) {
+    test(`repeat customer ${i}`, () => {
+      expect(firstOrderPrice(`u${i}`, 50)).toBe(50);
+    });
+  }
+});
+
+describe("referralPrintPrice thresholds", () => {
+  for (let i = 0; i < 100; i++) {
+    test(`referral count ${i}`, () => {
+      const count = i % 5;
+      const price = referralPrintPrice(count, 20);
+      if (count >= 3) expect(price).toBe(0);
+      else expect(price).toBe(20);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add more bulk tests for `incentives` utility

## Testing
- `npm run format`
- `npm test` *(fails: linting-diagnostics-9b3adf.test.js)*


------
https://chatgpt.com/codex/tasks/task_e_68795d5f8a10832d8b801e95475d505a