### PR TITLE
Add rollback guard test

### DIFF
--- a/tests/fixtures/knownGoodHash.json
+++ b/tests/fixtures/knownGoodHash.json
@@ -1,0 +1,5 @@
+{
+  "scripts/setup.sh": "723be7243a4939a57910ac213e4e4cbe083be40c081b671b638fa2ef6db53e2e",
+  "scripts/generate-glb-tests.js": "a8e826647b943100212df5e2bd0a7e29a6fc5e4c6601d37c1c3b4836533e2748",
+  ".env.example": "abbf320ef9fa4b666ee00c093e400f7d22f31d017a213bbb48f678965d90cde0"
+}

--- a/tests/rollback_guard_f47d90ab.test.ts
+++ b/tests/rollback_guard_f47d90ab.test.ts
@@ -1,0 +1,20 @@
+import fs from "fs";
+import path from "path";
+import crypto from "crypto";
+
+test("critical config has not regressed", () => {
+  const repoRoot = path.resolve(__dirname, "..");
+  const baseline = JSON.parse(
+    fs.readFileSync(
+      path.join(__dirname, "fixtures", "knownGoodHash.json"),
+      "utf8",
+    ),
+  );
+  const files = Object.keys(baseline);
+  for (const file of files) {
+    const filePath = path.join(repoRoot, file);
+    const content = fs.readFileSync(filePath);
+    const hash = crypto.createHash("sha256").update(content).digest("hex");
+    expect(hash).toBe(baseline[file]);
+  }
+});


### PR DESCRIPTION
## Summary
- guard against pipeline rollback by hashing key files

## Testing
- `npm run format`
- `node scripts/run-jest.js tests/rollback_guard_f47d90ab.test.ts`
- `npm test --silent` in `backend/`
- `npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_687a2068b6cc832da68fe2e8ed32fa1b