### PR TITLE
Add DOM utils test

### DIFF
--- a/backend/tests/frontend/domUtils.test.js
+++ b/backend/tests/frontend/domUtils.test.js
@@ -1,0 +1,35 @@
+const { JSDOM } = require("jsdom");
+const {
+  escapeHtml,
+  setSafeInnerHTML,
+} = require("../../../js/dom-utils-securityfix-79d3fa.ts");
+
+beforeEach(() => {
+  const { window } = new JSDOM("<body></body>");
+  global.document = window.document;
+});
+
+describe("escapeHtml", () => {
+  const cases = [
+    ["&", "&amp;"],
+    ["<", "&lt;"],
+    [">", "&gt;"],
+    ['"', "&quot;"],
+    ["'", "&#39;"],
+    ["plain", "plain"],
+    ["a<b>&c", "a&lt;b&gt;&amp;c"],
+  ];
+  test.each(cases)("escapes %s", (input, expected) => {
+    expect(escapeHtml(input)).toBe(expected);
+  });
+});
+
+describe("setSafeInnerHTML", () => {
+  test("sets sanitized HTML content", () => {
+    const el = global.document.createElement("div");
+    setSafeInnerHTML(el, ["<span>", "</span>"], "test & <b>bold</b>");
+    expect(el.innerHTML).toBe(
+      "<span>test &amp; &lt;b&gt;bold&lt;/b&gt;</span>",
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add frontend tests for DOM utils
- silence jsdoc tag warning in CI coverage test

## Testing
- `npm test` in `backend/`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_687a337731dc832dad38788d3acf086c