### PR TITLE
Add external API availability test

### DIFF
--- a/tests/checkoutStyles.83d9e6f7a2b1c4d.test.js
+++ b/tests/checkoutStyles.83d9e6f7a2b1c4d.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsdoc/check-tag-names */
 /**
  * @jest-environment jsdom
  */

--- a/tests/componentsRender_98c4d6f2a5b1e7g.test.js
+++ b/tests/componentsRender_98c4d6f2a5b1e7g.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsdoc/check-tag-names */
 /** @jest-environment jsdom */
 const React = require("react");
 const { render, screen } = require("@testing-library/react");

--- a/tests/test-external-api-availability-XpVIU86nGkXrFIM.test.ts
+++ b/tests/test-external-api-availability-XpVIU86nGkXrFIM.test.ts
@@ -1,0 +1,50 @@
+import fetch from "node-fetch";
+
+describe("external API availability", () => {
+  const stripeKey =
+    process.env.STRIPE_TEST_KEY || process.env.STRIPE_SECRET_KEY;
+  const hfKey = process.env.HF_API_KEY;
+
+  test("Stripe customers endpoint returns 200", async () => {
+    if (!stripeKey) {
+      console.warn("Skipping Stripe API check: STRIPE_TEST_KEY missing");
+      return;
+    }
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 10000);
+    const start = Date.now();
+    const res = await fetch("https://api.stripe.com/v1/customers", {
+      headers: { Authorization: `Bearer ${stripeKey}` },
+      signal: controller.signal,
+    });
+    const latency = Date.now() - start;
+    console.log(`Stripe latency: ${latency}ms`);
+    clearTimeout(timeout);
+    if (res.status === 401) {
+      throw new Error("Stripe auth failed (401)");
+    }
+    expect(res.status).toBe(200);
+  });
+
+  test("HuggingFace model list reachable", async () => {
+    if (!hfKey) {
+      console.warn("Skipping HuggingFace API check: HF_API_KEY missing");
+      return;
+    }
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 10000);
+    const start = Date.now();
+    const res = await fetch("https://huggingface.co/api/models?limit=1", {
+      headers: { Authorization: `Bearer ${hfKey}` },
+      signal: controller.signal,
+    });
+    const latency = Date.now() - start;
+    console.log(`HuggingFace latency: ${latency}ms`);
+    clearTimeout(timeout);
+    if (res.status === 401) {
+      throw new Error("HuggingFace auth failed (401)");
+    }
+    expect(res.status).toBe(200);
+    await res.json();
+  });
+});


### PR DESCRIPTION
## Summary
- test availability for Stripe and HuggingFace APIs
- silence jsdoc linter warnings on tests that set `@jest-environment`

## Testing
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_687a50d09a3c832da8afa98c9fb29aa5