### PR TITLE
Isolate test env with dotenv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,11 @@ jobs:
       - name: Install Husky hooks
         run: npm run prepare
 
+      - name: Prepare test env
+        run: |
+          cp .env.example .env.test
+          echo "DB_URL=postgres://user:pass@localhost/db" >> .env.test
+
       - name: Run CI
         env:
           PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright

--- a/backend/tests/setupGlobals.js
+++ b/backend/tests/setupGlobals.js
@@ -3,9 +3,11 @@
 global[Symbol.for("$$jest-deletion-mode")] = "off";
 
 const dotenv = require("dotenv");
+const path = require("path");
 const originalDotenvConfig = dotenv.config;
 dotenv.config = (options = {}) =>
   originalDotenvConfig({ quiet: true, ...options });
+dotenv.config({ path: path.resolve(__dirname, "../../.env.test") });
 
 const originalEmitWarning = process.emitWarning;
 process.emitWarning = (warning, ...args) => {

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,8 @@
 module.exports = {
-  setupFiles: ["<rootDir>/backend/tests/setupGlobals.js"],
+  setupFiles: [
+    "<rootDir>/test/jest.setup.ts",
+    "<rootDir>/backend/tests/setupGlobals.js",
+  ],
   setupFilesAfterEnv: ["<rootDir>/test/setupAuthMiddleware.js"],
   coverageThreshold: {
     global: {

--- a/test/jest.setup.ts
+++ b/test/jest.setup.ts
@@ -1,0 +1,2 @@
+import dotenv from "dotenv";
+dotenv.config({ path: ".env.test" });


### PR DESCRIPTION
## Summary
- load `.env.test` in Jest setup
- auto-create `.env.test` during CI runs

## Testing
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_687a32bb56d0832d8bcf20309046b1d2