### PR TITLE
ci: mock stripe secrets via env loader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,11 @@ jobs:
         run: |
           echo 'REQUIRED: intent/behavior tests'
       - uses: actions/checkout@v5
-      - name: Stripe preflight
-        run: |
-          echo "STRIPE_SECRET_KEY present: $([[ \"$STRIPE_SECRET_KEY\" =~ ^sk_ ]] && echo true || echo false)"
-          echo "STRIPE_WEBHOOK_SECRET present: $([[ \"$STRIPE_WEBHOOK_SECRET\" =~ ^whsec_ ]] && echo true || echo false)"
+      - name: Load Stripe env
+        run: node scripts/ci-env-preflight.js
+        env:
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+          STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,15 +5,13 @@ on: [push, pull_request]
 jobs:
   coverage:
     runs-on: ubuntu-latest
-    env:
-      STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
-      STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
     steps:
       - uses: actions/checkout@v5
-      - name: Stripe preflight
-        run: |
-          echo "STRIPE_SECRET_KEY present: $([[ \"$STRIPE_SECRET_KEY\" =~ ^sk_ ]] && echo true || echo false)"
-          echo "STRIPE_WEBHOOK_SECRET present: $([[ \"$STRIPE_WEBHOOK_SECRET\" =~ ^whsec_ ]] && echo true || echo false)"
+      - name: Load Stripe env
+        run: node scripts/ci-env-preflight.js
+        env:
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+          STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
       - uses: actions/setup-node@v4.4.0
         with:
           node-version: 20

--- a/.github/workflows/ensure_server_boots_185ecc2b50.yml
+++ b/.github/workflows/ensure_server_boots_185ecc2b50.yml
@@ -11,8 +11,6 @@ jobs:
       STRIPE_TEST_KEY: ${{ secrets.STRIPE_TEST_KEY }}
       # Fallback DB connection so check-env.sh passes
       DB_URL: ${{ secrets.DB_URL || 'postgres://user:pass@localhost:5432/testdb' }}
-      STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
-      STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
       HF_API_KEY: ${{ secrets.HF_API_KEY }}
       CLOUDFRONT_MODEL_DOMAIN: ${{ secrets.CLOUDFRONT_MODEL_DOMAIN }}
       SPARC3D_ENDPOINT: ${{ secrets.SPARC3D_ENDPOINT }}
@@ -26,10 +24,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
 
-      - name: Stripe preflight
-        run: |
-          echo "STRIPE_SECRET_KEY present: $([[ \"$STRIPE_SECRET_KEY\" =~ ^sk_ ]] && echo true || echo false)"
-          echo "STRIPE_WEBHOOK_SECRET present: $([[ \"$STRIPE_WEBHOOK_SECRET\" =~ ^whsec_ ]] && echo true || echo false)"
+      - name: Load Stripe env
+        run: node scripts/ci-env-preflight.js
+        env:
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+          STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/glb-tests.yml
+++ b/.github/workflows/glb-tests.yml
@@ -19,15 +19,13 @@ on:
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
-    env:
-      STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
-      STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
     steps:
       - uses: actions/checkout@v5
-      - name: Stripe preflight
-        run: |
-          echo "STRIPE_SECRET_KEY present: $([[ \"$STRIPE_SECRET_KEY\" =~ ^sk_ ]] && echo true || echo false)"
-          echo "STRIPE_WEBHOOK_SECRET present: $([[ \"$STRIPE_WEBHOOK_SECRET\" =~ ^whsec_ ]] && echo true || echo false)"
+      - name: Load Stripe env
+        run: node scripts/ci-env-preflight.js
+        env:
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+          STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -41,15 +39,13 @@ jobs:
   e2e-tests:
     needs: unit-tests
     runs-on: ubuntu-latest
-    env:
-      STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
-      STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
     steps:
       - uses: actions/checkout@v5
-      - name: Stripe preflight
-        run: |
-          echo "STRIPE_SECRET_KEY present: $([[ \"$STRIPE_SECRET_KEY\" =~ ^sk_ ]] && echo true || echo false)"
-          echo "STRIPE_WEBHOOK_SECRET present: $([[ \"$STRIPE_WEBHOOK_SECRET\" =~ ^whsec_ ]] && echo true || echo false)"
+      - name: Load Stripe env
+        run: node scripts/ci-env-preflight.js
+        env:
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+          STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -10,9 +10,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    env:
-      STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
-      STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
     strategy:
       matrix:
         node-version: 20
