### PR TITLE
Handle env failures in coverage script

### DIFF
--- a/backend/tests/coverageFailureHandling_dbe6fc.test.ts
+++ b/backend/tests/coverageFailureHandling_dbe6fc.test.ts
@@ -1,0 +1,36 @@
+import { spawnSync } from "child_process";
+import * as path from "path";
+import * as fs from "fs";
+
+const repoRoot = path.join(__dirname, "..", "..");
+const script = path.join(repoRoot, "scripts", "run-coverage.js");
+const stub = path.join(__dirname, "stubValidateFail.js");
+
+function runCoverage() {
+  const env = {
+    ...process.env,
+    NODE_OPTIONS: `--require ${stub}`,
+    HF_TOKEN: "x",
+    AWS_ACCESS_KEY_ID: "id",
+    AWS_SECRET_ACCESS_KEY: "secret",
+    DB_URL: "db",
+    STRIPE_SECRET_KEY: "sk",
+    SKIP_NET_CHECKS: "1",
+    SKIP_PW_DEPS: "1",
+  } as NodeJS.ProcessEnv;
+  return spawnSync(
+    process.execPath,
+    [script, "--runTestsByPath", "backend/tests/coverage/lcovParse.test.ts"],
+    { env, encoding: "utf8" },
+  );
+}
+
+describe("run-coverage env failure handling", () => {
+  test("warns but continues when validate-env fails", () => {
+    const result = runCoverage();
+    expect(result.status).toBe(0);
+    const output = result.stdout + result.stderr;
+    expect(output).toMatch(/validate-env failed/);
+    expect(output).toMatch(/Environment validation failed/);
+  });
+});

--- a/backend/tests/stubValidateFail.js
+++ b/backend/tests/stubValidateFail.js
@@ -1,0 +1,10 @@
+const child_process = require("child_process");
+const origExecSync = child_process.execSync;
+child_process.execSync = function (cmd, opts) {
+  if (cmd.includes("validate-env")) {
+    const err = new Error("validate-env failed");
+    err.status = 1;
+    throw err;
+  }
+  return origExecSync(cmd, opts);
+};

--- a/scripts/run-coverage.js
+++ b/scripts/run-coverage.js
@@ -12,7 +12,17 @@ require("./check-node-version.js");
 // Validate environment variables and dependencies just like the test and CI
 // scripts do. This prevents confusing failures when `npm run coverage` is run
 // without first executing the setup script.
-require("./assert-setup.js");
+const setupRes = spawnSync(
+  process.execPath,
+  [path.join(__dirname, "assert-setup.js")],
+  {
+    stdio: "inherit",
+    env: { ...process.env },
+  },
+);
+if (setupRes.status) {
+  console.warn("Environment validation failed; continuing anyway");
+}
 
 const extraArgs = process.argv.slice(2);
 if (extraArgs.includes("--help") || extraArgs.includes("-h")) {


### PR DESCRIPTION
## Summary
- warn instead of aborting when `validate-env` fails in `run-coverage.js`
- add test verifying coverage handles failed env validation

## Testing
- `npm run format` in `backend/`
- `npm test` in `backend/`

------
https://chatgpt.com/codex/tasks/task_e_687a24fca76c832db3e050c4e990b794