### PR TITLE
Add Node type definitions to backend

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -43,6 +43,7 @@
         "@babel/preset-typescript": "^7.27.1",
         "@eslint/js": "^9.30.1",
         "@types/jest": "^30.0.0",
+        "@types/node": "^24.0.14",
         "babel-jest": "^30.0.4",
         "coverage-badges-cli": "^2.1.0",
         "eslint": "^9.30.1",
@@ -6333,13 +6334,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "22.15.29",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.29.tgz",
-      "integrity": "sha512-LNdjOkUDlU1RZb8e1kOIUpN1qQUlzGkEtbVNo53vbrwDg5om6oduhm4SiUaPW5ASTXhAiP0jInWG8Qx9fVlOeQ==",
+      "version": "24.0.14",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.14.tgz",
+      "integrity": "sha512-4zXMWD91vBLGRtHK3YbIoFMia+1nqEz72coM42C5ETjnNCa/heoj7NT1G67iAfOqMmcfhuCZ4uNpyz8EjlAejw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.8.0"
       }
     },
     "node_modules/@types/pg": {
@@ -15081,9 +15082,9 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
       "devOptional": true,
       "license": "MIT"
     },

--- a/backend/package.json
+++ b/backend/package.json
@@ -77,6 +77,7 @@
     "@babel/preset-typescript": "^7.27.1",
     "@eslint/js": "^9.30.1",
     "@types/jest": "^30.0.0",
+    "@types/node": "^24.0.14",
     "babel-jest": "^30.0.4",
     "coverage-badges-cli": "^2.1.0",
     "eslint": "^9.30.1",

--- a/backend/tsconfig.build.json
+++ b/backend/tsconfig.build.json
@@ -8,7 +8,8 @@
     "skipLibCheck": true,
     "strict": false,
     "noEmitOnError": false,
-    "verbatimModuleSyntax": false
+    "verbatimModuleSyntax": false,
+    "types": ["node"]
   },
   "include": ["src/**/*.ts", "global.d.ts"]
 }

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -9,7 +9,8 @@
     "checkJs": false,
     "verbatimModuleSyntax": false,
     "esModuleInterop": true,
-    "noEmit": true
+    "noEmit": true,
+    "types": ["node"]
   },
   "include": ["src/**/*", "tests/**/*"],
   "exclude": ["coverage", "node_modules"]


### PR DESCRIPTION
## Summary
- add `@types/node` to backend dev dependencies
- include Node in `types` for backend tsconfigs

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: runCoverageScript.test.js, lintingDetailed.test.js, detailedLint.test.js, diagnostic-stripe-validate-2fb39dcee74.test.ts, linting.test.js, linting-diagnostics-9b3adf.test.js)*
- `npm run ci` *(fails during lint checks)*
- `npm run smoke` *(fails with TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_687aa3be2c68832d8c829ace1578f52d