### PR TITLE
fix: harden lint rules and parsing

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -10,28 +10,21 @@ const baseLogger = createLogger({
   transports: [consoleTransport],
 });
 
-// Format a log entry and send to console in JSON form
+/**
+ * Format a log entry and forward it to winston.
+ * @param {"info"|"warn"|"error"} level - log level for the message
+ * @param {string} msg - message to log
+ * @param {object} [meta] - additional metadata for the log entry
+ * @returns {void}
+ */
 function output(level, msg, meta = {}) {
   const { code, ...rest } = meta;
-  const entry = {
-    timestamp: new Date().toISOString(),
-    level,
-    message: msg,
-    ...(code ? { code } : {}),
-    ...rest,
-  };
-  const str = JSON.stringify(entry);
-  if (level === "error") {
-    console.error(str);
-  } else {
-    console.log(str);
-  }
   baseLogger.log({
     level,
     message: msg,
     ...(code ? { code } : {}),
     ...rest,
-    timestamp: entry.timestamp,
+    timestamp: new Date().toISOString(),
   });
 }
 

--- a/tests/helpers/run-eslint-via-execa.mjs
+++ b/tests/helpers/run-eslint-via-execa.mjs
@@ -2,14 +2,18 @@ import { execa } from 'execa';
 import { writeFile, unlink } from 'fs/promises';
 import { join } from 'path';
 
-const tmpFile = join(process.cwd(), 'tmp-eslint.ts');
-await writeFile(tmpFile, 'const answer: number = 42;\n');
-const { stdout } = await execa('npx', [
-  '--no-install',
-  'eslint',
-  '--rule',
-  'no-unused-vars:off',
-  tmpFile,
-]);
-await unlink(tmpFile);
-process.stdout.write(stdout);
+async function main() {
+  const tmpFile = join(process.cwd(), 'tmp-eslint.ts');
+  await writeFile(tmpFile, 'const answer: number = 42;\n');
+  const { stdout } = await execa('npx', [
+    '--no-install',
+    'eslint',
+    '--rule',
+    'no-unused-vars:off',
+    tmpFile,
+  ]);
+  await unlink(tmpFile);
+  process.stdout.write(stdout);
+}
+
+main();

--- a/tests/loggerLint.test.js
+++ b/tests/loggerLint.test.js
@@ -1,0 +1,60 @@
+const fs = require("fs");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+const repoRoot = path.resolve(__dirname, "..");
+
+function runEslint(rule, file) {
+  const args = ["--no-install", "eslint", "--format", "json"];
+  if (rule) {
+    args.push("--rule", `${rule}:error`);
+  }
+  args.push(file);
+  const res = spawnSync("npx", args, { cwd: repoRoot, encoding: "utf8" });
+  return JSON.parse(res.stdout || "[]");
+}
+
+describe("logger lint rules", () => {
+  const loggerFile = path.join(repoRoot, "src", "logger.js");
+
+  test("logger.js has required jsdoc", () => {
+    const results = runEslint("jsdoc/require-jsdoc", loggerFile);
+    const msgs = results.flatMap((f) =>
+      f.messages.filter((m) => m.ruleId === "jsdoc/require-jsdoc"),
+    );
+    expect(msgs).toEqual([]);
+  });
+
+  test("logger.js contains no console statements", () => {
+    const results = runEslint("no-console", loggerFile);
+    const msgs = results.flatMap((f) =>
+      f.messages.filter((m) => m.ruleId === "no-console"),
+    );
+    expect(msgs).toEqual([]);
+  });
+
+  test("no-console rule flags console usage", () => {
+    const tmp = path.join(repoRoot, `lint-${Date.now()}.js`);
+    fs.writeFileSync(tmp, 'console.log("hi");');
+    const results = runEslint("no-console", tmp);
+    fs.unlinkSync(tmp);
+    const msgs = results.flatMap((f) =>
+      f.messages.filter((m) => m.ruleId === "no-console"),
+    );
+    expect(msgs).toHaveLength(1);
+  });
+});
+
+describe("eslint helper is lint-free", () => {
+  test("run-eslint-via-execa.mjs has no lint errors", () => {
+    const file = path.join(
+      repoRoot,
+      "tests",
+      "helpers",
+      "run-eslint-via-execa.mjs",
+    );
+    const results = runEslint(null, file);
+    const msgs = results.flatMap((f) => f.messages);
+    expect(msgs).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- remove direct console output and add JSDoc in logger utility
- convert ESLint helper to async function
- add regression tests for no-console and jsdoc rules

## Testing
- `npx --no-install eslint --format json src/logger.js tests/helpers/run-eslint-via-execa.mjs tests/loggerLint.test.js`
- `npx --no-install jest tests/loggerLint.test.js tests/diagnostic-eslint-config.test.ts`
- `npm run format`
- `npm run validate-env` *(fails: Missing env var: STRIPE_SECRET_KEY)*
- `SKIP_PW_DEPS=1 npm run setup` *(fails: STRIPE_SECRET_KEY must be set)*

------
https://chatgpt.com/codex/tasks/task_e_68a4aff3883c832d8929d967da664abd