### PR TITLE
test: add build pipeline diagnostics

### DIFF
--- a/tests/ci/build-pipeline-diagnostic-6b7f9e18c3d2a4b1.test.ts
+++ b/tests/ci/build-pipeline-diagnostic-6b7f9e18c3d2a4b1.test.ts
@@ -1,0 +1,39 @@
+import { execSync } from "child_process";
+import { existsSync, rmSync } from "fs";
+import path from "path";
+
+const repoRoot = path.resolve(__dirname, "../..");
+const buildDir = path.join(repoRoot, "backend", "lib");
+const expectedEntry = path.join(buildDir, "pricing.js");
+
+function run(command: string, step: string): void {
+  try {
+    execSync(command, { cwd: repoRoot, stdio: "pipe" });
+  } catch (err: any) {
+    const output = err.stderr?.toString() || err.stdout?.toString() || err.message;
+    throw new Error(`${step} failed:\n${output}`);
+  }
+}
+
+describe("build pipeline diagnostics", () => {
+  test("TypeScript compilation succeeds", () => {
+    run("npx tsc --noEmit", "TypeScript compilation");
+  });
+
+  test("ESLint passes on TypeScript files", () => {
+    run('npx eslint "**/*.{ts,tsx}"', "ESLint");
+  });
+
+  test("build command emits expected artifacts", () => {
+    rmSync(buildDir, { recursive: true, force: true });
+    run("npm run build", "Build");
+    if (!existsSync(buildDir)) {
+      throw new Error(`Build output directory missing: ${path.relative(repoRoot, buildDir)}`);
+    }
+    if (!existsSync(expectedEntry)) {
+      throw new Error(
+        `Expected entry point missing: ${path.relative(repoRoot, expectedEntry)}`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest suite verifying typecheck, lint, build output and artifacts to pinpoint build pipeline failures

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup` *(fails: backend TypeScript errors)*
- `npm run format --prefix backend`
- `node scripts/run-jest.js tests/ci/build-pipeline-diagnostic-6b7f9e18c3d2a4b1.test.ts` *(fails: ESLint and build errors)*
- `npm test --prefix backend` *(fails: build step fails during setup)*


------
https://chatgpt.com/codex/tasks/task_e_68a4a8f512cc832d9643de1487681223