### PR TITLE
Add track bulk tests

### DIFF
--- a/tests/generated_frontend_b23e63d4.test.js
+++ b/tests/generated_frontend_b23e63d4.test.js
@@ -1,0 +1,35 @@
+/* eslint-disable jsdoc/check-tag-names */
+/**
+ * @jest-environment jsdom
+ */
+const { track } = require("../js/analytics.js");
+
+describe("track bulk", () => {
+  beforeEach(() => {
+    global.fetch = jest.fn(() => Promise.resolve({ ok: true }));
+    global.window = {
+      __TEST_HOOKS__: { trackEvent: jest.fn(), API_ORIGIN: "" },
+    };
+  });
+  afterEach(() => {
+    delete global.fetch;
+    delete global.window;
+  });
+  for (let i = 0; i < 200; i++) {
+    test(`send ${i}`, async () => {
+      await track(`event${i}`, { i });
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining(`/api/track/event${i}`),
+        expect.objectContaining({
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ i }),
+        }),
+      );
+      expect(global.window.__TEST_HOOKS__.trackEvent).toHaveBeenCalledWith(
+        `event${i}`,
+        { i },
+      );
+    });
+  }
+});

--- a/tests/generated_frontend_ef73b1c2.test.js
+++ b/tests/generated_frontend_ef73b1c2.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsdoc/check-tag-names */
 /**
  * @jest-environment jsdom
  */


### PR DESCRIPTION
## Summary
- add 200 bulk tests for analytics track
- silence jsdoc warnings in generated test

## Testing
- `npm run format`
- `npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_68795c6ad8d4832d95d697b0e73f24c8