### PR TITLE
fix: enforce real stripe secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,8 @@
 # .env.example
 DB_URL=postgres://user:password@localhost:5432/your_database
-STRIPE_SECRET_KEY=sk_test_...
-STRIPE_PUBLISHABLE_KEY=pk_test_...
-STRIPE_WEBHOOK_SECRET=whsec_...
+STRIPE_SECRET_KEY=
+STRIPE_PUBLISHABLE_KEY=
+STRIPE_WEBHOOK_SECRET=
 DALLE_SERVER_URL=http://localhost:5002
 AUTH_SECRET=your_jwt_secret
 PORT=3000

--- a/backend/config.js
+++ b/backend/config.js
@@ -2,6 +2,11 @@
 
 const { getEnv } = require("./src/lib/getEnv");
 const required = ["DB_URL", "STRIPE_SECRET_KEY", "STRIPE_WEBHOOK_SECRET"];
+const isPlaceholder = (val, ending) =>
+  !val ||
+  val === "your_stripe_key_here" ||
+  val === ending ||
+  val.endsWith(ending);
 const optionalGlb = [
   "CLOUDFRONT_MODEL_DOMAIN",
   "SPARC3D_ENDPOINT",
@@ -17,16 +22,19 @@ if (missingGlb.length) {
   console.warn(`Missing optional GLB env vars: ${missingGlb.join(", ")}`);
 }
 
+const stripeKey = getEnv("STRIPE_SECRET_KEY");
+if (isPlaceholder(stripeKey, "sk_test")) {
+  throw new Error("STRIPE_SECRET_KEY must be a live secret key");
+}
+const stripeWebhook = getEnv("STRIPE_WEBHOOK_SECRET");
+if (isPlaceholder(stripeWebhook, "whsec")) {
+  throw new Error("STRIPE_WEBHOOK_SECRET must be a live webhook secret");
+}
+
 module.exports = {
   dbUrl: getEnv("DB_URL"),
-  stripeKey: getEnv("STRIPE_SECRET_KEY"),
-  stripeWebhook: (() => {
-    const raw = getEnv("STRIPE_WEBHOOK_SECRET");
-    if (raw && raw.startsWith("whsec_")) {
-      return raw.split("_", 1)[0];
-    }
-    return raw;
-  })(),
+  stripeKey,
+  stripeWebhook,
   stripePublishable: getEnv("STRIPE_PUBLISHABLE_KEY", { default: "" }),
   dalleServerUrl: getEnv("DALLE_SERVER_URL", {
     default: "http://localhost:5002",

--- a/backend/server.js
+++ b/backend/server.js
@@ -10,9 +10,9 @@ if (process.env.NODE_ENV === "test") {
   if (!process.env.S3_BUCKET) {
     process.env.S3_BUCKET = "test-bucket";
   }
-  if (!process.env.STRIPE_WEBHOOK_SECRET) {
-    process.env.STRIPE_WEBHOOK_SECRET = "whsec";
-  }
+}
+if (!process.env.STRIPE_WEBHOOK_SECRET) {
+  throw new Error("STRIPE_WEBHOOK_SECRET must be set");
 }
 const express = require("express");
 const http2 = require("http2");

--- a/backend/tests/setupGlobals.js
+++ b/backend/tests/setupGlobals.js
@@ -62,18 +62,26 @@ if (!process.env.AWS_SECRET_ACCESS_KEY) {
 if (!process.env.DB_URL) {
   process.env.DB_URL = "postgres://user:pass@localhost/db";
 }
-if (!process.env.STRIPE_SECRET_KEY) {
-  process.env.STRIPE_SECRET_KEY = "sk_test";
+const isPlaceholder = (val, ending) =>
+  !val ||
+  val === "your_stripe_key_here" ||
+  val === ending ||
+  val.endsWith(ending);
+const stripeKey = process.env.STRIPE_SECRET_KEY;
+const webhook = process.env.STRIPE_WEBHOOK_SECRET;
+if (isPlaceholder(stripeKey, "sk_test")) {
+  throw new Error("STRIPE_SECRET_KEY must be set to a non-test value");
+}
+if (isPlaceholder(webhook, "whsec")) {
+  throw new Error("STRIPE_WEBHOOK_SECRET must be set to a non-test value");
 }
 if (!process.env.STRIPE_TEST_KEY) {
-  process.env.STRIPE_TEST_KEY = process.env.STRIPE_SECRET_KEY;
+  process.env.STRIPE_TEST_KEY = stripeKey;
 }
 if (!process.env.STRIPE_PUBLISHABLE_KEY) {
-  process.env.STRIPE_PUBLISHABLE_KEY = "pk_test";
+  process.env.STRIPE_PUBLISHABLE_KEY = "pk_live";
 }
-if (!process.env.STRIPE_WEBHOOK_SECRET) {
-  process.env.STRIPE_WEBHOOK_SECRET = "whsec";
-}
+global.__STRIPE_ENV__ = { stripeKey, stripeWebhook: webhook };
 
 // Ensure any proxy environment variables do not interfere with HTTP mocking
 for (const key of [

--- a/tests/stripeEnvPlaceholders.test.js
+++ b/tests/stripeEnvPlaceholders.test.js
@@ -1,0 +1,15 @@
+const env = global.__STRIPE_ENV__ || {};
+const isPlaceholder = (val, ending) =>
+  !val ||
+  val === "your_stripe_key_here" ||
+  val === ending ||
+  val.endsWith(ending);
+
+describe("stripe environment variables", () => {
+  test("STRIPE_SECRET_KEY is not a placeholder", () => {
+    expect(isPlaceholder(env.stripeKey, "sk_test")).toBe(false);
+  });
+  test("STRIPE_WEBHOOK_SECRET is not a placeholder", () => {
+    expect(isPlaceholder(env.stripeWebhook, "whsec")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- remove Stripe placeholder values from environment examples and server config
- validate STRIPE_SECRET_KEY and STRIPE_WEBHOOK_SECRET are real, non-placeholder values
- add a test ensuring Stripe secrets aren't set to `sk_test`/`whsec`

## Testing
- `npm run format --prefix backend`
- `node scripts/run-jest.js tests/stripeEnvPlaceholders.test.js`
- `npm test --prefix backend tests/config.test.js` *(fails: npm error command sh -c npm run build)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a4918660832db66223a95b1a6ab1