### PR TITLE
Add security helper modules

### DIFF
--- a/js/dom-utils-securityfix-79d3fa.ts
+++ b/js/dom-utils-securityfix-79d3fa.ts
@@ -1,0 +1,26 @@
+export function escapeHtml(input) {
+  return input.replace(/[&<>"']/g, (ch) => {
+    switch (ch) {
+      case "&":
+        return "&amp;";
+      case "<":
+        return "&lt;";
+      case ">":
+        return "&gt;";
+      case '"':
+        return "&quot;";
+      case "'":
+        return "&#39;";
+      default:
+        return ch;
+    }
+  });
+}
+
+export function setSafeInnerHTML(el, template, ...values) {
+  const safe = template.reduce((acc, part, i) => {
+    const val = i < values.length ? escapeHtml(String(values[i])) : "";
+    return acc + part + val;
+  }, "");
+  el.innerHTML = safe;
+}

--- a/scripts/exec-wrapper-securityfix-79d3fa.ts
+++ b/scripts/exec-wrapper-securityfix-79d3fa.ts
@@ -1,0 +1,16 @@
+import { spawnSync } from "child_process";
+
+export function execSafe(command, args = [], options = {}) {
+  const result = spawnSync(command, args, {
+    stdio: "inherit",
+    shell: false,
+    ...options,
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status && result.status !== 0) {
+    throw new Error(`Command failed: ${command} ${args.join(" ")}`);
+  }
+  return result.stdout ? result.stdout.toString() : "";
+}

--- a/tests/generated_frontend_ef73b1c2.test.js
+++ b/tests/generated_frontend_ef73b1c2.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable jsdoc/check-tag-names */
 /** Jest environment set to jsdom for DOM APIs */
 /* global localStorage */
 const { authHeaders } = require("../js/api.js");


### PR DESCRIPTION
## Summary
- add spawnSync wrapper for safer process execution
- add DOM utilities for safe innerHTML handling
- adjust ESLint config and remove unused directive

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_687a23d4e550832db6405d97b0a20392