### PR TITLE
Add GLB cache dedup test

### DIFF
--- a/backend/tests/glb/cacheDedup.test.ts
+++ b/backend/tests/glb/cacheDedup.test.ts
@@ -1,0 +1,32 @@
+import { createHash } from "crypto";
+import nock from "nock";
+import { generateGlb } from "../../src/lib/sparc3dClient";
+
+/** Ensure cached generation returns identical output */
+describe("glb caching", () => {
+  beforeEach(() => {
+    process.env.SPARC3D_ENDPOINT = "https://api.example/generate";
+    process.env.SPARC3D_TOKEN = "token";
+
+    const url = new URL(process.env.SPARC3D_ENDPOINT);
+    const data = Buffer.from("glbdata");
+    nock(url.origin)
+      .post(url.pathname)
+      .times(2)
+      .reply(200, data, { "Content-Type": "model/gltf-binary" });
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  test("same prompt yields identical glb", async () => {
+    const buf1 = await generateGlb({ prompt: "cube" });
+    const buf2 = await generateGlb({ prompt: "cube" });
+
+    const h1 = createHash("sha256").update(buf1).digest("hex");
+    const h2 = createHash("sha256").update(buf2).digest("hex");
+
+    expect(h1).toBe(h2);
+  });
+});


### PR DESCRIPTION
## Summary
- add regression test verifying that generating a GLB with the same prompt twice produces identical output

## Testing
- `npm run format` in `backend/`
- `npm test` in `backend/`

------
https://chatgpt.com/codex/tasks/task_e_687a3085a084832daf8b66cac06edfd8