### PR TITLE
Update tests to use https localhost

### DIFF
--- a/backend/tests/adminAds.test.js
+++ b/backend/tests/adminAds.test.js
@@ -1,5 +1,5 @@
 process.env.DB_URL = "postgres://user:pass@localhost/db";
-process.env.DALLE_API_URL = "http://localhost:5002/generate";
+process.env.DALLE_API_URL = "https://localhost:5002/generate";
 process.env.LLM_API_URL = "";
 process.env.STRIPE_SECRET_KEY = "test";
 process.env.STRIPE_WEBHOOK_SECRET = "whsec";

--- a/backend/tests/frontend/flashBanner.test.js
+++ b/backend/tests/frontend/flashBanner.test.js
@@ -25,7 +25,7 @@ function setupDom() {
   const dom = new JSDOM(html, {
     runScripts: "dangerously",
     resources: "usable",
-    url: "http://localhost/",
+    url: "https://localhost/",
   });
   global.window = dom.window;
   global.document = dom.window.document;

--- a/backend/tests/frontend/index.test.js
+++ b/backend/tests/frontend/index.test.js
@@ -28,7 +28,7 @@ describe("index validatePrompt", () => {
     const dom = new JSDOM(html, {
       runScripts: "dangerously",
       resources: "usable",
-      url: "http://localhost/",
+      url: "https://localhost/",
     });
     global.window = dom.window;
     global.document = dom.window.document;

--- a/backend/tests/frontend/login.test.js
+++ b/backend/tests/frontend/login.test.js
@@ -26,7 +26,7 @@ describe("login form", () => {
     const dom = new JSDOM(html, {
       runScripts: "dangerously",
       resources: "usable",
-      url: "http://localhost/login.html",
+      url: "https://localhost/login.html",
     });
     dom.window.document
       .querySelectorAll('script[src*="tailwind"]')

--- a/backend/tests/frontend/modelViewerLoader.test.js
+++ b/backend/tests/frontend/modelViewerLoader.test.js
@@ -56,7 +56,7 @@ test("falls back to local script when CDN fails", async () => {
     {
       runScripts: "dangerously",
       resources: "usable",
-      url: "http://localhost/",
+      url: "https://localhost/",
     },
   );
   global.window = dom.window;
@@ -100,7 +100,7 @@ test("rejects when both CDN and local scripts fail", async () => {
     {
       runScripts: "dangerously",
       resources: "usable",
-      url: "http://localhost/",
+      url: "https://localhost/",
     },
   );
   global.window = dom.window;
@@ -124,7 +124,7 @@ test("falls back when HEAD request fails", async () => {
     {
       runScripts: "dangerously",
       resources: "usable",
-      url: "http://localhost/",
+      url: "https://localhost/",
     },
   );
   global.window = dom.window;

--- a/backend/tests/frontend/profile.test.js
+++ b/backend/tests/frontend/profile.test.js
@@ -6,7 +6,7 @@ const { JSDOM } = require("jsdom");
 test("load displays models from API", async () => {
   const dom = new JSDOM('<div id="models"></div>', {
     runScripts: "dangerously",
-    url: "http://localhost/profile.html",
+    url: "https://localhost/profile.html",
   });
   global.window = dom.window;
   global.document = dom.window.document;

--- a/backend/tests/frontend/quantityDefault.test.js
+++ b/backend/tests/frontend/quantityDefault.test.js
@@ -23,7 +23,7 @@ function loadDom() {
   const dom = new JSDOM(html, {
     runScripts: "dangerously",
     resources: "usable",
-    url: "http://localhost/payment.html",
+    url: "https://localhost/payment.html",
   });
   global.window = dom.window;
   global.document = dom.window.document;

--- a/backend/tests/frontend/sharedModel.test.js
+++ b/backend/tests/frontend/sharedModel.test.js
@@ -23,7 +23,7 @@ function setup(url) {
 }
 
 test("loads model from API", async () => {
-  const dom = setup("http://localhost/share.html?slug=test");
+  const dom = setup("https://localhost/share.html?slug=test");
   dom.window.fetch = jest.fn(() =>
     Promise.resolve({
       ok: true,
@@ -38,7 +38,7 @@ test("loads model from API", async () => {
 });
 
 test("shows error when slug missing", () => {
-  const dom = setup("http://localhost/share.html");
+  const dom = setup("https://localhost/share.html");
   dom.window.document.dispatchEvent(new dom.window.Event("DOMContentLoaded"));
   expect(dom.window.document.getElementById("error").textContent).toBe(
     "Missing share link",

--- a/backend/tests/frontend/signup.test.js
+++ b/backend/tests/frontend/signup.test.js
@@ -26,7 +26,7 @@ describe("signup form", () => {
     const dom = new JSDOM(html, {
       runScripts: "dangerously",
       resources: "usable",
-      url: "http://localhost/signup.html",
+      url: "https://localhost/signup.html",
     });
     dom.window.document
       .querySelectorAll('script[src*="tailwind"]')

--- a/backend/tests/frontend/slotCount.test.js
+++ b/backend/tests/frontend/slotCount.test.js
@@ -46,7 +46,7 @@ describe("slot count", () => {
     const dom = new JSDOM(html, {
       runScripts: "dangerously",
       resources: "usable",
-      url: "http://localhost/payment.html?session_id=1",
+      url: "https://localhost/payment.html?session_id=1",
     });
     global.window = dom.window;
     global.document = dom.window.document;
@@ -71,7 +71,7 @@ describe("slot count", () => {
     const dom = new JSDOM(html, {
       runScripts: "dangerously",
       resources: "usable",
-      url: "http://localhost/payment.html",
+      url: "https://localhost/payment.html",
     });
     global.window = dom.window;
     global.document = dom.window.document;

--- a/backend/tests/frontend/viewerReady.test.js
+++ b/backend/tests/frontend/viewerReady.test.js
@@ -27,7 +27,7 @@ function setup() {
   const dom = new JSDOM(html, {
     runScripts: "dangerously",
     resources: "usable",
-    url: "http://localhost/",
+    url: "https://localhost/",
   });
   global.window = dom.window;
   global.document = dom.window.document;

--- a/backend/tests/modelViewerCdnFallback.test.ts
+++ b/backend/tests/modelViewerCdnFallback.test.ts
@@ -52,7 +52,7 @@ test("falls back to local script when CDN script fails", async () => {
     {
       runScripts: "dangerously",
       resources: "usable",
-      url: "http://localhost/",
+      url: "https://localhost/",
     },
   );
   global.window = dom.window;

--- a/backend/tests/payouts.test.js
+++ b/backend/tests/payouts.test.js
@@ -81,7 +81,7 @@ test("POST /api/stripe/connect creates link", async () => {
   const res = await request(app)
     .post("/api/stripe/connect")
     .set("authorization", `Bearer ${token}`)
-    .set("origin", "http://localhost");
+    .set("origin", "https://localhost");
   expect(res.status).toBe(200);
   expect(res.body.url).toBe("https://connect");
 });

--- a/tests/generated_api_0da9a298.test.js
+++ b/tests/generated_api_0da9a298.test.js
@@ -64,7 +64,7 @@ CREATE TABLE password_resets (
   const app = require("../backend/server");
   const server = app.listen(0);
   await new Promise((r) => server.once("listening", r));
-  const url = `http://localhost:${server.address().port}`;
+  const url = `https://localhost:${server.address().port}`;
   return { server, pool, url };
 }
 

--- a/tests/generated_api_2fc66fef.test.js
+++ b/tests/generated_api_2fc66fef.test.js
@@ -9,7 +9,7 @@ let baseUrl;
 
 beforeAll((done) => {
   server = http.createServer(app).listen(0, () => {
-    baseUrl = `http://localhost:${server.address().port}`;
+    baseUrl = `https://localhost:${server.address().port}`;
     done();
   });
 });

--- a/tests/generated_frontend_b5729acf.test.js
+++ b/tests/generated_frontend_b5729acf.test.js
@@ -1,44 +1,47 @@
+/* eslint-disable jsdoc/check-tag-names */
 /**
  * @jest-environment jsdom
  */
 
-const fetchMock = require('jest-fetch-mock');
+const fetchMock = require("jest-fetch-mock");
 fetchMock.enableMocks();
 
-const { track, flushAnalytics, setUserId } = require('../js/analytics.js');
+const { track, flushAnalytics } = require("../js/analytics.js");
 
-describe('whitelisted events', () => {
+describe("whitelisted events", () => {
   beforeEach(() => {
     fetchMock.resetMocks();
-    jest.useFakeTimers().setSystemTime(new Date('2020-01-01T00:00:00Z'));
+    jest.useFakeTimers().setSystemTime(new Date("2020-01-01T00:00:00Z"));
   });
   afterEach(() => {
     jest.useRealTimers();
   });
 
-  const events = ['page', 'click', 'cart', 'checkout', 'share'];
-  events.forEach(event => {
+  const events = ["page", "click", "cart", "checkout", "share"];
+  events.forEach((event) => {
     for (let i = 0; i < 10; i++) {
       test(`${event} event ${i}`, async () => {
-        fetchMock.mockResponseOnce('{}');
+        fetchMock.mockResponseOnce("{}");
         await track(event, { index: i });
         expect(fetch).toHaveBeenCalledWith(
           `/api/track/${event}`,
           expect.objectContaining({
-            method: 'POST',
-            headers: expect.objectContaining({ 'Content-Type': 'application/json' }),
-            body: JSON.stringify({ index: i, timestamp: expect.any(String) })
-          })
+            method: "POST",
+            headers: expect.objectContaining({
+              "Content-Type": "application/json",
+            }),
+            body: JSON.stringify({ index: i, timestamp: expect.any(String) }),
+          }),
         );
       });
     }
   });
 });
 
-describe('custom headers and payload validation', () => {
+describe("custom headers and payload validation", () => {
   beforeEach(() => {
     fetchMock.resetMocks();
-    jest.useFakeTimers().setSystemTime(new Date('2020-01-01T00:00:00Z'));
+    jest.useFakeTimers().setSystemTime(new Date("2020-01-01T00:00:00Z"));
   });
   afterEach(() => {
     jest.useRealTimers();
@@ -46,16 +49,19 @@ describe('custom headers and payload validation', () => {
 
   for (let i = 0; i < 50; i++) {
     test(`custom headers ${i}`, async () => {
-      fetchMock.mockResponseOnce('{}');
-      await track('click', { pos: i }, { headers: { 'X-Test': '1' } });
+      fetchMock.mockResponseOnce("{}");
+      await track("click", { pos: i }, { headers: { "X-Test": "1" } });
       const call = fetchMock.mock.calls[0];
-      expect(call[1].headers['X-Test']).toBe('1');
-      expect(JSON.parse(call[1].body)).toEqual({ pos: i, timestamp: expect.any(String) });
+      expect(call[1].headers["X-Test"]).toBe("1");
+      expect(JSON.parse(call[1].body)).toEqual({
+        pos: i,
+        timestamp: expect.any(String),
+      });
     });
   }
 });
 
-describe('retry logic with backoff', () => {
+describe("retry logic with backoff", () => {
   beforeEach(() => {
     fetchMock.resetMocks();
     jest.useFakeTimers();
@@ -66,11 +72,11 @@ describe('retry logic with backoff', () => {
 
   for (let i = 0; i < 50; i++) {
     test(`retry ${i}`, async () => {
-      fetchMock.mockRejectOnce(new Error('net')); // first failure
-      fetchMock.mockRejectOnce(new Error('net')); // second failure
-      fetchMock.mockResponseOnce('{}'); // success
+      fetchMock.mockRejectOnce(new Error("net")); // first failure
+      fetchMock.mockRejectOnce(new Error("net")); // second failure
+      fetchMock.mockResponseOnce("{}"); // success
 
-      const p = track('page', { step: i });
+      const p = track("page", { step: i });
 
       jest.advanceTimersByTime(100);
       await Promise.resolve();
@@ -84,7 +90,7 @@ describe('retry logic with backoff', () => {
   }
 });
 
-describe('batching and deduplication', () => {
+describe("batching and deduplication", () => {
   beforeEach(() => {
     fetchMock.resetMocks();
     jest.useFakeTimers();
@@ -95,9 +101,9 @@ describe('batching and deduplication', () => {
 
   for (let i = 0; i < 25; i++) {
     test(`batch group A ${i}`, async () => {
-      fetchMock.mockResponse('{}');
-      track('share', { id: i });
-      track('share', { id: i });
+      fetchMock.mockResponse("{}");
+      track("share", { id: i });
+      track("share", { id: i });
       jest.advanceTimersByTime(100);
       await Promise.resolve();
       expect(fetchMock.mock.calls.length).toBe(1);
@@ -106,8 +112,8 @@ describe('batching and deduplication', () => {
 
   for (let i = 0; i < 25; i++) {
     test(`batch flush ${i}`, async () => {
-      fetchMock.mockResponse('{}');
-      track('page', { id: i });
+      fetchMock.mockResponse("{}");
+      track("page", { id: i });
       await flushAnalytics();
       expect(fetchMock).toHaveBeenCalled();
     });

--- a/tests/generated_frontend_c664b58d.test.js
+++ b/tests/generated_frontend_c664b58d.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsdoc/check-tag-names */
 /**
  * @jest-environment jsdom
  * @eslint-env jest

--- a/tests/generated_frontend_c83b6ff1.test.js
+++ b/tests/generated_frontend_c83b6ff1.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsdoc/check-tag-names */
 /**
  * @jest-environment jsdom
  */

--- a/tests/load/models.yml
+++ b/tests/load/models.yml
@@ -1,5 +1,5 @@
 config:
-  target: "http://localhost:3000"
+  target: "https://localhost:3000"
   phases:
     - duration: 60
       arrivalRate: 10

--- a/tests/smoke-atomic/apiEndpoint_1a2b3c4d.test.js
+++ b/tests/smoke-atomic/apiEndpoint_1a2b3c4d.test.js
@@ -30,7 +30,7 @@ test("api generate endpoint returns json", async () => {
     stdio: "ignore",
   });
   await waitPort(3000);
-  const res = await fetch("http://localhost:3000/api/generate", {
+  const res = await fetch("https://localhost:3000/api/generate", {
     method: "POST",
   });
   expect(res.status).toBe(200);

--- a/tests/smoke-atomic/apiGenerate_g5h6i7j8.test.js
+++ b/tests/smoke-atomic/apiGenerate_g5h6i7j8.test.js
@@ -25,7 +25,7 @@ test("api /api/generate returns json", async () => {
   const env = { ...process.env, PORT: String(port) };
   const proc = spawn("npm", ["run", "serve"], { env });
   await waitForPort(port);
-  const res = await fetch(`http://localhost:${port}/api/generate`, {
+  const res = await fetch(`https://localhost:${port}/api/generate`, {
     method: "POST",
   });
   const body = await res.json();

--- a/tests/smoke-atomic/apiGenerate_m3n4o5p6.test.js
+++ b/tests/smoke-atomic/apiGenerate_m3n4o5p6.test.js
@@ -31,7 +31,7 @@ describe("generate endpoint", () => {
   });
 
   test("POST /api/generate returns glb_url", async () => {
-    const res = await fetch("http://localhost:3000/api/generate", {
+    const res = await fetch("https://localhost:3000/api/generate", {
       method: "POST",
     });
     expect(res.status).toBe(200);

--- a/tests/smoke-atomic/healthCheck_e5f6g7h8.test.js
+++ b/tests/smoke-atomic/healthCheck_e5f6g7h8.test.js
@@ -31,7 +31,7 @@ describe("health check", () => {
   });
 
   test("GET / responds within 5s", async () => {
-    const res = await fetch("http://localhost:3000/");
+    const res = await fetch("https://localhost:3000/");
     expect(res.status).toBe(200);
   });
 });

--- a/tests/smoke-atomic/httpHealthCheck_e7f8g9h0.test.js
+++ b/tests/smoke-atomic/httpHealthCheck_e7f8g9h0.test.js
@@ -8,7 +8,7 @@ test("root endpoint responds with 200", async () => {
   const proc = spawn("npm", ["run", "serve"], { env: process.env });
   for (let i = 0; i < 50; i++) {
     try {
-      const res = await fetch("http://localhost:3000/");
+      const res = await fetch("https://localhost:3000/");
       if (res.status === 200) {
         proc.kill();
         return;

--- a/tests/smoke-atomic/httpHealth_b3d8e7f6.test.js
+++ b/tests/smoke-atomic/httpHealth_b3d8e7f6.test.js
@@ -30,7 +30,7 @@ test("GET / responds with 200", async () => {
     stdio: "ignore",
   });
   await waitPort(3000);
-  const res = await fetch("http://localhost:3000/");
+  const res = await fetch("https://localhost:3000/");
   expect(res.status).toBe(200);
   proc.kill("SIGTERM");
 });

--- a/tests/smoke-atomic/playwrightReady_a4b5c6d7.test.js
+++ b/tests/smoke-atomic/playwrightReady_a4b5c6d7.test.js
@@ -35,7 +35,7 @@ test("viewerReady dataset becomes true", async () => {
   await waitPort(3000);
   const browser = await chromium.launch();
   const page = await browser.newPage();
-  await page.goto("http://localhost:3000/");
+  await page.goto("https://localhost:3000/");
   await page.waitForFunction("document.body.dataset.viewerReady", {
     timeout: 60000,
   });

--- a/tests/smoke-atomic/viewerReady_f1g2h3i4.test.js
+++ b/tests/smoke-atomic/viewerReady_f1g2h3i4.test.js
@@ -26,7 +26,7 @@ test("viewerReady flag present on homepage", async ({ page }) => {
   const env = { ...process.env, PORT: String(port) };
   const proc = spawn("npm", ["run", "serve"], { env });
   await waitForPort(port);
-  await page.goto(`http://localhost:${port}/`);
+  await page.goto(`https://localhost:${port}/`);
   await page.waitForFunction('document.body.dataset.viewerReady === "true"');
   const ready = await page.evaluate("document.body.dataset.viewerReady");
   expect(ready).toBe("true");

--- a/tests/smoke-atomic/viewerReady_i9j0k1l2.test.js
+++ b/tests/smoke-atomic/viewerReady_i9j0k1l2.test.js
@@ -28,7 +28,7 @@ test.skip("viewer ready on /", async () => {
   const browser = await chromium.launch();
   const page = await browser.newPage();
   try {
-    await page.goto("http://localhost:3000/");
+    await page.goto("https://localhost:3000/");
     await page.waitForFunction(
       () => document.body.dataset.viewerReady === "true",
       { timeout: 15000 },

--- a/tests/smoke-hang-diagnostics-57f3c8.test.js
+++ b/tests/smoke-hang-diagnostics-57f3c8.test.js
@@ -44,7 +44,7 @@ test("serve binds to port 3000", async () => {
 test("homepage responds at root", async () => {
   const proc = startServer();
   await waitForPort(3000);
-  const res = await fetch("http://localhost:3000/");
+  const res = await fetch("https://localhost:3000/");
   await stop(proc);
   expect(res.status).toBe(200);
 });
@@ -57,7 +57,7 @@ test("viewerReady script present", () => {
 test("static index.js loads", async () => {
   const proc = startServer();
   await waitForPort(3000);
-  const res = await fetch("http://localhost:3000/js/index.js");
+  const res = await fetch("https://localhost:3000/js/index.js");
   await stop(proc);
   expect(res.status).toBe(200);
 });
@@ -68,7 +68,7 @@ test("viewerReady within 10s", async () => {
   const browser = await chromium.launch();
   const page = await browser.newPage();
   const start = Date.now();
-  await page.goto("http://localhost:3000/");
+  await page.goto("https://localhost:3000/");
   await page.waitForFunction("document.body.dataset.viewerReady", {
     timeout: 10000,
   });

--- a/tests/smoke-hang-diagnostics-c9f8e7d6.test.js
+++ b/tests/smoke-hang-diagnostics-c9f8e7d6.test.js
@@ -43,7 +43,7 @@ describe("smoke hang diagnostics", () => {
   test("homepage responds at /", async () => {
     const proc = startServer();
     await waitPort(3000);
-    const res = await fetch("http://localhost:3000/");
+    const res = await fetch("https://localhost:3000/");
     proc.kill("SIGTERM");
     expect(res.status).toBe(200);
   });
@@ -51,7 +51,9 @@ describe("smoke hang diagnostics", () => {
   test("viewerReady marker present in page", async () => {
     const proc = startServer();
     await waitPort(3000);
-    const html = await (await fetch("http://localhost:3000/index.html")).text();
+    const html = await (
+      await fetch("https://localhost:3000/index.html")
+    ).text();
     proc.kill("SIGTERM");
     expect(html).toMatch(/viewerReady/);
   });
@@ -59,7 +61,7 @@ describe("smoke hang diagnostics", () => {
   test("static asset js/index.js loads", async () => {
     const proc = startServer();
     await waitPort(3000);
-    const res = await fetch("http://localhost:3000/js/index.js");
+    const res = await fetch("https://localhost:3000/js/index.js");
     proc.kill("SIGTERM");
     expect(res.status).toBe(200);
   });
@@ -68,7 +70,7 @@ describe("smoke hang diagnostics", () => {
     const proc = startServer();
     await waitPort(3000);
     const start = Date.now();
-    const res = await fetch("http://localhost:3000/healthz");
+    const res = await fetch("https://localhost:3000/healthz");
     const duration = Date.now() - start;
     proc.kill("SIGTERM");
     expect(res.status).toBe(200);

--- a/tests/smoke-hang-diagnostics-x1y2z3.test.js
+++ b/tests/smoke-hang-diagnostics-x1y2z3.test.js
@@ -52,7 +52,7 @@ test("serve binds on port 3000", async () => {
 test("homepage responds at root path", async () => {
   const { proc, port } = startServer(3100);
   await waitForPort(port);
-  const res = await fetch(`http://localhost:${port}/`);
+  const res = await fetch(`https://localhost:${port}/`);
   expect(res.status).toBe(200);
   proc.kill("SIGTERM");
 });
@@ -62,7 +62,7 @@ test("viewerReady marker appears", async () => {
   await waitForPort(port);
   const browser = await chromium.launch();
   const page = await browser.newPage();
-  await page.goto(`http://localhost:${port}/`);
+  await page.goto(`https://localhost:${port}/`);
   await page.waitForFunction('document.body.dataset.viewerReady === "true"', {
     timeout: 30000,
   });
@@ -75,7 +75,7 @@ test("viewerReady marker appears", async () => {
 test("static asset loads", async () => {
   const { proc, port } = startServer(3300);
   await waitForPort(port);
-  const res = await fetch(`http://localhost:${port}/js/ModelViewer.js`);
+  const res = await fetch(`https://localhost:${port}/js/ModelViewer.js`);
   expect(res.status).toBe(200);
   proc.kill("SIGTERM");
 });
@@ -94,7 +94,7 @@ test("viewer readiness under 30s", async () => {
   await waitForPort(port);
   const browser = await chromium.launch();
   const page = await browser.newPage();
-  await page.goto(`http://localhost:${port}/`);
+  await page.goto(`https://localhost:${port}/`);
   await page.waitForFunction('document.body.dataset.viewerReady === "true"', {
     timeout: 30000,
   });

--- a/tests/util.js
+++ b/tests/util.js
@@ -39,7 +39,7 @@ async function startServer(port = 4001) {
   return new Promise((resolve) => {
     const server = app.listen(port, () =>
       resolve({
-        url: `http://localhost:${port}`,
+        url: `https://localhost:${port}`,
         close: () => new Promise((r) => server.close(r)),
       }),
     );


### PR DESCRIPTION
## Summary
- replace `http://localhost` with `https://localhost` in all test files
- disable JSDoc linting for generated frontend tests

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687977da86b8832d959a5f06573f6fe3