### PR TITLE
Add test for glb request flow

### DIFF
--- a/e2e/frontendGlbRequest.test.tsx
+++ b/e2e/frontendGlbRequest.test.tsx
@@ -1,0 +1,46 @@
+import { test, expect } from "@playwright/test";
+import fs from "fs";
+import path from "path";
+
+const GLB_FIXTURE = path.join(__dirname, "..", "models", "bag.glb");
+
+const glbBytes = fs.readFileSync(GLB_FIXTURE);
+
+// Simulates a user generating a model and verifies the frontend receives
+// and renders the GLB returned from the backend.
+test("frontend glb request flow", async ({ page }) => {
+  // Mock the generation API to return a fixed glb URL.
+  await page.route("/api/generate", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ glb_url: "/mock/model.glb" }),
+    });
+  });
+
+  // Intercept the GLB download request and serve the fixture.
+  await page.route("/mock/model.glb", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "Content-Type": "model/gltf-binary" },
+      body: glbBytes,
+    });
+  });
+
+  await page.goto("/generate.html");
+  await page.waitForSelector("#gen-prompt", { state: "visible", timeout: 10000 });
+
+  const [glbResponse] = await Promise.all([
+    page.waitForResponse((res) => res.url().includes("/mock/model.glb")),
+    page.fill("#gen-prompt", "cube").then(() => page.click("#gen-submit")),
+  ]);
+
+  const buf = await glbResponse.body();
+  expect(buf.byteLength).toBeGreaterThan(1000);
+  expect(glbResponse.headers()["content-type"]).toContain("model/gltf-binary");
+
+  await page.waitForFunction(() => document.body.dataset.viewerReady === "true", {
+    timeout: 60000,
+  });
+  await expect(page.locator("#gen-app canvas")).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- create a Playwright test to check frontend receives a GLB
- verify the GLB response size, MIME type, and viewer rendering

## Testing
- `npm run format`
- `npm test` in `backend/`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_687a307ed964832da343528b10017f34