### PR TITLE
Fix Cloudflare symlink build issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "serve": "npm run build && node scripts/dev-server.js",
     "smoke": "node scripts/run-smoke.js",
     "build": "echo 'no build step'",
-    "postbuild": "npx ts-node scripts/check-broken-symlinks-9ac8f74db5e1c32.ts",
+    "postbuild": "node scripts/check-broken-symlinks-9ac8f74db5e1c32.js",
     "postinstall": "npm run build",
     "load": "artillery run tests/load/models.yml",
     "visual-test": "percy exec -- npm run e2e",

--- a/scripts/auto-cloudflare-config.ts
+++ b/scripts/auto-cloudflare-config.ts
@@ -28,7 +28,7 @@ function detectFramework() {
   return null;
 }
 
-function randomString(len) {
+function randomString(len: number): string {
   return crypto
     .randomBytes(len)
     .toString("base64")
@@ -36,14 +36,14 @@ function randomString(len) {
     .slice(0, len);
 }
 
-function readConfig(file) {
+function readConfig(file: string): any {
   if (!fs.existsSync(file)) return {};
   const txt = fs.readFileSync(file, "utf8");
   if (file.endsWith(".json")) return JSON.parse(txt);
   return yaml.parse(txt);
 }
 
-function writeConfig(file, data) {
+function writeConfig(file: string, data: any): void {
   if (file.endsWith(".json"))
     fs.writeFileSync(file, JSON.stringify(data, null, 2));
   else fs.writeFileSync(file, yaml.stringify(data));


### PR DESCRIPTION
## Summary
- revert symlink checker to JS so build doesn't require ts-node
- keep ignore list for tests/path-no-mise

## Testing
- `npm run format`
- `npm test` *(passed)*
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_687a693c454c832dba41394d3d6345de