@@ -20,10 +17,11 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Stripe preflight
-        run: |
-          echo "STRIPE_SECRET_KEY present: $([[ \"$STRIPE_SECRET_KEY\" =~ ^sk_ ]] && echo true || echo false)"
-          echo "STRIPE_WEBHOOK_SECRET present: $([[ \"$STRIPE_WEBHOOK_SECRET\" =~ ^whsec_ ]] && echo true || echo false)"
+      - name: Load Stripe env
+        run: node scripts/ci-env-preflight.js
+        env:
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+          STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/pipeline-smoke.yml
+++ b/.github/workflows/pipeline-smoke.yml
@@ -13,8 +13,6 @@ jobs:
     env:
       STRIPE_TEST_KEY: ${{ secrets.STRIPE_TEST_KEY }}
       DB_URL: ${{ secrets.DB_URL }}
-      STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
-      STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
       HF_API_KEY: ${{ secrets.HF_API_KEY }}
       CLOUDFRONT_MODEL_DOMAIN: ${{ secrets.CLOUDFRONT_MODEL_DOMAIN }}
       SPARC3D_ENDPOINT: ${{ secrets.SPARC3D_ENDPOINT }}
@@ -28,10 +26,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
 
-      - name: Stripe preflight
-        run: |
-          echo "STRIPE_SECRET_KEY present: $([[ \"$STRIPE_SECRET_KEY\" =~ ^sk_ ]] && echo true || echo false)"
-          echo "STRIPE_WEBHOOK_SECRET present: $([[ \"$STRIPE_WEBHOOK_SECRET\" =~ ^whsec_ ]] && echo true || echo false)"
+      - name: Load Stripe env
+        run: node scripts/ci-env-preflight.js
+        env:
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+          STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -9,15 +9,13 @@ on:
 jobs:
   smoke_test:
     runs-on: ubuntu-latest
-    env:
-      STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
-      STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
     steps:
       - uses: actions/checkout@v5
-      - name: Stripe preflight
-        run: |
-          echo "STRIPE_SECRET_KEY present: $([[ \"$STRIPE_SECRET_KEY\" =~ ^sk_ ]] && echo true || echo false)"
-          echo "STRIPE_WEBHOOK_SECRET present: $([[ \"$STRIPE_WEBHOOK_SECRET\" =~ ^whsec_ ]] && echo true || echo false)"
+      - name: Load Stripe env
+        run: node scripts/ci-env-preflight.js
+        env:
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+          STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/sync-space.yml
+++ b/.github/workflows/sync-space.yml
@@ -9,15 +9,14 @@ jobs:
     runs-on: ubuntu-latest
     env:
       STRIPE_TEST_KEY: ${{ secrets.STRIPE_TEST_KEY }}
-      STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
-      STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
 
     steps:
       - uses: actions/checkout@v5
-      - name: Stripe preflight
-        run: |
-          echo "STRIPE_SECRET_KEY present: $([[ \"$STRIPE_SECRET_KEY\" =~ ^sk_ ]] && echo true || echo false)"
-          echo "STRIPE_WEBHOOK_SECRET present: $([[ \"$STRIPE_WEBHOOK_SECRET\" =~ ^whsec_ ]] && echo true || echo false)"
+      - name: Load Stripe env
+        run: node scripts/ci-env-preflight.js
+        env:
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+          STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
 
       - name: Install git-lfs
         run: |

--- a/scripts/ci-env-preflight.js
+++ b/scripts/ci-env-preflight.js
@@ -1,16 +1,38 @@
 #!/usr/bin/env node
