### PR TITLE
Add package-lock sync test

### DIFF
--- a/tests/checkoutStyles.83d9e6f7a2b1c4d.test.js
+++ b/tests/checkoutStyles.83d9e6f7a2b1c4d.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsdoc/check-tag-names */
 /**
  * @jest-environment jsdom
  */

--- a/tests/componentsRender_98c4d6f2a5b1e7g.test.js
+++ b/tests/componentsRender_98c4d6f2a5b1e7g.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsdoc/check-tag-names */
 /** @jest-environment jsdom */
 const React = require("react");
 const { render, screen } = require("@testing-library/react");

--- a/tests/test-package-lock-sync-check-8f5c3e7b2a1d4f6.test.ts
+++ b/tests/test-package-lock-sync-check-8f5c3e7b2a1d4f6.test.ts
@@ -1,0 +1,49 @@
+import fs from "fs";
+import { spawnSync } from "child_process";
+
+function readJSON(p) {
+  return JSON.parse(fs.readFileSync(p, "utf8"));
+}
+
+test("package-lock.json is in sync with package.json", () => {
+  const pkg = readJSON("package.json");
+  const lock = readJSON("package-lock.json");
+
+  const expected = {
+    ...(pkg.dependencies || {}),
+    ...(pkg.devDependencies || {}),
+  };
+  const rootLock = lock.packages && lock.packages[""] ? lock.packages[""] : {};
+  const actual = {
+    ...(rootLock.dependencies || {}),
+    ...(rootLock.devDependencies || {}),
+  };
+
+  const mismatches = [];
+  for (const [name, spec] of Object.entries(expected)) {
+    if (!actual[name]) {
+      mismatches.push(`missing ${name}`);
+    } else if (actual[name] !== spec) {
+      mismatches.push(
+        `version mismatch for ${name}: expected ${spec} but lock has ${actual[name]}`,
+      );
+    }
+  }
+  for (const name of Object.keys(actual)) {
+    if (!(name in expected)) {
+      mismatches.push(`extra ${name}`);
+    }
+  }
+
+  if (mismatches.length) {
+    console.error("dependency mismatches:\n" + mismatches.join("\n"));
+    const ls = spawnSync("npm", ["ls", "--depth=0"], { encoding: "utf8" });
+    console.error(ls.stdout);
+    const audit = spawnSync("npm", ["audit", "fix", "--dry-run"], {
+      encoding: "utf8",
+    });
+    console.error(audit.stdout);
+  }
+
+  expect(mismatches).toEqual([]);
+});


### PR DESCRIPTION
## Summary
- ensure package-lock.json matches package.json
- silence jsdoc warnings for environment-tagged tests

## Testing
- `npm test tests/test-package-lock-sync-check-8f5c3e7b2a1d4f6.test.ts`
- `SKIP_PW_DEPS=1 npm run ci`
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_687a4fcd8154832dacc8155f242d9825