### PR TITLE
Fix Cloudflare build link errors

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -347,7 +347,7 @@
           <span class="sr-only">Close</span>
         </button>
         <model-viewer
-          src=""
+          src="about:blank"
           alt="3D model preview"
           environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
           camera-controls

--- a/competitions.html
+++ b/competitions.html
@@ -276,7 +276,7 @@
           <span class="sr-only">Close</span>
         </button>
         <model-viewer
-          src=""
+          src="about:blank"
           alt="3D model preview"
           environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
           camera-controls

--- a/library.html
+++ b/library.html
@@ -132,7 +132,7 @@
           <span class="sr-only">Close</span>
         </button>
         <model-viewer
-          src=""
+          src="about:blank"
           alt="3D model preview"
           environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
           camera-controls

--- a/my_creations.html
+++ b/my_creations.html
@@ -86,7 +86,7 @@
           <span class="sr-only">Close</span>
         </button>
         <model-viewer
-          src=""
+          src="about:blank"
           alt="3D model preview"
           environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
           camera-controls

--- a/my_profile.html
+++ b/my_profile.html
@@ -136,7 +136,7 @@
         />
         <model-viewer
           id="avatar-model-preview"
-          src=""
+          src="about:blank"
           alt="3D avatar preview"
           environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
           camera-controls
@@ -356,7 +356,7 @@
           <span class="sr-only">Close</span>
         </button>
         <model-viewer
-          src=""
+          src="about:blank"
           alt="3D model preview"
           environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
           camera-controls

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "test:unit": "npm test --prefix backend",
     "serve": "npm run build && node scripts/dev-server.js",
     "smoke": "node scripts/run-smoke.js",
+    "predeploy": "node scripts/check-missing-links.js",
     "build": "echo 'no build step'",
     "postbuild": "npx ts-node --transpile-only scripts/check-broken-symlinks-9ac8f74db5e1c32.ts",
     "postinstall": "npm run build",

--- a/profile.html
+++ b/profile.html
@@ -130,7 +130,7 @@
         />
         <model-viewer
           id="profile-avatar-model"
-          src=""
+          src="about:blank"
           alt="Profile 3D avatar"
           environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
           camera-controls
@@ -217,7 +217,7 @@
           <span class="sr-only">Close</span>
         </button>
         <model-viewer
-          src=""
+          src="about:blank"
           alt="3D model preview"
           environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
           camera-controls

--- a/scripts/check-missing-links.js
+++ b/scripts/check-missing-links.js
@@ -1,0 +1,53 @@
+const fs = require("fs");
+const path = require("path");
+
+const root = path.resolve(__dirname, "..");
+const dir = process.argv[2] ? path.resolve(root, process.argv[2]) : root;
+
+function walk(d) {
+  if (path.basename(d) === "node_modules") return;
+  const entries = fs.readdirSync(d, { withFileTypes: true });
+  for (const e of entries) {
+    const full = path.join(d, e.name);
+    if (e.isDirectory()) {
+      walk(full);
+    } else if (e.isFile() && e.name.endsWith(".html")) {
+      checkFile(full);
+    }
+  }
+}
+
+const missing = [];
+
+function checkFile(file) {
+  const html = fs.readFileSync(file, "utf8");
+  const regex = /(src|href)="(.*?)"/g;
+  let match;
+  while ((match = regex.exec(html))) {
+    const url = match[2];
+    if (
+      !url ||
+      url.startsWith("http") ||
+      url.startsWith("https") ||
+      url.startsWith("data:") ||
+      url.startsWith("#") ||
+      url === "about:blank"
+    ) {
+      continue;
+    }
+    const target = path.resolve(path.dirname(file), url.split("?")[0]);
+    if (!fs.existsSync(target)) {
+      missing.push(`${file}: ${url}`);
+    }
+  }
+}
+
+walk(dir);
+
+if (missing.length) {
+  console.error("Missing file references detected:");
+  for (const m of missing) console.error(" -", m);
+  process.exit(1);
+} else {
+  console.log("All referenced files exist.");
+}

--- a/share.html
+++ b/share.html
@@ -92,7 +92,7 @@
       <div class="w-full max-w-md h-80 relative">
         <model-viewer
           id="viewer"
-          src=""
+          src="about:blank"
           environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
           camera-controls
           style="width: 100%; height: 100%; display: block"


### PR DESCRIPTION
## Summary
- replace empty `src` attributes with `about:blank` placeholders
- add a `predeploy` script to verify referenced files exist

## Testing
- `npm run format` *(backend)*
- `npm test` *(fails: ts-node not installed)*
- `node scripts/check-missing-links.js`

------
https://chatgpt.com/codex/tasks/task_e_687a7d6f6750832d802a258f24425992