### PR TITLE
Add environment sanity check test

### DIFF
--- a/tests/env/envSanityCheck_0d4f2b3a.test.js
+++ b/tests/env/envSanityCheck_0d4f2b3a.test.js
@@ -1,0 +1,16 @@
+const patterns = [/your-/i, /localhost/i, /sk_test_/i, /abc123/i];
+
+describe("environment variable sanity check", () => {
+  test("no placeholder values present", () => {
+    const offenders = [];
+    for (const [key, value] of Object.entries(process.env)) {
+      if (typeof value !== "string") continue;
+      if (patterns.some((re) => re.test(value))) {
+        offenders.push(key);
+      }
+    }
+    if (offenders.length) {
+      throw new Error(`Placeholder values found in: ${offenders.join(", ")}`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add `envSanityCheck_0d4f2b3a.test.js` to catch placeholder env vars

## Testing
- `npm test` in `backend/`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_687a2f839924832d92cbfc91a8be2863