### PR TITLE
Add Hugging Face model API test

### DIFF
--- a/backend/tests/text-to-model-api-call-af3d9e.test.ts
+++ b/backend/tests/text-to-model-api-call-af3d9e.test.ts
@@ -1,0 +1,29 @@
+import fetch from "node-fetch";
+
+describe("HF text-to-model API", () => {
+  test("generates glb from prompt", async () => {
+    const token = process.env.HF_TOKEN;
+    const endpoint =
+      process.env.SPARC3D_ENDPOINT ||
+      "https://api-inference.huggingface.co/models/print2/Sparc3D";
+    if (!token) {
+      console.warn("Skipping HF API test: HF_TOKEN missing");
+      return;
+    }
+    const start = Date.now();
+    const res = await fetch(endpoint, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        Accept: "model/gltf-binary",
+      },
+      body: JSON.stringify({ inputs: "simple cube" }),
+    });
+    const buf = Buffer.from(await res.arrayBuffer());
+    const ms = Date.now() - start;
+    console.log(`HF API responded in ${ms}ms`);
+    expect(res.status).toBe(200);
+    expect(buf.slice(0, 4).toString()).toBe("glTF");
+  });
+});


### PR DESCRIPTION
## Summary
- add integration test for HF text-to-model endpoint

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a319d08a0832da300b3eb5724b49c