### PR TITLE
Add GLB integrity verification

### DIFF
--- a/scripts/verify-glb-integrity-329vkd.js
+++ b/scripts/verify-glb-integrity-329vkd.js
@@ -1,0 +1,37 @@
+const fs = require("fs");
+
+function fail(msg) {
+  console.error(msg);
+  process.exitCode = 1;
+}
+
+async function main() {
+  const file = process.argv[2];
+  if (!file) {
+    console.error(
+      "Usage: node scripts/verify-glb-integrity-329vkd.js <file.glb>",
+    );
+    process.exit(1);
+  }
+  let buf;
+  try {
+    buf = fs.readFileSync(file);
+  } catch (_err) {
+    console.error(`Failed to read file: ${file}`);
+    process.exit(1);
+  }
+  if (buf.length <= 1000) {
+    fail(`File too small (${buf.length} bytes)`);
+  }
+  if (buf.slice(0, 4).toString() !== "glTF") {
+    fail("Missing glTF magic header");
+  }
+  if (!buf.includes(Buffer.from("JSON"))) {
+    fail("Missing JSON chunk");
+  }
+  if (!buf.includes(Buffer.from("BIN"))) {
+    fail("Missing BIN chunk");
+  }
+}
+
+main();

--- a/tests/glb-integrity-checks.9238jfi.test.js
+++ b/tests/glb-integrity-checks.9238jfi.test.js
@@ -1,0 +1,38 @@
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { spawnSync } = require("child_process");
+const { Document, NodeIO } = require("@gltf-transform/core");
+
+async function createGlb() {
+  const doc = new Document();
+  doc.createBuffer();
+  const pos = doc
+    .createAccessor()
+    .setType("VEC3")
+    .setArray(new Float32Array([0, 0, 0, 1, 0, 0, 0, 1, 0]));
+  doc
+    .createMesh()
+    .addPrimitive(doc.createPrimitive().setAttribute("POSITION", pos));
+  doc.createNode("n").setMesh(doc.getRoot().listMeshes()[0]);
+  const io = new NodeIO();
+  const arr = await io.writeBinary(doc);
+  return Buffer.from(arr);
+}
+
+test("generated glb passes integrity check", async () => {
+  const buf = await createGlb();
+  const tmp = path.join(os.tmpdir(), `glb-${Date.now()}.glb`);
+  fs.writeFileSync(tmp, buf);
+  const res = spawnSync(
+    process.execPath,
+    [path.join("scripts", "verify-glb-integrity-329vkd.js"), tmp],
+    { encoding: "utf8" },
+  );
+  fs.unlinkSync(tmp);
+  const output = (res.stdout || "") + (res.stderr || "");
+  if (res.status !== 0) {
+    throw new Error(output);
+  }
+  expect(res.status).toBe(0);
+});


### PR DESCRIPTION
## Summary
- add `verify-glb-integrity-329vkd.js` for validating generated GLB files
- ensure generated GLBs are verified in new Jest test

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68797bc8b680832d92b5f28dd121542f