### PR TITLE
fix: allow mock env vars in tests

### DIFF
--- a/backend/__tests__/server-endpoints.test.ts
+++ b/backend/__tests__/server-endpoints.test.ts
@@ -34,9 +34,8 @@ let app;
 
 beforeAll(() => {
   process.env.NODE_ENV = "test";
-  process.env.STRIPE_WEBHOOK_SECRET = "whsec";
-  process.env.S3_BUCKET = "test-bucket";
-  process.env.CLOUDFRONT_MODEL_DOMAIN = "cdn.test";
+  const { applyMockEnv } = require("../src/lib/mockEnv");
+  applyMockEnv();
   app = require("../server");
 });
 

--- a/backend/config.js
+++ b/backend/config.js
@@ -9,7 +9,13 @@
 const { getEnv } = require("./src/lib/getEnv");
 const { applyMockEnv, mockSecrets } = require("./src/lib/mockEnv");
 
-applyMockEnv();
+const requireLive =
+  process.env.NODE_ENV === "production" ||
+  process.env.CI_REQUIRE_EXTERNAL === "1";
+
+if (!requireLive) {
+  applyMockEnv();
+}
 
 const required = ["DB_URL"];
 const optionalGlb = [
@@ -34,16 +40,11 @@ const stripeWebhook = getEnv("STRIPE_WEBHOOK_SECRET", {
   defaultValue: mockSecrets.STRIPE_WEBHOOK_SECRET,
 });
 
-const requireLive =
-  process.env.NODE_ENV === "production" ||
-  process.env.CI_REQUIRE_EXTERNAL === "1";
-if (requireLive) {
-  if (!/^sk_live/.test(stripeKey)) {
-    throw new Error("STRIPE_SECRET_KEY must be a live secret");
-  }
-  if (!/^whsec_/.test(stripeWebhook)) {
-    throw new Error("STRIPE_WEBHOOK_SECRET must be a live webhook secret");
-  }
+if (requireLive && !/^sk_live/.test(stripeKey)) {
+  throw new Error("STRIPE_SECRET_KEY must be a live secret");
+}
+if (requireLive && !/^whsec_/.test(stripeWebhook)) {
+  throw new Error("STRIPE_WEBHOOK_SECRET must be a live webhook secret");
 }
 
 module.exports = {

--- a/backend/src/lib/mockEnv.js
+++ b/backend/src/lib/mockEnv.js
@@ -1,15 +1,12 @@
-
-const crypto = require("crypto");
-const mockId = crypto.randomBytes(3).toString("hex");
-
 const mockSecrets = {
-  STRIPE_SECRET_KEY: `sk_test_${mockId}_mock`,
-  STRIPE_WEBHOOK_SECRET: `whsec_${mockId}_mock`,
-  AWS_ACCESS_KEY_ID: "AKIA_MOCK",
-  AWS_SECRET_ACCESS_KEY: "aws_secret_mock",
-  CF_PAGES_API_TOKEN: "cf_mock",
+  STRIPE_SECRET_KEY: "sk_test_mock",
+  STRIPE_WEBHOOK_SECRET: "whsec_mock",
+  AWS_ACCESS_KEY_ID: "mock",
+  AWS_SECRET_ACCESS_KEY: "mock",
+  AWS_REGION: "us-east-1",
+  S3_BUCKET: "mock-bucket",
+  DB_URL: "postgres://user:pass@localhost:5432/testdb",
   CLOUDFRONT_MODEL_DOMAIN: "cdn.test",
-  DB_URL: "postgres://localhost/test",
 };
 
 /**

--- a/backend/tests/env_loader_ci.test.ts
+++ b/backend/tests/env_loader_ci.test.ts
@@ -1,0 +1,22 @@
+const path = require("path");
+
+describe("env loader in CI", () => {
+  const configPath = path.resolve(__dirname, "../config.js");
+
+  afterEach(() => {
+    delete process.env.STRIPE_SECRET_KEY;
+    delete process.env.STRIPE_WEBHOOK_SECRET;
+    jest.resetModules();
+  });
+
+  test("falls back to mock secrets in test env", () => {
+    process.env.NODE_ENV = "test";
+    let cfg;
+    expect(() => {
+      cfg = require(configPath);
+    }).not.toThrow();
+    expect(cfg.stripeKey).toMatch(/^sk_test/);
+    expect(cfg.stripeWebhook).toMatch(/^whsec_/);
+  });
+});
+


### PR DESCRIPTION
## Summary
- gate Stripe live-secret checks to production or CI_REQUIRE_EXTERNAL
- seed mock env vars for non-prod and tests
- add CI coverage for env loader and update server tests

## Testing
- `npm run format`
- `SKIP_PW_DEPS=1 npm test tests/env_loader_ci.test.ts`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: npm error process terminated)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: SIGINT during run)*

------
https://chatgpt.com/codex/tasks/task_e_68a50799129c832d935c9df5330af56d