### PR TITLE
Add env vars healthcheck test

### DIFF
--- a/tests/env-vars-healthcheck_a7b3c9d0.test.ts
+++ b/tests/env-vars-healthcheck_a7b3c9d0.test.ts
@@ -1,0 +1,24 @@
+const { execFileSync } = require("child_process");
+const path = require("path");
+
+test("ci-health fails when DB_URL missing", () => {
+  let error;
+  try {
+    execFileSync("node", [path.join("scripts", "ci-health.js")], {
+      env: {
+        ...process.env,
+        DB_URL: "",
+        STRIPE_SECRET_KEY: "sk_test",
+        AWS_ACCESS_KEY_ID: "id",
+        AWS_SECRET_ACCESS_KEY: "secret",
+      },
+      encoding: "utf8",
+      stdio: "pipe",
+    });
+  } catch (e) {
+    error = e;
+  }
+  expect(error).toBeDefined();
+  const output = (error.stdout || "") + (error.stderr || "");
+  expect(output).toMatch(/Missing required env var: DB_URL/);
+});


### PR DESCRIPTION
## Summary
- verify ci-health.js exits when DB_URL is missing

## Testing
- `node scripts/run-jest.js tests/env-vars-healthcheck_a7b3c9d0.test.ts`
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails to show due to large output; last lines show coverage summary)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails with lint warnings)*
- `SKIP_PW_DEPS=1 npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_687a31bc7f64832da86e11bd8164ef1d