### PR TITLE
Add backend dependency sanity check

### DIFF
--- a/tests/debug/dependencySanityCheck_f9605c.test.js
+++ b/tests/debug/dependencySanityCheck_f9605c.test.js
@@ -1,0 +1,35 @@
+const path = require("path");
+const pkg = require("../../backend/package.json");
+
+const depsToCheck = ["stripe", "@aws-sdk/client-s3", "pg"];
+
+describe("dependency sanity check", () => {
+  test("required deps present with expected versions", () => {
+    const missing = [];
+    for (const dep of depsToCheck) {
+      try {
+        const pkgPath = path.join(
+          __dirname,
+          "..",
+          "..",
+          "backend",
+          "node_modules",
+          ...dep.split("/"),
+          "package.json",
+        );
+        const { version } = require(pkgPath);
+        console.log(`${dep} found, version ${version}`);
+        const expected = pkg.dependencies[dep];
+        if (expected && !version.startsWith(expected.replace(/^[^0-9]*/, ""))) {
+          missing.push(
+            `${dep} version mismatch: expected ${expected}, got ${version}`,
+          );
+        }
+      } catch (_err) {
+        console.log(`${dep} not found`);
+        missing.push(`${dep} missing`);
+      }
+    }
+    expect(missing).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- add `dependencySanityCheck_f9605c.test.js` under `tests/debug/` for quick confirmation that key backend packages are installed and match `package.json`
- run formatting and tests

## Testing
- `node scripts/run-jest.js tests/debug/dependencySanityCheck_f9605c.test.js`
- `npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_687a2f80936c832da2ac4941fd278016