### PR TITLE
Add frontend link verification test

### DIFF
--- a/e2e/link-image-check_q4w5e6r7t8y9u0i.test.ts
+++ b/e2e/link-image-check_q4w5e6r7t8y9u0i.test.ts
@@ -1,0 +1,37 @@
+import { test, expect } from "@playwright/test";
+
+test("no broken links or images", async ({ page }) => {
+  await page.goto("/index.html");
+  await page.waitForLoadState("load");
+
+  const hrefs = await page.$$eval("a[href]", (els) =>
+    els.map((el) => (el as HTMLAnchorElement).getAttribute("href")),
+  );
+  for (const href of hrefs) {
+    if (
+      !href ||
+      href.startsWith("#") ||
+      href.startsWith("mailto:") ||
+      href.startsWith("tel:")
+    )
+      continue;
+    const url = new URL(href, page.url()).toString();
+    if (!url.startsWith(page.url().split("/").slice(0, 3).join("/"))) continue; // skip external links
+    const res = await page.request.get(url);
+    expect(res.status(), `${url} status`).toBeLessThan(400);
+  }
+
+  const images = await page.$$eval("img", (imgs) =>
+    imgs.map((img) => ({
+      src: img.getAttribute("src"),
+      alt: img.getAttribute("alt"),
+    })),
+  );
+  for (const { src, alt } of images) {
+    expect(alt && alt.trim().length).toBeTruthy();
+    if (!src) continue;
+    const url = new URL(src, page.url()).toString();
+    const res = await page.request.get(url);
+    expect(res.status(), `${url} status`).toBeLessThan(400);
+  }
+});


### PR DESCRIPTION
## Summary
- check every DOM link and image for HTTP success and alt text

## Testing
- `npm test` in `backend/`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_687a35c97ee0832d8c0ca1401ccb9861