### PR TITLE
Add symlink check after build

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "serve": "npm run build && node scripts/dev-server.js",
     "smoke": "node scripts/run-smoke.js",
     "build": "echo 'no build step'",
+    "postbuild": "npx ts-node scripts/check-broken-symlinks-9ac8f74db5e1c32.ts",
     "postinstall": "npm run build",
     "load": "artillery run tests/load/models.yml",
     "visual-test": "percy exec -- npm run e2e",

--- a/scripts/check-broken-symlinks-9ac8f74db5e1c32.ts
+++ b/scripts/check-broken-symlinks-9ac8f74db5e1c32.ts
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+import fs from "fs";
+import path from "path";
+
+const repoRoot = path.resolve(__dirname, "..");
+const argDir = process.argv[2];
+const outputDir = argDir
+  ? path.resolve(repoRoot, argDir)
+  : fs.existsSync(path.join(repoRoot, "dist"))
+    ? path.join(repoRoot, "dist")
+    : repoRoot;
+
+const badPaths = [];
+
+function walk(dir) {
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch (err) {
+    badPaths.push(`${dir} (${err.code || err.message})`);
+    return;
+  }
+
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    try {
+      const lst = fs.lstatSync(full);
+      if (lst.isSymbolicLink()) {
+        try {
+          const target = fs.readlinkSync(full);
+          fs.statSync(path.resolve(path.dirname(full), target));
+        } catch {
+          badPaths.push(`broken symlink: ${full}`);
+          continue;
+        }
+      }
+      if (lst.isDirectory()) {
+        walk(full);
+      } else {
+        fs.accessSync(full, fs.constants.R_OK);
+      }
+    } catch (err) {
+      badPaths.push(`${full} (${err.code || err.message})`);
+    }
+  }
+}
+
+walk(outputDir);
+
+if (badPaths.length) {
+  console.error("Build output verification failed. Issues found:");
+  for (const p of badPaths) console.error(" -", p);
+  process.exit(1);
+}
+
+console.log("No broken symlinks or permission issues detected.");


### PR DESCRIPTION
## Summary
- add a postbuild script for verifying build output
- fail build when broken symlinks or permission issues are found

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a4cc7cc1c832da5c16270cfa0c6a1