### PR TITLE
ci: retry coveralls upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,8 +95,12 @@ jobs:
           sed -r 's/\x1B\[[0-9;]*[JKmsu]//g' coverage/lcov.info \
             > coverage/lcov.sanitized.info
 
-      - name: Upload to Coveralls
-        run: cat coverage/lcov.sanitized.info | npx coveralls
+      - name: Upload coverage to Coveralls
+        run: |
+          for i in 1 2 3; do
+            cat coverage/lcov.sanitized.info | npx coveralls && exit 0 || sleep 5
+          done
+          echo "Coveralls unavailable; continuing"
 
       - name: Check bundle size
         run: npm run bundle:size

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -36,6 +36,11 @@ jobs:
         run: CHECK_LCOV=1 node scripts/run-jest.js backend/__tests__/lcovExists.test.js
       - name: Verify coverage summary
         run: node scripts/run-jest.js backend/__tests__/coverageSummaryExists.test.js
-      - run: cat coverage/lcov.info | npx coveralls
+      - name: Upload coverage to Coveralls
+        run: |
+          for i in 1 2 3; do
+            cat coverage/lcov.info | npx coveralls && exit 0 || sleep 5
+          done
+          echo "Coveralls unavailable; continuing"
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}


### PR DESCRIPTION
## Summary
- retry Coveralls uploads so CI keeps running if the service is down

## Testing
- `npm run format`
- `npm test` *(fails: 2 failed test suites)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: command interrupted)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Playwright configuration error)*

------
https://chatgpt.com/codex/tasks/task_e_68a5aeab64b4832d91361ed920dbbdcb