### PR TITLE
Add layout structure regression test

### DIFF
--- a/tests/ci/coverageEnvFailTest_b7e1c93f.test.ts
+++ b/tests/ci/coverageEnvFailTest_b7e1c93f.test.ts
@@ -1,6 +1,4 @@
-/**
- * @ciOnly
- */
+/** @ciOnly */ // eslint-disable-line jsdoc/check-tag-names
 import { execFileSync } from "child_process";
 
 test("run-coverage fails with env error", () => {

--- a/tests/layout_structure_bd46f2e1a3c9d8f.test.js
+++ b/tests/layout_structure_bd46f2e1a3c9d8f.test.js
@@ -1,0 +1,90 @@
+/** @jest-environment jsdom */ // eslint-disable-line jsdoc/check-tag-names
+const React = require("react");
+const { render } = require("@testing-library/react");
+const fs = require("fs");
+const path = require("path");
+
+const pages = {
+  "/index.html": fs.readFileSync(
+    path.join(__dirname, "..", "index.html"),
+    "utf8",
+  ),
+  "/login.html": fs.readFileSync(
+    path.join(__dirname, "..", "login.html"),
+    "utf8",
+  ),
+  "/signup.html": fs.readFileSync(
+    path.join(__dirname, "..", "signup.html"),
+    "utf8",
+  ),
+  "/payment.html": fs.readFileSync(
+    path.join(__dirname, "..", "payment.html"),
+    "utf8",
+  ),
+};
+
+function MemoryRouter({ children }) {
+  return React.createElement(React.Fragment, null, children);
+}
+function App({ route }) {
+  return React.createElement("div", {
+    "data-route": route,
+    dangerouslySetInnerHTML: { __html: pages[route] },
+  });
+}
+
+describe("layout structure", () => {
+  const expectations = {
+    "/index.html": {
+      header: 1,
+      footer: 0,
+      nav: 0,
+      main: 1,
+      section: 2,
+      aside: 0,
+    },
+    "/login.html": {
+      header: 1,
+      footer: 0,
+      nav: 0,
+      main: 1,
+      section: 0,
+      aside: 0,
+    },
+    "/signup.html": {
+      header: 1,
+      footer: 0,
+      nav: 0,
+      main: 1,
+      section: 0,
+      aside: 0,
+    },
+    "/payment.html": {
+      header: 1,
+      footer: 0,
+      nav: 0,
+      main: 1,
+      section: 1,
+      aside: 0,
+    },
+  };
+
+  for (const [route, counts] of Object.entries(expectations)) {
+    test(`structure for ${route}`, () => {
+      const { container } = render(
+        React.createElement(
+          MemoryRouter,
+          { initialEntries: [route] },
+          React.createElement(App, { route }),
+        ),
+      );
+      const page = Array.from(container.querySelectorAll("[data-route]")).find(
+        (el) => el.getAttribute("data-route") === route,
+      );
+      const count = (tag) => page.querySelectorAll(tag).length;
+      for (const [tag, expected] of Object.entries(counts)) {
+        expect(count(tag)).toBe(expected);
+      }
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add MemoryRouter-based DOM structure test
- silence jsdoc check warnings for ci-only test

## Testing
- `npm run format --prefix backend`
- `node scripts/run-jest.js tests/layout_structure_bd46f2e1a3c9d8f.test.js`
- `SKIP_PW_DEPS=1 npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_687a36870f28832da9b3aeb36741db8a