### PR TITLE
feat: preserve env vars over dot env files

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -1,5 +1,5 @@
 // backend/db.js
-require("dotenv").config();
+require("dotenv").config({ override: false });
 const { Pool } = require("pg");
 const { v4: uuidv4 } = require("uuid");
 const { dbUrl } = require("./config");

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,6 +1,6 @@
 // backend/server.js
 
-require("dotenv").config();
+require("dotenv").config({ override: false });
 const { getEnv } = require("./utils/getEnv");
 const CLOUDFRONT_MODEL_DOMAIN = getEnv("CLOUDFRONT_MODEL_DOMAIN");
 if (!CLOUDFRONT_MODEL_DOMAIN && process.env.NODE_ENV !== "test") {

--- a/scripts/check-env.sh
+++ b/scripts/check-env.sh
@@ -12,10 +12,16 @@ load_env_file() {
   local file="$1"
   while IFS='=' read -r key value; do
     [[ "$key" =~ ^\s*# || -z "$key" ]] && continue
-    if [[ ! -v $key ]]; then
+    if [ -z "${!key+x}" ]; then
       export "$key"="$value"
     fi
   done < "$file"
+}
+
+is_placeholder() {
+  local val="$1"
+  local ending="$2"
+  [[ -z "$val" || "$val" == "your_stripe_key_here" || "$val" == "$ending" || "$val" == *"$ending" ]]
 }
 
 if [ -f .env ]; then
@@ -40,7 +46,17 @@ fi
 : "${AWS_SECRET_ACCESS_KEY:?AWS_SECRET_ACCESS_KEY must be set}"
 : "${DB_URL:?DB_URL must be set}"
 : "${STRIPE_SECRET_KEY:?STRIPE_SECRET_KEY must be set}"
+: "${STRIPE_WEBHOOK_SECRET:?STRIPE_WEBHOOK_SECRET must be set}"
 : "${CLOUDFRONT_MODEL_DOMAIN:?CLOUDFRONT_MODEL_DOMAIN must be set}"
+
+if is_placeholder "$STRIPE_SECRET_KEY" "sk_test"; then
+  echo "STRIPE_SECRET_KEY must be a live secret key" >&2
+  exit 1
+fi
+if is_placeholder "$STRIPE_WEBHOOK_SECRET" "whsec"; then
+  echo "STRIPE_WEBHOOK_SECRET must be a live webhook secret" >&2
+  exit 1
+fi
 required_node_major="${REQUIRED_NODE_MAJOR:-20}"
 current_major=$(node -v | sed -E "s/^v([0-9]+).*/\1/")
 if [ "$current_major" -lt "$required_node_major" ]; then

--- a/scripts/diagnose.sh
+++ b/scripts/diagnose.sh
@@ -2,9 +2,12 @@
 set -euo pipefail
 
 if [[ -f .env ]]; then
-  set -a
-  source .env
-  set +a
+  while IFS='=' read -r key value; do
+    [[ "$key" =~ ^\s*# || -z "$key" ]] && continue
+    if [ -z "${!key+x}" ]; then
+      export "$key"="$value"
+    fi
+  done < .env
 fi
 
 banner() {

--- a/scripts/validate-env.sh
+++ b/scripts/validate-env.sh
@@ -28,10 +28,16 @@ load_env_file() {
   local file="$1"
   while IFS='=' read -r key value; do
     [[ "$key" =~ ^\s*# || -z "$key" ]] && continue
-    if [[ ! -v $key ]]; then
+    if [ -z "${!key+x}" ]; then
       export "$key"="$value"
     fi
   done < "$file"
+}
+
+is_placeholder() {
+  local val="$1"
+  local ending="$2"
+  [[ -z "$val" || "$val" == "your_stripe_key_here" || "$val" == "$ending" || "$val" == *"$ending" ]]
 }
 
 if [ -f "$repo_root/.env" ]; then
@@ -94,6 +100,15 @@ if [ ${#missing[@]} -gt 0 ]; then
   echo "Missing required environment variables:" >&2
   printf '  - %s\n' "${missing[@]}" >&2
   echo "Please set them in your environment or .env file." >&2
+  exit 1
+fi
+
+if is_placeholder "$STRIPE_SECRET_KEY" "sk_test"; then
+  echo "STRIPE_SECRET_KEY must be a live secret key" >&2
+  exit 1
+fi
+if is_placeholder "$STRIPE_WEBHOOK_SECRET" "whsec"; then
+  echo "STRIPE_WEBHOOK_SECRET must be a live webhook secret" >&2
   exit 1
 fi
 

--- a/tests/ci/env_merge_precedence_7c3d1b.test.ts
+++ b/tests/ci/env_merge_precedence_7c3d1b.test.ts
@@ -1,0 +1,54 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+function loadEnvFile(file: string) {
+  const content = fs.readFileSync(file, 'utf8');
+  for (const line of content.split(/\r?\n/)) {
+    if (!line || line.startsWith('#')) continue;
+    const [key, value] = line.split('=', 2);
+    if (key && process.env[key] === undefined) {
+      process.env[key] = value;
+    }
+  }
+}
+
+describe('env merge precedence', () => {
+  const envPath = path.join(process.cwd(), '.env');
+  const configPath = require.resolve('../../backend/config');
+
+  afterEach(() => {
+    if (fs.existsSync(envPath)) fs.unlinkSync(envPath);
+    delete process.env.STRIPE_SECRET_KEY;
+    delete process.env.STRIPE_WEBHOOK_SECRET;
+    delete process.env.DB_URL;
+    delete require.cache[configPath];
+  });
+
+  it('preserves shell variables over .env', () => {
+    process.env.STRIPE_SECRET_KEY = 'sk_live_dummy';
+    process.env.STRIPE_WEBHOOK_SECRET = 'whsec_real_dummy';
+    process.env.DB_URL = 'postgres://user:pass@localhost/db';
+    fs.writeFileSync(envPath, 'STRIPE_SECRET_KEY=\nSTRIPE_WEBHOOK_SECRET=\n');
+
+    loadEnvFile(envPath);
+    expect(process.env.STRIPE_SECRET_KEY).toBe('sk_live_dummy');
+    expect(process.env.STRIPE_WEBHOOK_SECRET).toBe('whsec_real_dummy');
+    expect(() => require(configPath)).not.toThrow();
+  });
+
+  it('fails on placeholder values when env vars missing', () => {
+    fs.writeFileSync(
+      envPath,
+      'DB_URL=postgres://user:pass@localhost/db\nSTRIPE_SECRET_KEY=dummy_sk_test\nSTRIPE_WEBHOOK_SECRET=whsec\n',
+    );
+
+    loadEnvFile(envPath);
+    const result = spawnSync('node', ['-e', `require(${JSON.stringify(configPath)})`], {
+      env: { ...process.env },
+      encoding: 'utf8',
+    });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toMatch(/live (secret key|webhook secret)/);
+  });
+});


### PR DESCRIPTION
## Summary
- protect CI env values by loading `.env` entries only when variables are unset
- reject placeholder Stripe secrets during validation
- test that shell-provided secrets override `.env` values

## Testing
- `npm run format`
- `npm run format` (backend)
- `node scripts/run-jest.js tests/ci/env_merge_precedence_7c3d1b.test.ts`
- `npm test` *(fails: STRIPE_SECRET_KEY must be set to a non-test value)*
- `npm run ci` *(fails: Parsing error: "parserOptions.project" has been provided for @typescript-eslint/parser)*
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68a4c3a0d3ac832d9ba5cd4dfa9b97f6