### PR TITLE
test: add dependency installation stability checks

### DIFF
--- a/scripts/dependency-stability.js
+++ b/scripts/dependency-stability.js
@@ -1,0 +1,86 @@
+const { execSync } = require("child_process");
+
+function run(cmd, errMsg) {
+  try {
+    return execSync(cmd, {
+      stdio: ["ignore", "pipe", "pipe"],
+      encoding: "utf8",
+    });
+  } catch (err) {
+    const output = String(err.stdout || "") + String(err.stderr || "");
+    throw new Error(`${errMsg}:\n${output}`);
+  }
+}
+
+function verifyLockfileSync() {
+  run("npm install --no-audit --no-fund", "npm install failed");
+  const diff = run(
+    "git diff --name-only package.json package-lock.json",
+    "git diff failed",
+  ).trim();
+  if (diff) {
+    throw new Error(`Lockfile mismatch detected: ${diff}`);
+  }
+}
+
+function checkDeprecatedDependencies() {
+  let output;
+  try {
+    output = run("npm ls", "npm ls failed");
+  } catch (err) {
+    if (/deprecated|unsupported/i.test(err.message)) {
+      throw new Error(
+        `Deprecated or unsupported dependencies detected:\n${err.message}`,
+      );
+    }
+    throw new Error(`Dependency resolution failed:\n${err.message}`);
+  }
+  if (/deprecated|unsupported/i.test(output)) {
+    throw new Error(
+      `Deprecated or unsupported dependencies detected:\n${output}`,
+    );
+  }
+}
+
+function runNpmCi() {
+  try {
+    run("npm ci --no-audit --no-fund", "npm ci failed");
+  } catch (err) {
+    if (/postinstall/i.test(err.message)) {
+      throw new Error(
+        `Postinstall script failed during npm ci:\n${err.message}`,
+      );
+    }
+    throw err;
+  }
+}
+
+function runBuild() {
+  run("npm run build", "npm run build failed");
+}
+
+function checkAll() {
+  verifyLockfileSync();
+  checkDeprecatedDependencies();
+  runNpmCi();
+  runBuild();
+  console.log("Dependency installation stability check passed.");
+}
+
+if (require.main === module) {
+  try {
+    checkAll();
+  } catch (err) {
+    console.error(err.message);
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  run,
+  verifyLockfileSync,
+  checkDeprecatedDependencies,
+  runNpmCi,
+  runBuild,
+  checkAll,
+};

--- a/tests/dependencyInstallationStability.test.js
+++ b/tests/dependencyInstallationStability.test.js
@@ -1,0 +1,66 @@
+jest.mock("child_process", () => ({ execSync: jest.fn() }));
+const { execSync } = require("child_process");
+
+const {
+  verifyLockfileSync,
+  checkDeprecatedDependencies,
+  runNpmCi,
+  checkAll,
+} = require("../scripts/dependency-stability");
+
+describe("dependency installation stability", () => {
+  beforeEach(() => {
+    execSync.mockReset();
+  });
+
+  test("detects lockfile mismatch", () => {
+    execSync.mockReturnValueOnce("").mockReturnValueOnce("package-lock.json\n");
+    expect(() => verifyLockfileSync()).toThrow(/Lockfile mismatch detected/);
+    expect(execSync.mock.calls.map((c) => c[0])).toEqual([
+      "npm install --no-audit --no-fund",
+      "git diff --name-only package.json package-lock.json",
+    ]);
+  });
+
+  test("detects deprecated deps", () => {
+    execSync.mockReturnValueOnce("npm WARN deprecated foo\n");
+    expect(() => checkDeprecatedDependencies()).toThrow(/deprecated/);
+  });
+
+  test("fails on dependency resolution errors", () => {
+    execSync.mockImplementationOnce(() => {
+      const err = new Error("fail");
+      err.stderr = "npm ERR! broken";
+      throw err;
+    });
+    expect(() => checkDeprecatedDependencies()).toThrow(
+      /Dependency resolution failed/,
+    );
+  });
+
+  test("flags postinstall failures", () => {
+    execSync.mockImplementationOnce(() => {
+      const err = new Error("fail");
+      err.stderr = "postinstall script";
+      throw err;
+    });
+    expect(() => runNpmCi()).toThrow(/Postinstall script failed/);
+  });
+
+  test("runs full check", () => {
+    execSync
+      .mockReturnValueOnce("")
+      .mockReturnValueOnce("")
+      .mockReturnValueOnce("")
+      .mockReturnValueOnce("")
+      .mockReturnValueOnce("");
+    checkAll();
+    expect(execSync.mock.calls.map((c) => c[0])).toEqual([
+      "npm install --no-audit --no-fund",
+      "git diff --name-only package.json package-lock.json",
+      "npm ls",
+      "npm ci --no-audit --no-fund",
+      "npm run build",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add dependency stability script checking lockfile sync, deprecated packages, clean npm ci, and build
- cover lockfile, deprecation, resolution and postinstall scenarios with new tests

## Testing
- `npm run validate-env` (✅)
- `SKIP_PW_DEPS=1 npm run setup` (✅)
- `cd backend && npm run format` (✅)
- `cd backend && SKIP_PW_DEPS=1 npm test` (⚠️ process terminated)
- `node scripts/run-jest.js tests/dependencyInstallationStability.test.js` (⚠️ Failed to install dependencies: npm ci failed)
- `SKIP_PW_DEPS=1 npm run ci` (⚠️ npm error canceled)
- `SKIP_PW_DEPS=1 npm run smoke` (⚠️ interrupted during dependency install)


------
https://chatgpt.com/codex/tasks/task_e_68a4aa18c1a4832db9a6a21989588bab