### PR TITLE
Add security scan tests

### DIFF
--- a/js/adminFlashSale.js
+++ b/js/adminFlashSale.js
@@ -9,6 +9,7 @@ function setToken(token) {
 }
 
 import { API_BASE, authHeaders } from "./api.js";
+import { setSafeInnerHTML } from "./dom-utils-securityfix-79d3fa.ts";
 
 async function load() {
   const container = document.getElementById("sale");
@@ -26,9 +27,16 @@ async function load() {
   if (sale) {
     const div = document.createElement("div");
     div.className = "space-y-2";
-    div.innerHTML = `
-      <p>Active sale: ${sale.discount_percent}% off ${sale.product_type}</p>
-      <button id="end" class="bg-red-500 px-3 py-1 rounded">End Sale</button>`;
+    setSafeInnerHTML(
+      div,
+      [
+        "<p>Active sale: ",
+        "% off ",
+        '</p><button id="end" class="bg-red-500 px-3 py-1 rounded">End Sale</button>',
+      ],
+      sale.discount_percent,
+      sale.product_type,
+    );
     container.appendChild(div);
     div.querySelector("#end").addEventListener("click", async () => {
       const resp = await fetch(`${API_BASE}/admin/flash-sale/${sale.id}`, {
@@ -41,17 +49,9 @@ async function load() {
   } else {
     const div = document.createElement("div");
     div.className = "space-y-2";
-    div.innerHTML = `
-      <label class="block text-sm">Product Type
-        <input id="prod" class="w-full mt-1 p-2 rounded bg-[#1A1A1D] border border-white/10">
-      </label>
-      <label class="block text-sm">Discount %
-        <input id="disc" type="number" class="w-full mt-1 p-2 rounded bg-[#1A1A1D] border border-white/10">
-      </label>
-      <label class="block text-sm">Duration Minutes
-        <input id="mins" type="number" value="60" class="w-full mt-1 p-2 rounded bg-[#1A1A1D] border border-white/10">
-      </label>
-      <button id="start" class="bg-[#30D5C8] text-[#1A1A1D] px-3 py-1 rounded">Start Sale</button>`;
+    setSafeInnerHTML(div, [
+      '<label class="block text-sm">Product Type\n        <input id="prod" class="w-full mt-1 p-2 rounded bg-[#1A1A1D] border border-white/10">\n      </label>\n      <label class="block text-sm">Discount %\n        <input id="disc" type="number" class="w-full mt-1 p-2 rounded bg-[#1A1A1D] border border-white/10">\n      </label>\n      <label class="block text-sm">Duration Minutes\n        <input id="mins" type="number" value="60" class="w-full mt-1 p-2 rounded bg-[#1A1A1D] border border-white/10">\n      </label>\n      <button id="start" class="bg-[#30D5C8] text-[#1A1A1D] px-3 py-1 rounded">Start Sale</button>',
+    ]);
     container.appendChild(div);
     div.querySelector("#start").addEventListener("click", async () => {
       const now = Date.now();

--- a/tests/security/codeql-scan-7f3a9d2b6c1a.test.ts
+++ b/tests/security/codeql-scan-7f3a9d2b6c1a.test.ts
@@ -1,0 +1,63 @@
+const fs = require("fs");
+const glob = require("glob");
+
+describe("codeql security scans", () => {
+  test("download urls use https", () => {
+    const files = glob.sync("{scripts,backend,js}/**/*.{js,ts}", {
+      nodir: true,
+    });
+    const issues = [];
+    const urlRegex = /https?:\/\/[^\s'"`]+/g;
+    for (const file of files) {
+      const content = fs.readFileSync(file, "utf8");
+      const matches = content.match(urlRegex) || [];
+      for (const url of matches) {
+        if (
+          url.startsWith("http://") &&
+          !/http:\/\/(localhost|127\.0\.0\.1)/.test(url)
+        ) {
+          issues.push(`${file}:${url}`);
+        }
+      }
+    }
+    expect(issues).toEqual([]);
+  });
+
+  test("no unescaped backslashes in scripts", () => {
+    const files = glob.sync("scripts/**/*.{js,ts}", { nodir: true });
+    const issues = [];
+    const strRegex = /(['"`])((?:\\.|(?!\1).)*?)\\(?![\\nrt0'"`uux])/g;
+    for (const file of files) {
+      const content = fs.readFileSync(file, "utf8");
+      let match;
+      while ((match = strRegex.exec(content))) {
+        issues.push(`${file}:${match.index}`);
+      }
+    }
+    expect(issues).toEqual([]);
+  });
+
+  test("safe innerHTML usage", () => {
+    const files = glob.sync("js/**/*.js", { nodir: true });
+    let safeCount = 0;
+    for (const file of files) {
+      const content = fs.readFileSync(file, "utf8");
+      if (/setSafeInnerHTML\s*\(/.test(content)) safeCount++;
+    }
+    expect(safeCount).toBeGreaterThan(0);
+  });
+
+  test("no env var shell concatenation", () => {
+    const files = glob.sync("scripts/**/*.{js,ts}", { nodir: true });
+    const issues = [];
+    const pattern =
+      /(execSync|spawnSync|spawn)\s*\(\s*`[^`]*\${[^`]*process\.env/;
+    for (const file of files) {
+      const lines = fs.readFileSync(file, "utf8").split(/\r?\n/);
+      lines.forEach((line, idx) => {
+        if (pattern.test(line)) issues.push(`${file}:${idx + 1}`);
+      });
+    }
+    expect(issues).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- sanitize admin HTML updates with setSafeInnerHTML
- add codeql security scan tests to check url, escaping, DOM, and shell patterns

## Testing
- `npm run format` *(fails: npm WARN deprecated packages, but finishes)*
- `npm test` *(fails: eslint diagnostics and stripe validate tests)*

------
https://chatgpt.com/codex/tasks/task_e_687a97feda98832da65e1f06c3127223