### PR TITLE
ci: add env preflight and stripe mocking

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "coverage": "npm run coverage --prefix backend",
     "typecheck": "tsc --noEmit",
     "i18n:lint": "node scripts/i18n-lint.js",
-    "ci": "node scripts/assert-setup.js && npm run format:check && npm run lint && npm run typecheck && npm run i18n:lint && npm run test:ci && npm run test:a11y && npm run test:ui",
+    "ci": "node scripts/ci-env-preflight.js && node scripts/assert-setup.js && npm run format:check && npm run lint && npm run typecheck && npm run i18n:lint && npm run test:ci && npm run test:a11y && npm run test:ui",
     "test:ci": "cross-env JEST_CI=true npm run test-ci --prefix backend && node scripts/run-jest.js --runTestsByPath tests/ci/build-artifact-check-a1b2c3d4e5f6g7h.ts tests/ci",
     "test:update-threshold": "node scripts/update-coverage-threshold.js",
     "test:cf-readiness": "node scripts/run-jest.js tests/ci/test-cloudflare-deployment-readiness-4c7a3f2e1b0d9c8.test.ts scripts/__tests__/validate-static-refs-3ea7bd43ffcd123.test.ts",

--- a/scripts/ci-env-preflight.js
+++ b/scripts/ci-env-preflight.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+const required = [
+  "AWS_ACCESS_KEY_ID",
+  "AWS_SECRET_ACCESS_KEY",
+  "DB_URL",
+  "STRIPE_SECRET_KEY",
+  "STRIPE_WEBHOOK_SECRET",
+];
+const missing = required.filter((v) => !process.env[v]);
+if (missing.length) {
+  console.error(`Missing required env vars for CI: ${missing.join(", ")}`);
+  process.exit(1);
+}
+
+if (process.env.CI && process.env.CI_REQUIRE_EXTERNAL !== "1") {
+  const Module = require("module");
+  const originalLoad = Module._load;
+  Module._load = function (request, parent, isMain) {
+    if (request === "stripe") {
+      return function () {
+        return {
+          __mock: true,
+          webhooks: {
+            constructEvent: () => ({ id: "evt_test", type: "mock.event" }),
+          },
+        };
+      };
+    }
+    return originalLoad.apply(this, arguments);
+  };
+}

--- a/tests/ci/env_preflight_a1b2c3d4.test.ts
+++ b/tests/ci/env_preflight_a1b2c3d4.test.ts
@@ -1,0 +1,57 @@
+import path from "path";
+import { spawnSync } from "child_process";
+
+const script = path.resolve(__dirname, "../../scripts/ci-env-preflight.js");
+const node = process.execPath;
+
+describe("ci env preflight", () => {
+  test("fails when required envs missing", () => {
+    const result = spawnSync(node, [script], {
+      env: {},
+      encoding: "utf8",
+    });
+    expect(result.status).toBe(1);
+    expect(result.stderr).toMatch(/Missing required env vars for CI/);
+  });
+
+  test("mocks stripe by default in CI", () => {
+    const env = {
+      AWS_ACCESS_KEY_ID: "a",
+      AWS_SECRET_ACCESS_KEY: "b",
+      DB_URL: "postgres://u:p@localhost/db",
+      STRIPE_SECRET_KEY: "sk",
+      STRIPE_WEBHOOK_SECRET: "whsec",
+      CI: "1",
+    };
+    const result = spawnSync(
+      node,
+      [
+        "-e",
+        `require(${JSON.stringify(script)}); const Stripe=require('stripe'); const s=Stripe('k'); console.log(s.__mock?'mock':'real');`,
+      ],
+      { env, encoding: "utf8" },
+    );
+    expect(result.stdout.trim()).toBe("mock");
+  });
+
+  test("allows real stripe when CI_REQUIRE_EXTERNAL=1", () => {
+    const env = {
+      AWS_ACCESS_KEY_ID: "a",
+      AWS_SECRET_ACCESS_KEY: "b",
+      DB_URL: "postgres://u:p@localhost/db",
+      STRIPE_SECRET_KEY: "sk",
+      STRIPE_WEBHOOK_SECRET: "whsec",
+      CI: "1",
+      CI_REQUIRE_EXTERNAL: "1",
+    };
+    const result = spawnSync(
+      node,
+      [
+        "-e",
+        `require(${JSON.stringify(script)}); try { require('stripe'); console.log('loaded'); } catch { console.log('missing'); }`,
+      ],
+      { env, encoding: "utf8" },
+    );
+    expect(result.stdout.trim()).toBe("missing");
+  });
+});


### PR DESCRIPTION
## Summary
- check required env vars before CI runs
- mock Stripe client in CI unless `CI_REQUIRE_EXTERNAL=1`
- cover env preflight logic with dedicated tests

## Testing
- `npm run validate-env`
- `curl -I https://registry.npmjs.org`
- `curl -I https://cdn.playwright.dev`
- `SKIP_PW_DEPS=1 npm run setup` *(Playwright host dependencies warning)*
- `npm --prefix backend run format`
- `node scripts/run-jest.js tests/ci/env_preflight_a1b2c3d4.test.ts`
- `SKIP_PW_DEPS=1 npm run ci` *(aborted: running lint step)*
- `SKIP_PW_DEPS=1 npm run smoke` *(aborted during build)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b3fd2ad4832d91b0105c4d402007