### PR TITLE
Add Playwright error detection

### DIFF
--- a/e2e/support/playwright-error-hooks-8dj8yveiflqu4id.js
+++ b/e2e/support/playwright-error-hooks-8dj8yveiflqu4id.js
@@ -1,0 +1,31 @@
+const { test, expect } = require("@playwright/test");
+const messagesKey = Symbol("browserMessages");
+
+test.beforeEach(({ page }, testInfo) => {
+  const messages = [];
+  page.on("console", (msg) => {
+    const type = msg.type();
+    if (type === "error" || type === "warning") {
+      messages.push(`console.${type}: ${msg.text()}`);
+    }
+  });
+  page.on("pageerror", (error) => {
+    messages.push(`uncaught exception: ${error.message}`);
+  });
+  page.on("requestfailed", (request) => {
+    const failure = request.failure();
+    messages.push(
+      `request failed: ${request.url()} - ${failure && failure.errorText}`,
+    );
+  });
+  testInfo[messagesKey] = messages;
+});
+
+test.afterEach(async ({}, testInfo) => {
+  const messages = testInfo[messagesKey] || [];
+  if (messages.length) {
+    // eslint-disable-next-line no-console
+    console.error("Browser errors/warnings:", messages.join("\n"));
+    throw new Error(messages.join("\n"));
+  }
+});

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,4 +1,6 @@
 const { defineConfig } = require("@playwright/test");
+// Global hooks to fail on browser console errors, uncaught exceptions, and network failures
+require("./e2e/support/playwright-error-hooks-8dj8yveiflqu4id.js");
 const baseURL = process.env.PLAYWRIGHT_BASE_URL || "http://localhost:3000";
 
 module.exports = defineConfig({


### PR DESCRIPTION
## Summary
- add a Playwright support file to fail tests when browser console errors/warnings, uncaught exceptions, or network failures occur
- load the support file from `playwright.config.js`

## Testing
- `npm run format`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_687a35c7cb48832d9dc6eb6aa2d0c9a2