### PR TITLE
test: add eslint CI regression tests

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -59,7 +59,7 @@ module.exports = [
   },
   {
     languageOptions: {
-      ecmaVersion: 12,
+      ecmaVersion: 2022,
       globals: { ...globals.node, ...globals.es2021, ...globals.jest },
     },
   },

--- a/tests/eslint-ci.config.cjs
+++ b/tests/eslint-ci.config.cjs
@@ -1,0 +1,25 @@
+const baseConfig = require("../eslint.config.js");
+
+module.exports = [
+  ...baseConfig,
+  {
+    files: ["**/*.{js,jsx,ts,tsx,mjs}"] ,
+    ignores: ["tests/**"],
+    settings: {
+      jsdoc: {
+        tagNamePreference: {
+          "jest-environment": false,
+          todo: false,
+          fixme: false,
+        },
+      },
+    },
+    rules: {
+      "no-console": "error",
+      "jsdoc/require-jsdoc": "error",
+      "jsdoc/require-param": "error",
+      "jsdoc/require-returns": "error",
+      "jsdoc/check-tag-names": "error",
+    },
+  },
+];

--- a/tests/eslintCiRules.test.js
+++ b/tests/eslintCiRules.test.js
@@ -1,0 +1,60 @@
+const { spawnSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+const repoRoot = path.join(__dirname, "..");
+const configPath = path.join(__dirname, "eslint-ci.config.cjs");
+
+function runEslint(file) {
+  return spawnSync(
+    "npx",
+    ["eslint", file, "-f", "json", "--config", configPath],
+    { cwd: repoRoot, encoding: "utf8" },
+  );
+}
+
+describe("CI eslint regression checks", () => {
+  test("flags missing jsdoc and console usage", () => {
+    const tmp = path.join(repoRoot, "tmp-ci-lint.js");
+    fs.writeFileSync(
+      tmp,
+      "function demo(x){console.log(x);return x;}\n",
+    );
+    const res = runEslint(tmp);
+    fs.unlinkSync(tmp);
+    expect(res.status).not.toBe(0);
+    const messages = JSON.parse(res.stdout)[0].messages.map((m) => m.ruleId);
+    expect(messages).toEqual(
+      expect.arrayContaining(["jsdoc/require-jsdoc", "no-console"]),
+    );
+  });
+
+  test("validates params, returns and disallows blacklisted tags", () => {
+    const tmp = path.join(repoRoot, "tmp-ci-jsdoc.js");
+    fs.writeFileSync(
+      tmp,
+      "/**\n * Multiply numbers.\n * @todo remove\n */\nfunction mul(a,b){return a*b;}\n",
+    );
+    const res = runEslint(tmp);
+    fs.unlinkSync(tmp);
+    expect(res.status).not.toBe(0);
+    const rules = JSON.parse(res.stdout)[0].messages.map((m) => m.ruleId);
+    expect(rules).toEqual(
+      expect.arrayContaining([
+        "jsdoc/require-param",
+        "jsdoc/require-returns",
+        "jsdoc/check-tag-names",
+      ]),
+    );
+  });
+
+  test("parses mjs helpers with async/await", () => {
+    const file = path.join(__dirname, "helpers", "run-eslint-via-execa.mjs");
+    const res = runEslint(file);
+    if (res.status !== 0) {
+      console.error(res.stdout);
+      console.error(res.stderr);
+    }
+    expect(res.status).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- expand ESLint config to ES2022 for async/await in .mjs helpers
- add CI-focused ESLint config covering JSDoc, params/returns, tag blacklist and no-console
- add regression tests to ensure ESLint catches missing docs, bad tags and parses mjs helpers

## Testing
- `npm run validate-env` *(fails: Missing env var: STRIPE_SECRET_KEY)*
- `SKIP_PW_DEPS=1 npm run setup` *(fails: STRIPE_SECRET_KEY must be set)*
- `cd backend && npm run format`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing env var: STRIPE_SECRET_KEY)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing env var: STRIPE_WEBHOOK_SECRET)*
- `npx jest tests/eslintCiRules.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a4aff4960c832d9389a1fa9c6faecc