### PR TITLE
Add isolated GLB download test

### DIFF
--- a/tests/full-glb-download-check-04d24e066ef4.test.ts
+++ b/tests/full-glb-download-check-04d24e066ef4.test.ts
@@ -1,0 +1,27 @@
+import axios from "axios";
+import fs from "fs";
+import path from "path";
+
+const runTest = Boolean(process.env.TEST_GLB_DOWNLOAD_URL);
+
+(runTest ? test : test.skip)(
+  "Standalone .glb download returns valid model file",
+  async () => {
+    const url = String(process.env.TEST_GLB_DOWNLOAD_URL);
+    expect(url).toMatch(/^https?:\/\/.+\.glb$/);
+
+    const output = path.resolve(__dirname, `tmp/test-model-${Date.now()}.glb`);
+    const response = await axios.get(url, { responseType: "stream" });
+
+    expect(response.status).toBe(200);
+    const writeStream = fs.createWriteStream(output);
+    await new Promise((resolve, reject) => {
+      response.data.pipe(writeStream);
+      writeStream.on("finish", resolve);
+      writeStream.on("error", reject);
+    });
+
+    const stats = fs.statSync(output);
+    expect(stats.size).toBeGreaterThan(5000); // Expect at least 5KB
+  },
+);


### PR DESCRIPTION
## Summary
- add full-glb-download-check-04d24e066ef4.test.ts to verify model files can be downloaded when `TEST_GLB_DOWNLOAD_URL` is set

## Testing
- `npm run format`
- `node ../scripts/run-jest.js tests/full-glb-download-check-04d24e066ef4.test.ts`
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_687a323823c0832da02d28fbab8a226c