### PR TITLE
Add failing wait-on smoke test

### DIFF
--- a/tests/smoke/smokePortFail_a8b7c6d5.test.ts
+++ b/tests/smoke/smokePortFail_a8b7c6d5.test.ts
@@ -1,0 +1,25 @@
+const waitOn = require("wait-on");
+const app = require("../../backend/server");
+
+jest.setTimeout(10000);
+
+test("wait-on fails when server not on port 3000", async () => {
+  process.env.NODE_ENV = "test";
+  process.env.DB_URL = "postgres://user:pass@localhost/db";
+  process.env.STRIPE_SECRET_KEY = "sk_test";
+  process.env.STRIPE_WEBHOOK_SECRET = "whsec";
+  process.env.CLOUDFRONT_MODEL_DOMAIN = "cdn.test";
+  process.env.S3_BUCKET = "bucket";
+
+  const server = app.listen(3999);
+  let error;
+  try {
+    await waitOn({ resources: ["http://localhost:3000"], timeout: 1000 });
+  } catch (err) {
+    error = err;
+  } finally {
+    await new Promise((r) => server.close(r));
+  }
+  expect(error).toBeTruthy();
+  expect(String(error)).toMatch(/localhost:3000/);
+});


### PR DESCRIPTION
## Summary
- add smoke test for wait-on timeout when server binds different port

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a251dbaac832db18eb21940a461fb