### PR TITLE
Add asset diagnostic test for Cloudflare Pages

### DIFF
--- a/tests/checkoutStyles.83d9e6f7a2b1c4d.test.js
+++ b/tests/checkoutStyles.83d9e6f7a2b1c4d.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsdoc/check-tag-names */
 /**
  * @jest-environment jsdom
  */

--- a/tests/componentsRender_98c4d6f2a5b1e7g.test.js
+++ b/tests/componentsRender_98c4d6f2a5b1e7g.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsdoc/check-tag-names */
 /** @jest-environment jsdom */
 const React = require("react");
 const { render, screen } = require("@testing-library/react");

--- a/tests/diagnostic-cloudflare-assetcheck-cd7a6f94e38.test.ts
+++ b/tests/diagnostic-cloudflare-assetcheck-cd7a6f94e38.test.ts
@@ -1,0 +1,66 @@
+const fs = require("fs");
+const path = require("path");
+
+const repoRoot = path.resolve(__dirname, "..");
+
+function findBuildDir() {
+  const candidates = ["dist", "out", "build"];
+  for (const dir of candidates) {
+    const full = path.join(repoRoot, dir);
+    if (fs.existsSync(full) && fs.statSync(full).isDirectory()) {
+      return full;
+    }
+  }
+  return repoRoot;
+}
+
+function walk(dir, list = []) {
+  for (const entry of fs.readdirSync(dir)) {
+    if (entry.startsWith(".")) continue;
+    const full = path.join(dir, entry);
+    const stat = fs.lstatSync(full);
+    if (stat.isDirectory()) {
+      walk(full, list);
+    } else {
+      list.push(full);
+    }
+  }
+  return list;
+}
+
+describe("cloudflare asset diagnostics", () => {
+  test("build directory has accessible assets", () => {
+    process.env.CF_PAGES = "1";
+    const buildDir = findBuildDir();
+    expect(fs.existsSync(buildDir)).toBe(true);
+
+    const files = walk(buildDir);
+    expect(files.length).toBeGreaterThan(0);
+
+    for (const file of files) {
+      const stat = fs.lstatSync(file);
+      if (stat.isSymbolicLink()) {
+        const target = fs.realpathSync(file);
+        expect(target.startsWith(buildDir)).toBe(true);
+      }
+      const realStat = fs.statSync(file);
+      expect(realStat.size).toBeGreaterThan(0);
+    }
+
+    const index = path.join(buildDir, "index.html");
+    expect(fs.existsSync(index)).toBe(true);
+    const html = fs.readFileSync(index, "utf8");
+    const assetRefs = Array.from(html.matchAll(/(?:src|href)="([^"]+)"/g)).map(
+      (m) => m[1],
+    );
+    for (const ref of assetRefs) {
+      if (/^(?:https?:)?\/\//.test(ref)) continue;
+      if (ref.startsWith("data:")) continue;
+      const clean = ref.replace(/^\//, "");
+      const assetPath = path.join(buildDir, clean);
+      expect(fs.existsSync(assetPath)).toBe(true);
+      const st = fs.statSync(assetPath);
+      expect(st.size).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add diagnostic-cloudflare-assetcheck-cd7a6f94e38.test.ts to verify build outputs
- silence jsdoc warnings on two existing tests

## Testing
- `npm test --silent`
- `npm run format`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_687a4ed998c0832dbdb7fad269c51eb5