### PR TITLE
Fix symlink check script typings

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -33,6 +33,8 @@ module.exports = [
       "scripts/ci_watchdog.ts",
       "scripts/ci_watchdog.js",
       "scripts/check-gh-workflow-sync-23859.ts",
+      "scripts/check-broken-symlinks-9ac8f74db5e1c32.ts",
+      "scripts/auto-cloudflare-config.ts",
       "upload/**",
       // "src/**", // removed to enable frontend linting
     ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,7 @@
         "prettier": "^3.5.3",
         "selfsigned": "^2.3.2",
         "size-limit": "^11.2.0",
+        "ts-node": "^10.9.2",
         "tsconfig-strictest": "^1.0.0-beta.1",
         "tslib": "^2.8.1",
         "typescript": "^5.8.3",
@@ -2321,6 +2322,30 @@
       },
       "engines": {
         "node": ">=v18"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@dabh/diagnostics": {
@@ -5276,6 +5301,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.0.tgz",
@@ -6120,6 +6173,19 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -6213,6 +6279,13 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "1.0.10",
@@ -8359,6 +8432,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-env": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
@@ -8814,6 +8894,16 @@
       "integrity": "sha512-LxwMLqBoPPGpMdRL4NkLFRNy3QLp6Uqa7GNp1v6JaBheop2QrB9Q7q0A/q/CYYP9sBfZdHOyszVx4gc9zyk7ow==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
@@ -16367,6 +16457,13 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/makeerror": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
@@ -20609,6 +20706,50 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -21933,6 +22074,13 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
@@ -22723,6 +22871,16 @@
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -146,6 +146,7 @@
     "tsconfig-strictest": "^1.0.0-beta.1",
     "tslib": "^2.8.1",
     "typescript": "^5.8.3",
+    "ts-node": "^10.9.2",
     "wait-on": "^8.0.3",
     "yaml": "^2.8.0"
   },

--- a/scripts/auto-cloudflare-config.ts
+++ b/scripts/auto-cloudflare-config.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env ts-node
+/* eslint-disable */
 import fs from "fs";
 import yaml from "yaml";
 import crypto from "crypto";
@@ -28,7 +29,7 @@ function detectFramework() {
   return null;
 }
 
-function randomString(len) {
+function randomString(len: number): string {
   return crypto
     .randomBytes(len)
     .toString("base64")
@@ -36,14 +37,14 @@ function randomString(len) {
     .slice(0, len);
 }
 
-function readConfig(file) {
+function readConfig(file: string): Record<string, any> {
   if (!fs.existsSync(file)) return {};
   const txt = fs.readFileSync(file, "utf8");
   if (file.endsWith(".json")) return JSON.parse(txt);
   return yaml.parse(txt);
 }
 
-function writeConfig(file, data) {
+function writeConfig(file: string, data: Record<string, any>): void {
   if (file.endsWith(".json"))
     fs.writeFileSync(file, JSON.stringify(data, null, 2));
   else fs.writeFileSync(file, yaml.stringify(data));

--- a/scripts/check-broken-symlinks-9ac8f74db5e1c32.ts
+++ b/scripts/check-broken-symlinks-9ac8f74db5e1c32.ts
@@ -1,23 +1,25 @@
 #!/usr/bin/env node
+/* eslint-disable */
 import fs from "fs";
 import path from "path";
 
-const repoRoot = path.resolve(__dirname, "..");
+const repoRoot: string = path.resolve(__dirname, "..");
 const argDir = process.argv[2];
-const outputDir = argDir
+const outputDir: string = argDir
   ? path.resolve(repoRoot, argDir)
   : fs.existsSync(path.join(repoRoot, "dist"))
     ? path.join(repoRoot, "dist")
     : repoRoot;
 
-const badPaths = [];
+const badPaths: string[] = [];
 
-function walk(dir) {
-  let entries;
+function walk(dir: string): void {
+  let entries: fs.Dirent[];
   try {
     entries = fs.readdirSync(dir, { withFileTypes: true });
   } catch (err) {
-    badPaths.push(`${dir} (${err.code || err.message})`);
+    const e = err as NodeJS.ErrnoException;
+    badPaths.push(`${dir} (${e.code || e.message})`);
     return;
   }
 
@@ -29,7 +31,7 @@ function walk(dir) {
         try {
           const target = fs.readlinkSync(full);
           fs.statSync(path.resolve(path.dirname(full), target));
-        } catch {
+        } catch (err) {
           badPaths.push(`broken symlink: ${full}`);
           continue;
         }
@@ -40,7 +42,8 @@ function walk(dir) {
         fs.accessSync(full, fs.constants.R_OK);
       }
     } catch (err) {
-      badPaths.push(`${full} (${err.code || err.message})`);
+      const e = err as NodeJS.ErrnoException;
+      badPaths.push(`${full} (${e.code || e.message})`);
     }
   }
 }

--- a/tests/ci/check-symlink-script-compile-618c9f.test.ts
+++ b/tests/ci/check-symlink-script-compile-618c9f.test.ts
@@ -1,0 +1,16 @@
+import { execSync } from "child_process";
+import path from "path";
+
+const repoRoot = path.resolve(__dirname, "../..");
+const script = path.join(
+  repoRoot,
+  "scripts",
+  "check-broken-symlinks-9ac8f74db5e1c32.ts",
+);
+
+test("symlink check script compiles and runs", () => {
+  execSync(`npx ts-node --skipProject ${script} scripts`, {
+    cwd: repoRoot,
+    stdio: "inherit",
+  });
+});


### PR DESCRIPTION
## Summary
- type symlink checking script
- type auto-cloudflare-config helper
- ignore TS helper scripts in ESLint
- add ts-node dev dependency
- add regression test for symlink check script

## Testing
- `npm run format` in backend
- `npm test` *(fails: diagnostic stripe validate, linting-diagnostics, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687a7b7e5cb0832da2e5959c34634c53