### PR TITLE
Fix security issues

### DIFF
--- a/backend/tests/stubExecSync.js
+++ b/backend/tests/stubExecSync.js
@@ -75,6 +75,9 @@ child_process.spawnSync = function (cmd, args = [], opts = {}) {
   if (cmd.includes("npm")) {
     return { status: 0, stdout: "", stderr: "" };
   }
+  if (!/^[-\w/.]+$/.test(cmd)) {
+    throw new Error("unsafe command");
+  }
   return origSpawnSync(cmd, args, opts);
 };
 

--- a/js/index.js
+++ b/js/index.js
@@ -683,7 +683,15 @@ function renderThumbnails(arr) {
     // dimensions. This avoids oversized previews in Safari on iPad.
     wrap.className = "thumbnail-wrapper relative w-full h-full overflow-hidden";
     const img = document.createElement("img");
-    img.src = url;
+    try {
+      const parsed = new URL(url, window.location.href);
+      if (parsed.protocol === "javascript:") {
+        throw new Error("invalid url");
+      }
+      img.src = parsed.href;
+    } catch {
+      img.src = "";
+    }
     img.className = "w-full h-full rounded-md shadow-md";
     wrap.appendChild(img);
 

--- a/scripts/generate-glb-tests.js
+++ b/scripts/generate-glb-tests.js
@@ -193,7 +193,9 @@ for (const cluster of clusters) {
   content += `describe('${cluster.name}', () => {\n`;
   for (const t of cluster.tests) {
     for (let i = 0; i < repeat; i++) {
-      const testName = `${t.desc} case ${i + 1}`.replace(/'/g, "\\'");
+      const testName = `${t.desc} case ${i + 1}`
+        .replace(/\\/g, "\\\\")
+        .replace(/'/g, "\\'");
       content += `  it('${testName}', async () => {\n`;
       content += `    const buffer = Buffer.from([]); // TODO: generate ${t.type === "success" ? "valid" : "invalid"}Buffer\n`;
       if (t.type === "success") {

--- a/tests/smoke-hang-diagnostics-57f3c8.test.js
+++ b/tests/smoke-hang-diagnostics-57f3c8.test.js
@@ -28,7 +28,9 @@ describe.skip("insecure http fetch; https unavailable", () => {
   }
 
   function startServer(env = {}) {
-    return spawn("npm", ["run", "serve"], { env: { ...process.env, ...env } });
+    return spawn("npm", ["run", "serve"], {
+      env: { ...process.env, USE_HTTPS: "1", ...env },
+    });
   }
 
   async function stop(proc) {
@@ -45,7 +47,7 @@ describe.skip("insecure http fetch; https unavailable", () => {
   test("homepage responds at root", async () => {
     const proc = startServer();
     await waitForPort(3000);
-    const res = await fetch("http://localhost:3000/");
+    const res = await fetch("https://localhost:3000/");
     await stop(proc);
     expect(res.status).toBe(200);
   });
@@ -58,7 +60,7 @@ describe.skip("insecure http fetch; https unavailable", () => {
   test("static index.js loads", async () => {
     const proc = startServer();
     await waitForPort(3000);
-    const res = await fetch("http://localhost:3000/js/index.js");
+    const res = await fetch("https://localhost:3000/js/index.js");
     await stop(proc);
     expect(res.status).toBe(200);
   });
@@ -66,10 +68,10 @@ describe.skip("insecure http fetch; https unavailable", () => {
   test("viewerReady within 10s", async () => {
     const proc = startServer();
     await waitForPort(3000);
-    const browser = await chromium.launch();
+    const browser = await chromium.launch({ ignoreHTTPSErrors: true });
     const page = await browser.newPage();
     const start = Date.now();
-    await page.goto("http://localhost:3000/");
+    await page.goto("https://localhost:3000/");
     await page.waitForFunction("document.body.dataset.viewerReady", {
       timeout: 10000,
     });

--- a/tests/smoke-hang-diagnostics-c9f8e7d6.test.js
+++ b/tests/smoke-hang-diagnostics-c9f8e7d6.test.js
@@ -28,7 +28,7 @@ describe.skip("insecure http fetch; https unavailable", () => {
   function startServer() {
     const proc = spawn("npm", ["run", "serve"], {
       cwd: repoRoot,
-      env: { ...process.env, PORT: "3000", SKIP_PW_DEPS: "1" },
+      env: { ...process.env, PORT: "3000", SKIP_PW_DEPS: "1", USE_HTTPS: "1" },
       stdio: "ignore",
     });
     return proc;
@@ -44,7 +44,7 @@ describe.skip("insecure http fetch; https unavailable", () => {
     test("homepage responds at /", async () => {
       const proc = startServer();
       await waitPort(3000);
-      const res = await fetch("http://localhost:3000/");
+      const res = await fetch("https://localhost:3000/");
       proc.kill("SIGTERM");
       expect(res.status).toBe(200);
     });
@@ -53,7 +53,7 @@ describe.skip("insecure http fetch; https unavailable", () => {
       const proc = startServer();
       await waitPort(3000);
       const html = await (
-        await fetch("http://localhost:3000/index.html")
+        await fetch("https://localhost:3000/index.html")
       ).text();
       proc.kill("SIGTERM");
       expect(html).toMatch(/viewerReady/);
@@ -62,7 +62,7 @@ describe.skip("insecure http fetch; https unavailable", () => {
     test("static asset js/index.js loads", async () => {
       const proc = startServer();
       await waitPort(3000);
-      const res = await fetch("http://localhost:3000/js/index.js");
+      const res = await fetch("https://localhost:3000/js/index.js");
       proc.kill("SIGTERM");
       expect(res.status).toBe(200);
     });
@@ -71,7 +71,7 @@ describe.skip("insecure http fetch; https unavailable", () => {
       const proc = startServer();
       await waitPort(3000);
       const start = Date.now();
-      const res = await fetch("http://localhost:3000/healthz");
+      const res = await fetch("https://localhost:3000/healthz");
       const duration = Date.now() - start;
       proc.kill("SIGTERM");
       expect(res.status).toBe(200);

--- a/tests/smoke-hang-diagnostics-df535d.test.js
+++ b/tests/smoke-hang-diagnostics-df535d.test.js
@@ -28,7 +28,9 @@ describe.skip("insecure http fetch; https unavailable", () => {
   }
 
   function startServer(env = {}) {
-    return spawn("npm", ["run", "serve"], { env: { ...process.env, ...env } });
+    return spawn("npm", ["run", "serve"], {
+      env: { ...process.env, USE_HTTPS: "1", ...env },
+    });
   }
 
   async function stop(proc) {
@@ -45,7 +47,7 @@ describe.skip("insecure http fetch; https unavailable", () => {
   test("homepage responds at root", async () => {
     const proc = startServer();
     await waitForPort(3000);
-    const res = await fetch("http://localhost:3000/");
+    const res = await fetch("https://localhost:3000/");
     await stop(proc);
     expect(res.status).toBe(200);
   });
@@ -66,10 +68,10 @@ describe.skip("insecure http fetch; https unavailable", () => {
   test("viewerReady within 10s", async () => {
     const proc = startServer();
     await waitForPort(3000);
-    const browser = await chromium.launch();
+    const browser = await chromium.launch({ ignoreHTTPSErrors: true });
     const page = await browser.newPage();
     const start = Date.now();
-    await page.goto("http://localhost:3000/");
+    await page.goto("https://localhost:3000/");
     await page.waitForFunction("document.body.dataset.viewerReady", {
       timeout: 10000,
     });


### PR DESCRIPTION
## Summary
- sanitize preview URLs to avoid DOM injection
- escape backslashes when generating GLB tests
- block unsafe commands in stubExecSync
- use HTTPS in smoke hang diagnostics

## Testing
- `npm run format` (backend)
- `npm test` *(fails: ts-node installation prompt)*

------
https://chatgpt.com/codex/tasks/task_e_687a97f821a0832db19f476ab60690f5