### PR TITLE
chore: add AWS region to env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,7 @@ SPARC3D_TOKEN=your-token-here
 HF_TOKEN=your-huggingface-token
 HF_API_KEY=${HF_TOKEN}
 STABILITY_KEY=your-stability-key-here
+AWS_REGION=us-east-1
 AWS_ACCESS_KEY_ID=your-aws-access-key-id
 AWS_SECRET_ACCESS_KEY=your-aws-secret-access-key
 S3_BUCKET=your-s3-bucket


### PR DESCRIPTION
## Summary
- add AWS_REGION placeholder to `.env.example`

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Parsing error: Unexpected token :)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: TypeScript errors in stripe routes)*

------
https://chatgpt.com/codex/tasks/task_e_689e31aed4d8832d8eedb805dcc8dec9