### PR TITLE
fix: block additional protocols in thumbnail renderer

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -719,9 +719,8 @@ function renderThumbnails(arr) {
     const img = document.createElement("img");
     try {
       const parsed = new URL(url, window.location.href);
-      if (parsed.protocol === "javascript:") {
-        throw new Error("invalid url");
-      }
+      const blocked = new Set(["javascript:", "data:", "vbscript:"]);
+      if (blocked.has(parsed.protocol)) throw new Error("invalid url");
       img.src = parsed.href;
     } catch {
       img.src = "";
@@ -1335,3 +1334,8 @@ if (document.readyState !== "loading") {
   start();
 }
 window.addEventListener("DOMContentLoaded", start);
+
+if (typeof module !== "undefined") {
+  module.exports = { renderThumbnails };
+}
+export { renderThumbnails };

--- a/tests/renderThumbnails.test.js
+++ b/tests/renderThumbnails.test.js
@@ -1,0 +1,42 @@
+const { JSDOM } = require("jsdom");
+
+describe("renderThumbnails", () => {
+  let renderThumbnails;
+  let document;
+
+  beforeEach(() => {
+    jest.resetModules();
+    const dom = new JSDOM(
+      '<div id="image-preview-area"></div><textarea id="promptInput"></textarea>',
+      { url: "https://example.com" },
+    );
+    const { document: doc } = dom.window;
+    const realGet = doc.getElementById.bind(doc);
+    doc.getElementById = (id) =>
+      realGet(id) || {
+        addEventListener: () => {},
+        click: () => {},
+        getBoundingClientRect: () => ({ height: 0 }),
+        classList: { add: () => {}, remove: () => {}, toggle: () => {} },
+        style: {},
+      };
+    Object.defineProperty(doc, "readyState", {
+      value: "loading",
+      configurable: true,
+    });
+    dom.window.addEventListener = () => {};
+    global.window = dom.window;
+    global.document = doc;
+    global.localStorage = dom.window.localStorage;
+    global.navigator = dom.window.navigator;
+    global.fetch = () => Promise.resolve({});
+    ({ renderThumbnails } = require("../js/index.js"));
+    document = doc;
+  });
+
+  test.each(["data:", "vbscript:"])("rejects %s protocol", (proto) => {
+    renderThumbnails([`${proto}alert(1)`]);
+    const img = document.querySelector("img");
+    expect(img.getAttribute("src")).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary
- block `data:` and `vbscript:` protocols in thumbnail renderer
- add unit test to ensure unsafe protocols are rejected

## Testing
- `npm run format`
- `node scripts/run-jest.js tests/renderThumbnails.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a5c3f4536c832da39008027c20b40b