### PR TITLE
Add test for missing dir symlink

### DIFF
--- a/scripts/__tests__/check-symlinks-de41f2c6a8b903e.test.ts
+++ b/scripts/__tests__/check-symlinks-de41f2c6a8b903e.test.ts
@@ -1,0 +1,33 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { spawnSync } from 'child_process';
+
+const fsPromises = fs.promises;
+let tmpDir: string;
+const script = path.join('scripts', 'check-broken-symlinks-9ac8f74db5e1c32.ts');
+const tsNodeArgs = [
+  '-y',
+  'ts-node',
+  '--transpile-only',
+  '--compiler-options',
+  JSON.stringify({ module: 'CommonJS', moduleResolution: 'node' }),
+  script,
+];
+
+beforeEach(async () => {
+  tmpDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'symlink-test-'));
+});
+
+afterEach(async () => {
+  await fsPromises.rm(tmpDir, { recursive: true, force: true });
+});
+
+test('handles missing symlinked directory', () => {
+  const link = path.join(tmpDir, 'missing-dir');
+  fs.symlinkSync('no-such-dir', link, 'dir');
+  const result = spawnSync('npx', [...tsNodeArgs, tmpDir], { encoding: 'utf8' });
+  expect(result.error).toBeUndefined();
+  expect(result.status).toBe(1);
+  expect(result.stderr).toContain(`broken symlink: ${link}`);
+});


### PR DESCRIPTION
## Summary
- test missing symlinked directory in the symlink scanner

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: npm ci issues)*
- `node scripts/run-jest.js scripts/__tests__/check-symlinks-de41f2c6a8b903e.test.ts` *(fails: missing backend deps)*
- `npm run ci` *(fails during setup)*

------
https://chatgpt.com/codex/tasks/task_e_687a7f68ffe8832d96bc39bc739ad859