### PR TITLE
Update community carousel assets

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -272,13 +272,13 @@
                 class="carousel-slide flex-none p-4 flex flex-col sm:flex-row items-center justify-center gap-4"
               >
                 <img
-                  src="https://via.placeholder.com/400x300.png?text=Real+Print+Coming+Soon"
-                  alt="Real-life print placeholder"
+                  src="img/astro image.jpg"
+                  alt="Real-life print"
                   loading="lazy"
                   class="w-full sm:w-1/2 h-64 object-cover rounded-xl"
                 />
                 <model-viewer
-                  src="https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoomBox/glTF-Binary/BoomBox.glb"
+                  src="models/bag.glb"
                   alt="3D model preview"
                   environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
                   camera-controls


### PR DESCRIPTION
## Summary
- update the last slide on the Community Creations carousel to use local placeholder assets
- run formatter and backend tests

## Testing
- `npm run format`
- `npm test`
- `npm run ci` *(fails: eslint errors)*
- `npm run smoke` *(fails: type errors)*

------
https://chatgpt.com/codex/tasks/task_e_688a979b5cc8832db3e4aad55653a448