### PR TITLE
ci: add env loader preflight

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,8 +75,18 @@ jobs:
 
       - name: Prepare test env
         run: |
-          cp .env.example .env.test
-          echo "DB_URL=postgres://user:pass@localhost/db" >> .env.test
+          echo "DB_URL=postgres://user:pass@localhost/db" > .env.test
+
+      - name: Loader precedence preflight
+        env:
+          STRIPE_SECRET_KEY: sk_live_xxx
+          STRIPE_WEBHOOK_SECRET: whsec_xxx
+        run: |
+          cat <<'EOF' > /tmp/ci.env
+          STRIPE_SECRET_KEY=
+          STRIPE_WEBHOOK_SECRET=
+          EOF
+          node scripts/env-loader-preflight.js /tmp/ci.env
 
       - name: Run CI
         env:

--- a/scripts/env-loader-preflight.js
+++ b/scripts/env-loader-preflight.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+const dotenv = require("dotenv");
+
+const envFile = process.argv[2];
+const expectedSecret = process.env.STRIPE_SECRET_KEY;
+const expectedWebhook = process.env.STRIPE_WEBHOOK_SECRET;
+
+dotenv.config({ path: envFile });
+
+const okSecret = process.env.STRIPE_SECRET_KEY === expectedSecret;
+const okWebhook = process.env.STRIPE_WEBHOOK_SECRET === expectedWebhook;
+
+console.log(String(okSecret));
+console.log(String(okWebhook));

--- a/tests/ci/env_loader_preflight_ba718dce.test.ts
+++ b/tests/ci/env_loader_preflight_ba718dce.test.ts
@@ -1,0 +1,24 @@
+const { writeFileSync, unlinkSync } = require("fs");
+const { execSync } = require("child_process");
+const { tmpdir } = require("os");
+const { join } = require("path");
+const crypto = require("crypto");
+
+test("env loader respects exported values over .env", () => {
+  const tmp = join(
+    tmpdir(),
+    `env-preflight-${crypto.randomBytes(4).toString("hex")}.env`,
+  );
+  writeFileSync(tmp, "STRIPE_SECRET_KEY=\nSTRIPE_WEBHOOK_SECRET=\n");
+  const env = {
+    ...process.env,
+    STRIPE_SECRET_KEY: "sk_live_xxx",
+    STRIPE_WEBHOOK_SECRET: "whsec_xxx",
+  };
+  const out = execSync(`node scripts/env-loader-preflight.js ${tmp}`, { env })
+    .toString()
+    .trim()
+    .split("\n");
+  unlinkSync(tmp);
+  expect(out).toEqual(["true", "true"]);
+});


### PR DESCRIPTION
## Summary
- avoid blank .env override in CI and check loader precedence
- add test verifying env vars win over empty .env

## Testing
- `npm run format`
- `npm run format --prefix backend`
- `node scripts/run-jest.js tests/ci/env_loader_preflight_ba718dce.test.ts`
- `npm test --prefix backend` *(fails: STRIPE_WEBHOOK_SECRET must be a live webhook secret)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c3a63824832d9546efbfe71f7871