### PR TITLE
test: add diagnostics for Cloudflare config

### DIFF
--- a/scripts/auto-cloudflare-config.ts
+++ b/scripts/auto-cloudflare-config.ts
@@ -43,7 +43,6 @@ function randomString(len: number): string {
     .slice(0, len);
 }
 
-
 function readConfig(file: string): Record<string, unknown> {
   if (!fs.existsSync(file)) return {};
   const txt = fs.readFileSync(file, "utf8");
@@ -57,7 +56,7 @@ function writeConfig(file: string, data: Record<string, unknown>): void {
   else fs.writeFileSync(file, yaml.stringify(data));
 }
 
-const cfg: Record<string, any> = readConfig(configFile);
+const cfg: Record<string, any> = readConfig(configFile) || {};
 if (!cfg.buildCommand) {
   const fw = detectFramework();
   if (fw) {
@@ -70,3 +69,63 @@ writeConfig(configFile, cfg);
 const tsName = `cloudflare-pages-config-${randomString(15)}.ts`;
 fs.writeFileSync(tsName, `export default ${JSON.stringify(cfg, null, 2)};\n`);
 console.log(`Updated ${configFile} and generated ${tsName}`);
+
+export function validateEnv(): void {
+  const required: Record<string, string | undefined> = {
+    CLOUDFLARE_API_TOKEN: process.env.CLOUDFLARE_API_TOKEN,
+    CLOUDFLARE_ZONE_ID: process.env.CLOUDFLARE_ZONE_ID,
+    CLOUDFLARE_ACCOUNT_ID: process.env.CLOUDFLARE_ACCOUNT_ID,
+  };
+  for (const [key, value] of Object.entries(required)) {
+    if (!value || /^(?:<.*>|your_|example)/i.test(value)) {
+      throw new Error(`Missing ${key} – did you forget to set it?`);
+    }
+  }
+}
+
+type DnsRecord = {
+  type: string;
+  name: string;
+  content: string;
+};
+
+export async function updateDnsRecord(
+  record: DnsRecord,
+  { dryRun = false }: { dryRun?: boolean } = {},
+): Promise<void> {
+  validateEnv();
+  const zone = process.env.CLOUDFLARE_ZONE_ID!;
+  const token = process.env.CLOUDFLARE_API_TOKEN!;
+  const base = `https://api.cloudflare.com/client/v4/zones/${zone}/dns_records`;
+  const headers = {
+    Authorization: `Bearer ${token}`,
+    "Content-Type": "application/json",
+  };
+  if (dryRun) {
+    console.log(`[dry-run] upsert DNS record ${record.name}`);
+    return;
+  }
+  const res = await fetch(base, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(record),
+  });
+  if (!res.ok) {
+    let message = "request failed";
+    try {
+      const data = await res.json();
+      message =
+        data?.errors?.[0]?.message ||
+        (res.status === 401
+          ? "invalid api token"
+          : res.status === 403
+            ? "permission denied"
+            : res.status === 404
+              ? "zone not found"
+              : message);
+    } catch {
+      message = res.statusText || message;
+    }
+    throw new Error(message);
+  }
+}

--- a/tests/diagnostic_auto_cloudflare_integration_9b1c7d3e5f.test.ts
+++ b/tests/diagnostic_auto_cloudflare_integration_9b1c7d3e5f.test.ts
@@ -1,0 +1,126 @@
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+const mockFs = {
+  readFileSync: jest.fn(() => "{}"),
+  writeFileSync: jest.fn(),
+  existsSync: jest.fn(() => false),
+};
+jest.mock("fs", () => mockFs);
+
+process.argv = ["node", "test", "cfg.json"];
+const {
+  updateDnsRecord,
+  validateEnv,
+} = require("../scripts/auto-cloudflare-config.ts");
+
+describe("cloudflare configuration diagnostics", () => {
+  describe("environment variables", () => {
+    test("throws when required variables are missing", () => {
+      delete process.env.CLOUDFLARE_API_TOKEN;
+      delete process.env.CLOUDFLARE_ZONE_ID;
+      delete process.env.CLOUDFLARE_ACCOUNT_ID;
+      expect(() => validateEnv()).toThrow(
+        "Missing CLOUDFLARE_API_TOKEN – did you forget to set it?",
+      );
+    });
+
+    test("throws on placeholder values", () => {
+      process.env.CLOUDFLARE_API_TOKEN = "<token>";
+      process.env.CLOUDFLARE_ZONE_ID = "your_zone";
+      process.env.CLOUDFLARE_ACCOUNT_ID = "example";
+      expect(() => validateEnv()).toThrow(
+        "Missing CLOUDFLARE_API_TOKEN – did you forget to set it?",
+      );
+    });
+
+    test("passes when variables are set", () => {
+      process.env.CLOUDFLARE_API_TOKEN = "token";
+      process.env.CLOUDFLARE_ZONE_ID = "zone";
+      process.env.CLOUDFLARE_ACCOUNT_ID = "acct";
+      expect(() => validateEnv()).not.toThrow();
+    });
+  });
+
+  test("dry-run DNS update uses no network", async () => {
+    process.env.CLOUDFLARE_API_TOKEN = "token";
+    process.env.CLOUDFLARE_ZONE_ID = "zone";
+    process.env.CLOUDFLARE_ACCOUNT_ID = "acct";
+    const originalFetch = global.fetch;
+    const fetchMock = jest.fn();
+    global.fetch = fetchMock;
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    await updateDnsRecord(
+      { type: "A", name: "example.com", content: "1.2.3.4" },
+      { dryRun: true },
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(logSpy.mock.calls.some((c) => c[0].includes("[dry-run]"))).toBe(
+      true,
+    );
+    logSpy.mockRestore();
+    global.fetch = originalFetch;
+  });
+
+  describe("error handling", () => {
+    async function expectError(status, message) {
+      process.env.CLOUDFLARE_API_TOKEN = "token";
+      process.env.CLOUDFLARE_ZONE_ID = "zone";
+      process.env.CLOUDFLARE_ACCOUNT_ID = "acct";
+      global.fetch = jest
+        .fn()
+        .mockResolvedValue({
+          ok: false,
+          status,
+          json: async () => ({ errors: [{ message }] }),
+        });
+      await expect(
+        updateDnsRecord({ type: "A", name: "foo", content: "1.1.1.1" }),
+      ).rejects.toThrow(message);
+    }
+
+    test("invalid API token", async () => {
+      await expectError(401, "invalid api token");
+    });
+
+    test("zone not found", async () => {
+      await expectError(404, "zone not found");
+    });
+
+    test("permission denied", async () => {
+      await expectError(403, "permission denied");
+    });
+  });
+
+  test("ESLint passes with no warnings", () => {
+    const repoRoot = path.join(__dirname, "..");
+    const child = `
+      const { ESLint } = require('eslint');
+      (async () => {
+        const eslint = new ESLint({ cwd: ${JSON.stringify(repoRoot)} });
+        const results = await eslint.lintFiles(['scripts/auto-cloudflare-config.ts']);
+        process.stdout.write(JSON.stringify(results));
+      })().catch(err => { console.error(err); process.exit(1); });
+    `;
+    const proc = spawnSync(
+      process.execPath,
+      ["--experimental-vm-modules", "--eval", child],
+      { cwd: repoRoot, encoding: "utf8" },
+    );
+    if (proc.status !== 0) {
+      console.error(proc.stderr);
+    }
+    expect(proc.status).toBe(0);
+    const results = JSON.parse(proc.stdout || "[]");
+    const problems = results.reduce(
+      (sum, r) => sum + r.errorCount + r.warningCount,
+      0,
+    );
+    if (problems !== 0) {
+      const messages = results
+        .flatMap((r) => r.messages.map((m) => m.message))
+        .join("\n");
+      throw new Error(`ESLint reported problems:\n${messages}`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add environment validation and DNS update helpers to auto-cloudflare-config
- create diagnostic tests for Cloudflare config script covering env vars, dry-run, error handling, and linting

## Testing
- `npm run format --prefix backend`
- `SKIP_ROOT_DEPS_CHECK=1 node scripts/run-jest.js tests/diagnostic_auto_cloudflare_integration_9b1c7d3e5f.test.ts scripts/__tests__/auto-cloudflare-config-xvpfhoqbxmsielp.test.ts scripts/__tests__/auto-cloudflare-config-a1b2c3d4e5f6g7h.test.ts scripts/__tests__/auto-cloudflare-config-compile.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a4a501bf70832d8c7e1c89508bf943