### PR TITLE
Add static export reference validator

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "ci": "node scripts/assert-setup.js && npm run format:check && npm run lint && npm run typecheck && npm run i18n:lint && npm run test:ci && npm run test:a11y && npm run test:ui",
     "test:ci": "cross-env JEST_CI=true npm run test-ci --prefix backend && node scripts/run-jest.js --runTestsByPath tests/ci/build-artifact-check-a1b2c3d4e5f6g7h.ts tests/ci",
     "test:update-threshold": "node scripts/update-coverage-threshold.js",
-    "test:cf-readiness": "node scripts/run-jest.js tests/ci/test-cloudflare-deployment-readiness-4c7a3f2e1b0d9c8.test.ts",
+    "test:cf-readiness": "node scripts/run-jest.js tests/ci/test-cloudflare-deployment-readiness-4c7a3f2e1b0d9c8.test.ts scripts/__tests__/validate-static-refs-3ea7bd43ffcd123.test.ts",
     "update-lint-baseline": "node scripts/update-lint-baseline.js",
     "test:stability": "node scripts/test-stability.js",
     "deps:check": "npx -y lockfile-diff HEAD package-lock.json && npx -y lockfile-diff HEAD backend/package-lock.json && npx -y lockfile-diff HEAD backend/hunyuan_server/package-lock.json",

--- a/scripts/__tests__/validate-static-refs-3ea7bd43ffcd123.test.ts
+++ b/scripts/__tests__/validate-static-refs-3ea7bd43ffcd123.test.ts
@@ -1,0 +1,61 @@
+import fs from "fs";
+import path from "path";
+
+const OUTPUT_DIR_CANDIDATES = ["out", ".next", "public"];
+const EXPORT_DIR =
+  process.env.NEXT_EXPORT_DIR ||
+  OUTPUT_DIR_CANDIDATES.find((d) => fs.existsSync(d));
+
+function collectFiles(dir, exts, files = []) {
+  if (!fs.existsSync(dir)) return files;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) collectFiles(full, exts, files);
+    else if (entry.isFile() && exts.includes(path.extname(entry.name)))
+      files.push(full);
+  }
+  return files;
+}
+
+function extractRefs(content) {
+  const refs = [];
+  const attrRegex = /(?:href|src)="([^"#?]+)(?:[?#][^"]*)?"/g;
+  const cssUrlRegex = /url\((?:"|')?([^"')?#]+)(?:[?#][^"')]*)?(?:"|')?\)/g;
+  const importRegex = /import\(\s*['"]([^'"]+)['"]\s*\)/g;
+  const fromRegex = /from\s+['"]([^'"]+)['"]/g;
+  let m;
+  while ((m = attrRegex.exec(content))) refs.push(m[1]);
+  while ((m = cssUrlRegex.exec(content))) refs.push(m[1]);
+  while ((m = importRegex.exec(content))) refs.push(m[1]);
+  while ((m = fromRegex.exec(content))) refs.push(m[1]);
+  return refs;
+}
+
+function isRelative(ref) {
+  return !/^(?:[a-z]+:|\/|#)/i.test(ref);
+}
+
+test("static output has no broken relative references", () => {
+  if (!EXPORT_DIR) {
+    console.warn("No static output directory found; skipping check.");
+    return;
+  }
+  const exts = [".html", ".js", ".css"];
+  const files = collectFiles(EXPORT_DIR, exts);
+  const missing = [];
+  for (const file of files) {
+    const content = fs.readFileSync(file, "utf8");
+    const refs = extractRefs(content);
+    for (const ref of refs) {
+      if (!isRelative(ref)) continue;
+      const resolved = path.resolve(path.dirname(file), ref);
+      if (!fs.existsSync(resolved)) {
+        missing.push(`${path.relative(EXPORT_DIR, file)} -> ${ref}`);
+      }
+    }
+  }
+  if (missing.length) {
+    console.error("Broken references:\n" + missing.join("\n"));
+  }
+  expect(missing).toEqual([]);
+});


### PR DESCRIPTION
## Summary
- add test checking for broken references in static output
- run new test in Cloudflare deployment readiness script

## Testing
- `npm run format --prefix backend`
- `npm run test:cf-readiness`


------
https://chatgpt.com/codex/tasks/task_e_687a7d740370832d8d1704dc01f4e833