### PR TITLE
Fix ts-node install and add CI test

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "serve": "npm run build && node scripts/dev-server.js",
     "smoke": "node scripts/run-smoke.js",
     "build": "echo 'no build step'",
-    "postbuild": "npx ts-node scripts/check-broken-symlinks-9ac8f74db5e1c32.ts",
+    "postbuild": "npx --yes ts-node --transpile-only scripts/check-broken-symlinks-9ac8f74db5e1c32.ts",
     "postinstall": "npm run build",
     "load": "artillery run tests/load/models.yml",
     "visual-test": "percy exec -- npm run e2e",

--- a/tests/postBuildScript.test.js
+++ b/tests/postBuildScript.test.js
@@ -1,0 +1,7 @@
+const pkg = require("../package.json");
+
+describe("postbuild script", () => {
+  test("uses non-interactive ts-node invocation", () => {
+    expect(pkg.scripts.postbuild).toMatch(/npx --yes ts-node --transpile-only/);
+  });
+});


### PR DESCRIPTION
## Summary
- avoid interactive ts-node install in postbuild script
- cover postbuild script in tests

## Testing
- `SKIP_PW_DEPS=1 npm run format`
- `npm run format --prefix backend`
- `STRIPE_SECRET_KEY=sk_live_abc123 npm test --prefix backend` *(fails: diagnostic stripe validate)*

------
https://chatgpt.com/codex/tasks/task_e_687a7a74ec24832dbbecb704596c3e46