### PR TITLE
Add server wait-on diagnostic test

### DIFF
--- a/tests/ci/diagnostic-server-waiton-c01ebf750a9.test.ts
+++ b/tests/ci/diagnostic-server-waiton-c01ebf750a9.test.ts
@@ -1,0 +1,57 @@
+/* eslint-disable jsdoc/check-tag-names */
+/**
+ * @ciOnly
+ */
+import { spawn } from "child_process";
+import path from "path";
+
+jest.setTimeout(15000);
+
+describe("server start diagnostics", () => {
+  let proc;
+  let logs = "";
+
+  afterEach(() => {
+    if (proc) proc.kill();
+  });
+
+  test("responds on / within 10s", async () => {
+    const serverPath = path.join(__dirname, "..", "..", "backend", "server.js");
+    proc = spawn(process.execPath, [serverPath], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    proc.stdout?.on("data", (d) => {
+      logs += d.toString();
+    });
+    proc.stderr?.on("data", (d) => {
+      logs += d.toString();
+    });
+
+    const deadline = Date.now() + 10000;
+    let lastError = new Error("timeout");
+
+    while (Date.now() < deadline) {
+      try {
+        const ac = new AbortController();
+        const timer = setTimeout(() => ac.abort(), 1000);
+        const res = await fetch("http://localhost:3000", { signal: ac.signal });
+        clearTimeout(timer);
+        if (res.status === 200) {
+          const text = await res.text();
+          expect(text.trim().toLowerCase().startsWith("<!doctype html")).toBe(
+            true,
+          );
+          return;
+        }
+        lastError = new Error(`status ${res.status}`);
+      } catch (err) {
+        lastError = err;
+      }
+      await new Promise((r) => setTimeout(r, 250));
+    }
+
+    throw new Error(
+      `Server failed to respond within 10s: ${lastError?.stack || lastError}\n${logs}`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add `diagnostic-server-waiton-c01ebf750a9.test.ts` to check server startup
- poll localhost and verify 200 HTML within 10 seconds

## Testing
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_687a4ede3714832db54cae89f0d1b112