### PR TITLE
Fix ESLint warnings in autogenerated tests

### DIFF
--- a/tests/generated_frontend_b5729acf.test.js
+++ b/tests/generated_frontend_b5729acf.test.js
@@ -1,6 +1,5 @@
-/**
- * @jest-environment jsdom
- */
+/* eslint-disable jsdoc/check-tag-names */
+/** @jest-environment jsdom */
 
 const fetchMock = require("jest-fetch-mock");
 fetchMock.enableMocks();

--- a/tests/generated_frontend_c664b58d.test.js
+++ b/tests/generated_frontend_c664b58d.test.js
@@ -1,7 +1,5 @@
-/**
- * @jest-environment jsdom
- * @eslint-env jest
- */
+/* eslint-disable jsdoc/check-tag-names */
+/** @jest-environment jsdom */
 /* global localStorage */
 const {
   addToBasket,

--- a/tests/generated_frontend_c83b6ff1.test.js
+++ b/tests/generated_frontend_c83b6ff1.test.js
@@ -1,6 +1,5 @@
-/**
- * @jest-environment jsdom
- */
+/* eslint-disable jsdoc/check-tag-names */
+/** @jest-environment jsdom */
 const React = require("react");
 const { render, screen } = require("@testing-library/react");
 


### PR DESCRIPTION
## Summary
- disable jsdoc tag checking in several autogenerated frontend tests

## Testing
- `npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_687a13fb83b4832d9cc1032cb6e60ed6