### PR TITLE
Add temp GLB cleanup for backend tests

### DIFF
--- a/backend/__tests__/glbPrep.test.ts
+++ b/backend/__tests__/glbPrep.test.ts
@@ -1,6 +1,7 @@
 import fs from "fs";
 import path from "path";
 import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
+const cleanupGlbArtifacts = require("../../scripts/cleanupGlbArtifacts.js");
 
 jest.mock("@aws-sdk/client-s3", () => ({
   S3Client: jest.fn(),
@@ -66,4 +67,8 @@ describe("glb prep helpers", () => {
       "image file not found",
     );
   });
+});
+
+afterAll(() => {
+  cleanupGlbArtifacts();
 });

--- a/scripts/cleanupGlbArtifacts.js
+++ b/scripts/cleanupGlbArtifacts.js
@@ -1,0 +1,36 @@
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+
+function removeGlbFiles(dir) {
+  if (!fs.existsSync(dir)) return;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, entry.name);
+    try {
+      if (entry.isDirectory()) {
+        removeGlbFiles(p);
+      } else if (entry.isFile() && p.endsWith(".glb")) {
+        fs.unlinkSync(p);
+      }
+    } catch (_err) {
+      // ignore failures
+    }
+  }
+}
+
+function cleanupGlbArtifacts() {
+  const base = path.join(os.tmpdir(), "test");
+  removeGlbFiles(base);
+  const parent = os.tmpdir();
+  for (const entry of fs.readdirSync(parent, { withFileTypes: true })) {
+    if (entry.isDirectory() && entry.name.startsWith("test")) {
+      removeGlbFiles(path.join(parent, entry.name));
+    }
+  }
+}
+
+if (require.main === module) {
+  cleanupGlbArtifacts();
+}
+
+module.exports = cleanupGlbArtifacts;


### PR DESCRIPTION
## Summary
- create `cleanupGlbArtifacts.js` to remove temporary `.glb` files
- invoke cleanup after `glbPrep` tests

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_687a30832b28832d97321ad49b8a0a07