### PR TITLE
Add Stripe integration diagnostic test

### DIFF
--- a/backend/tests/diagnostic-stripe-validate-2fb39dcee74.test.ts
+++ b/backend/tests/diagnostic-stripe-validate-2fb39dcee74.test.ts
@@ -1,0 +1,30 @@
+const Stripe = require("stripe");
+
+/**
+ * This diagnostic suite ensures the CI environment provides real Stripe
+ * credentials and that they are functional.
+ */
+describe("diagnostic stripe validate", () => {
+  const secret = process.env.STRIPE_SECRET_KEY;
+  const webhook = process.env.STRIPE_WEBHOOK_SECRET;
+
+  test("required env vars are present", () => {
+    if (!secret) {
+      throw new Error("STRIPE_SECRET_KEY missing");
+    }
+    if (!webhook) {
+      throw new Error("STRIPE_WEBHOOK_SECRET missing");
+    }
+    // Fail if using placeholders from example env files
+    expect(secret).toMatch(/^sk_/);
+    expect(secret).not.toMatch(/dummy|your|sk_test$/);
+    expect(webhook).toMatch(/^whsec_/);
+    expect(webhook).not.toMatch(/dummy|your|whsec$/);
+  });
+
+  test("stripe client boots and lists customers", async () => {
+    const stripe = new Stripe(secret, { apiVersion: "2024-08-16" });
+    const list = await stripe.customers.list({ limit: 1 });
+    expect(Array.isArray(list.data)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add `diagnostic-stripe-validate-2fb39dcee74.test.ts` to verify Stripe secrets and basic API connectivity

## Testing
- `node scripts/run-jest.js backend/tests/diagnostic-stripe-validate-2fb39dcee74.test.ts` *(fails: `STRIPE_SECRET_KEY` placeholder)*
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_687a4ecf2224832d9e2ccbe7eee66e38