### PR TITLE
Split lint tests for better diagnostics

### DIFF
--- a/tests/generated_frontend_b5729acf.test.js
+++ b/tests/generated_frontend_b5729acf.test.js
@@ -1,44 +1,48 @@
+/* eslint-disable jsdoc/check-tag-names */
 /**
  * @jest-environment jsdom
  */
+/* eslint-enable jsdoc/check-tag-names */
 
-const fetchMock = require('jest-fetch-mock');
+const fetchMock = require("jest-fetch-mock");
 fetchMock.enableMocks();
 
-const { track, flushAnalytics, setUserId } = require('../js/analytics.js');
+const { track, flushAnalytics } = require("../js/analytics.js");
 
-describe('whitelisted events', () => {
+describe("whitelisted events", () => {
   beforeEach(() => {
     fetchMock.resetMocks();
-    jest.useFakeTimers().setSystemTime(new Date('2020-01-01T00:00:00Z'));
+    jest.useFakeTimers().setSystemTime(new Date("2020-01-01T00:00:00Z"));
   });
   afterEach(() => {
     jest.useRealTimers();
   });
 
-  const events = ['page', 'click', 'cart', 'checkout', 'share'];
-  events.forEach(event => {
+  const events = ["page", "click", "cart", "checkout", "share"];
+  events.forEach((event) => {
     for (let i = 0; i < 10; i++) {
       test(`${event} event ${i}`, async () => {
-        fetchMock.mockResponseOnce('{}');
+        fetchMock.mockResponseOnce("{}");
         await track(event, { index: i });
         expect(fetch).toHaveBeenCalledWith(
           `/api/track/${event}`,
           expect.objectContaining({
-            method: 'POST',
-            headers: expect.objectContaining({ 'Content-Type': 'application/json' }),
-            body: JSON.stringify({ index: i, timestamp: expect.any(String) })
-          })
+            method: "POST",
+            headers: expect.objectContaining({
+              "Content-Type": "application/json",
+            }),
+            body: JSON.stringify({ index: i, timestamp: expect.any(String) }),
+          }),
         );
       });
     }
   });
 });
 
-describe('custom headers and payload validation', () => {
+describe("custom headers and payload validation", () => {
   beforeEach(() => {
     fetchMock.resetMocks();
-    jest.useFakeTimers().setSystemTime(new Date('2020-01-01T00:00:00Z'));
+    jest.useFakeTimers().setSystemTime(new Date("2020-01-01T00:00:00Z"));
   });
   afterEach(() => {
     jest.useRealTimers();
@@ -46,16 +50,19 @@ describe('custom headers and payload validation', () => {
 
   for (let i = 0; i < 50; i++) {
     test(`custom headers ${i}`, async () => {
-      fetchMock.mockResponseOnce('{}');
-      await track('click', { pos: i }, { headers: { 'X-Test': '1' } });
+      fetchMock.mockResponseOnce("{}");
+      await track("click", { pos: i }, { headers: { "X-Test": "1" } });
       const call = fetchMock.mock.calls[0];
-      expect(call[1].headers['X-Test']).toBe('1');
-      expect(JSON.parse(call[1].body)).toEqual({ pos: i, timestamp: expect.any(String) });
+      expect(call[1].headers["X-Test"]).toBe("1");
+      expect(JSON.parse(call[1].body)).toEqual({
+        pos: i,
+        timestamp: expect.any(String),
+      });
     });
   }
 });
 
-describe('retry logic with backoff', () => {
+describe("retry logic with backoff", () => {
   beforeEach(() => {
     fetchMock.resetMocks();
     jest.useFakeTimers();
@@ -66,11 +73,11 @@ describe('retry logic with backoff', () => {
 
   for (let i = 0; i < 50; i++) {
     test(`retry ${i}`, async () => {
-      fetchMock.mockRejectOnce(new Error('net')); // first failure
-      fetchMock.mockRejectOnce(new Error('net')); // second failure
-      fetchMock.mockResponseOnce('{}'); // success
+      fetchMock.mockRejectOnce(new Error("net")); // first failure
+      fetchMock.mockRejectOnce(new Error("net")); // second failure
+      fetchMock.mockResponseOnce("{}"); // success
 
-      const p = track('page', { step: i });
+      const p = track("page", { step: i });
 
       jest.advanceTimersByTime(100);
       await Promise.resolve();
@@ -84,7 +91,7 @@ describe('retry logic with backoff', () => {
   }
 });
 
-describe('batching and deduplication', () => {
+describe("batching and deduplication", () => {
   beforeEach(() => {
     fetchMock.resetMocks();
     jest.useFakeTimers();
@@ -95,9 +102,9 @@ describe('batching and deduplication', () => {
 
   for (let i = 0; i < 25; i++) {
     test(`batch group A ${i}`, async () => {
-      fetchMock.mockResponse('{}');
-      track('share', { id: i });
-      track('share', { id: i });
+      fetchMock.mockResponse("{}");
+      track("share", { id: i });
+      track("share", { id: i });
       jest.advanceTimersByTime(100);
       await Promise.resolve();
       expect(fetchMock.mock.calls.length).toBe(1);
@@ -106,8 +113,8 @@ describe('batching and deduplication', () => {
 
   for (let i = 0; i < 25; i++) {
     test(`batch flush ${i}`, async () => {
-      fetchMock.mockResponse('{}');
-      track('page', { id: i });
+      fetchMock.mockResponse("{}");
+      track("page", { id: i });
       await flushAnalytics();
       expect(fetchMock).toHaveBeenCalled();
     });

--- a/tests/generated_frontend_c664b58d.test.js
+++ b/tests/generated_frontend_c664b58d.test.js
@@ -1,7 +1,9 @@
+/* eslint-disable jsdoc/check-tag-names */
 /**
  * @jest-environment jsdom
- * @eslint-env jest
  */
+/* eslint-enable jsdoc/check-tag-names */
+/* eslint-env jest */
 /* global localStorage */
 const {
   addToBasket,

--- a/tests/generated_frontend_c83b6ff1.test.js
+++ b/tests/generated_frontend_c83b6ff1.test.js
@@ -1,6 +1,8 @@
+/* eslint-disable jsdoc/check-tag-names */
 /**
  * @jest-environment jsdom
  */
+/* eslint-enable jsdoc/check-tag-names */
 const React = require("react");
 const { render, screen } = require("@testing-library/react");
 


### PR DESCRIPTION
## Summary
- split `tests/linting.test.js` into per-file and per-rule checks
- silence `jsdoc/check-tag-names` warnings in generated tests
- remove unused variable from generated test

## Testing
- `npm test --prefix backend`
- `node scripts/run-jest.js tests/linting.test.js`

------
https://chatgpt.com/codex/tasks/task_e_687977bb8bcc832dbbf85974eb0d6dd6