### PR TITLE
Fix TypeScript compile errors in scripts

### DIFF
--- a/scripts/auto-cloudflare-config.ts
+++ b/scripts/auto-cloudflare-config.ts
@@ -6,7 +6,7 @@ import crypto from "crypto";
 const configFile = process.argv[2] || "cloudflare-pages.config.json";
 const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
 
-function detectFramework() {
+function detectFramework(): string | null {
   const deps = { ...pkg.dependencies, ...pkg.devDependencies };
   if (
     fs.existsSync("next.config.js") ||
@@ -28,7 +28,7 @@ function detectFramework() {
   return null;
 }
 
-function randomString(len) {
+function randomString(len: number): string {
   return crypto
     .randomBytes(len)
     .toString("base64")
@@ -36,14 +36,14 @@ function randomString(len) {
     .slice(0, len);
 }
 
-function readConfig(file) {
+function readConfig(file: string): Record<string, unknown> {
   if (!fs.existsSync(file)) return {};
   const txt = fs.readFileSync(file, "utf8");
   if (file.endsWith(".json")) return JSON.parse(txt);
   return yaml.parse(txt);
 }
 
-function writeConfig(file, data) {
+function writeConfig(file: string, data: Record<string, unknown>): void {
   if (file.endsWith(".json"))
     fs.writeFileSync(file, JSON.stringify(data, null, 2));
   else fs.writeFileSync(file, yaml.stringify(data));

--- a/scripts/check-broken-symlinks-9ac8f74db5e1c32.ts
+++ b/scripts/check-broken-symlinks-9ac8f74db5e1c32.ts
@@ -10,14 +10,15 @@ const outputDir = argDir
     ? path.join(repoRoot, "dist")
     : repoRoot;
 
-const badPaths = [];
+const badPaths: string[] = [];
 
-function walk(dir) {
+function walk(dir: string): void {
   let entries;
   try {
     entries = fs.readdirSync(dir, { withFileTypes: true });
   } catch (err) {
-    badPaths.push(`${dir} (${err.code || err.message})`);
+    const error = err as NodeJS.ErrnoException;
+    badPaths.push(`${dir} (${error.code || error.message})`);
     return;
   }
 
@@ -40,7 +41,8 @@ function walk(dir) {
         fs.accessSync(full, fs.constants.R_OK);
       }
     } catch (err) {
-      badPaths.push(`${full} (${err.code || err.message})`);
+      const error = err as NodeJS.ErrnoException;
+      badPaths.push(`${full} (${error.code || error.message})`);
     }
   }
 }


### PR DESCRIPTION
## Summary
- strengthen typing in `check-broken-symlinks` script
- add explicit types to `auto-cloudflare-config`

## Testing
- `npm run format`
- `SKIP_PW_DEPS=1 SKIP_NET_CHECKS=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_687a7a9be7d0832d826eff49298a9bd2