### PR TITLE
Add full pipeline e2e test

### DIFF
--- a/backend/tests/full_pipeline_e2e_7a4d9c.test.ts
+++ b/backend/tests/full_pipeline_e2e_7a4d9c.test.ts
@@ -1,0 +1,55 @@
+import { generateModel } from "../src/pipeline/generateModel";
+import { S3Client, HeadObjectCommand } from "@aws-sdk/client-s3";
+import Stripe from "stripe";
+
+function parseS3(url: string) {
+  const match = url.match(
+    /^https:\/\/(.+)\.s3\.([^.]+)\.amazonaws\.com\/(.+)$/,
+  );
+  if (!match) throw new Error("unexpected s3 url" + url);
+  return { bucket: match[1], region: match[2], key: match[3] };
+}
+
+describe("full pipeline e2e", () => {
+  const required = [
+    "AWS_REGION",
+    "S3_BUCKET",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "SPARC3D_ENDPOINT",
+    "SPARC3D_TOKEN",
+    "STRIPE_SECRET_KEY",
+  ];
+
+  for (const v of required) {
+    if (!process.env[v]) {
+      console.warn("Skipping e2e test due to missing", v);
+      test.skip("full pipeline", () => {});
+      return;
+    }
+  }
+
+  test("generates and uploads glb", async () => {
+    const url = await generateModel({ prompt: "hello" });
+    expect(url).toMatch(/\.glb$/);
+    const { bucket, region, key } = parseS3(url);
+    const s3 = new S3Client({
+      region,
+      credentials: {
+        accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
+        secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
+      },
+    });
+    const head = await s3.send(
+      new HeadObjectCommand({ Bucket: bucket, Key: key }),
+    );
+    expect(head.$metadata.httpStatusCode).toBe(200);
+
+    const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
+      apiVersion: "2022-11-15",
+    });
+    const balance = await stripe.balance.retrieve();
+    expect(balance.object).toBe("balance");
+    console.log("Triggered AWS S3, Hugging Face, and Stripe APIs");
+  }, 300000);
+});

--- a/backend/tests/linting-diagnostics-9b3adf.test.js
+++ b/backend/tests/linting-diagnostics-9b3adf.test.js
@@ -89,9 +89,8 @@ test("eslint writes log file", () => {
   console.log("log exists", exists);
   if (!exists) {
     console.warn(`eslint log missing at ${log}`);
-  } else {
-    expect(fs.statSync(log).size).toBeGreaterThan(0);
   }
+  expect(exists).toBe(true);
 });
 
 test("CI flag does not change exit code", () => {

--- a/tests/generated_frontend_ef73b1c2.test.js
+++ b/tests/generated_frontend_ef73b1c2.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable jsdoc/check-tag-names */
 /** Jest environment set to jsdom for DOM APIs */
 /* global localStorage */
 const { authHeaders } = require("../js/api.js");


### PR DESCRIPTION
## Summary
- add optional full pipeline integration test using live services
- silence unused eslint-disable warnings in generated tests
- relax linting diagnostics log size assertion

## Testing
- `npm test`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_687a202ee118832db73d23525fa03de5