### PR TITLE
Ensure DB_URL in CI setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,6 +193,7 @@ jobs:
       - name: Run smoke tests with fallback env
         env:
           STRIPE_TEST_KEY: dummy
+          DB_URL: postgres://localhost:5432/dev
         run: |
           npm run setup
           npm run smoke

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,6 +11,8 @@ jobs:
         with:
           node-version: 20
       - run: SKIP_PW_DEPS=1 npm run setup
+        env:
+          DB_URL: postgres://localhost:5432/dev
       - run: SKIP_PW_DEPS=1 npm run coverage
       - name: Coverage summary
         run: |


### PR DESCRIPTION
## Summary
- supply a fallback DB_URL when `npm run setup` runs in CI

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: ENOENT lib)*

------
https://chatgpt.com/codex/tasks/task_e_687a7ed28d24832db58c271ff1f8533a