### PR TITLE
Add glb pipeline e2e test

### DIFF
--- a/tests/glbPipelineE2ETest__bd81dcf1.test.ts
+++ b/tests/glbPipelineE2ETest__bd81dcf1.test.ts
@@ -1,0 +1,30 @@
+import axios from "axios";
+import { generateModel } from "../backend/src/pipeline/generateModel";
+
+// These tests run the full production pipeline against live services using
+// credentials from process.env. They will fail if required secrets are not set.
+describe("GLB pipeline end-to-end", () => {
+  jest.setTimeout(600000); // allow up to 10 minutes per test
+
+  const prompts = [
+    "a flying car made of crystals",
+    "a 3D model of a medieval sword",
+    "a cybernetic bird drone",
+    "an alien space station",
+    "a futuristic underwater city",
+  ];
+
+  for (const prompt of prompts) {
+    test(`generates GLB for "${prompt}"`, async () => {
+      const url = await generateModel({ prompt });
+      expect(typeof url).toBe("string");
+
+      const res = await axios.get(url, { responseType: "arraybuffer" });
+      const buf = Buffer.from(res.data);
+      expect(Buffer.isBuffer(buf)).toBe(true);
+      expect(buf.length).toBeGreaterThan(0);
+      expect(buf.slice(0, 4).toString()).toBe("glTF");
+      expect(res.headers["content-type"]).toMatch(/model\/gltf-binary/);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add end-to-end glb pipeline test hitting live APIs

## Testing
- `npm run format`
- `node scripts/run-jest.js tests/glbPipelineE2ETest__bd81dcf1.test.ts --runTestsByPath` *(fails: STABILITY_KEY is not set)*

------
https://chatgpt.com/codex/tasks/task_e_687a0d29e838832d9b61d9e2efc03271