### PR TITLE
Fix lint errors for broken symlink script

### DIFF
--- a/scripts/check-broken-symlinks-9ac8f74db5e1c32.ts
+++ b/scripts/check-broken-symlinks-9ac8f74db5e1c32.ts
@@ -17,7 +17,8 @@ function walk(dir) {
   try {
     entries = fs.readdirSync(dir, { withFileTypes: true });
   } catch (err) {
-    badPaths.push(`${dir} (${err.code || err.message})`);
+    const code = err.code || err.message;
+    badPaths.push(`${dir} (${code})`);
     return;
   }
 
@@ -40,7 +41,8 @@ function walk(dir) {
         fs.accessSync(full, fs.constants.R_OK);
       }
     } catch (err) {
-      badPaths.push(`${full} (${err.code || err.message})`);
+      const code = err.code || err.message;
+      badPaths.push(`${full} (${code})`);
     }
   }
 }


### PR DESCRIPTION
## Summary
- update check-broken-symlinks script to use plain JS so eslint parses it

## Testing
- `npm run format`
- `npm test` *(fails: diagnostic stripe validate cannot reach Stripe)*

------
https://chatgpt.com/codex/tasks/task_e_687a7b3f2ddc832d9cb77123bdc8cfa8