### PR TITLE
Add server env fail test

### DIFF
--- a/tests/server/serverEnvFailTest_7bd6e2f9.test.ts
+++ b/tests/server/serverEnvFailTest_7bd6e2f9.test.ts
@@ -1,0 +1,20 @@
+// critical
+import { execFileSync } from "child_process";
+import path from "path";
+
+describe("server env validation", () => {
+  test("fails to start without CLOUDFRONT_MODEL_DOMAIN", () => {
+    const server = path.join(__dirname, "..", "..", "backend", "server.js");
+    expect(() => {
+      execFileSync("node", [server], {
+        env: {
+          ...process.env,
+          NODE_ENV: "production",
+          CLOUDFRONT_MODEL_DOMAIN: "",
+        },
+        encoding: "utf8",
+        timeout: 5000,
+      });
+    }).toThrow(/CLOUDFRONT_MODEL_DOMAIN/);
+  });
+});


### PR DESCRIPTION
## Summary
- add critical server env check test

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a2513e2e8832d9d10e729b4b21908