### PR TITLE
Add coverage tracker test

### DIFF
--- a/backend/tests/lintingDetailed.test.js
+++ b/backend/tests/lintingDetailed.test.js
@@ -9,7 +9,10 @@ test("detailed backend ESLint report", () => {
   // directory is gitignored and may not exist in fresh clones, so ensure it
   // is present before invoking ESLint.
   const coverageDir = path.join(backendDir, "coverage");
-  if (!fs.existsSync(coverageDir)) fs.mkdirSync(coverageDir);
+  if (!fs.existsSync(coverageDir)) {
+    fs.mkdirSync(coverageDir, { recursive: true });
+    fs.writeFileSync(path.join(coverageDir, ".gitkeep"), "");
+  }
   const output = execSync(`npx eslint -f json .`, {
     cwd: backendDir,
     encoding: "utf8",

--- a/tests/generated_frontend_b5729acf.test.js
+++ b/tests/generated_frontend_b5729acf.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsdoc/check-tag-names */
 /**
  * @jest-environment jsdom
  */

--- a/tests/generated_frontend_c664b58d.test.js
+++ b/tests/generated_frontend_c664b58d.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsdoc/check-tag-names */
 /**
  * @jest-environment jsdom
  * @eslint-env jest

--- a/tests/generated_frontend_c83b6ff1.test.js
+++ b/tests/generated_frontend_c83b6ff1.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsdoc/check-tag-names */
 /**
  * @jest-environment jsdom
  */

--- a/tests/test_coverage_tracker_83191b.test.ts
+++ b/tests/test_coverage_tracker_83191b.test.ts
@@ -1,0 +1,37 @@
+import { execFileSync } from "child_process";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import glob from "glob";
+
+test("all tests executed in coverage run", () => {
+  const repoRoot = path.resolve(__dirname, "..");
+  const testFiles = glob.sync("tests/**/*.test.{js,ts}", {
+    cwd: repoRoot,
+    absolute: true,
+  });
+
+  const outFile = path.join(os.tmpdir(), `jest-cover-${Date.now()}.json`);
+  execFileSync(
+    "node",
+    ["scripts/run-jest.js", "--coverage", "--json", `--outputFile=${outFile}`],
+    {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        SKIP_NET_CHECKS: "1",
+        SKIP_PW_DEPS: "1",
+        AWS_ACCESS_KEY_ID: "id",
+        AWS_SECRET_ACCESS_KEY: "secret",
+        DB_URL: "db",
+        STRIPE_SECRET_KEY: "sk",
+      },
+      stdio: "ignore",
+    },
+  );
+
+  const data = JSON.parse(fs.readFileSync(outFile, "utf8"));
+  const executed = new Set(data.testResults.map((t) => path.resolve(t.name)));
+  const missed = testFiles.filter((f) => !executed.has(f));
+  expect(missed).toEqual([]);
+});


### PR DESCRIPTION
## Summary
- keep eslint happy on generated tests by disabling jsdoc check
- create coverage dir in lintingDetailed test
- ensure generated tests compile for eslint
- add a test that reruns Jest with coverage and verifies all tests ran

## Testing
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_687a17a62a74832d99e2bb0e19ecc88d