### PR TITLE
Fix Node type errors

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -91,6 +91,7 @@
     "jest-localstorage-mock": "^2.4.26",
     "jest-retries": "^1.0.1",
     "jsdom": "^26.1.0",
+    "@types/node": "^24.0.10",
     "lighthouse": "^12.7.1",
     "nock": "^13.3.3",
     "openapi-to-postmanv2": "^3.0.0",

--- a/backend/tsconfig.build.json
+++ b/backend/tsconfig.build.json
@@ -8,7 +8,8 @@
     "skipLibCheck": true,
     "strict": false,
     "noEmitOnError": false,
-    "verbatimModuleSyntax": false
+    "verbatimModuleSyntax": false,
+    "types": ["node"]
   },
   "include": ["src/**/*.ts", "global.d.ts"]
 }

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -9,7 +9,8 @@
     "checkJs": false,
     "verbatimModuleSyntax": false,
     "esModuleInterop": true,
-    "noEmit": true
+    "noEmit": true,
+    "types": ["node"]
   },
   "include": ["src/**/*", "tests/**/*"],
   "exclude": ["coverage", "node_modules"]


### PR DESCRIPTION
## Summary
- add `@types/node` to backend dev dependencies
- include Node type definitions in backend TS configs

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: TypeScript errors in dev server build)*

------
https://chatgpt.com/codex/tasks/task_e_687aa3b2de88832dbb6f0a9c51865e67