### PR TITLE
ci: configure Cloudflare Pages build command

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,5 @@
+name = "mvp-website"
+pages_build_output_dir = "frontend/dist"
+
+[build]
+command = "npm run build:frontend"


### PR DESCRIPTION
## Summary
- configure Cloudflare Pages to run `npm run build:frontend`
- publish build artifacts from `frontend/dist`

## Testing
- `npm run format` (backend)
- `npm test` (backend, fails: parsing error and JSDoc missing param)
- `SKIP_PW_DEPS=1 npm run ci` (fails: interrupted after Prettier check)
- `SKIP_PW_DEPS=1 npm run smoke` (fails: interrupted during serve)


------
https://chatgpt.com/codex/tasks/task_e_68a5aeb627e4832dbfe6d19108964b40