### PR TITLE
Handle missing STABILITY_KEY

### DIFF
--- a/tests/glbPipelineE2ETest__bd81dcf1.test.ts
+++ b/tests/glbPipelineE2ETest__bd81dcf1.test.ts
@@ -1,9 +1,11 @@
 import axios from "axios";
 import { generateModel } from "../backend/src/pipeline/generateModel";
 
+const run = process.env.STABILITY_KEY ? describe : describe.skip;
+
 // These tests run the full production pipeline against live services using
 // credentials from process.env. They will fail if required secrets are not set.
-describe("GLB pipeline end-to-end", () => {
+run("GLB pipeline end-to-end", () => {
   jest.setTimeout(600000); // allow up to 10 minutes per test
 
   const prompts = [

--- a/tests/stabilityKeyGuard.test.ts
+++ b/tests/stabilityKeyGuard.test.ts
@@ -1,0 +1,19 @@
+const { textToImage } = require("../backend/src/lib/textToImage.js");
+
+describe("STABILITY_KEY guard", () => {
+  const original = process.env.STABILITY_KEY;
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.STABILITY_KEY;
+    } else {
+      process.env.STABILITY_KEY = original;
+    }
+  });
+
+  test("throws when STABILITY_KEY is not set", async () => {
+    delete process.env.STABILITY_KEY;
+    await expect(textToImage("hello")).rejects.toThrow(
+      "STABILITY_KEY is not set",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- skip GLB pipeline tests when STABILITY_KEY is undefined
- assert textToImage errors without STABILITY_KEY
- silence jsdoc warnings in generated frontend tests

## Testing
- `npm test -- tests/stabilityKeyGuard.test.ts tests/glbPipelineE2ETest__bd81dcf1.test.ts`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_687a140ec85c832d8d8fff0094787711