### PR TITLE
fix: remove individual names from payment pages

### DIFF
--- a/luckybox-payment.html
+++ b/luckybox-payment.html
@@ -657,7 +657,7 @@
           <p>
             Due to incredibly high demand, delivery will take ~3 days.<br />
             Please allow for this. –
-            <span class="text-white">The print2 team: Jia and Matthew</span>
+            <span class="text-white">The print2 team</span>
           </p>
         </div>
       </div>

--- a/minis-checkout.html
+++ b/minis-checkout.html
@@ -658,7 +658,7 @@
           <p>
             Due to incredibly high demand, delivery will take ~3 days.<br />
             Please allow for this. –
-            <span class="text-white">The print2 team: Jia and Matthew</span>
+            <span class="text-white">The print2 team</span>
           </p>
         </div>
       </div>

--- a/payment.html
+++ b/payment.html
@@ -640,7 +640,7 @@
           <p>
             Due to incredibly high demand, delivery will take ~3 days.<br />
             Please allow for this. –
-            <span class="text-white">The print2 team: Jia and Matthew</span>
+            <span class="text-white">The print2 team</span>
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- omit individual team member names so the payments pages sign off as "The print2 team"

## Testing
- `npm run format`
- `npm run format` (backend)
- `npm test` (failed: diagnostic stripe validate and lint diagnostics)
- `SKIP_PW_DEPS=1 npm run ci` (failed: ESLint parsing errors)
- `SKIP_PW_DEPS=1 npm run smoke` (failed: TypeScript errors in backend routes)


------
https://chatgpt.com/codex/tasks/task_e_68936147f7f0832daf3a3335bb5aaed4