### PR TITLE
docs: document backend env helpers

### DIFF
--- a/backend/config.js
+++ b/backend/config.js
@@ -1,5 +1,11 @@
 "use strict";
 
+/**
+ * Loads environment variables for the backend and applies fallbacks for local
+ * development. Missing required variables are logged to the console.
+ *
+ * @module backend/config
+ */
 const { getEnv } = require("./src/lib/getEnv");
 const { applyMockEnv, mockSecrets } = require("./src/lib/mockEnv");
 

--- a/backend/src/lib/mockEnv.js
+++ b/backend/src/lib/mockEnv.js
@@ -1,3 +1,9 @@
+/**
+ * Mock secret values used during local development and testing.
+ * These defaults prevent tests from failing when environment variables are
+ * missing.
+ * @type {Record<string, string>}
+ */
 const mockSecrets = {
   STRIPE_SECRET_KEY: "sk_test_mock",
   STRIPE_WEBHOOK_SECRET: "whsec_mock",
@@ -8,6 +14,12 @@ const mockSecrets = {
   DB_URL: "postgres://localhost/test",
 };
 
+/**
+ * Apply default mock values to an environment object when keys are missing.
+ *
+ * @param {NodeJS.ProcessEnv} [env=process.env] - Environment object to mutate.
+ * @returns {NodeJS.ProcessEnv} The updated environment.
+ */
 function applyMockEnv(env = process.env) {
   for (const [key, value] of Object.entries(mockSecrets)) {
     if (!env[key]) {


### PR DESCRIPTION
## Summary
- document backend configuration loader
- add JSDoc for mock environment helper

## Testing
- `npm run format`
- `node scripts/run-jest.js backend/tests/serverLint.test.js backend/tests/lintingDetailed.test.js`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Parsing error: "parserOptions.project" has been provided for @typescript-eslint/parser ...)*

------
https://chatgpt.com/codex/tasks/task_e_68a4dcb7d008832da1b1930c0daa9cd6