### PR TITLE
fix: type-check stripe routes

### DIFF
--- a/backend/src/routes/stripe/create-checkout-session.ts
+++ b/backend/src/routes/stripe/create-checkout-session.ts
@@ -1,15 +1,31 @@
-import { Router, type NextFunction, type Request, type Response } from "express";
+import { Router } from "express";
+import type {
+  NextFunction,
+  Request as ExpressRequest,
+  Response as ExpressResponse,
+} from "express";
 import Stripe from "stripe";
-import db from "../../db";
+import db from "../../../db";
 
 const router = Router();
 const stripe = new Stripe(process.env["STRIPE_KEY"] as string, {
   apiVersion: "2025-06-30.basil",
 });
 
+interface CheckoutSessionBody {
+  price: number;
+  qty?: number;
+  metadata?: Record<string, string>;
+  userId?: string;
+}
+
 router.post(
   "/api/create-checkout-session",
-  async (req: Request, res: Response, next: NextFunction) => {
+  async (
+    req: ExpressRequest<unknown, unknown, CheckoutSessionBody>,
+    res: ExpressResponse,
+    next: NextFunction,
+  ) => {
   try {
     const { price, qty = 1, metadata = {}, userId } = req.body;
 
@@ -19,7 +35,7 @@ router.post(
         "SELECT COUNT(*) FROM orders WHERE user_id=$1",
         [userId],
       );
-      const orderCount = parseInt(rows[0].count, 10) || 0;
+      const orderCount = parseInt((rows[0] as any).count, 10) || 0;
       if (orderCount === 0) {
         unitAmount = Math.floor(unitAmount * 0.9);
       }

--- a/backend/src/routes/stripe/webhook.ts
+++ b/backend/src/routes/stripe/webhook.ts
@@ -1,13 +1,13 @@
-import express, {
-  Router,
-  type NextFunction,
-  type Request,
-  type Response,
+import express, { Router } from "express";
+import type {
+  NextFunction,
+  Request as ExpressRequest,
+  Response as ExpressResponse,
 } from "express";
 import Stripe from "stripe";
-import db from "../../db";
-import { enqueuePrint } from "../../queue/printQueue";
-import { enqueuePrint as enqueueDbPrint } from "../../queue/dbPrintQueue";
+import db from "../../../db";
+import { enqueuePrint } from "../../../queue/printQueue";
+import { enqueuePrint as enqueueDbPrint } from "../../../queue/dbPrintQueue";
 
 const router = Router();
 const stripe = new Stripe(process.env["STRIPE_KEY"] as string, {
@@ -17,7 +17,11 @@ const stripe = new Stripe(process.env["STRIPE_KEY"] as string, {
 router.post(
   "/api/webhook/stripe",
   express.raw({ type: "application/json" }),
-  async (req: Request, res: Response, next: NextFunction) => {
+  async (
+    req: ExpressRequest<unknown, unknown, Buffer>,
+    res: ExpressResponse,
+    next: NextFunction,
+  ) => {
     try {
       const sig = req.headers["stripe-signature"] as string;
       const event = stripe.webhooks.constructEvent(

--- a/backend/tests/stripeRoutes.type.test.ts
+++ b/backend/tests/stripeRoutes.type.test.ts
@@ -1,0 +1,38 @@
+import { spawnSync } from "child_process";
+import path from "path";
+
+test("Stripe routes type-check", () => {
+  const backendDir = path.resolve(__dirname, "..");
+  const result = spawnSync(
+    "npx",
+    [
+      "tsc",
+      "--noEmit",
+      "--pretty",
+      "false",
+      "--module",
+      "CommonJS",
+      "--target",
+      "ES2022",
+      "--types",
+      "node",
+      "--esModuleInterop",
+      "true",
+      "--allowJs",
+      "true",
+      "--moduleResolution",
+      "node",
+      "src/routes/stripe/create-checkout-session.ts",
+      "src/routes/stripe/webhook.ts",
+    ],
+    { cwd: backendDir, encoding: "utf-8" },
+  );
+
+  if (result.status !== 0) {
+    if (result.stdout) console.error(result.stdout);
+    if (result.stderr) console.error(result.stderr);
+  }
+
+  expect(result.status).toBe(0);
+});
+


### PR DESCRIPTION
## Summary
- type checkout session body and import Express types
- ensure Stripe webhook handles Buffer body and fix imports
- add regression test to type-check Stripe routes

## Testing
- `npm run format` (backend)
- `npm test` (fails: STRIPE_WEBHOOK_SECRET must be a live webhook secret)
- `SKIP_PW_DEPS=1 npm run ci` (partial, aborted)
- `SKIP_PW_DEPS=1 npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_68a4aff8b254832da7be004b3b4a085e