### PR TITLE
Fix TypeScript lint failures in scripts

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -92,6 +92,16 @@ module.exports = [
     rules: { "jsdoc/require-jsdoc": "off" },
   },
   {
+    files: ["scripts/**/*.ts"],
+    languageOptions: {
+      parser: require("@typescript-eslint/parser"),
+      parserOptions: { ecmaVersion: "latest", sourceType: "module" },
+    },
+    plugins: {
+      "@typescript-eslint": require("@typescript-eslint/eslint-plugin"),
+    },
+  },
+  {
     files: ["js/**/*"],
     rules: { "jsdoc/require-jsdoc": "off" },
   },

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "serve": "npm run build && node scripts/dev-server.js",
     "smoke": "node scripts/run-smoke.js",
     "build": "echo 'no build step'",
-    "postbuild": "npx ts-node scripts/check-broken-symlinks-9ac8f74db5e1c32.ts",
+    "postbuild": "npx --yes ts-node scripts/check-broken-symlinks-9ac8f74db5e1c32.ts",
     "postinstall": "npm run build",
     "load": "artillery run tests/load/models.yml",
     "visual-test": "percy exec -- npm run e2e",

--- a/scripts/auto-cloudflare-config.ts
+++ b/scripts/auto-cloudflare-config.ts
@@ -6,7 +6,7 @@ import crypto from "crypto";
 const configFile = process.argv[2] || "cloudflare-pages.config.json";
 const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
 
-function detectFramework() {
+function detectFramework(): string | null {
   const deps = { ...pkg.dependencies, ...pkg.devDependencies };
   if (
     fs.existsSync("next.config.js") ||
@@ -28,7 +28,7 @@ function detectFramework() {
   return null;
 }
 
-function randomString(len) {
+function randomString(len: number): string {
   return crypto
     .randomBytes(len)
     .toString("base64")
@@ -36,14 +36,14 @@ function randomString(len) {
     .slice(0, len);
 }
 
-function readConfig(file) {
+function readConfig(file: string): any {
   if (!fs.existsSync(file)) return {};
   const txt = fs.readFileSync(file, "utf8");
   if (file.endsWith(".json")) return JSON.parse(txt);
   return yaml.parse(txt);
 }
 
-function writeConfig(file, data) {
+function writeConfig(file: string, data: unknown): void {
   if (file.endsWith(".json"))
     fs.writeFileSync(file, JSON.stringify(data, null, 2));
   else fs.writeFileSync(file, yaml.stringify(data));

--- a/scripts/check-broken-symlinks-9ac8f74db5e1c32.ts
+++ b/scripts/check-broken-symlinks-9ac8f74db5e1c32.ts
@@ -10,14 +10,15 @@ const outputDir = argDir
     ? path.join(repoRoot, "dist")
     : repoRoot;
 
-const badPaths = [];
+const badPaths: string[] = [];
 
-function walk(dir) {
-  let entries;
+function walk(dir: string): void {
+  let entries: fs.Dirent[];
   try {
     entries = fs.readdirSync(dir, { withFileTypes: true });
   } catch (err) {
-    badPaths.push(`${dir} (${err.code || err.message})`);
+    const e = err as { code?: string; message?: string };
+    badPaths.push(`${dir} (${e.code || e.message})`);
     return;
   }
 
@@ -40,7 +41,8 @@ function walk(dir) {
         fs.accessSync(full, fs.constants.R_OK);
       }
     } catch (err) {
-      badPaths.push(`${full} (${err.code || err.message})`);
+      const e = err as { code?: string; message?: string };
+      badPaths.push(`${full} (${e.code || e.message})`);
     }
   }
 }


### PR DESCRIPTION
## Summary
- add TypeScript parser for script linting
- fix typing in `auto-cloudflare-config.ts`
- fix typing in `check-broken-symlinks` script
- ensure postbuild uses non-interactive npx

## Testing
- `npm run format`
- `npx --yes tsc -p scripts/tsconfig.json`
- `npx --no-install eslint scripts/check-broken-symlinks-9ac8f74db5e1c32.ts`
- `npx --no-install eslint scripts/auto-cloudflare-config.ts`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Node 25 is required)*

------
https://chatgpt.com/codex/tasks/task_e_687a7b1f89d8832db622d9dd1d6e8429