### PR TITLE
Add env var check test

### DIFF
--- a/scripts/__tests__/check-env-dbfailpass.test.ts
+++ b/scripts/__tests__/check-env-dbfailpass.test.ts
@@ -1,0 +1,31 @@
+import { spawnSync } from 'child_process';
+import path from 'path';
+
+const script = path.join(__dirname, '..', 'check-env.sh');
+
+function run(env: NodeJS.ProcessEnv) {
+  return spawnSync('bash', [script], { env, encoding: 'utf8' });
+}
+
+describe('check-env.sh required vars', () => {
+  const baseEnv = {
+    AWS_ACCESS_KEY_ID: 'id',
+    AWS_SECRET_ACCESS_KEY: 'secret',
+    STRIPE_SECRET_KEY: 'sk',
+    CLOUDFRONT_MODEL_DOMAIN: 'cdn',
+    SKIP_NET_CHECKS: '1',
+  };
+
+  test('fails when DB_URL missing', () => {
+    const result = run({ ...process.env, ...baseEnv });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toMatch(/DB_URL.*must be set/);
+  });
+
+  test('passes with dummy DB_URL', () => {
+    const env = { ...process.env, ...baseEnv, DB_URL: 'postgres://u:p@h/db' };
+    const result = run(env);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('✅ environment OK');
+  });
+});


### PR DESCRIPTION
## Summary
- ensure `check-env.sh` fails when `DB_URL` is missing
- allow dummy values to pass

## Testing
- `npm run setup` *(fails: Parameter 'len' implicitly has an 'any' type)*
- `npm run format` *(fails: Parameter 'len' implicitly has an 'any' type)*
- `node scripts/run-jest.js scripts/__tests__/check-env-dbfailpass.test.ts` *(fails: Missing backend dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687a7ed7e6b8832dbfd3bff782ce048d