### PR TITLE
Add env secrets presence test

### DIFF
--- a/tests/env/envSecretsPresence_7f5cde4b.test.ts
+++ b/tests/env/envSecretsPresence_7f5cde4b.test.ts
@@ -1,0 +1,35 @@
+import fs from "fs";
+import path from "path";
+
+describe("required secrets present", () => {
+  const required = [
+    "DB_URL",
+    "STRIPE_SECRET_KEY",
+    "STRIPE_WEBHOOK_SECRET",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "HF_TOKEN",
+  ];
+
+  function loadEnvFile() {
+    const envPath = path.resolve(__dirname, "..", "..", ".env");
+    const result = {};
+    if (fs.existsSync(envPath)) {
+      for (const line of fs.readFileSync(envPath, "utf8").split(/\r?\n/)) {
+        const m = line.match(/^([^#=]+)=(.*)$/);
+        if (m) result[m[1].trim()] = m[2].trim();
+      }
+    }
+    return result;
+  }
+
+  test("all secrets defined", () => {
+    const fileVars = loadEnvFile();
+    const missing = required.filter((name) => {
+      return !(process.env[name] || fileVars[name]);
+    });
+    if (missing.length) {
+      throw new Error(`Missing secrets: ${missing.join(", ")}`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add envSecretsPresence test in `tests/env`
- ensure all required secrets exist in .env or environment

## Testing
- `npm test` in `backend/`
- `node scripts/run-jest.js`


------
https://chatgpt.com/codex/tasks/task_e_687a25104b3c832d95a3082da612ec25