### PR TITLE
fix: normalize port and set workflow defaults

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
 
   tests:
     runs-on: ubuntu-latest
+    env:
+      PORT: 3000
+      DB_URL: postgres://user:pass@localhost:5432/testdb
     steps:
       - name: REQUIRED
         run: |

--- a/.github/workflows/ensure_server_boots_185ecc2b50.yml
+++ b/.github/workflows/ensure_server_boots_185ecc2b50.yml
@@ -20,6 +20,7 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       S3_BUCKET: ${{ secrets.S3_BUCKET }}
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
+      PORT: 3000
     steps:
       - name: Checkout code
         uses: actions/checkout@v5

--- a/.github/workflows/glb-ci-alerts-938dhf.yml
+++ b/.github/workflows/glb-ci-alerts-938dhf.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   notify:
     runs-on: ubuntu-latest
+    env:
+      PORT: 3000
+      DB_URL: postgres://user:pass@localhost:5432/testdb
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4

--- a/.github/workflows/glb-tests.yml
+++ b/.github/workflows/glb-tests.yml
@@ -39,6 +39,9 @@ jobs:
   e2e-tests:
     needs: unit-tests
     runs-on: ubuntu-latest
+    env:
+      PORT: 3000
+      DB_URL: postgres://user:pass@localhost:5432/testdb
     steps:
       - uses: actions/checkout@v5
       - name: Load Stripe env

--- a/.github/workflows/pipeline-smoke.yml
+++ b/.github/workflows/pipeline-smoke.yml
@@ -22,6 +22,7 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       S3_BUCKET: ${{ secrets.S3_BUCKET }}
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
+      PORT: 3000
     steps:
       - name: Checkout code
         uses: actions/checkout@v5

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      PORT: 3000
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4

--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   smoke_test:
     runs-on: ubuntu-latest
+    env:
+      PORT: 3000
+      DB_URL: postgres://user:pass@localhost:5432/testdb
     steps:
       - uses: actions/checkout@v5
       - name: Load Stripe env

--- a/.github/workflows/sync-space.yml
+++ b/.github/workflows/sync-space.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       STRIPE_TEST_KEY: ${{ secrets.STRIPE_TEST_KEY }}
+      PORT: 3000
+      DB_URL: postgres://user:pass@localhost:5432/testdb
 
     steps:
       - uses: actions/checkout@v5

--- a/backend/server.js
+++ b/backend/server.js
@@ -213,7 +213,9 @@ const uploadsDir = path.join(__dirname, "..", "uploads");
 fs.mkdirSync(uploadsDir, { recursive: true });
 const upload = multer({ dest: uploadsDir });
 
-const PORT = config.port;
+const port = Number.parseInt(process.env.PORT || "3000", 10);
+const PORT =
+  Number.isNaN(port) || port < 1 || port > 65535 ? 3000 : port;
 
 function computePrintSlots(date = new Date()) {
   const dtf = new Intl.DateTimeFormat("en-US", {


### PR DESCRIPTION
## Summary
- normalize backend port with fallback to 3000
- plumb PORT and DB_URL through smoke/e2e workflows and wait-on localhost

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: process terminated signal SIGINT)*
- `npm run ci` *(fails: ERR_INVALID_ARG_TYPE)*
- `npm run smoke` *(partial run, aborted during setup)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f0da7db4832dbadc5b1f46abe053