### PR TITLE
Add build output check

### DIFF
--- a/docs/backend-build.md
+++ b/docs/backend-build.md
@@ -1,0 +1,3 @@
+# Backend build instructions
+
+Run `npm run build` from the repository root to compile TypeScript sources in the backend. If the command fails or `backend/lib` is missing, ensure dependencies are installed with `npm run setup` and try again.

--- a/tests/ci/backend-lib-build-check-abc123.test.ts
+++ b/tests/ci/backend-lib-build-check-abc123.test.ts
@@ -1,0 +1,26 @@
+import { execSync } from "child_process";
+import fs from "fs";
+import path from "path";
+
+describe("backend build artifacts", () => {
+  const repoRoot = path.resolve(__dirname, "../..");
+  const backendDir = path.join(repoRoot, "backend");
+  const libDir = path.join(backendDir, "lib");
+
+  test("TypeScript output exists after build", () => {
+    execSync("npm run build", { cwd: repoRoot, stdio: "inherit" });
+    if (!fs.existsSync(libDir)) {
+      throw new Error(
+        `Missing ${path.relative(repoRoot, libDir)} directory after build. ` +
+          `See docs/backend-build.md for help.`,
+      );
+    }
+    const files = fs.readdirSync(libDir).filter((f) => f.endsWith(".js"));
+    if (files.length === 0) {
+      throw new Error(
+        `No compiled JS files found in ${path.relative(repoRoot, libDir)}. ` +
+          `See docs/backend-build.md for help.`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add backend build docs
- check for TypeScript output under `backend/lib`

## Testing
- `npm run format`
- `node scripts/run-jest.js tests/ci/backend-lib-build-check-abc123.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_687a97eda370832dabcc7f87db7f6fd1