### PR TITLE
feat: validate Cloudflare config inputs

### DIFF
--- a/scripts/auto-cloudflare-config.ts
+++ b/scripts/auto-cloudflare-config.ts
@@ -4,11 +4,25 @@ import fs from "fs";
 import yaml from "yaml";
 import crypto from "crypto";
 
-const configFile = process.argv[2] || "cloudflare-pages.config.json";
+const args = process.argv.slice(2);
+const dryRunIndex = args.indexOf("--dry-run");
+const dryRun = dryRunIndex !== -1;
+if (dryRun) args.splice(dryRunIndex, 1);
+const configFile = args[0] || "cloudflare-pages.config.json";
 const pkg: {
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
 } = JSON.parse(fs.readFileSync("package.json", "utf8"));
+
+function ensureRequired(values: Record<string, string | undefined>): void {
+  for (const [key, val] of Object.entries(values)) {
+    if (!val || /YOUR_|REPLACE_ME|^\s*$/.test(val)) {
+      throw new Error(
+        `Missing required ${key}. Set the ${key} environment variable or add a valid value to ${configFile}.`,
+      );
+    }
+  }
+}
 
 function detectFramework(): string | null {
   const deps: Record<string, string> = {
@@ -43,7 +57,6 @@ function randomString(len: number): string {
     .slice(0, len);
 }
 
-
 function readConfig(file: string): Record<string, unknown> {
   if (!fs.existsSync(file)) return {};
   const txt = fs.readFileSync(file, "utf8");
@@ -58,15 +71,22 @@ function writeConfig(file: string, data: Record<string, unknown>): void {
 }
 
 const cfg: Record<string, any> = readConfig(configFile);
+ensureRequired({
+  CF_API_TOKEN: process.env.CF_API_TOKEN || cfg.apiToken,
+  CF_ZONE_ID: process.env.CF_ZONE_ID || cfg.zoneId,
+  CF_ACCOUNT_ID: process.env.CF_ACCOUNT_ID || cfg.accountId,
+});
 if (!cfg.buildCommand) {
   const fw = detectFramework();
   if (fw) {
     cfg.buildCommand = "npm run build";
   }
 }
-
-writeConfig(configFile, cfg);
-
-const tsName = `cloudflare-pages-config-${randomString(15)}.ts`;
-fs.writeFileSync(tsName, `export default ${JSON.stringify(cfg, null, 2)};\n`);
-console.log(`Updated ${configFile} and generated ${tsName}`);
+if (!dryRun) {
+  writeConfig(configFile, cfg);
+  const tsName = `cloudflare-pages-config-${randomString(15)}.ts`;
+  fs.writeFileSync(tsName, `export default ${JSON.stringify(cfg, null, 2)};\n`);
+  console.log(`Updated ${configFile} and generated ${tsName}`);
+} else {
+  console.log(`Validated ${configFile} (dry run)`);
+}

--- a/tests/diagnostic_auto_cloudflare_config_b73e2.test.ts
+++ b/tests/diagnostic_auto_cloudflare_config_b73e2.test.ts
@@ -1,0 +1,44 @@
+import { execFileSync, spawnSync } from "child_process";
+import path from "path";
+import fs from "fs";
+import os from "os";
+
+const script = path.resolve(__dirname, "../scripts/auto-cloudflare-config.ts");
+
+describe("auto-cloudflare-config", () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "cf-config-"));
+  const cfgPath = path.join(tmpDir, "config.json");
+
+  beforeEach(() => {
+    fs.writeFileSync(
+      cfgPath,
+      JSON.stringify({ buildCommand: "echo build" }, null, 2),
+    );
+  });
+
+  it("exits cleanly with valid inputs", () => {
+    expect(() =>
+      execFileSync("npx", ["-y", "ts-node", script, cfgPath, "--dry-run"], {
+        env: {
+          ...process.env,
+          CF_API_TOKEN: "token",
+          CF_ZONE_ID: "zone",
+          CF_ACCOUNT_ID: "account",
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  it("fails with informative error when env vars are missing", () => {
+    const res = spawnSync(
+      "npx",
+      ["-y", "ts-node", script, cfgPath, "--dry-run"],
+      {
+        env: { ...process.env },
+        encoding: "utf-8",
+      },
+    );
+    expect(res.status).not.toBe(0);
+    expect(res.stderr).toMatch(/Missing required/);
+  });
+});


### PR DESCRIPTION
## Summary
- enforce required Cloudflare environment variables and support dry run in `auto-cloudflare-config`
- add diagnostic test covering success and failure paths

## Testing
- `npm run setup` *(fails: Conversion of type 'ReadableStream' to type 'Order'...)*
- `npm run format` in `backend/`
- `npm test` in `backend/` *(fails: Property 'qty' does not exist on type 'ReadableStream'...)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: npm run build)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Command failed: bash scripts/setup-codex-9b08f7c1.sh)*
- `node scripts/run-jest.js tests/diagnostic_auto_cloudflare_config_b73e2.test.ts` *(fails: Missing backend dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a4fb4450832d832d33f2b5a35951