### PR TITLE
Add docs drift detector test

### DIFF
--- a/tests/docs_drift_detector_b3e0812f.test.ts
+++ b/tests/docs_drift_detector_b3e0812f.test.ts
@@ -1,0 +1,25 @@
+import fs from "fs";
+import path from "path";
+
+describe("documentation service coverage", () => {
+  const services = ["Sparc3D", "Hugging Face", "S3", "Stripe", "SendGrid"];
+
+  function read(file) {
+    try {
+      return fs.readFileSync(file, "utf8");
+    } catch {
+      return "";
+    }
+  }
+
+  test("README and setup docs mention all services", () => {
+    const repoRoot = path.join(__dirname, "..");
+    const content =
+      read(path.join(repoRoot, "README.md")) +
+      read(path.join(repoRoot, "docs", "setup.md")) +
+      read(path.join(repoRoot, "docs", "env.md"));
+    for (const svc of services) {
+      expect(content).toContain(svc);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add `docs_drift_detector_b3e0812f.test.ts` to ensure docs mention core services

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_687a20ae55cc832dae8bdc13ad46a555