### PR TITLE
Fix Cloudflare build workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,11 +12,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # — Uncomment & adjust these if you ever need a build step:
-      # - name: Install dependencies
-      #   run: npm ci
-      # - name: Build
-      #   run: npm run build
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
 
       - name: Publish to Cloudflare Pages
         uses: cloudflare/pages-action@v1
@@ -24,4 +23,4 @@ jobs:
           apiToken: ${{ secrets.CF_PAGES_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
           projectName: ${{ secrets.CF_PAGES_PROJECT }}
-          directory: '.'
+          directory: 'dist'

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -41,7 +41,10 @@ module.exports = [
     settings: {
       jsdoc: {
         tagNamePreference: {
-          "jest-environment": false,
+          "jest-environment": "jest-environment",
+        },
+        additionalTagNames: {
+          custom: ["jest-environment"],
         },
       },
     },
@@ -97,7 +100,9 @@ module.exports = [
   },
   {
     files: ["tests/**/*"],
-    rules: { "jsdoc/require-jsdoc": "off" },
+    rules: {
+      "jsdoc/require-jsdoc": "off",
+    },
   },
   ...frontend,
 ];

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "test:unit": "npm test --prefix backend",
     "serve": "npm run build && node scripts/dev-server.js",
     "smoke": "node scripts/run-smoke.js",
-    "build": "echo 'no build step'",
+    "build": "bash scripts/build-c02a4d5e6f7b8c9.sh",
     "postinstall": "npm run build",
     "load": "artillery run tests/load/models.yml",
     "visual-test": "percy exec -- npm run e2e",

--- a/scripts/build-c02a4d5e6f7b8c9.sh
+++ b/scripts/build-c02a4d5e6f7b8c9.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+rm -rf dist
+mkdir -p dist
+rsync -av --exclude='backend' --exclude='node_modules' --exclude='dist' --exclude='.git' --exclude='.github' --exclude='infra' --exclude='deploy' --exclude='scripts' --exclude='test' --exclude='tests' --exclude='docs' ./ dist/

--- a/tests/checkoutForm.react.test.js
+++ b/tests/checkoutForm.react.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable jsdoc/check-tag-names */
 /**
  * @jest-environment jsdom
  */

--- a/tests/generated_frontend_9ad4e5b1.test.js
+++ b/tests/generated_frontend_9ad4e5b1.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable jsdoc/check-tag-names */
 /**
  * @jest-environment jsdom
  */

--- a/tests/generated_frontend_b5729acf.test.js
+++ b/tests/generated_frontend_b5729acf.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable jsdoc/check-tag-names */
 /**
  * @jest-environment jsdom
  */

--- a/tests/generated_frontend_bdfbbf6e.test.js
+++ b/tests/generated_frontend_bdfbbf6e.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable jsdoc/check-tag-names */
 /**
  * @jest-environment jsdom
  */

--- a/tests/generated_frontend_c664b58d.test.js
+++ b/tests/generated_frontend_c664b58d.test.js
@@ -1,7 +1,5 @@
-/* eslint-disable jsdoc/check-tag-names */
 /**
  * @jest-environment jsdom
- * @eslint-env jest
  */
 /* global localStorage */
 const {

--- a/tests/generated_frontend_c83b6ff1.test.js
+++ b/tests/generated_frontend_c83b6ff1.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable jsdoc/check-tag-names */
 /**
  * @jest-environment jsdom
  */

--- a/tests/generated_frontend_ef552632.test.js
+++ b/tests/generated_frontend_ef552632.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable jsdoc/check-tag-names */
 /**
  * @jest-environment jsdom
  */


### PR DESCRIPTION
## Summary
- add npm build step in Cloudflare Pages workflow
- output built files to `dist`
- create build script to copy static assets
- allow `@jest-environment` tag in ESLint config
- remove unused ESLint disables in generated tests

## Testing
- `npm run format`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_687a4cc07988832d82451a68abc3fc05