### PR TITLE
refactor: migrate print3 storage keys to print2

### DIFF
--- a/js/addons.js
+++ b/js/addons.js
@@ -1,3 +1,37 @@
+(() => {
+  try {
+    const map = {
+      print3Basket: "print2Basket",
+      print3Model: "print2Model",
+      print3JobId: "print2JobId",
+      print3Material: "print2Material",
+      print3Color: "print2Color",
+      print3EtchName: "print2EtchName",
+      print3Email: "print2Email",
+      print3ShipName: "print2ShipName",
+      print3ShipAddress: "print2ShipAddress",
+      print3ShipCity: "print2ShipCity",
+      print3ShipZip: "print2ShipZip",
+      print3DiscountCode: "print2DiscountCode",
+      print3CheckoutItems: "print2CheckoutItems",
+      print3Prompt: "print2Prompt",
+      print3Images: "print2Images",
+      print3Saved: "print2Saved",
+      print3CommunityOpen: "print2CommunityOpen",
+      print3CommunityState: "print2CommunityState",
+    };
+    for (const [oldKey, newKey] of Object.entries(map)) {
+      const val = localStorage.getItem(oldKey);
+      if (val !== null && localStorage.getItem(newKey) === null) {
+        localStorage.setItem(newKey, val);
+        localStorage.removeItem(oldKey);
+      }
+    }
+  } catch {
+    // ignore
+  }
+})();
+
 const API_BASE = (window.API_ORIGIN || "") + "/api";
 
 function renderPreview() {
@@ -55,7 +89,7 @@ function initLuckybox() {
     '#luckybox-tiers input[value="multicolour"]',
   );
   if (defaultRadio) defaultRadio.checked = true;
-  localStorage.setItem("print3Material", "multi");
+  localStorage.setItem("print2Material", "multi");
   function selectedTier() {
     const checked = document.querySelector(
       '#luckybox-tiers input[name="luckybox-tier"]:checked',
@@ -71,7 +105,7 @@ function initLuckybox() {
         : tier === "premium"
           ? "premium"
           : "single";
-    localStorage.setItem("print3Material", material);
+    localStorage.setItem("print2Material", material);
   }
   tierRadios.forEach((r) => r.addEventListener("change", update));
   update();

--- a/js/basket.js
+++ b/js/basket.js
@@ -1,4 +1,38 @@
-const KEY = "print3Basket";
+(() => {
+  try {
+    const map = {
+      print3Basket: "print2Basket",
+      print3Model: "print2Model",
+      print3JobId: "print2JobId",
+      print3Material: "print2Material",
+      print3Color: "print2Color",
+      print3EtchName: "print2EtchName",
+      print3Email: "print2Email",
+      print3ShipName: "print2ShipName",
+      print3ShipAddress: "print2ShipAddress",
+      print3ShipCity: "print2ShipCity",
+      print3ShipZip: "print2ShipZip",
+      print3DiscountCode: "print2DiscountCode",
+      print3CheckoutItems: "print2CheckoutItems",
+      print3Prompt: "print2Prompt",
+      print3Images: "print2Images",
+      print3Saved: "print2Saved",
+      print3CommunityOpen: "print2CommunityOpen",
+      print3CommunityState: "print2CommunityState",
+    };
+    for (const [oldKey, newKey] of Object.entries(map)) {
+      const val = localStorage.getItem(oldKey);
+      if (val !== null && localStorage.getItem(newKey) === null) {
+        localStorage.setItem(newKey, val);
+        localStorage.removeItem(oldKey);
+      }
+    }
+  } catch {
+    // ignore
+  }
+})();
+
+const KEY = "print2Basket";
 const API_BASE = (window.API_ORIGIN || "") + "/api";
 export function getBasket() {
   try {
@@ -96,10 +130,10 @@ export function removeFromBasket(index) {
     }).catch(() => {});
   }
   try {
-    const arr = JSON.parse(localStorage.getItem("print3CheckoutItems"));
+    const arr = JSON.parse(localStorage.getItem("print2CheckoutItems"));
     if (Array.isArray(arr) && index >= 0 && index < arr.length) {
       arr.splice(index, 1);
-      localStorage.setItem("print3CheckoutItems", JSON.stringify(arr));
+      localStorage.setItem("print2CheckoutItems", JSON.stringify(arr));
     }
   } catch {}
   updateBadge();
@@ -108,7 +142,7 @@ export function removeFromBasket(index) {
 }
 export function clearBasket() {
   saveBasket([]);
-  localStorage.removeItem("print3CheckoutItems");
+  localStorage.removeItem("print2CheckoutItems");
   const token = localStorage.getItem("token");
   if (token) {
     fetch(`${API_BASE}/cart`, {
@@ -292,18 +326,18 @@ export function setupBasketUI() {
     if (items.length === 1) {
       const item = items[0];
       if (item.modelUrl) {
-        localStorage.setItem("print3Model", item.modelUrl);
+        localStorage.setItem("print2Model", item.modelUrl);
       }
       if (item.jobId) {
-        localStorage.setItem("print3JobId", item.jobId);
+        localStorage.setItem("print2JobId", item.jobId);
       } else {
-        localStorage.removeItem("print3JobId");
+        localStorage.removeItem("print2JobId");
       }
     }
     // Save basket contents for payment page navigation
     try {
       const existing =
-        JSON.parse(localStorage.getItem("print3CheckoutItems")) || [];
+        JSON.parse(localStorage.getItem("print2CheckoutItems")) || [];
       const checkoutItems = items.map((it, idx) => {
         const prev = existing[idx] || {};
         return {
@@ -311,15 +345,15 @@ export function setupBasketUI() {
           jobId: it.jobId,
           snapshot: it.snapshot || prev.snapshot || "",
           material:
-            prev.material || localStorage.getItem("print3Material") || "multi",
+            prev.material || localStorage.getItem("print2Material") || "multi",
           color: prev.color || null,
           // Preserve personalised etch text per model for the payment page.
           etchName:
-            prev.etchName || localStorage.getItem("print3EtchName") || "",
+            prev.etchName || localStorage.getItem("print2EtchName") || "",
         };
       });
       localStorage.setItem(
-        "print3CheckoutItems",
+        "print2CheckoutItems",
         JSON.stringify(checkoutItems),
       );
     } catch {}
@@ -370,11 +404,11 @@ export function setupBasketUI() {
   viewerCheckoutBtn.addEventListener("click", () => {
     const model = viewerCheckoutBtn.dataset.model;
     const job = viewerCheckoutBtn.dataset.job;
-    if (model) localStorage.setItem("print3Model", model);
+    if (model) localStorage.setItem("print2Model", model);
     if (job) {
-      localStorage.setItem("print3JobId", job);
+      localStorage.setItem("print2JobId", job);
     } else {
-      localStorage.removeItem("print3JobId");
+      localStorage.removeItem("print2JobId");
     }
   });
   function setTier(tier) {
@@ -391,13 +425,13 @@ export function setupBasketUI() {
     }
     const material =
       tier === "bronze" ? "single" : tier === "gold" ? "premium" : "multi";
-    localStorage.setItem("print3Material", material);
+    localStorage.setItem("print2Material", material);
   }
   viewerTierToggle?.addEventListener("click", (ev) => {
     const btn = ev.target.closest("button[data-tier]");
     if (btn) setTier(btn.dataset.tier);
   });
-  const storedMat = localStorage.getItem("print3Material");
+  const storedMat = localStorage.getItem("print2Material");
   if (storedMat === "single") setTier("bronze");
   else if (storedMat === "premium") setTier("gold");
   else setTier("silver");

--- a/js/cart.js
+++ b/js/cart.js
@@ -1,5 +1,40 @@
-const API_BASE = (window.API_ORIGIN || "") + "/api";
 import { getBasket, removeFromBasket } from "./basket.js";
+
+(() => {
+  try {
+    const map = {
+      print3Basket: "print2Basket",
+      print3Model: "print2Model",
+      print3JobId: "print2JobId",
+      print3Material: "print2Material",
+      print3Color: "print2Color",
+      print3EtchName: "print2EtchName",
+      print3Email: "print2Email",
+      print3ShipName: "print2ShipName",
+      print3ShipAddress: "print2ShipAddress",
+      print3ShipCity: "print2ShipCity",
+      print3ShipZip: "print2ShipZip",
+      print3DiscountCode: "print2DiscountCode",
+      print3CheckoutItems: "print2CheckoutItems",
+      print3Prompt: "print2Prompt",
+      print3Images: "print2Images",
+      print3Saved: "print2Saved",
+      print3CommunityOpen: "print2CommunityOpen",
+      print3CommunityState: "print2CommunityState",
+    };
+    for (const [oldKey, newKey] of Object.entries(map)) {
+      const val = localStorage.getItem(oldKey);
+      if (val !== null && localStorage.getItem(newKey) === null) {
+        localStorage.setItem(newKey, val);
+        localStorage.removeItem(oldKey);
+      }
+    }
+  } catch {
+    // ignore
+  }
+})();
+
+const API_BASE = (window.API_ORIGIN || "") + "/api";
 
 function render() {
   const list = document.getElementById("cart-items");
@@ -25,7 +60,7 @@ function render() {
       const q = parseInt(input.value, 10) || 1;
       const items = getBasket();
       items[idx].quantity = q;
-      localStorage.setItem("print3Basket", JSON.stringify(items));
+      localStorage.setItem("print2Basket", JSON.stringify(items));
       if (it.serverId) {
         const token = localStorage.getItem("token");
         if (token)

--- a/js/community.js
+++ b/js/community.js
@@ -1,8 +1,42 @@
 import { captureSnapshots } from "./snapshot.js";
 
+(() => {
+  try {
+    const map = {
+      print3Basket: "print2Basket",
+      print3Model: "print2Model",
+      print3JobId: "print2JobId",
+      print3Material: "print2Material",
+      print3Color: "print2Color",
+      print3EtchName: "print2EtchName",
+      print3Email: "print2Email",
+      print3ShipName: "print2ShipName",
+      print3ShipAddress: "print2ShipAddress",
+      print3ShipCity: "print2ShipCity",
+      print3ShipZip: "print2ShipZip",
+      print3DiscountCode: "print2DiscountCode",
+      print3CheckoutItems: "print2CheckoutItems",
+      print3Prompt: "print2Prompt",
+      print3Images: "print2Images",
+      print3Saved: "print2Saved",
+      print3CommunityOpen: "print2CommunityOpen",
+      print3CommunityState: "print2CommunityState",
+    };
+    for (const [oldKey, newKey] of Object.entries(map)) {
+      const val = localStorage.getItem(oldKey);
+      if (val !== null && localStorage.getItem(newKey) === null) {
+        localStorage.setItem(newKey, val);
+        localStorage.removeItem(oldKey);
+      }
+    }
+  } catch {
+    // ignore
+  }
+})();
+
 const API_BASE = (window.API_ORIGIN || "") + "/api";
 
-const OPEN_KEY = "print3CommunityOpen";
+const OPEN_KEY = "print2CommunityOpen";
 const FALLBACK_GLB = "models/bag.glb";
 
 function addBasketModel(model) {
@@ -17,7 +51,7 @@ function addBasketModel(model) {
 
 const SEARCH_DELAY = 300;
 
-const STATE_KEY = "print3CommunityState";
+const STATE_KEY = "print2CommunityState";
 
 async function fetchComments(id) {
   try {
@@ -312,12 +346,12 @@ function createCard(model) {
   div.querySelector(".purchase").addEventListener("click", (e) => {
     e.stopPropagation();
     sessionStorage.setItem("fromCommunity", "1");
-    localStorage.setItem("print3Model", model.model_url);
-    localStorage.setItem("print3JobId", model.job_id);
-    localStorage.removeItem("print3Basket");
+    localStorage.setItem("print2Model", model.model_url);
+    localStorage.setItem("print2JobId", model.job_id);
+    localStorage.removeItem("print2Basket");
     try {
       localStorage.setItem(
-        "print3CheckoutItems",
+        "print2CheckoutItems",
         JSON.stringify([
           {
             modelUrl: model.model_url,
@@ -360,12 +394,12 @@ function createViewerCard(modelUrl) {
   div.querySelector(".purchase")?.addEventListener("click", (e) => {
     e.stopPropagation();
     sessionStorage.setItem("fromCommunity", "1");
-    localStorage.setItem("print3Model", modelUrl);
-    localStorage.setItem("print3JobId", "");
-    localStorage.removeItem("print3Basket");
+    localStorage.setItem("print2Model", modelUrl);
+    localStorage.setItem("print2JobId", "");
+    localStorage.removeItem("print2Basket");
     try {
       localStorage.setItem(
-        "print3CheckoutItems",
+        "print2CheckoutItems",
         JSON.stringify([{ modelUrl, jobId: "", snapshot: "" }]),
       );
     } catch {}

--- a/js/competitions.js
+++ b/js/competitions.js
@@ -1,5 +1,39 @@
 import { captureSnapshots } from "./snapshot.js";
 
+(() => {
+  try {
+    const map = {
+      print3Basket: "print2Basket",
+      print3Model: "print2Model",
+      print3JobId: "print2JobId",
+      print3Material: "print2Material",
+      print3Color: "print2Color",
+      print3EtchName: "print2EtchName",
+      print3Email: "print2Email",
+      print3ShipName: "print2ShipName",
+      print3ShipAddress: "print2ShipAddress",
+      print3ShipCity: "print2ShipCity",
+      print3ShipZip: "print2ShipZip",
+      print3DiscountCode: "print2DiscountCode",
+      print3CheckoutItems: "print2CheckoutItems",
+      print3Prompt: "print2Prompt",
+      print3Images: "print2Images",
+      print3Saved: "print2Saved",
+      print3CommunityOpen: "print2CommunityOpen",
+      print3CommunityState: "print2CommunityState",
+    };
+    for (const [oldKey, newKey] of Object.entries(map)) {
+      const val = localStorage.getItem(oldKey);
+      if (val !== null && localStorage.getItem(newKey) === null) {
+        localStorage.setItem(newKey, val);
+        localStorage.removeItem(oldKey);
+      }
+    }
+  } catch {
+    // ignore
+  }
+})();
+
 const API_BASE = (window.API_ORIGIN || "") + "/api";
 
 const prefetchedModels = new Set();
@@ -77,8 +111,8 @@ function openViewer(modelUrl, jobId, snapshot = "") {
 
 function purchase(modelUrl, jobId) {
   sessionStorage.setItem("fromCompetitions", "1");
-  localStorage.setItem("print3Model", modelUrl);
-  localStorage.setItem("print3JobId", jobId);
+  localStorage.setItem("print2Model", modelUrl);
+  localStorage.setItem("print2JobId", jobId);
   window.location.href = "payment.html";
 }
 

--- a/js/index.js
+++ b/js/index.js
@@ -2,6 +2,40 @@
 import { shareOn } from "./share.js";
 import { track } from "./analytics.js";
 
+(() => {
+  try {
+    const map = {
+      print3Basket: "print2Basket",
+      print3Model: "print2Model",
+      print3JobId: "print2JobId",
+      print3Material: "print2Material",
+      print3Color: "print2Color",
+      print3EtchName: "print2EtchName",
+      print3Email: "print2Email",
+      print3ShipName: "print2ShipName",
+      print3ShipAddress: "print2ShipAddress",
+      print3ShipCity: "print2ShipCity",
+      print3ShipZip: "print2ShipZip",
+      print3DiscountCode: "print2DiscountCode",
+      print3CheckoutItems: "print2CheckoutItems",
+      print3Prompt: "print2Prompt",
+      print3Images: "print2Images",
+      print3Saved: "print2Saved",
+      print3CommunityOpen: "print2CommunityOpen",
+      print3CommunityState: "print2CommunityState",
+    };
+    for (const [oldKey, newKey] of Object.entries(map)) {
+      const val = localStorage.getItem(oldKey);
+      if (val !== null && localStorage.getItem(newKey) === null) {
+        localStorage.setItem(newKey, val);
+        localStorage.removeItem(oldKey);
+      }
+    }
+  } catch {
+    // ignore
+  }
+})();
+
 const API_BASE = (window.API_ORIGIN || "") + "/api";
 const TZ = "America/New_York";
 // Local fallback model used when generation fails or the viewer hasn't loaded a model yet.
@@ -95,8 +129,8 @@ const LOW_POLY_GLB = FALLBACK_GLB_LOW;
 
 function resetMaterialSelection() {
   try {
-    if (!localStorage.getItem("print3Material")) {
-      localStorage.setItem("print3Material", "multi");
+    if (!localStorage.getItem("print2Material")) {
+      localStorage.setItem("print2Material", "multi");
     }
   } catch {
     /* ignore quota errors */
@@ -549,7 +583,7 @@ async function fetchProfile() {
 async function buyNow() {
   if (!userProfile) return;
   if (window.setWizardStage) window.setWizardStage("purchase");
-  const jobId = localStorage.getItem("print3JobId");
+  const jobId = localStorage.getItem("print2JobId");
   const res = await fetch("/api/create-order", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -714,7 +748,7 @@ function renderThumbnails(arr) {
         previewUrls = [...arr];
       }
       try {
-        localStorage.setItem("print3Images", JSON.stringify(arr));
+        localStorage.setItem("print2Images", JSON.stringify(arr));
       } catch {
         /* ignore storage errors */
       }
@@ -775,7 +809,7 @@ async function processFiles(files) {
   schedule(async () => {
     const thumbs = await Promise.all(uploadedFiles.map((f) => getThumbnail(f)));
     try {
-      localStorage.setItem("print3Images", JSON.stringify(thumbs));
+      localStorage.setItem("print2Images", JSON.stringify(thumbs));
     } catch {
       /* ignore storage errors */
     }
@@ -844,12 +878,12 @@ refs.submitBtn.addEventListener("click", async () => {
   if (window.setWizardStage) window.setWizardStage("building");
 
   try {
-    localStorage.setItem("print3Prompt", prompt);
+    localStorage.setItem("print2Prompt", prompt);
     localStorage.setItem("hasGenerated", "true");
 
     const url = await fetchGlb(prompt, uploadedFiles);
-    localStorage.setItem("print3Model", url);
-    localStorage.setItem("print3JobId", lastJobId);
+    localStorage.setItem("print2Model", url);
+    localStorage.setItem("print2JobId", lastJobId);
 
     editsPending = false;
 
@@ -947,13 +981,13 @@ async function init() {
       } else if (refs.viewer.src === FALLBACK_GLB && hiStart !== null) {
         const t = Math.round(performance.now() - hiStart);
         console.log("Model load time", t, "ms");
-        localStorage.setItem("print3Model", FALLBACK_GLB);
+        localStorage.setItem("print2Model", FALLBACK_GLB);
         refs.viewer.removeEventListener("load", handleLoad);
       }
     };
     refs.viewer.addEventListener("load", handleLoad);
     refs.viewer.src = LOW_POLY_GLB;
-    localStorage.removeItem("print3JobId");
+    localStorage.removeItem("print2JobId");
     refs.viewer.addEventListener(
       "load",
       () => {
@@ -1008,8 +1042,8 @@ async function init() {
     }
   });
 
-  const prompt = localStorage.getItem("print3Prompt");
-  const thumbs = JSON.parse(localStorage.getItem("print3Images") || "[]");
+  const prompt = localStorage.getItem("print2Prompt");
+  const thumbs = JSON.parse(localStorage.getItem("print2Images") || "[]");
 
   const oldPlaceholders = [
     "Describe your 3D print request…",
@@ -1025,7 +1059,7 @@ async function init() {
       refs.promptInput.dispatchEvent(new Event("input"));
       usePlaceholder = false;
     } else {
-      localStorage.removeItem("print3Prompt");
+      localStorage.removeItem("print2Prompt");
     }
   }
   if (usePlaceholder) {
@@ -1058,12 +1092,12 @@ async function init() {
   // Ensure checkout uses the model currently shown in the viewer
   refs.checkoutBtn?.addEventListener("click", () => {
     if (refs.viewer?.src) {
-      localStorage.setItem("print3Model", refs.viewer.src);
+      localStorage.setItem("print2Model", refs.viewer.src);
     }
     if (lastJobId) {
-      localStorage.setItem("print3JobId", lastJobId);
+      localStorage.setItem("print2JobId", lastJobId);
     } else {
-      localStorage.removeItem("print3JobId");
+      localStorage.removeItem("print2JobId");
     }
     try {
       const items = [
@@ -1073,8 +1107,8 @@ async function init() {
           snapshot: lastSnapshot || "",
         },
       ];
-      localStorage.setItem("print3CheckoutItems", JSON.stringify(items));
-      localStorage.removeItem("print3Basket");
+      localStorage.setItem("print2CheckoutItems", JSON.stringify(items));
+      localStorage.removeItem("print2Basket");
     } catch {}
     if (window.setWizardStage) window.setWizardStage("purchase");
   });

--- a/js/library.js
+++ b/js/library.js
@@ -1,3 +1,37 @@
+(() => {
+  try {
+    const map = {
+      print3Basket: "print2Basket",
+      print3Model: "print2Model",
+      print3JobId: "print2JobId",
+      print3Material: "print2Material",
+      print3Color: "print2Color",
+      print3EtchName: "print2EtchName",
+      print3Email: "print2Email",
+      print3ShipName: "print2ShipName",
+      print3ShipAddress: "print2ShipAddress",
+      print3ShipCity: "print2ShipCity",
+      print3ShipZip: "print2ShipZip",
+      print3DiscountCode: "print2DiscountCode",
+      print3CheckoutItems: "print2CheckoutItems",
+      print3Prompt: "print2Prompt",
+      print3Images: "print2Images",
+      print3Saved: "print2Saved",
+      print3CommunityOpen: "print2CommunityOpen",
+      print3CommunityState: "print2CommunityState",
+    };
+    for (const [oldKey, newKey] of Object.entries(map)) {
+      const val = localStorage.getItem(oldKey);
+      if (val !== null && localStorage.getItem(newKey) === null) {
+        localStorage.setItem(newKey, val);
+        localStorage.removeItem(oldKey);
+      }
+    }
+  } catch {
+    // ignore
+  }
+})();
+
 const API_BASE = (window.API_ORIGIN || "") + "/api";
 
 function createCard(order) {
@@ -13,14 +47,14 @@ function createCard(order) {
     <button class="remix absolute bottom-1 right-1 text-xs bg-green-600 px-1 rounded">Remix</button>`;
   div.querySelector(".reorder").addEventListener("click", (e) => {
     e.stopPropagation();
-    localStorage.setItem("print3Model", order.model_url);
-    localStorage.setItem("print3JobId", order.job_id);
+    localStorage.setItem("print2Model", order.model_url);
+    localStorage.setItem("print2JobId", order.job_id);
     window.location.href = "payment.html";
   });
   div.querySelector(".remix").addEventListener("click", (e) => {
     e.stopPropagation();
     try {
-      localStorage.setItem("print3Prompt", order.prompt || "");
+      localStorage.setItem("print2Prompt", order.prompt || "");
     } catch {}
     const url = `index.html?sr=${encodeURIComponent(order.model_url)}`;
     window.location.href = url;

--- a/js/marketplace.js
+++ b/js/marketplace.js
@@ -1,3 +1,37 @@
+(() => {
+  try {
+    const map = {
+      print3Basket: "print2Basket",
+      print3Model: "print2Model",
+      print3JobId: "print2JobId",
+      print3Material: "print2Material",
+      print3Color: "print2Color",
+      print3EtchName: "print2EtchName",
+      print3Email: "print2Email",
+      print3ShipName: "print2ShipName",
+      print3ShipAddress: "print2ShipAddress",
+      print3ShipCity: "print2ShipCity",
+      print3ShipZip: "print2ShipZip",
+      print3DiscountCode: "print2DiscountCode",
+      print3CheckoutItems: "print2CheckoutItems",
+      print3Prompt: "print2Prompt",
+      print3Images: "print2Images",
+      print3Saved: "print2Saved",
+      print3CommunityOpen: "print2CommunityOpen",
+      print3CommunityState: "print2CommunityState",
+    };
+    for (const [oldKey, newKey] of Object.entries(map)) {
+      const val = localStorage.getItem(oldKey);
+      if (val !== null && localStorage.getItem(newKey) === null) {
+        localStorage.setItem(newKey, val);
+        localStorage.removeItem(oldKey);
+      }
+    }
+  } catch {
+    // ignore
+  }
+})();
+
 const API_BASE = (window.API_ORIGIN || "") + "/api";
 
 function createCard(item) {
@@ -6,8 +40,8 @@ function createCard(item) {
     "model-card relative h-32 bg-[#2A2A2E] border border-white/10 rounded-xl flex items-center justify-center";
   div.innerHTML = `<model-viewer src="${item.file_path}" alt="Model" environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr" camera-controls auto-rotate loading="lazy" crossOrigin="anonymous" class="w-full h-full bg-[#2A2A2E] rounded-xl"></model-viewer>\n<progress max="100" value="${item.royalty_percent || 0}" class="absolute left-1 bottom-1 w-16 h-2"></progress>\n<button class="buy absolute bottom-1 right-1 font-bold text-lg py-1.5 px-4 rounded-full shadow-md transition border-2 border-black" style="background-color:#30D5C8;color:#1A1A1D;transform:scale(0.78);transform-origin:right bottom;">Buy</button>`;
   div.querySelector(".buy").addEventListener("click", () => {
-    localStorage.setItem("print3Model", item.file_path);
-    if (item.job_id) localStorage.setItem("print3JobId", item.job_id);
+    localStorage.setItem("print2Model", item.file_path);
+    if (item.job_id) localStorage.setItem("print2JobId", item.job_id);
     sessionStorage.setItem("fromMarketplace", "1");
     window.location.href = "payment.html";
   });

--- a/js/my_profile.js
+++ b/js/my_profile.js
@@ -1,5 +1,39 @@
 import { captureSnapshots } from "./snapshot.js";
 
+(() => {
+  try {
+    const map = {
+      print3Basket: "print2Basket",
+      print3Model: "print2Model",
+      print3JobId: "print2JobId",
+      print3Material: "print2Material",
+      print3Color: "print2Color",
+      print3EtchName: "print2EtchName",
+      print3Email: "print2Email",
+      print3ShipName: "print2ShipName",
+      print3ShipAddress: "print2ShipAddress",
+      print3ShipCity: "print2ShipCity",
+      print3ShipZip: "print2ShipZip",
+      print3DiscountCode: "print2DiscountCode",
+      print3CheckoutItems: "print2CheckoutItems",
+      print3Prompt: "print2Prompt",
+      print3Images: "print2Images",
+      print3Saved: "print2Saved",
+      print3CommunityOpen: "print2CommunityOpen",
+      print3CommunityState: "print2CommunityState",
+    };
+    for (const [oldKey, newKey] of Object.entries(map)) {
+      const val = localStorage.getItem(oldKey);
+      if (val !== null && localStorage.getItem(newKey) === null) {
+        localStorage.setItem(newKey, val);
+        localStorage.removeItem(oldKey);
+      }
+    }
+  } catch {
+    // ignore
+  }
+})();
+
 const API_BASE = (window.API_ORIGIN || "") + "/api";
 
 function startOfWeek(d = new Date()) {
@@ -42,8 +76,8 @@ async function loadPrintOfWeek() {
     const m = models[0];
     container.innerHTML = `\n      <img src="${m.snapshot || ""}" alt="${m.title || "Model"}" class="w-full h-48 object-contain mb-2" />\n      <button class="bg-[#30D5C8] text-[#1A1A1D] px-3 py-1 rounded-xl">Buy</button>`;
     container.querySelector("button").addEventListener("click", () => {
-      localStorage.setItem("print3Model", m.model_url);
-      localStorage.setItem("print3JobId", m.job_id);
+      localStorage.setItem("print2Model", m.model_url);
+      localStorage.setItem("print2JobId", m.job_id);
       window.location.href = "payment.html";
     });
     wrapper.classList.remove("hidden");
@@ -86,8 +120,8 @@ function createCard(model) {
   div.innerHTML = `\n    <img src="${model.snapshot || ""}" alt="Model" class="w-full h-full object-contain pointer-events-none" />\n    <span class="sr-only">${model.prompt || "Model"}</span>\n    <button class="purchase absolute bottom-1 left-1 text-xs bg-blue-600 px-1 rounded">Buy</button>`;
   div.querySelector(".purchase").addEventListener("click", (e) => {
     e.stopPropagation();
-    localStorage.setItem("print3Model", model.model_url);
-    localStorage.setItem("print3JobId", model.job_id);
+    localStorage.setItem("print2Model", model.model_url);
+    localStorage.setItem("print2JobId", model.job_id);
     window.location.href = "payment.html";
   });
   div.addEventListener("click", () => {

--- a/js/payment.js
+++ b/js/payment.js
@@ -1,3 +1,39 @@
+import { track } from "./analytics.js";
+
+(() => {
+  try {
+    const map = {
+      print3Basket: "print2Basket",
+      print3Model: "print2Model",
+      print3JobId: "print2JobId",
+      print3Material: "print2Material",
+      print3Color: "print2Color",
+      print3EtchName: "print2EtchName",
+      print3Email: "print2Email",
+      print3ShipName: "print2ShipName",
+      print3ShipAddress: "print2ShipAddress",
+      print3ShipCity: "print2ShipCity",
+      print3ShipZip: "print2ShipZip",
+      print3DiscountCode: "print2DiscountCode",
+      print3CheckoutItems: "print2CheckoutItems",
+      print3Prompt: "print2Prompt",
+      print3Images: "print2Images",
+      print3Saved: "print2Saved",
+      print3CommunityOpen: "print2CommunityOpen",
+      print3CommunityState: "print2CommunityState",
+    };
+    for (const [oldKey, newKey] of Object.entries(map)) {
+      const val = localStorage.getItem(oldKey);
+      if (val !== null && localStorage.getItem(newKey) === null) {
+        localStorage.setItem(newKey, val);
+        localStorage.removeItem(oldKey);
+      }
+    }
+  } catch {
+    // ignore
+  }
+})();
+
 // Initialize Stripe after the library loads to avoid breaking the rest of the
 // page if the network request for Stripe fails. This variable will be assigned
 // once the DOM content is ready.
@@ -46,7 +82,6 @@ const PRINT_CLUB_ANNUAL_PRICE = Math.round(
 let selectedPrice = PRICES.multi;
 const SINGLE_BORDER_COLOR = "#60a5fa";
 const API_BASE = (window.API_ORIGIN || "") + "/api";
-import { track } from "./analytics.js";
 // Time zone used to reset local purchase counts at 1 AM Eastern
 const TZ = "America/New_York";
 let flashTimerId = null;
@@ -122,12 +157,12 @@ async function fetchPaymentInit() {
 }
 
 // Restore previously selected material option and colour
-let storedMaterial = localStorage.getItem("print3Material");
-let storedColor = localStorage.getItem("print3Color");
+let storedMaterial = localStorage.getItem("print2Material");
+let storedColor = localStorage.getItem("print2Color");
 const personalise = qs("personalise");
 if (personalise !== null) {
   storedMaterial = "multi";
-  localStorage.setItem("print3Material", storedMaterial);
+  localStorage.setItem("print2Material", storedMaterial);
 }
 if (storedMaterial && PRICES[storedMaterial]) {
   selectedPrice = PRICES[storedMaterial];
@@ -380,7 +415,7 @@ async function createCheckout(
   etchName,
   useCredit,
 ) {
-  const jobId = localStorage.getItem("print3JobId");
+  const jobId = localStorage.getItem("print2JobId");
   const res = await fetch(`${API_BASE}/create-order`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -508,13 +543,13 @@ async function initPaymentPage() {
     "discount-code",
   ];
   const persistMap = {
-    "ship-name": "print3ShipName",
-    "etch-name": "print3EtchName",
-    "checkout-email": "print3Email",
-    "ship-address": "print3ShipAddress",
-    "ship-city": "print3ShipCity",
-    "ship-zip": "print3ShipZip",
-    "discount-code": "print3DiscountCode",
+    "ship-name": "print2ShipName",
+    "etch-name": "print2EtchName",
+    "checkout-email": "print2Email",
+    "ship-address": "print2ShipAddress",
+    "ship-city": "print2ShipCity",
+    "ship-zip": "print2ShipZip",
+    "discount-code": "print2DiscountCode",
   };
   const highlightValid = (el) => {
     if (!el) return;
@@ -687,7 +722,7 @@ async function initPaymentPage() {
         checkoutItems[currentIndex].etchName = "";
         saveCheckoutItems();
       }
-      localStorage.removeItem("print3EtchName");
+      localStorage.removeItem("print2EtchName");
       etchInput.classList.add("cursor-not-allowed");
       etchInput.classList.add(
         "border-[#30D5C8]",
@@ -810,7 +845,7 @@ async function initPaymentPage() {
       if (r.checked) {
         selectedPrice = PRICES[r.value] || PRICES.single;
         storedMaterial = r.value;
-        localStorage.setItem("print3Material", r.value);
+        localStorage.setItem("print2Material", r.value);
         if (checkoutItems[currentIndex]) {
           checkoutItems[currentIndex].material = r.value;
           if (r.value !== "single") {
@@ -831,7 +866,7 @@ async function initPaymentPage() {
             }
             if (originalColor) applyModelColor(originalColor, true);
             storedColor = null;
-            localStorage.removeItem("print3Color");
+            localStorage.removeItem("print2Color");
           }
         }
         updatePayButton();
@@ -929,8 +964,8 @@ async function initPaymentPage() {
       if (factor) applyModelColor(factor);
       storedColor = color;
       storedMaterial = "single";
-      localStorage.setItem("print3Color", color);
-      localStorage.setItem("print3Material", "single");
+      localStorage.setItem("print2Color", color);
+      localStorage.setItem("print2Material", "single");
       if (checkoutItems[currentIndex]) {
         checkoutItems[currentIndex].material = "single";
         checkoutItems[currentIndex].color = color;
@@ -970,13 +1005,13 @@ async function initPaymentPage() {
         viewer.src = src || storedModel || FALLBACK_GLB;
       }
     }
-    if (item.jobId) localStorage.setItem("print3JobId", item.jobId);
-    else localStorage.removeItem("print3JobId");
+    if (item.jobId) localStorage.setItem("print2JobId", item.jobId);
+    else localStorage.removeItem("print2JobId");
     storedMaterial = item.material || "multi";
     storedColor = item.color || null;
-    localStorage.setItem("print3Material", storedMaterial);
-    if (storedColor) localStorage.setItem("print3Color", storedColor);
-    else localStorage.removeItem("print3Color");
+    localStorage.setItem("print2Material", storedMaterial);
+    if (storedColor) localStorage.setItem("print2Color", storedColor);
+    else localStorage.removeItem("print2Color");
     const radio = document.querySelector(
       `#material-options input[value="${storedMaterial}"]`,
     );
@@ -990,7 +1025,7 @@ async function initPaymentPage() {
     }
     if (etchInput) {
       etchInput.value = item.etchName || "";
-      localStorage.setItem("print3EtchName", item.etchName || "");
+      localStorage.setItem("print2EtchName", item.etchName || "");
       highlightValid(etchInput);
     }
     if (storedMaterial === "single") {
@@ -1044,10 +1079,10 @@ async function initPaymentPage() {
     checkoutItems.splice(idx, 1);
     saveCheckoutItems();
     try {
-      const basket = JSON.parse(localStorage.getItem("print3Basket")) || [];
+      const basket = JSON.parse(localStorage.getItem("print2Basket")) || [];
       if (idx >= 0 && idx < basket.length) {
         basket.splice(idx, 1);
-        localStorage.setItem("print3Basket", JSON.stringify(basket));
+        localStorage.setItem("print2Basket", JSON.stringify(basket));
       }
     } catch {}
     if (checkoutItems.length) {
@@ -1180,13 +1215,13 @@ async function initPaymentPage() {
   } else {
     loader.hidden = false;
     // Assign the model source only after the load/error listeners are in place
-    const storedModel = sanitizeUrl(localStorage.getItem("print3Model"));
+    const storedModel = sanitizeUrl(localStorage.getItem("print2Model"));
     if (viewer) viewer.src = storedModel || FALLBACK_GLB;
   }
   // Load saved basket items unless this is the Luckybox page
   if (!window.location.pathname.endsWith("luckybox-payment.html")) {
     try {
-      const arr = JSON.parse(localStorage.getItem("print3CheckoutItems"));
+      const arr = JSON.parse(localStorage.getItem("print2CheckoutItems"));
       if (Array.isArray(arr) && arr.length) {
         if (
           arr.length === 1 &&
@@ -1202,14 +1237,14 @@ async function initPaymentPage() {
       }
     } catch {}
   } else {
-    localStorage.removeItem("print3CheckoutItems");
+    localStorage.removeItem("print2CheckoutItems");
   }
 
   // Sync checkout items with the current basket in case this page was
   // opened directly and the stored list is stale.
   if (!window.location.pathname.endsWith("luckybox-payment.html")) {
     try {
-      const basket = JSON.parse(localStorage.getItem("print3Basket")) || [];
+      const basket = JSON.parse(localStorage.getItem("print2Basket")) || [];
       if (
         basket.length &&
         (basket.length !== checkoutItems.length ||
@@ -1227,11 +1262,11 @@ async function initPaymentPage() {
             snapshot: it.snapshot || prev.snapshot || "",
             material:
               prev.material ||
-              localStorage.getItem("print3Material") ||
+              localStorage.getItem("print2Material") ||
               "multi",
             color: prev.color || null,
             etchName:
-              prev.etchName || localStorage.getItem("print3EtchName") || "",
+              prev.etchName || localStorage.getItem("print2EtchName") || "",
             qty: (() => {
               let q = prev.qty ?? it.quantity;
               if (basket.length === 1 && (q == null || parseInt(q, 10) === 1)) {
@@ -1243,7 +1278,7 @@ async function initPaymentPage() {
           };
         });
         localStorage.setItem(
-          "print3CheckoutItems",
+          "print2CheckoutItems",
           JSON.stringify(checkoutItems),
         );
       }
@@ -1256,7 +1291,7 @@ async function initPaymentPage() {
     });
     try {
       localStorage.setItem(
-        "print3CheckoutItems",
+        "print2CheckoutItems",
         JSON.stringify(checkoutItems),
       );
     } catch {}
@@ -1264,7 +1299,7 @@ async function initPaymentPage() {
   function saveCheckoutItems() {
     try {
       localStorage.setItem(
-        "print3CheckoutItems",
+        "print2CheckoutItems",
         JSON.stringify(checkoutItems),
       );
     } catch {}
@@ -1278,10 +1313,10 @@ async function initPaymentPage() {
     updateNavButtons();
   } else {
     const first = checkoutItems[0];
-    if (first.jobId) localStorage.setItem("print3JobId", first.jobId);
-    else localStorage.removeItem("print3JobId");
+    if (first.jobId) localStorage.setItem("print2JobId", first.jobId);
+    else localStorage.removeItem("print2JobId");
     storedMaterial = first.material || storedMaterial;
-    localStorage.setItem("print3Material", storedMaterial);
+    localStorage.setItem("print2Material", storedMaterial);
     showItem(0);
     if (removeBtn) {
       if (checkoutItems.length > 1) removeBtn.classList.remove("hidden");
@@ -1365,7 +1400,7 @@ async function initPaymentPage() {
       }
 
       nextBtn.addEventListener("click", () => {
-        localStorage.setItem("print3Prompt", suggestion);
+        localStorage.setItem("print2Prompt", suggestion);
         window.location.href = "index.html";
       });
       nextModal.classList.remove("hidden");
@@ -1523,7 +1558,7 @@ async function initPaymentPage() {
       ? checkoutItems
       : [
           {
-            jobId: localStorage.getItem("print3JobId"),
+            jobId: localStorage.getItem("print2JobId"),
             material: selectedMaterialValue(),
             etchName: etchName || "",
             qty,
@@ -1534,7 +1569,7 @@ async function initPaymentPage() {
     let bulkApplied = false;
     for (const item of items) {
       const q = Math.max(1, parseInt(item.qty || qty, 10));
-      if (item.jobId) localStorage.setItem("print3JobId", item.jobId);
+      if (item.jobId) localStorage.setItem("print2JobId", item.jobId);
       selectedPrice = PRICES[item.material] || PRICES.single;
       let discount = computeDiscountFor(item.material, q);
       if (!bulkApplied && bulk > 0) {
@@ -1705,7 +1740,7 @@ window.addEventListener("pageshow", (e) => {
 
 // Refresh the page if basket contents change in another tab
 window.addEventListener("storage", (e) => {
-  if (e.key === "print3CheckoutItems") {
+  if (e.key === "print2CheckoutItems") {
     window.location.reload();
   }
 });

--- a/js/profile.js
+++ b/js/profile.js
@@ -1,4 +1,38 @@
 import { captureSnapshots } from "./snapshot.js";
+
+(() => {
+  try {
+    const map = {
+      print3Basket: "print2Basket",
+      print3Model: "print2Model",
+      print3JobId: "print2JobId",
+      print3Material: "print2Material",
+      print3Color: "print2Color",
+      print3EtchName: "print2EtchName",
+      print3Email: "print2Email",
+      print3ShipName: "print2ShipName",
+      print3ShipAddress: "print2ShipAddress",
+      print3ShipCity: "print2ShipCity",
+      print3ShipZip: "print2ShipZip",
+      print3DiscountCode: "print2DiscountCode",
+      print3CheckoutItems: "print2CheckoutItems",
+      print3Prompt: "print2Prompt",
+      print3Images: "print2Images",
+      print3Saved: "print2Saved",
+      print3CommunityOpen: "print2CommunityOpen",
+      print3CommunityState: "print2CommunityState",
+    };
+    for (const [oldKey, newKey] of Object.entries(map)) {
+      const val = localStorage.getItem(oldKey);
+      if (val !== null && localStorage.getItem(newKey) === null) {
+        localStorage.setItem(newKey, val);
+        localStorage.removeItem(oldKey);
+      }
+    }
+  } catch {
+    // ignore
+  }
+})();
 const API_BASE = (window.API_ORIGIN || "") + "/api";
 function authHeaders() {
   const admin = localStorage.getItem("adminToken");
@@ -21,8 +55,8 @@ function createCard(model) {
   div.innerHTML = `\n    <img src="${model.snapshot || ""}" alt="Model" class="w-full h-full object-contain pointer-events-none" />\n    <span class="sr-only">${model.prompt || "Model"}</span>\n    <button class="purchase absolute bottom-1 left-1 text-xs bg-blue-600 px-1 rounded">Reorder</button>\n    <button class="add-basket absolute bottom-1 right-1 text-xs bg-green-600 px-1 rounded">Add</button>`;
   div.querySelector(".purchase").addEventListener("click", (e) => {
     e.stopPropagation();
-    localStorage.setItem("print3Model", model.model_url);
-    localStorage.setItem("print3JobId", model.job_id);
+    localStorage.setItem("print2Model", model.model_url);
+    localStorage.setItem("print2JobId", model.job_id);
     window.location.href = "payment.html";
   });
   div.querySelector(".add-basket").addEventListener("click", (e) => {

--- a/js/saveList.js
+++ b/js/saveList.js
@@ -1,4 +1,38 @@
-const KEY = "print3Saved";
+(() => {
+  try {
+    const map = {
+      print3Basket: "print2Basket",
+      print3Model: "print2Model",
+      print3JobId: "print2JobId",
+      print3Material: "print2Material",
+      print3Color: "print2Color",
+      print3EtchName: "print2EtchName",
+      print3Email: "print2Email",
+      print3ShipName: "print2ShipName",
+      print3ShipAddress: "print2ShipAddress",
+      print3ShipCity: "print2ShipCity",
+      print3ShipZip: "print2ShipZip",
+      print3DiscountCode: "print2DiscountCode",
+      print3CheckoutItems: "print2CheckoutItems",
+      print3Prompt: "print2Prompt",
+      print3Images: "print2Images",
+      print3Saved: "print2Saved",
+      print3CommunityOpen: "print2CommunityOpen",
+      print3CommunityState: "print2CommunityState",
+    };
+    for (const [oldKey, newKey] of Object.entries(map)) {
+      const val = localStorage.getItem(oldKey);
+      if (val !== null && localStorage.getItem(newKey) === null) {
+        localStorage.setItem(newKey, val);
+        localStorage.removeItem(oldKey);
+      }
+    }
+  } catch {
+    // ignore
+  }
+})();
+
+const KEY = "print2Saved";
 export function getSaved() {
   try {
     return JSON.parse(localStorage.getItem(KEY)) || [];

--- a/js/share.js
+++ b/js/share.js
@@ -1,5 +1,40 @@
-const API_BASE = (window.API_ORIGIN || "") + "/api";
 import { track } from "./analytics.js";
+
+(() => {
+  try {
+    const map = {
+      print3Basket: "print2Basket",
+      print3Model: "print2Model",
+      print3JobId: "print2JobId",
+      print3Material: "print2Material",
+      print3Color: "print2Color",
+      print3EtchName: "print2EtchName",
+      print3Email: "print2Email",
+      print3ShipName: "print2ShipName",
+      print3ShipAddress: "print2ShipAddress",
+      print3ShipCity: "print2ShipCity",
+      print3ShipZip: "print2ShipZip",
+      print3DiscountCode: "print2DiscountCode",
+      print3CheckoutItems: "print2CheckoutItems",
+      print3Prompt: "print2Prompt",
+      print3Images: "print2Images",
+      print3Saved: "print2Saved",
+      print3CommunityOpen: "print2CommunityOpen",
+      print3CommunityState: "print2CommunityState",
+    };
+    for (const [oldKey, newKey] of Object.entries(map)) {
+      const val = localStorage.getItem(oldKey);
+      if (val !== null && localStorage.getItem(newKey) === null) {
+        localStorage.setItem(newKey, val);
+        localStorage.removeItem(oldKey);
+      }
+    }
+  } catch {
+    // ignore
+  }
+})();
+
+const API_BASE = (window.API_ORIGIN || "") + "/api";
 
 async function captureSnapshot(glbUrl) {
   if (!glbUrl) return null;
@@ -29,7 +64,7 @@ async function captureSnapshot(glbUrl) {
 async function shareOn(
   network,
   link = "https://print2.io",
-  textMsg = "Check out print3!",
+  textMsg = "Check out print2!",
 ) {
   const shareLink = link;
   const url = encodeURIComponent(shareLink);
@@ -68,7 +103,7 @@ async function shareOn(
   }
   const modelUrl =
     typeof localStorage !== "undefined"
-      ? localStorage.getItem("print3Model")
+      ? localStorage.getItem("print2Model")
       : null;
   if (navigator.share && modelUrl) {
     try {
@@ -77,7 +112,7 @@ async function shareOn(
       const blob = await response.blob();
       const file = new File([blob], "model.png", { type: "image/png" });
       await navigator.share({
-        title: "print3 model",
+        title: "print2 model",
         text: textMsg,
         url: shareLink,
         files: [file],

--- a/js/subredditLanding.js
+++ b/js/subredditLanding.js
@@ -1,3 +1,37 @@
+(() => {
+  try {
+    const map = {
+      print3Basket: "print2Basket",
+      print3Model: "print2Model",
+      print3JobId: "print2JobId",
+      print3Material: "print2Material",
+      print3Color: "print2Color",
+      print3EtchName: "print2EtchName",
+      print3Email: "print2Email",
+      print3ShipName: "print2ShipName",
+      print3ShipAddress: "print2ShipAddress",
+      print3ShipCity: "print2ShipCity",
+      print3ShipZip: "print2ShipZip",
+      print3DiscountCode: "print2DiscountCode",
+      print3CheckoutItems: "print2CheckoutItems",
+      print3Prompt: "print2Prompt",
+      print3Images: "print2Images",
+      print3Saved: "print2Saved",
+      print3CommunityOpen: "print2CommunityOpen",
+      print3CommunityState: "print2CommunityState",
+    };
+    for (const [oldKey, newKey] of Object.entries(map)) {
+      const val = localStorage.getItem(oldKey);
+      if (val !== null && localStorage.getItem(newKey) === null) {
+        localStorage.setItem(newKey, val);
+        localStorage.removeItem(oldKey);
+      }
+    }
+  } catch {
+    // ignore
+  }
+})();
+
 const API_BASE = (window.API_ORIGIN || "") + "/api";
 
 function getParam(name) {
@@ -26,8 +60,8 @@ window.addEventListener("DOMContentLoaded", async () => {
   const entry = await fetchSubredditInfo(sr);
   if (entry && viewer) {
     viewer.src = entry.glb;
-    localStorage.setItem("print3Model", entry.glb);
-    localStorage.removeItem("print3JobId");
+    localStorage.setItem("print2Model", entry.glb);
+    localStorage.removeItem("print2JobId");
   }
 
   if (quoteEl) {


### PR DESCRIPTION
## Summary
- rename `print3` localStorage keys and identifiers to `print2`
- add startup migration to move old `print3` keys to new `print2` ones
- update share messaging to reference print2

## Testing
- `npm run format`
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: diagnostic stripe validate, detailedLint)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: ESLint parsing errors)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: TypeScript compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_688e482d7e0c832d95c4d6ad262095a6