### PR TITLE
test: add stripe webhook prod gate

### DIFF
--- a/tests/ci/diagnostic_stripe_webhook_prod_gate.test.ts
+++ b/tests/ci/diagnostic_stripe_webhook_prod_gate.test.ts
@@ -1,0 +1,38 @@
+const { getEnv } = require("../../backend/src/lib/getEnv");
+const { mockSecrets } = require("../../backend/src/lib/mockEnv");
+
+const requireExternal =
+  process.env.NODE_ENV === "production" ||
+  process.env.CI_REQUIRE_EXTERNAL === "1";
+
+if (!requireExternal) {
+  console.log(
+    "diagnostic: mock Stripe secrets in use; skipping production gate",
+  );
+}
+
+(requireExternal ? test : test.skip)(
+  "production Stripe secrets are configured",
+  () => {
+    const stripeKey = getEnv("STRIPE_SECRET_KEY");
+    const webhookSecret = getEnv("STRIPE_WEBHOOK_SECRET");
+
+    const invalid = (val, prefix, mockVal) =>
+      typeof val !== "string" ||
+      !val.startsWith(prefix) ||
+      val === mockVal ||
+      /_(test|mock)/.test(val);
+
+    if (invalid(stripeKey, "sk_", mockSecrets.STRIPE_SECRET_KEY)) {
+      throw new Error(
+        "STRIPE_SECRET_KEY must be a real key starting with 'sk_' (no test/mock placeholders)",
+      );
+    }
+
+    if (invalid(webhookSecret, "whsec_", mockSecrets.STRIPE_WEBHOOK_SECRET)) {
+      throw new Error(
+        "STRIPE_WEBHOOK_SECRET must be a real key starting with 'whsec_' (no test/mock placeholders)",
+      );
+    }
+  },
+);


### PR DESCRIPTION
## Summary
- add diagnostic test to ensure real Stripe secrets when production or CI_REQUIRE_EXTERNAL

## Testing
- `npm run format --prefix backend`
- `node scripts/run-jest.js tests/ci/diagnostic_stripe_webhook_prod_gate.test.ts`
- `npm test --prefix backend` *(fails: setup script attempted to run, aborted)*
- `npm run ci` *(fails: triggers setup script, aborted)*
- `npm run smoke` *(fails: triggers setup-codex, aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68a4defe5fdc832dbe0aaa5de796f631