### PR TITLE
Add secret env validation test

### DIFF
--- a/tests/checkSecrets-env-p1q2r3.test.ts
+++ b/tests/checkSecrets-env-p1q2r3.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+
+describe("GitHub CI Secrets Check", () => {
+  const requiredVars = [
+    "STRIPE_SECRET_KEY",
+    "DB_URL",
+    "HF_API_KEY",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "SPARC3D_TOKEN",
+    "STABILITY_KEY",
+  ];
+
+  it("should have all required secrets defined", () => {
+    for (const key of requiredVars) {
+      expect(process.env[key], `${key} is missing`).toBeTruthy();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add `checkSecrets-env-p1q2r3.test.ts` to validate CI secrets
- run formatting and tests

## Testing
- `npm run format` in `backend/`
- `npm test` in `backend/`


------
https://chatgpt.com/codex/tasks/task_e_687a23cdb184832d97e740592f8d7ffa