### PR TITLE
Add frontend env build check

### DIFF
--- a/tests/env-check-7d93f1c0a5b4e2f.test.ts
+++ b/tests/env-check-7d93f1c0a5b4e2f.test.ts
@@ -1,0 +1,27 @@
+import { spawnSync } from "child_process";
+import path from "path";
+
+const required = [
+  "STRIPE_PUBLISHABLE_KEY",
+  "SUPABASE_URL",
+  "SUPABASE_ANON_KEY",
+];
+
+function assertFrontendEnv() {
+  const missing = required.filter((name) => !process.env[name]);
+  if (missing.length) {
+    throw new Error(`Missing frontend env vars: ${missing.join(", ")}`);
+  }
+}
+
+describe("frontend build env check", () => {
+  test("all required vars defined", () => {
+    assertFrontendEnv();
+    const result = spawnSync("npm", ["run", "build"], {
+      cwd: path.resolve(__dirname, ".."),
+      env: process.env,
+      encoding: "utf8",
+    });
+    expect(result.status).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- verify frontend env vars during build

## Testing
- `npm test ../tests/env-check-7d93f1c0a5b4e2f.test.ts` *(fails when SUPABASE vars unset)*
- `export SUPABASE_URL=http://localhost; export SUPABASE_ANON_KEY=testkey; node scripts/run-jest.js tests/env-check-7d93f1c0a5b4e2f.test.ts`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_687a4cc7523c832db51a0cf080cae2bf