### PR TITLE
Fix ESLint warnings in generated tests

### DIFF
--- a/backend/tests/linting.test.js
+++ b/backend/tests/linting.test.js
@@ -7,6 +7,7 @@ test("repository passes ESLint with no warnings", () => {
     encoding: "utf-8",
     stdio: ["ignore", "pipe", "pipe"],
     shell: true,
+    env: { ...process.env, NODE_V8_COVERAGE: "" },
   });
 
   // If ESLint found anything (exit code !== 0) or spawn failed, print it out

--- a/tests/generated_frontend_b5729acf.test.js
+++ b/tests/generated_frontend_b5729acf.test.js
@@ -1,6 +1,4 @@
-/**
- * @jest-environment jsdom
- */
+// @jest-environment jsdom
 
 const fetchMock = require("jest-fetch-mock");
 fetchMock.enableMocks();

--- a/tests/generated_frontend_c664b58d.test.js
+++ b/tests/generated_frontend_c664b58d.test.js
@@ -1,7 +1,5 @@
-/**
- * @jest-environment jsdom
- * @eslint-env jest
- */
+// @jest-environment jsdom
+/* eslint-env jest */
 /* global localStorage */
 const {
   addToBasket,

--- a/tests/generated_frontend_c83b6ff1.test.js
+++ b/tests/generated_frontend_c83b6ff1.test.js
@@ -1,6 +1,4 @@
-/**
- * @jest-environment jsdom
- */
+// @jest-environment jsdom
 const React = require("react");
 const { render, screen } = require("@testing-library/react");
 

--- a/tests/lintingDetailed.test.js
+++ b/tests/lintingDetailed.test.js
@@ -1,7 +1,10 @@
 const { execSync } = require("child_process");
 
 test("detailed ESLint report", () => {
-  const output = execSync("npx eslint . -f json", { encoding: "utf8" });
+  const output = execSync("npx eslint . -f json", {
+    encoding: "utf8",
+    env: { ...process.env, NODE_V8_COVERAGE: "" },
+  });
   const results = JSON.parse(output);
   const errors = results
     .flatMap((r) => r.messages.map((m) => ({ ...m, file: r.filePath })))


### PR DESCRIPTION
## Summary
- silence jsdoc warnings in generated frontend tests
- ignore V8 coverage when running ESLint in tests

## Testing
- `npm test --prefix backend`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_687a13fb83b4832d9cc1032cb6e60ed6