### PR TITLE
test: add frontend element presence checks

### DIFF
--- a/tests/frontend-elements.test.js
+++ b/tests/frontend-elements.test.js
@@ -1,0 +1,43 @@
+const fs = require("fs");
+const path = require("path");
+const { JSDOM } = require("jsdom");
+
+describe("frontend key elements", () => {
+  const load = (file) => {
+    const filePath = path.join(__dirname, "..", file);
+    const html = fs.readFileSync(filePath, "utf8");
+    return new JSDOM(html).window.document;
+  };
+
+  describe("index.html", () => {
+    let document;
+    beforeAll(() => {
+      document = load("index.html");
+    });
+
+    test("navigation links are present", () => {
+      expect(
+        document.querySelector('a[href="competitions.html"]'),
+      ).not.toBeNull();
+      expect(document.getElementById("addons-link")).not.toBeNull();
+      expect(document.getElementById("profile-link")).not.toBeNull();
+    });
+
+    test("stats ticker exists", () => {
+      expect(document.getElementById("stats-ticker")).not.toBeNull();
+    });
+  });
+
+  describe("login.html", () => {
+    let document;
+    beforeAll(() => {
+      document = load("login.html");
+    });
+
+    test("header links remain", () => {
+      expect(document.getElementById("back-link")).not.toBeNull();
+      expect(document.getElementById("earn-rewards-badge")).not.toBeNull();
+      expect(document.getElementById("print-club-badge")).not.toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest tests ensuring critical navigation and badge elements remain on index and login pages

## Testing
- `npm run format`
- `npm run format --prefix backend`
- `npm test` *(fails: diagnostic stripe validate, linting diagnostics)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: parsing errors in scripts)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: TypeScript errors in stripe routes)*


------
https://chatgpt.com/codex/tasks/task_e_68971af35b50832d82eb8b258ed5064f