### PR TITLE
Refactor symlink check script

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -33,6 +33,8 @@ module.exports = [
       "scripts/ci_watchdog.ts",
       "scripts/ci_watchdog.js",
       "scripts/check-gh-workflow-sync-23859.ts",
+      "scripts/check-broken-symlinks-9ac8f74db5e1c32.ts",
+      "scripts/auto-cloudflare-config.ts",
       "upload/**",
       // "src/**", // removed to enable frontend linting
     ],

--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
     "size-limit": "^11.2.0",
     "tsconfig-strictest": "^1.0.0-beta.1",
     "tslib": "^2.8.1",
+    "ts-node": "^10.9.2",
     "typescript": "^5.8.3",
     "wait-on": "^8.0.3",
     "yaml": "^2.8.0"

--- a/scripts/auto-cloudflare-config.ts
+++ b/scripts/auto-cloudflare-config.ts
@@ -6,7 +6,11 @@ import crypto from "crypto";
 const configFile = process.argv[2] || "cloudflare-pages.config.json";
 const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
 
-function detectFramework() {
+/**
+ * Detect a commonly used framework in the project.
+ * @returns {string | null} The framework name or null when none found.
+ */
+function detectFramework(): string | null {
   const deps = { ...pkg.dependencies, ...pkg.devDependencies };
   if (
     fs.existsSync("next.config.js") ||
@@ -28,7 +32,12 @@ function detectFramework() {
   return null;
 }
 
-function randomString(len) {
+/**
+ * Generate a random alphanumeric string.
+ * @param {number} len Length of the string.
+ * @returns {string} Random string.
+ */
+function randomString(len: number): string {
   return crypto
     .randomBytes(len)
     .toString("base64")
@@ -36,14 +45,24 @@ function randomString(len) {
     .slice(0, len);
 }
 
-function readConfig(file) {
+/**
+ * Read a JSON or YAML config file.
+ * @param {string} file Path to the config file.
+ * @returns {Record<string, unknown>} Parsed configuration.
+ */
+function readConfig(file: string): Record<string, unknown> {
   if (!fs.existsSync(file)) return {};
   const txt = fs.readFileSync(file, "utf8");
   if (file.endsWith(".json")) return JSON.parse(txt);
   return yaml.parse(txt);
 }
 
-function writeConfig(file, data) {
+/**
+ * Write configuration back to disk.
+ * @param {string} file Output file path.
+ * @param {Record<string, unknown>} data Config data to write.
+ */
+function writeConfig(file: string, data: Record<string, unknown>): void {
   if (file.endsWith(".json"))
     fs.writeFileSync(file, JSON.stringify(data, null, 2));
   else fs.writeFileSync(file, yaml.stringify(data));

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -8,5 +8,9 @@
     "noImplicitAny": true,
     "strictNullChecks": true
   },
-  "files": ["ci_watchdog.ts", "auto-cloudflare-config.ts"]
+  "files": [
+    "ci_watchdog.ts",
+    "auto-cloudflare-config.ts",
+    "check-broken-symlinks-9ac8f74db5e1c32.ts"
+  ]
 }


### PR DESCRIPTION
## Summary
- ignore typed scripts in ESLint config
- add `ts-node` dev dependency
- convert build helper and symlink checker to typed TypeScript

## Testing
- `npm run format` in backend
- `npm test` *(fails: runCoverageMissingDeps, runCoverageScript, detailedLint, diagnostic-stripe-validate, linting-diagnostics)*

------
https://chatgpt.com/codex/tasks/task_e_687a703499f8832d957363c6c5c01fca