### PR TITLE
Add CI env var validation test

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "typecheck": "tsc --noEmit",
     "i18n:lint": "node scripts/i18n-lint.js",
     "ci": "node scripts/assert-setup.js && npm run format:check && npm run lint && npm run typecheck && npm run i18n:lint && npm run test:ci && npm run test:a11y",
-    "test:ci": "cross-env JEST_CI=true npm run test-ci --prefix backend",
+    "test:ci": "cross-env JEST_CI=true npm run test-ci --prefix backend && node scripts/run-jest.js tests/ci",
     "test:update-threshold": "node scripts/update-coverage-threshold.js",
     "test:stability": "node scripts/test-stability.js",
     "deps:check": "npx -y lockfile-diff HEAD package-lock.json && npx -y lockfile-diff HEAD backend/package-lock.json && npx -y lockfile-diff HEAD backend/hunyuan_server/package-lock.json",

--- a/tests/ci/envVarValidation_e4c5d2b1.test.ts
+++ b/tests/ci/envVarValidation_e4c5d2b1.test.ts
@@ -1,0 +1,24 @@
+const checks = {
+  DB_URL: /:\/\//,
+  STRIPE_SECRET_KEY: /^sk_test_/,
+  STRIPE_PUBLISHABLE_KEY: /^pk_test_/,
+  STRIPE_WEBHOOK_SECRET: /^whsec_/,
+};
+
+describe("CI env var validation", () => {
+  for (const [name, pattern] of Object.entries(checks)) {
+    test(`${name} is set and matches ${pattern}`, () => {
+      const value = process.env[name];
+      if (!value) {
+        throw new Error(`Missing required env var: ${name}`);
+      }
+      if (!pattern.test(value)) {
+        throw new Error(`Invalid format for ${name}: ${value}`);
+      }
+    });
+  }
+
+  test("running in CI context", () => {
+    expect(process.env.NODE_ENV).not.toBe("production");
+  });
+});


### PR DESCRIPTION
## Summary
- add envVarValidation_e4c5d2b1.test.ts to verify required variables and formats
- run new tests during `npm run test:ci`

## Testing
- `npm run format --prefix backend`
- `SKIP_PW_DEPS=1 npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_687a24f0e104832d9607a4fba19de6f7