### PR TITLE
refactor: rename print3 references to print2

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -1707,7 +1707,7 @@ app.get("/shared/:slug", async (req, res) => {
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta property="og:title" content="print3 shared model" />
+    <meta property="og:title" content="print2 shared model" />
     <meta property="og:description" content="${prompt.replace(/"/g, "&quot;")}" />
     <meta property="og:image" content="${ogImage}" />
     <meta property="og:url" content="${req.protocol}://${req.get("host")}/shared/${share.slug}" />
@@ -1738,7 +1738,7 @@ app.get("/community/model/:id", async (req, res) => {
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta property="og:title" content="print3 community model" />
+    <meta property="og:title" content="print2 community model" />
     <meta property="og:description" content="${prompt.replace(/"/g, "&quot;")}" />
     <meta property="og:image" content="${ogImage}" />
     <meta property="og:url" content="${req.protocol}://${req.get("host")}/community/model/${req.params.id}" />
@@ -1769,7 +1769,7 @@ app.get("/item/:id", async (req, res) => {
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta property="og:title" content="print3 model" />
+    <meta property="og:title" content="print2 model" />
     <meta property="og:description" content="${prompt.replace(/"/g, "&quot;")}" />
     <meta property="og:image" content="${ogImage}" />
     <meta property="og:url" content="${req.protocol}://${req.get("host")}/item/${req.params.id}" />

--- a/backend/subreddit_models.json
+++ b/backend/subreddit_models.json
@@ -7,22 +7,22 @@
   "art": {
     "subreddit": "art",
     "glb": "models/reddit_art.glb",
-    "quote": "Create artistic masterpieces<br />with print3!"
+    "quote": "Create artistic masterpieces<br />with print2!"
   },
   "3dprinting": {
     "subreddit": "3dprinting",
     "glb": "models/reddit_3dprinting.glb",
-    "quote": "Turn your CAD files into reality<br />with print3!"
+    "quote": "Turn your CAD files into reality<br />with print2!"
   },
   "gamedev": {
     "subreddit": "gamedev",
     "glb": "models/reddit_gamedev.glb",
-    "quote": "Bring your game ideas to life<br />with print3!"
+    "quote": "Bring your game ideas to life<br />with print2!"
   },
   "mechanicalkeyboards": {
     "subreddit": "mechanicalkeyboards",
     "glb": "models/reddit_mk.glb",
-    "quote": "Craft custom keyboard parts<br />using print3!"
+    "quote": "Craft custom keyboard parts<br />using print2!"
   },
   "magic": {
     "subreddit": "magic",

--- a/backend/tests/frontend/quantityDefault.test.js
+++ b/backend/tests/frontend/quantityDefault.test.js
@@ -37,7 +37,7 @@ function loadDom() {
 test("single item defaults quantity to 2", async () => {
   const dom = loadDom();
   dom.window.localStorage.setItem(
-    "print3Basket",
+    "print2Basket",
     JSON.stringify([{ modelUrl: "m", jobId: "j" }]),
   );
   dom.window.document.dispatchEvent(new dom.window.Event("DOMContentLoaded"));

--- a/deploy/helm/print2/Chart.yaml
+++ b/deploy/helm/print2/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: print2
+version: 0.1.0
+appVersion: "1.0"
+description: Helm chart for the Print2 service

--- a/deploy/helm/print2/templates/_helpers.tpl
+++ b/deploy/helm/print2/templates/_helpers.tpl
@@ -1,0 +1,7 @@
+{{- define "print2.name" -}}
+{{ .Chart.Name }}
+{{- end -}}
+
+{{- define "print2.fullname" -}}
+{{ include "print2.name" . }}
+{{- end -}}

--- a/deploy/helm/print2/templates/deployment.yaml
+++ b/deploy/helm/print2/templates/deployment.yaml
@@ -1,18 +1,18 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "print3.fullname" . }}
+  name: {{ include "print2.fullname" . }}
   labels:
-    app: {{ include "print3.name" . }}
+    app: {{ include "print2.name" . }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: {{ include "print3.name" . }}
+      app: {{ include "print2.name" . }}
   template:
     metadata:
       labels:
-        app: {{ include "print3.name" . }}
+        app: {{ include "print2.name" . }}
     spec:
       containers:
         - name: {{ .Chart.Name }}

--- a/deploy/helm/print2/values.yaml
+++ b/deploy/helm/print2/values.yaml
@@ -1,9 +1,9 @@
 image:
-  repository: ghcr.io/print3/print3
+  repository: ghcr.io/print2/print2
   tag: "latest"
 
 db:
-  url: "postgres://user:pass@db:5432/print3"
+  url: "postgres://user:pass@db:5432/print2"
 
 stripe:
   publishableKey: "pk_test"

--- a/deploy/helm/print3/Chart.yaml
+++ b/deploy/helm/print3/Chart.yaml
@@ -1,5 +1,0 @@
-apiVersion: v2
-name: print3
-version: 0.1.0
-appVersion: "1.0"
-description: Helm chart for the Print3 service

--- a/deploy/helm/print3/templates/_helpers.tpl
+++ b/deploy/helm/print3/templates/_helpers.tpl
@@ -1,7 +1,0 @@
-{{- define "print3.name" -}}
-{{ .Chart.Name }}
-{{- end -}}
-
-{{- define "print3.fullname" -}}
-{{ include "print3.name" . }}
-{{- end -}}

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,11 +1,11 @@
 # Deploying with Helm
 
-This project includes a Helm chart under `deploy/helm/print3`. Tagged releases (`v*.*.*`) package the chart and upload it as a release asset.
+This project includes a Helm chart under `deploy/helm/print2`. Tagged releases (`v*.*.*`) package the chart and upload it as a release asset.
 
 Download the package from the release page and install it with:
 
 ```bash
-helm install my-print3 print3-0.1.0.tgz \
+helm install my-print2 print2-0.1.0.tgz \
   --set image.tag=<version> \
   --set db.url=<database-url> \
   --set stripe.publishableKey=<key> \

--- a/js/payment.js
+++ b/js/payment.js
@@ -1044,10 +1044,10 @@ async function initPaymentPage() {
     checkoutItems.splice(idx, 1);
     saveCheckoutItems();
     try {
-      const basket = JSON.parse(localStorage.getItem("print3Basket")) || [];
+      const basket = JSON.parse(localStorage.getItem("print2Basket")) || [];
       if (idx >= 0 && idx < basket.length) {
         basket.splice(idx, 1);
-        localStorage.setItem("print3Basket", JSON.stringify(basket));
+        localStorage.setItem("print2Basket", JSON.stringify(basket));
       }
     } catch {}
     if (checkoutItems.length) {
@@ -1209,7 +1209,7 @@ async function initPaymentPage() {
   // opened directly and the stored list is stale.
   if (!window.location.pathname.endsWith("luckybox-payment.html")) {
     try {
-      const basket = JSON.parse(localStorage.getItem("print3Basket")) || [];
+      const basket = JSON.parse(localStorage.getItem("print2Basket")) || [];
       if (
         basket.length &&
         (basket.length !== checkoutItems.length ||


### PR DESCRIPTION
## Summary
- rename Helm chart to `print2` and update image and database references
- adjust backend strings and tests from `print3` to `print2`
- update documentation and supporting scripts for `print2`

## Testing
- `npm run format` (backend)
- `npm test` *(fails: missing Stripe credentials and eslint parsing errors)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: eslint parsing errors)*
- `SKIP_PW_DEPS=1 npm run smoke` *(TypeScript errors during build)*

------
https://chatgpt.com/codex/tasks/task_e_688e482cc66c832d94042b58fb324457