### PR TITLE
Add environment snapshot test

### DIFF
--- a/tests/__snapshots__/env_stability_snapshot_b74d2e91.test.ts.snap
+++ b/tests/__snapshots__/env_stability_snapshot_b74d2e91.test.ts.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`env stability snapshot matches baseline and required vars present 1`] = `
+{
+  "AWS_ACCESS_KEY_ID": "<set>",
+  "AWS_SECRET_ACCESS_KEY": "<set>",
+  "CLOUDFRONT_MODEL_DOMAIN": "<set>",
+  "DB_URL": "<set>",
+  "HF_TOKEN": undefined,
+  "SPARC3D_TOKEN": "<set>",
+  "STABILITY_KEY": undefined,
+  "STRIPE_SECRET_KEY": "<set>",
+  "STRIPE_WEBHOOK_SECRET": "<set>",
+}
+`;

--- a/tests/env_stability_snapshot_b74d2e91.test.ts
+++ b/tests/env_stability_snapshot_b74d2e91.test.ts
@@ -1,0 +1,29 @@
+const critical = [
+  "SPARC3D_TOKEN",
+  "CLOUDFRONT_MODEL_DOMAIN",
+  "STABILITY_KEY",
+  "HF_TOKEN",
+  "AWS_ACCESS_KEY_ID",
+  "AWS_SECRET_ACCESS_KEY",
+  "DB_URL",
+  "STRIPE_SECRET_KEY",
+  "STRIPE_WEBHOOK_SECRET",
+];
+
+function snapshotEnv() {
+  const out = {};
+  for (const key of critical) {
+    out[key] = process.env[key] ? "<set>" : undefined;
+  }
+  return out;
+}
+
+describe("env stability snapshot", () => {
+  test("matches baseline and required vars present", () => {
+    const snap = snapshotEnv();
+    console.log("env snapshot", JSON.stringify(snap, null, 2));
+    expect(snap.SPARC3D_TOKEN).toBe("<set>");
+    expect(snap.CLOUDFRONT_MODEL_DOMAIN).toBe("<set>");
+    expect(snap).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
## Summary
- add env stability snapshot test
- capture sanitized environment variables for CI health

## Testing
- `node scripts/run-jest.js tests/env_stability_snapshot_b74d2e91.test.ts`
- `npm test --prefix backend`
- `npm run format --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_687a206364f4832d8359694abfa4c987