### PR TITLE
ci: disable cloudflare pages deploy on prs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   deploy:
+    if: vars.ENABLE_PAGES == '1'
     runs-on: ubuntu-latest
 
     steps:
@@ -30,3 +31,9 @@ jobs:
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
           projectName: ${{ secrets.CF_PAGES_PROJECT }}
           directory: '.'
+
+  pages-disabled:
+    if: vars.ENABLE_PAGES != '1'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Pages deploy is disabled for PRs; enable via repo variable."


### PR DESCRIPTION
## Summary
- gate Cloudflare Pages deployment behind `ENABLE_PAGES` variable
- log when Pages deploy is skipped on PRs

## Testing
- `npm run format`
- `SKIP_PW_DEPS=1 npm test` *(fails: setup runs and hangs)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: ENOTEMPTY rmdir lodash-es)*
- `SKIP_PW_DEPS=1 npm run smoke` *(aborted: no output)*


------
https://chatgpt.com/codex/tasks/task_e_68a4ff5244f0832d827d7f6f042bb9e0