### PR TITLE
Add mise installer test

### DIFF
--- a/tests/bin-noop-npx/npx
+++ b/tests/bin-noop-npx/npx
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exit 0

--- a/tests/bin-noop-ping/npm
+++ b/tests/bin-noop-ping/npm
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+if [[ "$1" == "ci" || "$1" == "ping" ]]; then
+  exit 0
+fi
+exec "$REAL_NPM" "$@"

--- a/tests/bin-noop-rm/rm
+++ b/tests/bin-noop-rm/rm
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exit 0

--- a/tests/bin-noop-sudo/sudo
+++ b/tests/bin-noop-sudo/sudo
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exit 0

--- a/tests/path-no-mise/bash
+++ b/tests/path-no-mise/bash
@@ -1,0 +1,1 @@
+/usr/bin/bash

--- a/tests/path-no-mise/cat
+++ b/tests/path-no-mise/cat
@@ -1,0 +1,1 @@
+/usr/bin/cat

--- a/tests/path-no-mise/chmod
+++ b/tests/path-no-mise/chmod
@@ -1,0 +1,1 @@
+/usr/bin/chmod

--- a/tests/path-no-mise/curl
+++ b/tests/path-no-mise/curl
@@ -1,0 +1,1 @@
+/usr/bin/curl

--- a/tests/path-no-mise/grep
+++ b/tests/path-no-mise/grep
@@ -1,0 +1,1 @@
+/usr/bin/grep

--- a/tests/path-no-mise/mkdir
+++ b/tests/path-no-mise/mkdir
@@ -1,0 +1,1 @@
+/usr/bin/mkdir

--- a/tests/path-no-mise/rm
+++ b/tests/path-no-mise/rm
@@ -1,0 +1,1 @@
+/usr/bin/rm

--- a/tests/path-no-mise/sleep
+++ b/tests/path-no-mise/sleep
@@ -1,0 +1,1 @@
+/usr/bin/sleep

--- a/tests/setup/testMiseInstaller_98c6b7a2.test.js
+++ b/tests/setup/testMiseInstaller_98c6b7a2.test.js
@@ -1,0 +1,76 @@
+const path = require("path");
+const https = require("https");
+const { spawnSync, execSync } = require("child_process");
+
+function head(url) {
+  return new Promise((resolve, reject) => {
+    const req = https.request(url, { method: "HEAD" }, (res) => {
+      resolve(res.statusCode || 0);
+    });
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+jest.setTimeout(20000);
+
+describe("mise installer", () => {
+  test("setup.sh installs mise without http 404", async () => {
+    let status;
+    try {
+      status = await head("https://mise.run");
+    } catch (err) {
+      console.warn("Skipping mise download check:", err.message);
+    }
+    if (status !== undefined) {
+      expect(status).not.toBe(404);
+    }
+
+    const basePath = process.env.PATH.split(":")
+      .filter((p) => !p.includes("/usr/bin") && !p.endsWith("/bin"))
+      .join(":");
+    const env = {
+      ...process.env,
+      HF_TOKEN: "test",
+      AWS_ACCESS_KEY_ID: "id",
+      AWS_SECRET_ACCESS_KEY: "secret",
+      DB_URL: "postgres://user:pass@localhost/db",
+      STRIPE_SECRET_KEY: "sk_test",
+      CLOUDFRONT_MODEL_DOMAIN: "cdn.test",
+      SKIP_NET_CHECKS: "1",
+      SKIP_PW_DEPS: "1",
+      REAL_NPM: execSync("command -v npm").toString().trim(),
+      REAL_NPX: execSync("command -v npx").toString().trim(),
+      PATH:
+        path.join(__dirname, "..", "bin-install-mise") +
+        ":" +
+        path.join(__dirname, "..", "bin-noop-ping") +
+        ":" +
+        path.join(__dirname, "..", "bin-noop-npx") +
+        ":" +
+        path.join(__dirname, "..", "bin-noop-sudo") +
+        ":" +
+        path.join(__dirname, "..", "bin-noop-rm") +
+        ":" +
+        path.join(__dirname, "..", "path-no-mise") +
+        ":" +
+        basePath,
+    };
+
+    const result = spawnSync("bash", ["scripts/install-mise.sh"], {
+      env,
+      encoding: "utf8",
+      timeout: 20000,
+    });
+
+    if (result.error) throw result.error;
+    expect(result.status).toBe(0);
+    const combined = (result.stdout || "") + (result.stderr || "");
+    expect(combined).not.toMatch(/mise installation failed/i);
+
+    const log = result.stdout + (result.stderr || "");
+    expect(log).toMatch(/mise installed/);
+    expect(log).not.toMatch(/404/);
+    expect(log).not.toMatch(/checksum/i);
+  });
+});


### PR DESCRIPTION
## Summary
- test the mise installer with a sandboxed setup script
- add helper stubs so the install runs quickly without network access

## Testing
- `node scripts/run-jest.js tests/setup/testMiseInstaller_98c6b7a2.test.js`

------
https://chatgpt.com/codex/tasks/task_e_687a250ceb04832db92f280e0ed97cae