### PR TITLE
Enforce HTTPS for apt check

### DIFF
--- a/scripts/network-check.js
+++ b/scripts/network-check.js
@@ -32,7 +32,7 @@ const targets = [
     required: false,
   },
   {
-    url: process.env.APT_CHECK_URL || "http://archive.ubuntu.com",
+    url: process.env.APT_CHECK_URL || "https://archive.ubuntu.com",
     name: "apt archive",
     required: !process.env.SKIP_PW_DEPS,
   },

--- a/tests/download_security_check_7523.test.ts
+++ b/tests/download_security_check_7523.test.ts
@@ -1,0 +1,27 @@
+import fs from "fs";
+import path from "path";
+import https from "https";
+import http from "http";
+
+function fetch(url) {
+  return new Promise((resolve) => {
+    const mod = url.startsWith("https://") ? https : http;
+    mod.get(url, () => resolve()).on("error", () => resolve());
+  });
+}
+
+describe("download url security", () => {
+  test("all download urls use https", async () => {
+    const file = path.join(__dirname, "..", "scripts", "network-check.js");
+    const content = fs.readFileSync(file, "utf8");
+    const matches = content.match(/https?:\/\/[^'"\s,]+/g) || [];
+    const urls = Array.from(
+      new Set(matches.filter((u) => !u.includes("localhost"))),
+    );
+    expect(urls.length).toBeGreaterThan(0);
+    for (const url of urls) {
+      expect(url.startsWith("https://")).toBe(true);
+      await fetch(url);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- use HTTPS for Ubuntu archive in network-check script
- add test validating URLs use HTTPS and attempting downloads

## Testing
- `node scripts/run-jest.js tests/download_security_check_7523.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_687a17a0747c832da74cb9004c6ec50d