### PR TITLE
Add GLB generation Playwright tests

### DIFF
--- a/e2e/e2e-nightly-glb.9283nlt.spec.ts
+++ b/e2e/e2e-nightly-glb.9283nlt.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from "@playwright/test";
+import axios from "axios";
+
+const PROMPTS = [
+  "red cube",
+  "yellow sphere",
+  "small house",
+  "futuristic car",
+  "ancient vase",
+];
+
+async function fetchWithRetry(url: string, options: any = {}, retries = 1) {
+  for (let i = 0; ; i++) {
+    try {
+      return await axios({ url, ...options });
+    } catch (err) {
+      if (i >= retries) throw err;
+    }
+  }
+}
+
+async function generateAndValidate(page, prompt: string) {
+  await page.goto("/generate.html");
+  await page.waitForSelector("#gen-prompt", {
+    state: "visible",
+    timeout: 30000,
+  });
+  await page.fill("#gen-prompt", prompt);
+  const start = Date.now();
+  await page.click("#gen-submit");
+  await page.waitForFunction(() => (document as any).body.dataset.viewerReady, {
+    timeout: 180000,
+  });
+  const glbUrl = await page.locator("model-viewer").getAttribute("src");
+  expect(glbUrl).toBeTruthy();
+  const head = await fetchWithRetry(glbUrl!, { method: "HEAD" });
+  expect(head.status).toBe(200);
+  const res = await fetchWithRetry(glbUrl!, { responseType: "arraybuffer" });
+  expect(res.data.byteLength).toBeGreaterThan(0);
+  expect(Buffer.from(res.data).toString("ascii", 0, 4)).toBe("glTF");
+  const size = parseInt(head.headers["content-length"] || res.data.byteLength);
+  expect(size).toBeGreaterThan(1000);
+  return Date.now() - start;
+}
+
+test.describe("nightly glb generation", () => {
+  for (const prompt of PROMPTS) {
+    test(`generate for: ${prompt}`, async ({ page }) => {
+      const ms = await generateAndValidate(page, prompt);
+      console.log(`prompt \"${prompt}\" finished in ${ms}ms`);
+    });
+  }
+});

--- a/e2e/e2e-smoke-glb.3289sms.spec.ts
+++ b/e2e/e2e-smoke-glb.3289sms.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from "@playwright/test";
+import axios from "axios";
+
+const PROMPT = "basic cube model";
+
+async function generateAndValidate(page, prompt: string) {
+  await page.goto("/generate.html");
+  await page.waitForSelector("#gen-prompt", {
+    state: "visible",
+    timeout: 30000,
+  });
+  await page.fill("#gen-prompt", prompt);
+  const start = Date.now();
+  await page.click("#gen-submit");
+  await page.waitForFunction(() => (document as any).body.dataset.viewerReady, {
+    timeout: 180000,
+  });
+  const glbUrl = await page.locator("model-viewer").getAttribute("src");
+  expect(glbUrl).toBeTruthy();
+  const head = await axios.head(glbUrl!);
+  expect(head.status).toBe(200);
+  const res = await axios.get(glbUrl!, { responseType: "arraybuffer" });
+  expect(res.data.byteLength).toBeGreaterThan(0);
+  expect(Buffer.from(res.data).toString("ascii", 0, 4)).toBe("glTF");
+  const size = parseInt(head.headers["content-length"] || res.data.byteLength);
+  expect(size).toBeGreaterThan(1000);
+  return Date.now() - start;
+}
+
+test("glb generation smoke", async ({ page }) => {
+  const ms = await generateAndValidate(page, PROMPT);
+  console.log(`generation time ${ms}ms`);
+});


### PR DESCRIPTION
## Summary
- add smoke and nightly GLB generation flows for Playwright

## Testing
- `npm run format` in `backend/`
- `npm test` *(fails: eslint detailed results & linting diagnostics)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: lint issues)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68797bbc7dd4832d943c8ef3c43e2911