### PR TITLE
Add build output integrity test

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "serve": "npm run build && node scripts/dev-server.js",
     "smoke": "node scripts/run-smoke.js",
     "build": "echo 'no build step'",
-    "postbuild": "npx ts-node scripts/check-broken-symlinks-9ac8f74db5e1c32.ts",
+    "postbuild": "node scripts/check-broken-symlinks-9ac8f74db5e1c32.js",
     "postinstall": "npm run build",
     "load": "artillery run tests/load/models.yml",
     "visual-test": "percy exec -- npm run e2e",

--- a/scripts/check-broken-symlinks-9ac8f74db5e1c32.js
+++ b/scripts/check-broken-symlinks-9ac8f74db5e1c32.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-import fs from "fs";
-import path from "path";
+const fs = require("fs");
+const path = require("path");
 
 const repoRoot: string = path.resolve(__dirname, "..");
 const argDir: string | undefined = process.argv[2];

--- a/tests/ci/build-output-integrity-8f711tk14uhiu7r.test.ts
+++ b/tests/ci/build-output-integrity-8f711tk14uhiu7r.test.ts
@@ -1,0 +1,74 @@
+/* eslint-disable jsdoc/check-tag-names */
+/**
+ * @ciOnly
+ */
+import fs from "fs";
+import path from "path";
+import { execSync } from "child_process";
+
+function detectOutputDir(root: string): string {
+  const candidates = [".next", "build", "dist", "out"];
+  for (const dir of candidates) {
+    const full = path.join(root, dir);
+    if (fs.existsSync(full)) {
+      return full;
+    }
+  }
+  return root;
+}
+
+function walk(dir: string, list: string[] = []): string[] {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === "node_modules" || entry.name === ".git") {
+      continue;
+    }
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(full, list);
+    } else {
+      list.push(full);
+    }
+  }
+  return list;
+}
+
+test("production build has no symlinks or missing assets", () => {
+  execSync("npm run build", { stdio: "inherit" });
+
+  const root = path.resolve(__dirname, "..");
+  const outputDir = detectOutputDir(root);
+  const files = walk(outputDir);
+
+  const symlinks: string[] = [];
+  const missingRefs: string[] = [];
+
+  for (const file of files) {
+    const rel = path.relative(root, file);
+    const lst = fs.lstatSync(file);
+    if (lst.isSymbolicLink()) {
+      symlinks.push(rel);
+      continue;
+    }
+    fs.accessSync(file, fs.constants.R_OK);
+
+    if (/\.(html|css|js|json)$/.test(file)) {
+      const content = fs.readFileSync(file, "utf8");
+      const regex =
+        /(?:href|src)=['"]([^'"#]+)['"]|url\(['"]?([^'"\)]+)['"]?\)/g;
+      let match: RegExpExecArray | null;
+      while ((match = regex.exec(content))) {
+        const ref = match[1] || match[2];
+        if (!ref || /^(?:https?:|data:|#|\/)/.test(ref)) {
+          continue;
+        }
+        const refPath = path.resolve(path.dirname(file), ref);
+        if (!fs.existsSync(refPath)) {
+          missingRefs.push(`${rel} -> ${ref}`);
+        }
+      }
+    }
+  }
+
+  expect(symlinks).toEqual([]);
+  expect(missingRefs).toEqual([]);
+});


### PR DESCRIPTION
## Summary
- add CI test verifying build output integrity and asset presence
- avoid interactive ts-node in postbuild script

## Testing
- `npm run format --prefix backend`
- `SKIP_PW_DEPS=1 npm test --prefix backend` *(fails: auto-cloudflare-config.ts implicit any errors)*

------
https://chatgpt.com/codex/tasks/task_e_687a69415f50832d8d93ecefd903f313