### PR TITLE
Add CI stage reporting script

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -29,6 +29,7 @@ module.exports = [
       "backend/**",
       "scripts/ci_watchdog.ts",
       "scripts/ci_watchdog.js",
+      "scripts/report-ci-stages-b735ac.ts",
       "upload/**",
       "src/**",
     ],

--- a/scripts/report-ci-stages-b735ac.js
+++ b/scripts/report-ci-stages-b735ac.js
@@ -1,0 +1,45 @@
+"use strict";
+var __importDefault =
+  (this && this.__importDefault) ||
+  function (mod) {
+    return mod && mod.__esModule ? mod : { default: mod };
+  };
+Object.defineProperty(exports, "__esModule", { value: true });
+
+const node_fs_1 = __importDefault(require("node:fs"));
+const node_path_1 = __importDefault(require("node:path"));
+const steps = [
+  "setup",
+  "lint",
+  "smoke",
+  "coverage",
+  "glb pipeline",
+  "env snapshot",
+];
+// Accept a JSON file mapping step names to Status
+const inputPath = process.env.CI_STAGES_FILE || "";
+let data = {};
+if (inputPath && node_fs_1.default.existsSync(inputPath)) {
+  data = JSON.parse(node_fs_1.default.readFileSync(inputPath, "utf8"));
+}
+const results = steps.map((step) => {
+  const st = data[step] ?? {
+    exitCode: Number(
+      process.env[`${step.toUpperCase().replace(/ /g, "_")}_STATUS`] || 0,
+    ),
+  };
+  return { step, status: st.exitCode === 0 ? "ok" : `failed (${st.exitCode})` };
+});
+let allGood = true;
+for (const r of results) {
+  if (r.status !== "ok") allGood = false;
+}
+console.table(results);
+const logDir = node_path_1.default.join(process.cwd(), "ci-reports");
+node_fs_1.default.mkdirSync(logDir, { recursive: true });
+const logFile = node_path_1.default.join(logDir, "ci-summary-b735ac.log");
+node_fs_1.default.writeFileSync(
+  logFile,
+  results.map((r) => `${r.step}: ${r.status}`).join("\n"),
+);
+if (!allGood) process.exit(1);

--- a/scripts/report-ci-stages-b735ac.ts
+++ b/scripts/report-ci-stages-b735ac.ts
@@ -1,0 +1,49 @@
+/* eslint-disable */
+import fs from "node:fs";
+import path from "node:path";
+
+const steps = [
+  "setup",
+  "lint",
+  "smoke",
+  "coverage",
+  "glb pipeline",
+  "env snapshot",
+];
+
+interface Status {
+  exitCode: number;
+}
+
+// Accept a JSON file mapping step names to Status
+const inputPath = process.env.CI_STAGES_FILE || "";
+let data: Record<string, Status> = {};
+if (inputPath && fs.existsSync(inputPath)) {
+  data = JSON.parse(fs.readFileSync(inputPath, "utf8"));
+}
+
+const results = steps.map((step) => {
+  const st = data[step] ?? {
+    exitCode: Number(
+      process.env[`${step.toUpperCase().replace(/ /g, "_")}_STATUS`] || 0,
+    ),
+  };
+  return { step, status: st.exitCode === 0 ? "ok" : `failed (${st.exitCode})` };
+});
+
+let allGood = true;
+for (const r of results) {
+  if (r.status !== "ok") allGood = false;
+}
+
+console.table(results);
+
+const logDir = path.join(process.cwd(), "ci-reports");
+fs.mkdirSync(logDir, { recursive: true });
+const logFile = path.join(logDir, "ci-summary-b735ac.log");
+fs.writeFileSync(
+  logFile,
+  results.map((r) => `${r.step}: ${r.status}`).join("\n"),
+);
+
+if (!allGood) process.exit(1);

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -8,5 +8,5 @@
     "noImplicitAny": true,
     "strictNullChecks": true
   },
-  "files": ["ci_watchdog.ts"]
+  "files": ["ci_watchdog.ts", "report-ci-stages-b735ac.ts"]
 }


### PR DESCRIPTION
## Summary
- add `report-ci-stages-b735ac.ts` to summarize CI results
- compile new script via `tsconfig.json`
- ignore the new script in ESLint config

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_687a20a66948832da5272247f30b73a6