### PR TITLE
Add DOM snapshots for major routes

### DIFF
--- a/e2e/ui-regression-wuxuyyiiilt9aax.spec.ts
+++ b/e2e/ui-regression-wuxuyyiiilt9aax.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from "@playwright/test";
+
+const routes = [
+  { name: "home", url: "/index.html" },
+  { name: "editor", url: "/generate.html" },
+  { name: "upload", url: "/designer_upload.html" },
+  { name: "checkout", url: "/payment.html" },
+  { name: "success", url: "/share.html" },
+  { name: "settings", url: "/profile.html" },
+];
+
+test.describe("ui regression", () => {
+  for (const route of routes) {
+    test(route.name, async ({ page }) => {
+      await page.goto(route.url);
+      await page.waitForLoadState("networkidle");
+      const dom = await page.evaluate(() => document.documentElement.outerHTML);
+      expect(dom).toMatchSnapshot(`${route.name}.html`);
+    });
+  }
+});

--- a/tests/checkoutStyles.83d9e6f7a2b1c4d.test.js
+++ b/tests/checkoutStyles.83d9e6f7a2b1c4d.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsdoc/check-tag-names */
 /**
  * @jest-environment jsdom
  */

--- a/tests/componentsRender_98c4d6f2a5b1e7g.test.js
+++ b/tests/componentsRender_98c4d6f2a5b1e7g.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable jsdoc/check-tag-names */
 /** @jest-environment jsdom */
 const React = require("react");
 const { render, screen } = require("@testing-library/react");


### PR DESCRIPTION
## Summary
- disable jsdoc check for a couple of tests
- add ui-regression-wuxuyyiiilt9aax.spec.ts to snapshot DOM for major pages

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_687a4b6bb6f8832daf6de48543cdf4fd