### PR TITLE
Add lint regression guard test

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "ci": "node scripts/assert-setup.js && npm run format:check && npm run lint && npm run typecheck && npm run i18n:lint && npm run test:ci && npm run test:a11y",
     "test:ci": "cross-env JEST_CI=true npm run test-ci --prefix backend",
     "test:update-threshold": "node scripts/update-coverage-threshold.js",
+    "update-lint-baseline": "node scripts/update-lint-baseline.js",
     "test:stability": "node scripts/test-stability.js",
     "deps:check": "npx -y lockfile-diff HEAD package-lock.json && npx -y lockfile-diff HEAD backend/package-lock.json && npx -y lockfile-diff HEAD backend/hunyuan_server/package-lock.json",
     "deps:dedupe": "npm dedupe",

--- a/scripts/check-lint-regression.js
+++ b/scripts/check-lint-regression.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+const { execSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+const repoRoot = path.resolve(__dirname, "..");
+const baselinePath = path.join(repoRoot, "tests", "lintBaseline.json");
+let baseline = { errorCount: 0, warningCount: 0 };
+if (fs.existsSync(baselinePath)) {
+  try {
+    baseline = JSON.parse(fs.readFileSync(baselinePath, "utf8"));
+  } catch (err) {
+    console.error("Failed to read baseline:", err);
+  }
+}
+
+const output = execSync("pnpm exec eslint . -f json", {
+  cwd: repoRoot,
+  encoding: "utf8",
+});
+const results = JSON.parse(output);
+const counts = results.reduce(
+  (acc, r) => {
+    acc.errorCount += r.errorCount || 0;
+    acc.warningCount += r.warningCount || 0;
+    return acc;
+  },
+  { errorCount: 0, warningCount: 0 },
+);
+
+if (
+  counts.errorCount > baseline.errorCount ||
+  counts.warningCount > baseline.warningCount
+) {
+  console.error(
+    `Lint count increased. Errors: ${counts.errorCount} (baseline ${baseline.errorCount}), ` +
+      `warnings: ${counts.warningCount} (baseline ${baseline.warningCount}).`,
+  );
+  process.exit(1);
+}
+console.log(
+  `ESLint errors ${counts.errorCount}, warnings ${counts.warningCount} within baseline`,
+);

--- a/scripts/update-lint-baseline.js
+++ b/scripts/update-lint-baseline.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+const { execSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+const repoRoot = path.resolve(__dirname, "..");
+const baselinePath = path.join(repoRoot, "tests", "lintBaseline.json");
+
+const output = execSync("pnpm exec eslint . -f json", {
+  cwd: repoRoot,
+  encoding: "utf8",
+});
+const results = JSON.parse(output);
+const counts = results.reduce(
+  (acc, r) => {
+    acc.errorCount += r.errorCount || 0;
+    acc.warningCount += r.warningCount || 0;
+    return acc;
+  },
+  { errorCount: 0, warningCount: 0 },
+);
+
+fs.writeFileSync(baselinePath, JSON.stringify(counts, null, 2));
+console.log(`Updated lint baseline at ${baselinePath}`);

--- a/tests/lintBaseline.json
+++ b/tests/lintBaseline.json
@@ -1,0 +1,4 @@
+{
+  "errorCount": 0,
+  "warningCount": 0
+}

--- a/tests/lint_regression_guard_78c92f2d.test.ts
+++ b/tests/lint_regression_guard_78c92f2d.test.ts
@@ -1,0 +1,14 @@
+const { execFileSync } = require("child_process");
+const path = require("path");
+
+describe("lint regression guard", () => {
+  test("eslint footprint does not grow", () => {
+    const script = path.join(
+      __dirname,
+      "..",
+      "scripts",
+      "check-lint-regression.js",
+    );
+    execFileSync("node", [script], { stdio: "inherit" });
+  });
+});


### PR DESCRIPTION
## Summary
- check eslint footprint against a baseline
- add script to update lint baseline
- store baseline with zero errors/warnings

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687a20618da8832db4f56f9a75d058d8