### PR TITLE
fix: add node types for CodeQL build

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,7 +28,8 @@ jobs:
           languages: javascript-typescript
       - name: Build
         run: |
-          node scripts/run-npm-ci.js
+          npm ci
+          npm --prefix backend ci
           npm run build
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3.29.9

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -45,7 +45,7 @@
         "@eslint/js": "^9.30.1",
         "@types/express": "^5.0.3",
         "@types/jest": "^30.0.0",
-        "@types/node": "^24.0.14",
+        "@types/node": "^20.0.0",
         "babel-jest": "^30.0.4",
         "coverage-badges-cli": "^2.1.0",
         "eslint": "^9.30.1",
@@ -6386,13 +6386,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.0.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.14.tgz",
-      "integrity": "sha512-4zXMWD91vBLGRtHK3YbIoFMia+1nqEz72coM42C5ETjnNCa/heoj7NT1G67iAfOqMmcfhuCZ4uNpyz8EjlAejw==",
+      "version": "20.19.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.11.tgz",
+      "integrity": "sha512-uug3FEEGv0r+jrecvUUpbY8lLisvIjg6AAic6a2bSP5OEOLeJsDSnvhCDov7ipFFMXS3orMpzlmi0ZcuGkBbow==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.8.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/pg": {
@@ -15171,9 +15171,9 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
-      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "devOptional": true,
       "license": "MIT"
     },

--- a/backend/package.json
+++ b/backend/package.json
@@ -79,7 +79,7 @@
     "@eslint/js": "^9.30.1",
     "@types/express": "^5.0.3",
     "@types/jest": "^30.0.0",
-    "@types/node": "^24.0.14",
+    "@types/node": "^20.0.0",
     "babel-jest": "^30.0.4",
     "coverage-badges-cli": "^2.1.0",
     "eslint": "^9.30.1",

--- a/backend/tsconfig.build.json
+++ b/backend/tsconfig.build.json
@@ -2,7 +2,9 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "noEmit": false,
-    "noEmitOnError": false
+    "noEmitOnError": false,
+    "types": ["node"],
+    "skipLibCheck": true
   },
   "include": ["src/**/*.ts", "global.d.ts"]
 }


### PR DESCRIPTION
## Summary
- add Node 20 type definitions to backend
- include node types and skip lib check in backend build config
- ensure CodeQL workflow installs dependencies before building

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: repeatedly runs setup without executing tests)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: setup script aborts before tests)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: script exits after env check)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ae895f78832da86d9676b3c034c8