### PR TITLE
Add React error boundary test

### DIFF
--- a/tests/test-component-error-boundaries-rds567890abcXYZ.test.tsx
+++ b/tests/test-component-error-boundaries-rds567890abcXYZ.test.tsx
@@ -1,0 +1,48 @@
+/* eslint-disable jsdoc/check-tag-names */
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+// Force react-places-autocomplete used by CheckoutForm to throw during render
+jest.mock("react-places-autocomplete", () => {
+  return () => {
+    throw new Error("mock failure");
+  };
+});
+
+const CheckoutForm = require("../src/components/CheckoutForm.js").default;
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+  componentDidCatch() {}
+  render() {
+    if (this.state.hasError) {
+      return React.createElement("div", { role: "alert" }, "boundary caught");
+    }
+    return this.props.children;
+  }
+}
+
+describe("react component error boundaries", () => {
+  test("CheckoutForm fails gracefully", () => {
+    expect(() =>
+      render(
+        React.createElement(
+          ErrorBoundary,
+          null,
+          React.createElement(CheckoutForm, { invalidProp: {} })
+        )
+      )
+    ).not.toThrow();
+    expect(screen.getByRole("alert")).toHaveTextContent("boundary caught");
+  });
+});


### PR DESCRIPTION
## Summary
- add test to ensure components fail gracefully in a React error boundary

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687a50d368d0832da60d46fb64dff74e