### PR TITLE
Add offline notes for env validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,8 @@ These guidelines apply to all automated agents (e.g. the Codex agent) working on
    blocked, adjust your environment or proxy settings. When access to the
    Playwright CDN fails (for example the proxy returns HTTP 4xx responses), set
    `SKIP_PW_DEPS=1` before running the setup or validate scripts so the CDN check
-   is skipped.
+   is skipped. If the registry is also unreachable but dependencies are already
+   installed, set `SKIP_NET_CHECKS=1` to bypass the network check.
 7. **Install dependencies** – run `npm run setup` at the repository root **before your first `npm run ci`**. Run it again whenever the container is restarted or if Playwright tests fail with messages like "Test was interrupted" or "page.evaluate: Test ended". This script unsets proxy variables, checks registry connectivity, runs `npm ci` in the root and `backend/`, and installs Playwright browsers.
    - If `npm ci` fails with an `EUSAGE` error complaining that packages are missing from the lock file, run `npm install` in the affected directory and then re-run the setup script.
    - Set `SKIP_PW_DEPS=1` before running the setup script if Playwright dependencies are already installed. This skips the long `apt-get` step and reduces CI time. The `smoke` script also runs the setup script, so use `SKIP_PW_DEPS=1 npm run smoke` to avoid reinstalling Playwright dependencies when they are already present.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,9 @@ The server uses `STRIPE_LIVE_KEY` when `NODE_ENV=production`; otherwise `STRIPE_
    Ensure your environment can reach `https://registry.npmjs.org`,
    `https://cdn.playwright.dev`, and `http://archive.ubuntu.com`. The setup
    script downloads packages, browsers, and system libraries from these domains,
-   so network restrictions may cause it to fail.
+   so network restrictions may cause it to fail. If connectivity is blocked but
+   dependencies are already installed, set `SKIP_NET_CHECKS=1` to bypass the
+   network check.
 
 3. Verify your environment and test pipeline:
 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "serve": "npm run build && node scripts/dev-server.js",
     "smoke": "node scripts/run-smoke.js",
     "build": "echo 'no build step'",
-    "postbuild": "npx ts-node scripts/check-broken-symlinks-9ac8f74db5e1c32.ts",
+    "postbuild": "node scripts/check-broken-symlinks-9ac8f74db5e1c32.js",
     "postinstall": "npm run build",
     "load": "artillery run tests/load/models.yml",
     "visual-test": "percy exec -- npm run e2e",

--- a/scripts/auto-cloudflare-config.js
+++ b/scripts/auto-cloudflare-config.js
@@ -1,7 +1,7 @@
-#!/usr/bin/env ts-node
-import fs from "fs";
-import yaml from "yaml";
-import crypto from "crypto";
+#!/usr/bin/env node
+const fs = require("fs");
+const yaml = require("yaml");
+const crypto = require("crypto");
 
 const configFile = process.argv[2] || "cloudflare-pages.config.json";
 const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));

--- a/scripts/check-broken-symlinks-9ac8f74db5e1c32.js
+++ b/scripts/check-broken-symlinks-9ac8f74db5e1c32.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-import fs from "fs";
-import path from "path";
+const fs = require("fs");
+const path = require("path");
 
 const repoRoot = path.resolve(__dirname, "..");
 const argDir = process.argv[2];

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -8,5 +8,5 @@
     "noImplicitAny": true,
     "strictNullChecks": true
   },
-  "files": ["ci_watchdog.ts", "auto-cloudflare-config.ts"]
+  "files": ["ci_watchdog.ts"]
 }

--- a/scripts/validate-env.sh
+++ b/scripts/validate-env.sh
@@ -143,7 +143,7 @@ if [[ -z "${SKIP_NET_CHECKS:-}" ]]; then
       echo "Network check failed for Playwright CDN, setting SKIP_PW_DEPS=1." >&2
       export SKIP_PW_DEPS=1
     else
-      echo "Network check failed. Ensure access to the npm registry and Playwright CDN." >&2
+      echo "Network check failed. Ensure access to the npm registry and Playwright CDN, or set SKIP_NET_CHECKS=1 if dependencies are already installed." >&2
       exit 1
     fi
   fi


### PR DESCRIPTION
## Summary
- mention using `SKIP_NET_CHECKS=1` when registry access is blocked
- update validate-env error message
- avoid requiring `ts-node` by converting scripts to JS

## Testing
- `npm test` *(fails: An error occurred with our connection to Stripe)*
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_687a79f64728832dab3cae434bed17f2