### PR TITLE
Add pipeline fire drill test

### DIFF
--- a/tests/glb/test_pipeline_fire_drill_9e59a6bf.test.ts
+++ b/tests/glb/test_pipeline_fire_drill_9e59a6bf.test.ts
@@ -1,0 +1,40 @@
+import logger from "../../src/logger";
+
+jest.mock("../../backend/src/lib/prepareImage", () => ({
+  prepareImage: jest.fn().mockResolvedValue("http://img"),
+}));
+
+jest.mock("../../backend/src/lib/textToImage", () => ({
+  textToImage: jest.fn().mockResolvedValue("http://img"),
+}));
+
+jest.mock("../../backend/src/lib/imageToText", () => ({
+  imageToText: jest.fn().mockResolvedValue("prompt"),
+}));
+
+jest.mock("../../backend/src/lib/sparc3dClient", () => ({
+  generateGlb: jest.fn().mockResolvedValue(Buffer.from("bad")),
+}));
+
+jest.mock("../../backend/src/lib/preserveColors", () => ({
+  preserveColors: jest.fn(async (b) => b),
+}));
+
+jest.mock("../../backend/src/lib/storeGlb", () => ({
+  storeGlb: jest.fn(() => {
+    throw new Error("Invalid GLB");
+  }),
+}));
+
+const { generateModel } = require("../../backend/src/pipeline/generateModel");
+
+describe("pipeline fire drill", () => {
+  test("handles malformed GLB without false success", async () => {
+    const errSpy = jest.spyOn(logger, "error").mockImplementation(() => {});
+    await expect(
+      generateModel({ prompt: "p", image: "data:image/png;base64,AA==" }),
+    ).rejects.toThrow("Invalid GLB");
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- add safety check for handling malformed GLB data

## Testing
- `node scripts/run-jest.js tests/glb/test_pipeline_fire_drill_9e59a6bf.test.ts`
- `npm run format --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_687982a6eec8832dad163a6dd5563e73