### PR TITLE
Fix TypeScript script compilation

### DIFF
--- a/scripts/auto-cloudflare-config.js
+++ b/scripts/auto-cloudflare-config.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env ts-node
+// @ts-check
 import fs from "fs";
 import yaml from "yaml";
 import crypto from "crypto";
@@ -28,6 +29,11 @@ function detectFramework() {
   return null;
 }
 
+/**
+ * Generate a random alphanumeric string.
+ * @param {number} len
+ * @returns {string}
+ */
 function randomString(len) {
   return crypto
     .randomBytes(len)
@@ -36,6 +42,11 @@ function randomString(len) {
     .slice(0, len);
 }
 
+/**
+ * Read a YAML or JSON config file.
+ * @param {string} file
+ * @returns {any}
+ */
 function readConfig(file) {
   if (!fs.existsSync(file)) return {};
   const txt = fs.readFileSync(file, "utf8");
@@ -43,6 +54,11 @@ function readConfig(file) {
   return yaml.parse(txt);
 }
 
+/**
+ * Write a YAML or JSON config file.
+ * @param {string} file
+ * @param {any} data
+ */
 function writeConfig(file, data) {
   if (file.endsWith(".json"))
     fs.writeFileSync(file, JSON.stringify(data, null, 2));

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -6,7 +6,10 @@
     "types": ["node"],
     "strict": true,
     "noImplicitAny": true,
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true
   },
-  "files": ["ci_watchdog.ts", "auto-cloudflare-config.ts"]
+  "files": ["ci_watchdog.ts", "auto-cloudflare-config.js"]
 }

--- a/tests/scriptsTypecheck.test.js
+++ b/tests/scriptsTypecheck.test.js
@@ -1,0 +1,5 @@
+const { execSync } = require("child_process");
+
+test("scripts compile", () => {
+  execSync("npx tsc -p scripts/tsconfig.json", { stdio: "inherit" });
+});


### PR DESCRIPTION
## Summary
- convert `auto-cloudflare-config` to checked JS
- allow JS files in `scripts/tsconfig.json`
- add test to ensure script compilation succeeds

## Testing
- `npm run setup` *(with `SKIP_PW_DEPS=1`)*
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: eslint diagnostics and stripe validate)*

------
https://chatgpt.com/codex/tasks/task_e_687a7aa8dc08832d83debdb490ab8bf1