### PR TITLE
Add npm integrity check test

### DIFF
--- a/tests/generated_frontend_b5729acf.test.js
+++ b/tests/generated_frontend_b5729acf.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsdoc/check-tag-names */
 /**
  * @jest-environment jsdom
  */

--- a/tests/generated_frontend_c664b58d.test.js
+++ b/tests/generated_frontend_c664b58d.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsdoc/check-tag-names */
 /**
  * @jest-environment jsdom
  * @eslint-env jest

--- a/tests/generated_frontend_c83b6ff1.test.js
+++ b/tests/generated_frontend_c83b6ff1.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsdoc/check-tag-names */
 /**
  * @jest-environment jsdom
  */

--- a/tests/npm_integrity_check_2d3b9b.test.ts
+++ b/tests/npm_integrity_check_2d3b9b.test.ts
@@ -1,0 +1,10 @@
+import { spawnSync } from "child_process";
+
+test("npm ci succeeds with no missing deps", () => {
+  const res = spawnSync("npm", ["ci", "--ignore-scripts"], {
+    encoding: "utf8",
+  });
+  const output = `${res.stdout || ""}${res.stderr || ""}`;
+  expect(res.status).toBe(0);
+  expect(output).not.toMatch(/missing dependencies/i);
+});


### PR DESCRIPTION
## Summary
- run `npm install` in backend with no changes
- add npm integrity test that runs `npm ci`
- silence jsdoc tag warnings

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_687a178eb780832d93d38ba5194adc1a