### PR TITLE
Add GLB route checks

### DIFF
--- a/backend/tests/full-glb-api-route-check-dab123.test.ts
+++ b/backend/tests/full-glb-api-route-check-dab123.test.ts
@@ -1,0 +1,22 @@
+const request = require("supertest");
+const app = require("../server");
+
+const routes = [
+  "/api/models/generate",
+  "/api/models/status",
+  "/api/models/download",
+];
+
+const itMaybe = process.env.RUN_GLB_ROUTE_CHECK ? test : test.skip;
+
+describe("GLB API route 2xx checks", () => {
+  routes.forEach((route) => {
+    itMaybe(`Route ${route} returns 2xx`, async () => {
+      const res = await request(app)
+        .get(route)
+        .set("Authorization", `Bearer ${process.env.TEST_TOKEN}`);
+      expect(res.status).toBeGreaterThanOrEqual(200);
+      expect(res.status).toBeLessThan(300);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add optional test to verify GLB generation API routes

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a323e8364832dbaf04b3678c3b5b8