### PR TITLE
Add cross-browser Playwright test

### DIFF
--- a/e2e/crossBrowserFlow_0a1b2c3d4e5f6g7.test.js
+++ b/e2e/crossBrowserFlow_0a1b2c3d4e5f6g7.test.js
@@ -1,0 +1,42 @@
+const { test, expect, playwright } = require("@playwright/test");
+
+const browsers = ["chromium", "firefox", "webkit"];
+
+for (const browserName of browsers) {
+  test.describe(browserName, () => {
+    test.use({ browserName });
+
+    test("homepage and editor flow", async ({ page }, testInfo) => {
+      const consoleMessages = [];
+      page.on("console", (msg) => {
+        if (["warning", "error"].includes(msg.type())) {
+          consoleMessages.push(`${msg.type()}: ${msg.text()}`);
+        }
+      });
+      page.on("pageerror", (err) =>
+        consoleMessages.push(`pageerror: ${err.message}`),
+      );
+
+      // Homepage
+      const response = await page.goto("/index.html");
+      expect(response?.status()).toBe(200);
+      await page.waitForSelector("#wizard-banner", { state: "visible" });
+      const homeShot = await page.screenshot();
+      await testInfo.attach(`home-${browserName}.png`, {
+        body: homeShot,
+        contentType: "image/png",
+      });
+
+      // Editor flow - use submit design page as representative editor
+      await page.goto("/designer_upload.html");
+      await page.waitForSelector("text=Submit Design", { timeout: 10000 });
+      const editorShot = await page.screenshot();
+      await testInfo.attach(`editor-${browserName}.png`, {
+        body: editorShot,
+        contentType: "image/png",
+      });
+
+      expect(consoleMessages).toEqual([]);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add a cross-browser Playwright test covering homepage and editor flow

## Testing
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_687a368d9bac832d950525eba9416ff4