### PR TITLE
Add server env prereq test

### DIFF
--- a/tests/ci/test-server-env-prereq-check-af93k8x2ms4n05q.test.ts
+++ b/tests/ci/test-server-env-prereq-check-af93k8x2ms4n05q.test.ts
@@ -1,0 +1,29 @@
+const { spawnSync } = require("child_process");
+const path = require("path");
+
+test("backend server environment prerequisites", () => {
+  const server = path.join(__dirname, "..", "..", "backend", "server.js");
+  const res = spawnSync("node", [server], {
+    env: { ...process.env, PORT: "3999" },
+    encoding: "utf8",
+    timeout: 3000,
+  });
+
+  const output = `${res.stdout || ""}${res.stderr || ""}`;
+  if (/Missing required env/.test(output)) {
+    console.log(output);
+  }
+
+  if (res.status !== null && res.status !== 0) {
+    console.log(output);
+    throw new Error(`Server exited with code ${res.status}`);
+  }
+
+  if (res.error && res.error.code === "ETIMEDOUT") {
+    return; // server stayed up past timeout
+  }
+
+  if (res.status === 0 && output.trim() === "") {
+    throw new Error("Server exited silently without logs");
+  }
+});


### PR DESCRIPTION
## Summary
- add a CI test that spawns `backend/server.js` to verify env vars

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_687a50d78e40832db2881c53596a2420