### PR TITLE
fix: use CloudFront domain for checkout link

### DIFF
--- a/backend/src/routes/checkout.js
+++ b/backend/src/routes/checkout.js
@@ -62,7 +62,9 @@ router.post(
         const order = exports.orders.get(session.id);
         if (order && !order.paid) {
           order.paid = true;
-          const link = `https://huggingface.co/spaces/print2/Sparc3D/resolve/main/output/${order.slug}.glb`;
+          const link = process.env.CLOUDFRONT_MODEL_DOMAIN
+            ? `https://${process.env.CLOUDFRONT_MODEL_DOMAIN}/${order.slug}.glb`
+            : order.slug;
           await (0, mail_1.sendMail)(order.email, "Your model is ready", link);
         }
       }

--- a/backend/src/routes/checkout.ts
+++ b/backend/src/routes/checkout.ts
@@ -4,6 +4,7 @@ import { PRODUCT } from "../pricing";
 import { sendMail } from "../../mail";
 
 export interface Order {
+  /** S3 object key (without `.glb`) returned from `storeGlb` */
   slug: string;
   email: string;
   paid?: boolean;
@@ -68,7 +69,9 @@ router.post(
         const order = orders.get(session.id);
         if (order && !order.paid) {
           order.paid = true;
-          const link = `https://huggingface.co/spaces/print2/Sparc3D/resolve/main/output/${order.slug}.glb`;
+          const link = process.env.CLOUDFRONT_MODEL_DOMAIN
+            ? `https://${process.env.CLOUDFRONT_MODEL_DOMAIN}/${order.slug}.glb`
+            : order.slug;
           await sendMail(order.email, "Your model is ready", link);
         }
       }


### PR DESCRIPTION
## Summary
- send CloudFront model URL in checkout emails instead of hard-coded HuggingFace link
- document that order slug corresponds to storeGlb object key

## Testing
- `npm run format` *(passing)*
- `npm test` *(fails: diagnostic stripe validate, linting)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: ESLint parsing errors)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: TypeScript build errors)*

------
https://chatgpt.com/codex/tasks/task_e_689e324abfdc832da1dd0650bfab3a11