### PR TITLE
test: guard critical frontend elements

### DIFF
--- a/tests/frontendElementPresence.test.js
+++ b/tests/frontendElementPresence.test.js
@@ -1,0 +1,26 @@
+const fs = require("fs");
+const path = require("path");
+
+describe("frontend HTML integrity", () => {
+  const repoRoot = path.join(__dirname, "..");
+
+  function load(file) {
+    return fs.readFileSync(path.join(repoRoot, file), "utf8");
+  }
+
+  test("index.html retains critical elements", () => {
+    const html = load("index.html");
+    expect(html).toMatch(/id="purchase-popups"/);
+    expect(html).toMatch(
+      /<script type="module" src="js\/index.js" defer><\/script>/,
+    );
+    expect(html).toMatch(/id="printclub-modal"/);
+  });
+
+  test("generate.html retains generator root", () => {
+    const html = load("generate.html");
+    expect(html).toMatch(/id="gen-app"/);
+    expect(html).toMatch(/js\/modelGenerator.js/);
+    expect(html).toMatch(/js\/trackingPixel.js/);
+  });
+});


### PR DESCRIPTION
## Summary
- add regression tests to ensure important sections stay in `index.html` and `generate.html`

## Testing
- `npm run format`
- `node scripts/run-jest.js tests/frontendElementPresence.test.js`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: parsing error in scripts and test files)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: TypeScript errors in backend stripe routes)*

------
https://chatgpt.com/codex/tasks/task_e_68971af35b50832d82eb8b258ed5064f