### PR TITLE
Add smoke test for CheckoutForm

### DIFF
--- a/tests/componentsRender_98c4d6f2a5b1e7g.test.js
+++ b/tests/componentsRender_98c4d6f2a5b1e7g.test.js
@@ -1,0 +1,38 @@
+/** @jest-environment jsdom */
+const React = require("react");
+const { render, screen } = require("@testing-library/react");
+require("@babel/register")({
+  presets: [[require.resolve("@babel/preset-react"), { runtime: "automatic" }]],
+  plugins: [
+    [require.resolve("@babel/plugin-syntax-typescript"), { isTSX: true }],
+  ],
+  extensions: [".js", ".jsx"],
+});
+
+jest.mock("react-places-autocomplete", () => {
+  const React = require("react");
+  return ({ value, onChange, children }) =>
+    React.createElement(
+      "div",
+      null,
+      children({
+        getInputProps: (props) => ({
+          ...props,
+          value,
+          onChange: (e) => onChange(e.target.value),
+        }),
+        suggestions: [],
+        getSuggestionItemProps: () => ({}),
+        loading: false,
+      }),
+    );
+});
+
+const CheckoutForm = require("../src/components/CheckoutForm.js").default;
+
+describe("component smoke tests", () => {
+  test("CheckoutForm renders", () => {
+    render(React.createElement(CheckoutForm));
+    expect(screen.getByRole("button", { name: /submit/i })).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- create `componentsRender_98c4d6f2a5b1e7g.test.js` with jsdom environment
- load `CheckoutForm` with Babel register
- verify the form renders successfully

## Testing
- `node scripts/run-jest.js tests/componentsRender_98c4d6f2a5b1e7g.test.js`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_687a3689e694832db71e9cd96b4be071