### PR TITLE
Fix type errors in symlink checker

### DIFF
--- a/scripts/check-broken-symlinks-9ac8f74db5e1c32.ts
+++ b/scripts/check-broken-symlinks-9ac8f74db5e1c32.ts
@@ -2,22 +2,26 @@
 import fs from "fs";
 import path from "path";
 
-const repoRoot = path.resolve(__dirname, "..");
-const argDir = process.argv[2];
-const outputDir = argDir
+const repoRoot: string = path.resolve(__dirname, "..");
+const argDir: string | undefined = process.argv[2];
+const outputDir: string = argDir
   ? path.resolve(repoRoot, argDir)
   : fs.existsSync(path.join(repoRoot, "dist"))
     ? path.join(repoRoot, "dist")
     : repoRoot;
 
-const badPaths = [];
+const badPaths: string[] = [];
 
-function walk(dir) {
-  let entries;
+function walk(dir: string): void {
+  let entries: fs.Dirent[];
   try {
     entries = fs.readdirSync(dir, { withFileTypes: true });
-  } catch (err) {
-    badPaths.push(`${dir} (${err.code || err.message})`);
+  } catch (err: unknown) {
+    const message =
+      err && err instanceof Error
+        ? (err as NodeJS.ErrnoException).code ?? err.message
+        : String(err);
+    badPaths.push(`${dir} (${message})`);
     return;
   }
 
@@ -39,8 +43,12 @@ function walk(dir) {
       } else {
         fs.accessSync(full, fs.constants.R_OK);
       }
-    } catch (err) {
-      badPaths.push(`${full} (${err.code || err.message})`);
+    } catch (err: unknown) {
+      const message =
+        err && err instanceof Error
+          ? (err as NodeJS.ErrnoException).code ?? err.message
+          : String(err);
+      badPaths.push(`${full} (${message})`);
     }
   }
 }


### PR DESCRIPTION
## Summary
- add explicit types and error handling in `check-broken-symlinks-9ac8f74db5e1c32.ts`

## Testing
- `npx --yes --package typescript tsc scripts/check-broken-symlinks-9ac8f74db5e1c32.ts --noEmit --esModuleInterop`


------
https://chatgpt.com/codex/tasks/task_e_687a70ff7814832db9893af63eb3ba91