### PR TITLE
ci: build frontend before pages deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,8 +18,8 @@ jobs:
         with:
           node-version: 20
 
-      - name: Install dependencies
-        run: npm ci
+      - name: Build frontend
+        run: npm ci && npm run build:frontend
 
       - name: Run deployment readiness test
         run: npm run test:cf-readiness
@@ -27,10 +27,11 @@ jobs:
       - name: Publish to Cloudflare Pages
         uses: cloudflare/pages-action@v1
         with:
-          apiToken: ${{ secrets.CF_PAGES_API_TOKEN }}
-          accountId: ${{ secrets.CF_ACCOUNT_ID }}
           projectName: ${{ secrets.CF_PAGES_PROJECT }}
-          directory: '.'
+          accountId:   ${{ secrets.CF_ACCOUNT_ID }}
+          apiToken:    ${{ secrets.CF_PAGES_API_TOKEN }}
+          directory:   ./frontend/dist
+          wranglerVersion: '3'
 
   pages-disabled:
     if: vars.ENABLE_PAGES != '1'

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,5 +1,2 @@
 name = "mvp-website"
 pages_build_output_dir = "frontend/dist"
-
-[build]
-command = "npm run build:frontend"


### PR DESCRIPTION
## Summary
- remove wrangler build section and point Pages output to frontend/dist
- build frontend before Cloudflare Pages deploy and specify deployment settings

## Testing
- `npm run format`
- `npm test` *(fails: 4 failed, 2 skipped)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 8 failed, 16 skipped)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68a5bbf38130832d9cf3d0292efe094a