### PR TITLE
ci: ensure preflight has github env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
           echo 'REQUIRED: intent/behavior tests'
       - uses: actions/checkout@v5
       - name: Stripe preflight
+        env:
+          GITHUB_ENV: ${{ runner.temp }}/env.out
         run: |
           echo "STRIPE_SECRET_KEY present: $([[ \"$STRIPE_SECRET_KEY\" =~ ^sk_ ]] && echo true || echo false)"
           echo "STRIPE_WEBHOOK_SECRET present: $([[ \"$STRIPE_WEBHOOK_SECRET\" =~ ^whsec_ ]] && echo true || echo false)"
@@ -66,6 +68,7 @@ jobs:
         env:
           STRIPE_SECRET_KEY: sk_live_xxx
           STRIPE_WEBHOOK_SECRET: whsec_xxx
+          GITHUB_ENV: ${{ runner.temp }}/env.out
         run: |
           cat <<'EOF' > /tmp/ci.env
           STRIPE_SECRET_KEY=

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Stripe preflight
+        env:
+          GITHUB_ENV: ${{ runner.temp }}/env.out
         run: |
           echo "STRIPE_SECRET_KEY present: $([[ \"$STRIPE_SECRET_KEY\" =~ ^sk_ ]] && echo true || echo false)"
           echo "STRIPE_WEBHOOK_SECRET present: $([[ \"$STRIPE_WEBHOOK_SECRET\" =~ ^whsec_ ]] && echo true || echo false)"

--- a/.github/workflows/ensure_server_boots_185ecc2b50.yml
+++ b/.github/workflows/ensure_server_boots_185ecc2b50.yml
@@ -27,6 +27,8 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Stripe preflight
+        env:
+          GITHUB_ENV: ${{ runner.temp }}/env.out
         run: |
           echo "STRIPE_SECRET_KEY present: $([[ \"$STRIPE_SECRET_KEY\" =~ ^sk_ ]] && echo true || echo false)"
           echo "STRIPE_WEBHOOK_SECRET present: $([[ \"$STRIPE_WEBHOOK_SECRET\" =~ ^whsec_ ]] && echo true || echo false)"

--- a/.github/workflows/glb-tests.yml
+++ b/.github/workflows/glb-tests.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Stripe preflight
+        env:
+          GITHUB_ENV: ${{ runner.temp }}/env.out
         run: |
           echo "STRIPE_SECRET_KEY present: $([[ \"$STRIPE_SECRET_KEY\" =~ ^sk_ ]] && echo true || echo false)"
           echo "STRIPE_WEBHOOK_SECRET present: $([[ \"$STRIPE_WEBHOOK_SECRET\" =~ ^whsec_ ]] && echo true || echo false)"
@@ -47,6 +49,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Stripe preflight
+        env:
+          GITHUB_ENV: ${{ runner.temp }}/env.out
         run: |
           echo "STRIPE_SECRET_KEY present: $([[ \"$STRIPE_SECRET_KEY\" =~ ^sk_ ]] && echo true || echo false)"
           echo "STRIPE_WEBHOOK_SECRET present: $([[ \"$STRIPE_WEBHOOK_SECRET\" =~ ^whsec_ ]] && echo true || echo false)"

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -21,6 +21,8 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Stripe preflight
+        env:
+          GITHUB_ENV: ${{ runner.temp }}/env.out
         run: |
           echo "STRIPE_SECRET_KEY present: $([[ \"$STRIPE_SECRET_KEY\" =~ ^sk_ ]] && echo true || echo false)"
           echo "STRIPE_WEBHOOK_SECRET present: $([[ \"$STRIPE_WEBHOOK_SECRET\" =~ ^whsec_ ]] && echo true || echo false)"

--- a/.github/workflows/pipeline-smoke.yml
+++ b/.github/workflows/pipeline-smoke.yml
@@ -29,6 +29,8 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Stripe preflight
+        env:
+          GITHUB_ENV: ${{ runner.temp }}/env.out
         run: |
           echo "STRIPE_SECRET_KEY present: $([[ \"$STRIPE_SECRET_KEY\" =~ ^sk_ ]] && echo true || echo false)"
           echo "STRIPE_WEBHOOK_SECRET present: $([[ \"$STRIPE_WEBHOOK_SECRET\" =~ ^whsec_ ]] && echo true || echo false)"

--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Stripe preflight
+        env:
+          GITHUB_ENV: ${{ runner.temp }}/env.out
         run: |
           echo "STRIPE_SECRET_KEY present: $([[ \"$STRIPE_SECRET_KEY\" =~ ^sk_ ]] && echo true || echo false)"
           echo "STRIPE_WEBHOOK_SECRET present: $([[ \"$STRIPE_WEBHOOK_SECRET\" =~ ^whsec_ ]] && echo true || echo false)"

--- a/.github/workflows/sync-space.yml
+++ b/.github/workflows/sync-space.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Stripe preflight
+        env:
+          GITHUB_ENV: ${{ runner.temp }}/env.out
         run: |
           echo "STRIPE_SECRET_KEY present: $([[ \"$STRIPE_SECRET_KEY\" =~ ^sk_ ]] && echo true || echo false)"
           echo "STRIPE_WEBHOOK_SECRET present: $([[ \"$STRIPE_WEBHOOK_SECRET\" =~ ^whsec_ ]] && echo true || echo false)"


### PR DESCRIPTION
## Summary
- ensure Stripe preflight steps run with explicit GITHUB_ENV in all workflows
- include GITHUB_ENV for loader precedence preflight in CI workflow

## Testing
- `npm run format`
- `npm test` *(fails: stripe route and linting detailed tests)*
- `SKIP_PW_DEPS=1 npm run ci` *(partial, interrupted)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68a4de1147f8832d8aebf63b81e01c37