### PR TITLE
Add symlink integrity check for Cloudflare build

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "smoke": "node scripts/run-smoke.js",
     "predeploy": "node scripts/check-missing-links.js",
     "build": "echo 'no build step'",
-    "postbuild": "npx ts-node --transpile-only scripts/check-broken-symlinks-9ac8f74db5e1c32.ts",
+    "postbuild": "npx ts-node --transpile-only scripts/check-broken-symlinks-9ac8f74db5e1c32.ts && npx ts-node --transpile-only scripts/cloudflare_symlink_check_e4dd1b9.ts",
     "postinstall": "npm run build",
     "load": "artillery run tests/load/models.yml",
     "visual-test": "percy exec -- npm run e2e",

--- a/scripts/cloudflare_symlink_check_e4dd1b9.ts
+++ b/scripts/cloudflare_symlink_check_e4dd1b9.ts
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+// @ts-nocheck
+import fs from 'fs';
+import path from 'path';
+
+const repoRoot = path.resolve(__dirname, '..');
+const argDir = process.argv[2];
+const outputDir = argDir
+  ? path.resolve(repoRoot, argDir)
+  : fs.existsSync(path.join(repoRoot, 'dist'))
+    ? path.join(repoRoot, 'dist')
+    : fs.existsSync(path.join(repoRoot, 'out'))
+      ? path.join(repoRoot, 'out')
+      : repoRoot;
+
+const issues: string[] = [];
+
+function walk(dir: string) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isSymbolicLink()) {
+      checkSymlink(full);
+    }
+    if (entry.isDirectory()) {
+      walk(full);
+    }
+  }
+}
+
+function checkSymlink(file: string) {
+  let target: string;
+  try {
+    target = fs.readlinkSync(file);
+  } catch {
+    issues.push(`unreadable symlink: ${file}`);
+    return;
+  }
+  const resolved = path.resolve(path.dirname(file), target);
+  try {
+    fs.accessSync(resolved, fs.constants.R_OK);
+  } catch {
+    issues.push(`symlink target inaccessible: ${file} -> ${target}`);
+    return;
+  }
+  if (!resolved.startsWith(outputDir)) {
+    issues.push(`symlink escapes output directory: ${file} -> ${target}`);
+  }
+}
+
+walk(outputDir);
+
+if (issues.length) {
+  console.error('Cloudflare symlink check failed:');
+  for (const msg of issues) console.error(' -', msg);
+  process.exit(1);
+}
+
+console.log('Cloudflare symlink check passed.');


### PR DESCRIPTION
## Summary
- add cloudflare_symlink_check_e4dd1b9.ts for verifying symlink targets
- run the new checker from the `postbuild` script

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: Setup ran but heavy dependency install prevented completion)*

------
https://chatgpt.com/codex/tasks/task_e_687a9762ff90832d8d5f3871d4592963