### PR TITLE
ci: retry coveralls uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PORT: 3000
-      CI_REQUIRE_EXTERNAL: '0'
+      CI_REQUIRE_EXTERNAL: "0"
     steps:
       - name: REQUIRED
         run: |
@@ -31,7 +31,7 @@ jobs:
     env:
       PORT: 3000
       DB_URL: postgres://user:pass@localhost:5432/testdb
-      CI_REQUIRE_EXTERNAL: '0'
+      CI_REQUIRE_EXTERNAL: "0"
     steps:
       - name: REQUIRED
         run: |
@@ -84,23 +84,18 @@ jobs:
       - name: Run CI
         env:
           PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
-          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: '0'
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "0"
         run: npm run ci
 
       - name: Run coverage
         run: SKIP_PW_DEPS=1 npm run coverage
 
       - name: Sanitize coverage for Coveralls
-        run: |
-          sed -r 's/\x1B\[[0-9;]*[JKmsu]//g' coverage/lcov.info \
-            > coverage/lcov.sanitized.info
+        run: sed -r -i 's/\x1B\[[0-9;]*[JKmsu]//g' coverage/lcov.info
 
       - name: Upload coverage to Coveralls
-        run: |
-          for i in 1 2 3; do
-            cat coverage/lcov.sanitized.info | npx coveralls && exit 0 || sleep 5
-          done
-          echo "Coveralls unavailable; continuing"
+        run: npm run coveralls:retry
+        continue-on-error: true
 
       - name: Check bundle size
         run: npm run bundle:size

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -37,10 +37,7 @@ jobs:
       - name: Verify coverage summary
         run: node scripts/run-jest.js backend/__tests__/coverageSummaryExists.test.js
       - name: Upload coverage to Coveralls
-        run: |
-          for i in 1 2 3; do
-            cat coverage/lcov.info | npx coveralls && exit 0 || sleep 5
-          done
-          echo "Coveralls unavailable; continuing"
+        run: npm run coveralls:retry
+        continue-on-error: true
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "e2e": "playwright test",
     "test:e2e": "playwright test",
     "test:unit": "npm test --prefix backend",
+    "coveralls:retry": "node scripts/coveralls-retry.js",
     "serve": "npm run build && node scripts/dev-server.js",
     "smoke": "node scripts/run-smoke.js",
     "predeploy": "node scripts/check-missing-links.js",

--- a/scripts/coveralls-retry.js
+++ b/scripts/coveralls-retry.js
@@ -1,0 +1,45 @@
+const fs = require("fs");
+const { spawn } = require("child_process");
+
+const file = "coverage/lcov.info";
+if (!fs.existsSync(file)) {
+  console.error(`Missing ${file}`);
+  process.exit(1);
+}
+const lcov = fs.readFileSync(file, "utf8");
+
+const delays = [5000, 10000, 20000, 40000, 60000];
+
+async function upload(attempt = 0) {
+  return new Promise((resolve) => {
+    const child = spawn("npx", ["coveralls"], {
+      stdio: ["pipe", "inherit", "pipe"],
+    });
+    let stderr = "";
+    child.stderr.on("data", (d) => {
+      const t = d.toString();
+      stderr += t;
+      process.stderr.write(t);
+    });
+    child.on("close", async (code) => {
+      if (code === 0) return resolve(true);
+      if (/5(03|04)/.test(stderr) && attempt < delays.length) {
+        const wait = delays[attempt];
+        console.warn(`Coveralls HTTP error; retrying in ${wait / 1000}s`);
+        setTimeout(() => resolve(upload(attempt + 1)), wait);
+      } else if (/5(03|04)/.test(stderr)) {
+        console.warn("Coveralls HTTP error; giving up after retries");
+        resolve(false);
+      } else {
+        process.exit(code || 1);
+      }
+    });
+    child.stdin.write(lcov);
+    child.stdin.end();
+  });
+}
+
+upload().then((success) => {
+  if (!success) console.warn("Coveralls unavailable; continuing");
+  process.exit(0);
+});


### PR DESCRIPTION
## Summary
- retry Coveralls uploads with exponential backoff
- mark Coveralls steps as non-blocking

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend tests/api.test.js` (fails: 1 failed, 67 passed)
- `SKIP_PW_DEPS=1 npm run ci` (fails: parserOptions.project errors)
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68a5d57a27b0832da851add71d86d540