-const required = [
-  "AWS_ACCESS_KEY_ID",
-  "AWS_SECRET_ACCESS_KEY",
-  "DB_URL",
-  "STRIPE_SECRET_KEY",
-  "STRIPE_WEBHOOK_SECRET",
-];
-const missing = required.filter((v) => !process.env[v]);
+const fs = require("fs");
+
+const required = ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "DB_URL"];
+const stripeVars = ["STRIPE_SECRET_KEY", "STRIPE_WEBHOOK_SECRET"];
+
+let missing = required.filter((v) => !process.env[v]);
+
+if (process.env.CI_REQUIRE_EXTERNAL === "1") {
+  missing = missing.concat(stripeVars.filter((v) => !process.env[v]));
+}
+
 if (missing.length) {
   console.error(`Missing required env vars for CI: ${missing.join(", ")}`);
   process.exit(1);
 }
+
+const mocked = [];
+for (const key of stripeVars) {
+  if (!process.env[key]) {
+    process.env[key] =
+      key === "STRIPE_SECRET_KEY" ? "sk_test_mock" : "whsec_mock";
+    mocked.push(key);
+  }
+  fs.appendFileSync(process.env.GITHUB_ENV, `${key}=${process.env[key]}\n`);
+}
+
+for (const key of required) {
+  fs.appendFileSync(process.env.GITHUB_ENV, `${key}=${process.env[key]}\n`);
+}
+
+mocked.forEach((k) => console.log(`Mocked ${k}`));
+stripeVars
+  .filter((k) => !mocked.includes(k))
+  .forEach((k) => console.log(`Using live ${k}`));
 
 if (process.env.CI && process.env.CI_REQUIRE_EXTERNAL !== "1") {
   const Module = require("module");

--- a/tests/ci/stripe_env_fallback.test.ts
+++ b/tests/ci/stripe_env_fallback.test.ts
@@ -1,0 +1,35 @@
+const { execSync } = require("child_process");
+const { readFileSync, unlinkSync } = require("fs");
+const { tmpdir } = require("os");
+const { join } = require("path");
+const crypto = require("crypto");
+
+test("ci-env-preflight uses mock stripe secrets when absent", () => {
+  const tmp = join(tmpdir(), `ci-env-${crypto.randomBytes(4).toString("hex")}`);
+  const env = { ...process.env };
+  delete env.STRIPE_SECRET_KEY;
+  delete env.STRIPE_WEBHOOK_SECRET;
+  env.GITHUB_ENV = tmp;
+  env.AWS_ACCESS_KEY_ID = "x";
+  env.AWS_SECRET_ACCESS_KEY = "y";
+  env.DB_URL = "postgres://user:pass@localhost/db";
+  execSync("node scripts/ci-env-preflight.js", { env });
+  const out = readFileSync(tmp, "utf8");
+  unlinkSync(tmp);
+  expect(out).toMatch(/STRIPE_SECRET_KEY=sk_test_mock/);
+  expect(out).toMatch(/STRIPE_WEBHOOK_SECRET=whsec_mock/);
+});
+
+test("ci-env-preflight fails when stripe secrets required", () => {
+  const tmp = join(tmpdir(), `ci-env-${crypto.randomBytes(4).toString("hex")}`);
+  const env = { ...process.env };
+  delete env.STRIPE_SECRET_KEY;
+  delete env.STRIPE_WEBHOOK_SECRET;
+  env.GITHUB_ENV = tmp;
+  env.CI_REQUIRE_EXTERNAL = "1";
+  env.AWS_ACCESS_KEY_ID = "x";
+  env.AWS_SECRET_ACCESS_KEY = "y";
+  env.DB_URL = "postgres://user:pass@localhost/db";
+  expect(() => execSync("node scripts/ci-env-preflight.js", { env })).toThrow();
+  if (require("fs").existsSync(tmp)) unlinkSync(tmp);
+});


### PR DESCRIPTION
## Summary
- use ci-env-preflight in workflows to load Stripe secrets or mocks
- mock Stripe secrets when missing and log which values were mocked vs live
- test env loader fallback and required secret enforcement

## Testing
- `npm run format`
- `npm run format --prefix backend`
- `node scripts/run-jest.js tests/ci/stripe_env_fallback.test.ts`
- `npm test --prefix backend` *(fails: STRIPE_WEBHOOK_SECRET must be a live webhook secret)*
- `SKIP_PW_DEPS=1 npm run ci` *(failed: missing GITHUB_ENV initially)*
- `SKIP_PW_DEPS=1 npm run smoke` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d1fb907c832db335f2b9e3202588