### PR TITLE
fix: update logo paths

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -14,7 +14,7 @@
       property="og:description"
       content="Browse and share 3D models created by the print3 community."
     />
-    <meta property="og:image" content="img/boxlogo.png" />
+    <meta property="og:image" content="img/box%20logo.png" />
     <script src="js/applyColorScheme.js"></script>
     <link rel="preconnect" href="https://modelviewer.dev" crossorigin />
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />

--- a/addons.html
+++ b/addons.html
@@ -10,7 +10,7 @@
       property="og:description"
       content="Unlock extra bases, props and accessories for your models."
     />
-    <meta property="og:image" content="img/boxlogo.png" />
+    <meta property="og:image" content="img/box%20logo.png" />
 
     <script src="js/applyColorScheme.js"></script>
     <script src="https://cdn.tailwindcss.com"></script>

--- a/backend/server.js
+++ b/backend/server.js
@@ -1702,7 +1702,7 @@ app.get("/shared/:slug", async (req, res) => {
     const prompt = rows[0]?.prompt || "Shared model";
     const ogImage = rows[0]?.snapshot
       ? `${req.protocol}://${req.get("host")}${rows[0].snapshot}`
-      : `${req.protocol}://${req.get("host")}/img/boxlogo.png`;
+      : `${req.protocol}://${req.get("host")}/img/box%20logo.png`;
     res.send(`<!doctype html>
 <html lang="en">
   <head>
@@ -1733,7 +1733,7 @@ app.get("/community/model/:id", async (req, res) => {
     );
     if (!rows.length) return res.status(404).send("Not found");
     const prompt = rows[0].title || rows[0].prompt || "Community model";
-    const ogImage = `${req.protocol}://${req.get("host")}/img/boxlogo.png`;
+    const ogImage = `${req.protocol}://${req.get("host")}/img/box%20logo.png`;
     res.send(`<!doctype html>
 <html lang="en">
   <head>
@@ -1764,7 +1764,7 @@ app.get("/item/:id", async (req, res) => {
     );
     if (!rows.length) return res.status(404).send("Not found");
     const prompt = rows[0].title || rows[0].prompt || "Community model";
-    const ogImage = `${req.protocol}://${req.get("host")}/img/boxlogo.png`;
+    const ogImage = `${req.protocol}://${req.get("host")}/img/box%20logo.png`;
     res.send(`<!doctype html>
 <html lang="en">
   <head>

--- a/competitions.html
+++ b/competitions.html
@@ -9,7 +9,7 @@
       property="og:description"
       content="Join print3 contests and showcase your 3D designs."
     />
-    <meta property="og:image" content="img/boxlogo.png" />
+    <meta property="og:image" content="img/box%20logo.png" />
     <script src="js/applyColorScheme.js"></script>
     <link rel="preconnect" href="https://modelviewer.dev" crossorigin />
     <script src="https://cdn.tailwindcss.com"></script>

--- a/designer_upload.html
+++ b/designer_upload.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Submit Design</title>
     <meta property="og:title" content="Submit Design – print3" />
-    <meta property="og:image" content="img/boxlogo.png" />
+    <meta property="og:image" content="img/box%20logo.png" />
     <script src="js/applyColorScheme.js"></script>
     <script src="https://cdn.tailwindcss.com"></script>
     <link

--- a/e2e/full-session.vxiz75p2hujwq57.test.js
+++ b/e2e/full-session.vxiz75p2hujwq57.test.js
@@ -45,7 +45,7 @@ test("full user session home -> editor -> upload -> checkout -> success", async 
   await expect(page.locator("#viewer")).toBeVisible();
 
   // Upload image file
-  const img = path.join(__dirname, "..", "img", "boxlogo.png");
+  const img = path.join(__dirname, "..", "img", "box logo.png");
   await page.setInputFiles("#uploadInput", img);
   await expect(page.locator("#image-preview-area")).toBeVisible();
 

--- a/earn-rewards.html
+++ b/earn-rewards.html
@@ -9,7 +9,7 @@
       property="og:description"
       content="Learn how to earn rewards on print2."
     />
-    <meta property="og:image" content="img/boxlogo.png" />
+    <meta property="og:image" content="img/box%20logo.png" />
     <script src="js/applyColorScheme.js"></script>
     <script src="https://cdn.tailwindcss.com"></script>
     <link

--- a/generate.html
+++ b/generate.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Generate Model</title>
     <meta property="og:title" content="Generate Model – print3" />
-    <meta property="og:image" content="img/boxlogo.png" />
+    <meta property="og:image" content="img/box%20logo.png" />
     <script src="js/applyColorScheme.js"></script>
     <script src="https://cdn.tailwindcss.com"></script>
   </head>

--- a/index.html
+++ b/index.html
@@ -19,18 +19,18 @@
       property="og:description"
       content="Describe your idea or upload images and print3 turns them into 3D models you can print."
     />
-    <meta property="og:image" content="img/boxlogo.png" />
+    <meta property="og:image" content="img/box%20logo.png" />
 
     <!-- Preload hero images -->
     <link
       rel="preload"
-      href="img/textlogo.png"
+      href="img/text%20logo.png"
       as="image"
       fetchpriority="high"
     />
     <link
       rel="preload"
-      href="img/boxlogo.png"
+      href="img/box%20logo.png"
       as="image"
       fetchpriority="high"
     />
@@ -189,7 +189,7 @@
 
     <header class="relative flex items-center justify-between py-4 px-6">
       <div class="flex flex-col items-start">
-        <img src="img/textlogo.png" alt="print3" class="h-10 w-auto" />
+        <img src="img/text%20logo.png" alt="print2" class="h-10 w-auto" />
         <div class="mt-1 flex flex-col text-sm opacity-90">
           <p class="text-gray-400">
             <span class="text-white">5400+</span> prints
@@ -438,8 +438,8 @@
       <section id="prompt-section" class="w-full max-w-xl">
         <div class="flex flex-col items-center text-center">
           <img
-            src="img/boxlogo.png"
-            alt="print3 cube"
+            src="img/box%20logo.png"
+            alt="print2 cube"
             class="w-32 h-auto mb-4"
           />
           <h1 class="text-2xl font-semibold mb-4">

--- a/library.html
+++ b/library.html
@@ -9,7 +9,7 @@
       property="og:description"
       content="Browse your previous prints and reorder."
     />
-    <meta property="og:image" content="img/boxlogo.png" />
+    <meta property="og:image" content="img/box%20logo.png" />
     <script src="js/applyColorScheme.js"></script>
     <link rel="preconnect" href="https://modelviewer.dev" crossorigin />
     <script src="https://cdn.tailwindcss.com"></script>

--- a/login.html
+++ b/login.html
@@ -9,7 +9,7 @@
       property="og:description"
       content="Access your print3 account to manage models and orders."
     />
-    <meta property="og:image" content="img/boxlogo.png" />
+    <meta property="og:image" content="img/box%20logo.png" />
     <script src="js/applyColorScheme.js"></script>
     <script src="https://cdn.tailwindcss.com"></script>
     <link

--- a/my-uploads.html
+++ b/my-uploads.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>My Uploads</title>
     <meta property="og:title" content="My Uploads – print3" />
-    <meta property="og:image" content="img/boxlogo.png" />
+    <meta property="og:image" content="img/box%20logo.png" />
     <script src="js/applyColorScheme.js"></script>
     <script src="https://cdn.tailwindcss.com"></script>
   </head>

--- a/my_creations.html
+++ b/my_creations.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>My Creations</title>
     <meta property="og:title" content="My Creations – print3" />
-    <meta property="og:image" content="img/boxlogo.png" />
+    <meta property="og:image" content="img/box%20logo.png" />
     <script src="js/applyColorScheme.js"></script>
     <link rel="preconnect" href="https://modelviewer.dev" crossorigin />
     <script src="https://cdn.tailwindcss.com"></script>

--- a/my_profile.html
+++ b/my_profile.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>My Profile</title>
     <meta property="og:title" content="My Profile – print3" />
-    <meta property="og:image" content="img/boxlogo.png" />
+    <meta property="og:image" content="img/box%20logo.png" />
     <script src="js/applyColorScheme.js"></script>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="preconnect" href="https://modelviewer.dev" crossorigin />

--- a/printclub.html
+++ b/printclub.html
@@ -9,7 +9,7 @@
       property="og:description"
       content="Join the print3 print2 Pro for weekly prints and exclusive perks."
     />
-    <meta property="og:image" content="img/boxlogo.png" />
+    <meta property="og:image" content="img/box%20logo.png" />
     <script src="js/applyColorScheme.js"></script>
     <script src="https://cdn.tailwindcss.com"></script>
     <link

--- a/profile.html
+++ b/profile.html
@@ -9,7 +9,7 @@
       property="og:description"
       content="View your generated models and past orders."
     />
-    <meta property="og:image" content="img/boxlogo.png" />
+    <meta property="og:image" content="img/box%20logo.png" />
     <script src="js/applyColorScheme.js"></script>
     <link rel="preconnect" href="https://modelviewer.dev" crossorigin />
     <script src="https://cdn.tailwindcss.com"></script>

--- a/request-reset.html
+++ b/request-reset.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Password Reset Request</title>
     <meta property="og:title" content="Reset Password – print3" />
-    <meta property="og:image" content="img/boxlogo.png" />
+    <meta property="og:image" content="img/box%20logo.png" />
     <script src="js/applyColorScheme.js"></script>
     <script src="https://cdn.tailwindcss.com"></script>
     <link

--- a/reset-password.html
+++ b/reset-password.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Reset Password</title>
     <meta property="og:title" content="Reset Password – print3" />
-    <meta property="og:image" content="img/boxlogo.png" />
+    <meta property="og:image" content="img/box%20logo.png" />
     <script src="js/applyColorScheme.js"></script>
     <script src="https://cdn.tailwindcss.com"></script>
     <link

--- a/share.html
+++ b/share.html
@@ -9,7 +9,7 @@
       property="og:description"
       content="View a 3D model shared on print3."
     />
-    <meta property="og:image" content="img/boxlogo.png" />
+    <meta property="og:image" content="img/box%20logo.png" />
     <script src="js/applyColorScheme.js"></script>
     <link rel="preconnect" href="https://modelviewer.dev" crossorigin />
     <script src="https://cdn.tailwindcss.com"></script>

--- a/signup.html
+++ b/signup.html
@@ -9,7 +9,7 @@
       property="og:description"
       content="Access your print3 account to manage models and orders."
     />
-    <meta property="og:image" content="img/boxlogo.png" />
+    <meta property="og:image" content="img/box%20logo.png" />
     <script src="js/applyColorScheme.js"></script>
     <script src="https://cdn.tailwindcss.com"></script>
     <link

--- a/tests/smoke-hang-diagnostics-a1b2c3.test.js
+++ b/tests/smoke-hang-diagnostics-a1b2c3.test.js
@@ -49,7 +49,7 @@ describe.skip("insecure http fetch; https unavailable", () => {
       const server = startDevServer(0);
       const port = server.address().port;
       await waitPort(port);
-      const res = await fetch(`http://127.0.0.1:${port}/img/boxlogo.png`);
+      const res = await fetch(`http://127.0.0.1:${port}/img/box%20logo.png`);
       server.close();
       expect(res.status).toBe(200);
     });


### PR DESCRIPTION
## Summary
- replace remaining print3 logos with new print2 versions across pages and tests
- update server-side OG image URLs to point at new logo asset

## Testing
- `npm run format`
- `npm test` *(fails: diagnostic-stripe-validate, lintingDetailed)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: parsing errors)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: TypeScript errors in Stripe routes)*


------
https://chatgpt.com/codex/tasks/task_e_688e4a6812f0832d8f099b3395bea763