### PR TITLE
fix: update stripe integration with strict types

### DIFF
--- a/backend/src/routes/checkout.ts
+++ b/backend/src/routes/checkout.ts
@@ -1,4 +1,8 @@
-import express from "express";
+import express, {
+  type NextFunction,
+  type Request,
+  type Response,
+} from "express";
 import Stripe from "stripe";
 import { PRODUCT } from "../pricing";
 import { sendMail } from "../../mail";
@@ -13,24 +17,26 @@ export interface Order {
 export const orders = new Map<string, Order>();
 
 const secretKey =
-  process.env.NODE_ENV === "production"
-    ? process.env.STRIPE_LIVE_KEY || process.env.STRIPE_SECRET_KEY
-    : process.env.STRIPE_TEST_KEY || process.env.STRIPE_SECRET_KEY;
+  process.env["NODE_ENV"] === "production"
+    ? process.env["STRIPE_LIVE_KEY"] || process.env["STRIPE_SECRET_KEY"]
+    : process.env["STRIPE_TEST_KEY"] || process.env["STRIPE_SECRET_KEY"];
 if (!secretKey) {
   throw new Error("Stripe key not configured");
 }
-const stripe = new Stripe(secretKey);
+const stripe = new Stripe(secretKey, { apiVersion: "2025-06-30.basil" });
 
 const router = express.Router();
 (router as any).orders = orders;
 
-router.post("/api/checkout", async (req, res, next) => {
+router.post(
+  "/api/checkout",
+  async (req: Request, res: Response, next: NextFunction) => {
   try {
     const { slug, email } = req.body as Order;
     if (!slug || !email) {
       return res.status(400).json({ error: "missing fields" });
     }
-    const session = await stripe.checkout.sessions.create({
+    const sessionParams: Stripe.Checkout.SessionCreateParams = {
       mode: "payment",
       line_items: [
         {
@@ -45,7 +51,8 @@ router.post("/api/checkout", async (req, res, next) => {
       metadata: { slug, email },
       success_url: `${req.headers.origin}/success?session_id={CHECKOUT_SESSION_ID}`,
       cancel_url: `${req.headers.origin}/cancel`,
-    });
+    };
+    const session = await stripe.checkout.sessions.create(sessionParams);
     orders.set(session.id, { slug, email, paid: false });
     res.json({ checkoutUrl: session.url });
   } catch (err) {
@@ -56,21 +63,22 @@ router.post("/api/checkout", async (req, res, next) => {
 router.post(
   "/api/stripe/webhook",
   express.raw({ type: "application/json" }),
-  async (req, res, next) => {
+  async (req: Request, res: Response, next: NextFunction) => {
     try {
       const sig = req.headers["stripe-signature"] as string;
       const event = stripe.webhooks.constructEvent(
         req.body,
         sig,
-        process.env.STRIPE_WEBHOOK_SECRET || "",
+        process.env["STRIPE_WEBHOOK_SECRET"] || "",
       );
       if (event.type === "checkout.session.completed") {
         const session = event.data.object as Stripe.Checkout.Session;
         const order = orders.get(session.id);
         if (order && !order.paid) {
           order.paid = true;
-          const link = process.env.CLOUDFRONT_MODEL_DOMAIN
-            ? `https://${process.env.CLOUDFRONT_MODEL_DOMAIN}/${order.slug}.glb`
+          const domain = process.env["CLOUDFRONT_MODEL_DOMAIN"];
+          const link = domain
+            ? `https://${domain}/${order.slug}.glb`
             : order.slug;
           await sendMail(order.email, "Your model is ready", link);
         }

--- a/backend/src/routes/stripe/create-checkout-session.ts
+++ b/backend/src/routes/stripe/create-checkout-session.ts
@@ -1,13 +1,15 @@
-import { Router } from "express";
+import { Router, type NextFunction, type Request, type Response } from "express";
 import Stripe from "stripe";
 import db from "../../db";
 
 const router = Router();
-const stripe = new Stripe(process.env.STRIPE_KEY as string, {
-  apiVersion: "2022-11-15",
+const stripe = new Stripe(process.env["STRIPE_KEY"] as string, {
+  apiVersion: "2025-06-30.basil",
 });
 
-router.post("/api/create-checkout-session", async (req, res, next) => {
+router.post(
+  "/api/create-checkout-session",
+  async (req: Request, res: Response, next: NextFunction) => {
   try {
     const { price, qty = 1, metadata = {}, userId } = req.body;
 
@@ -23,7 +25,7 @@ router.post("/api/create-checkout-session", async (req, res, next) => {
       }
     }
 
-    const sessionParams = {
+    const sessionParams: Stripe.Checkout.SessionCreateParams = {
       mode: "payment",
       payment_method_types: ["card"],
       line_items: [

--- a/backend/src/routes/stripe/webhook.ts
+++ b/backend/src/routes/stripe/webhook.ts
@@ -1,24 +1,29 @@
-import express, { Router } from "express";
+import express, {
+  Router,
+  type NextFunction,
+  type Request,
+  type Response,
+} from "express";
 import Stripe from "stripe";
 import db from "../../db";
 import { enqueuePrint } from "../../queue/printQueue";
 import { enqueuePrint as enqueueDbPrint } from "../../queue/dbPrintQueue";
 
 const router = Router();
-const stripe = new Stripe(process.env.STRIPE_KEY as string, {
-  apiVersion: "2022-11-15",
+const stripe = new Stripe(process.env["STRIPE_KEY"] as string, {
+  apiVersion: "2025-06-30.basil",
 });
 
 router.post(
   "/api/webhook/stripe",
   express.raw({ type: "application/json" }),
-  async (req, res, next) => {
+  async (req: Request, res: Response, next: NextFunction) => {
     try {
       const sig = req.headers["stripe-signature"] as string;
       const event = stripe.webhooks.constructEvent(
         req.body,
         sig,
-        process.env.STRIPE_WEBHOOK_SECRET as string,
+        process.env["STRIPE_WEBHOOK_SECRET"] as string,
       );
       if (event.type === "checkout.session.completed") {
         const session = event.data.object as Stripe.Checkout.Session;
@@ -26,15 +31,10 @@ router.post(
           "paid",
           session.id,
         ]);
-        if (session.metadata?.jobId) {
-          await enqueueDbPrint(
-            session.metadata.jobId,
-            session.id,
-            {},
-            null,
-            null,
-          );
-          enqueuePrint(session.metadata.jobId);
+        const jobId = session.metadata?.jobId;
+        if (jobId) {
+          await enqueueDbPrint(jobId, session.id, {}, null, null);
+          enqueuePrint(jobId);
         }
       }
       res.sendStatus(200);

--- a/backend/tests/diagnostic-stripe-validate-2fb39dcee74.test.ts
+++ b/backend/tests/diagnostic-stripe-validate-2fb39dcee74.test.ts
@@ -27,7 +27,7 @@ const skip = process.env.CI && (secretPlaceholder || webhookPlaceholder);
   });
 
   test("stripe client boots and lists customers", async () => {
-    const stripe = new Stripe(secret, { apiVersion: "2024-08-16" });
+    const stripe = new Stripe(secret, { apiVersion: "2025-06-30.basil" });
     const list = await stripe.customers.list({ limit: 1 });
     expect(Array.isArray(list.data)).toBe(true);
   });

--- a/backend/tests/full_pipeline_e2e_7a4d9c.test.ts
+++ b/backend/tests/full_pipeline_e2e_7a4d9c.test.ts
@@ -46,7 +46,7 @@ describe("full pipeline e2e", () => {
     expect(head.$metadata.httpStatusCode).toBe(200);
 
     const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, {
-      apiVersion: "2022-11-15",
+      apiVersion: "2025-06-30.basil",
     });
     const balance = await stripe.balance.retrieve();
     expect(balance.object).toBe("balance");

--- a/scripts/test-webhook.js
+++ b/scripts/test-webhook.js
@@ -7,7 +7,9 @@ const { orders } = require("../backend/src/routes/checkout");
   const port = 4001;
   process.env.STRIPE_WEBHOOK_SECRET =
     process.env.STRIPE_WEBHOOK_SECRET || "whsec_test";
-  const stripe = new Stripe("sk_test_dummy");
+  const stripe = new Stripe("sk_test_dummy", {
+    apiVersion: "2025-06-30.basil",
+  });
   const { url, close } = await startServer(port);
   const sessionId = `sess_${Date.now()}`;
   orders.set(sessionId, {

--- a/tests/diagnostic-stripe-types.test.ts
+++ b/tests/diagnostic-stripe-types.test.ts
@@ -1,0 +1,33 @@
+const ts = require("typescript");
+const path = require("path");
+
+function typecheck(file) {
+  const configPath = path.join(__dirname, "../backend/tsconfig.json");
+  const config = ts.readConfigFile(configPath, ts.sys.readFile);
+  const parsed = ts.parseJsonConfigFileContent(
+    config.config,
+    ts.sys,
+    path.dirname(configPath),
+  );
+  const baseFiles = [path.join(__dirname, "../backend/global.d.ts")];
+  const program = ts.createProgram([...baseFiles, file], {
+    ...parsed.options,
+    noEmit: true,
+  });
+  const diagnostics = ts.getPreEmitDiagnostics(program);
+  expect(diagnostics).toEqual([]);
+}
+
+describe("diagnostic stripe types", () => {
+  test("routes compile", () => {
+    typecheck(
+      path.join(
+        __dirname,
+        "../backend/src/routes/stripe/create-checkout-session.ts",
+      ),
+    );
+    typecheck(
+      path.join(__dirname, "../backend/src/routes/stripe/webhook.ts"),
+    );
+  });
+});

--- a/tests/full/pipeline_component_diagnostics_09df71.test.js
+++ b/tests/full/pipeline_component_diagnostics_09df71.test.js
@@ -90,7 +90,9 @@ describe("Stripe charge", () => {
   });
 
   test("creates charge successfully", async () => {
-    const stripe = new Stripe("sk_test");
+    const stripe = new Stripe("sk_test", {
+      apiVersion: "2025-06-30.basil",
+    });
     const res = await stripe.charges.create({
       amount: 100,
       currency: "usd",

--- a/tests/full/pipeline_component_diagnostics_0e088e.test.js
+++ b/tests/full/pipeline_component_diagnostics_0e088e.test.js
@@ -91,7 +91,9 @@ describe("Stripe charge", () => {
   });
 
   test("creates charge successfully", async () => {
-    const stripe = new Stripe("sk_test");
+    const stripe = new Stripe("sk_test", {
+      apiVersion: "2025-06-30.basil",
+    });
     const res = await stripe.charges.create({
       amount: 100,
       currency: "usd",


### PR DESCRIPTION
## Summary
- update Stripe routes to latest API version and typed SessionCreateParams
- add diagnostic test to typecheck Stripe route handlers

## Testing
- `npm run format --prefix backend`
- `CI=1 npm test --prefix backend` *(fails: lintingDetailed.test.js and missing Stripe keys)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: eslint parsing errors in scripts)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68a495a764e8832d89b53f85c787a166