### PR TITLE
test: block external HTTP traffic

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,7 @@ Thank you for helping improve this project! Please follow these steps to keep ou
 - All new code should include appropriate tests.
 - CI runs `npm run ci` and `npm test`; please ensure these succeed locally.
 - If Playwright dependencies are already installed you can set `SKIP_PW_DEPS=1` when running setup or CI to skip the lengthy install step.
+- Mock all external HTTP calls in tests. Only `localhost` traffic is permitted; any other network access must be stubbed with tools like [nock](https://github.com/nock/nock).
 
 ## How to run tests / lint / coverage / smoke
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,7 +3,10 @@ module.exports = {
     "<rootDir>/test/jest.setup.ts",
     "<rootDir>/backend/tests/setupGlobals.js",
   ],
-  setupFilesAfterEnv: ["<rootDir>/test/setupAuthMiddleware.js"],
+  setupFilesAfterEnv: [
+    "<rootDir>/test/setupAuthMiddleware.js",
+    "<rootDir>/tests/setup/nock.ts",
+  ],
   coverageThreshold: {
     global: {
       branches: 55,

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,7 @@
         "lint-staged": "^16.1.2",
         "lockfile-diff": "^0.1.0",
         "markdownlint-cli2": "^0.10.0",
+        "nock": "^13.5.6",
         "playwright": "^1.54.1",
         "prettier": "^3.5.3",
         "selfsigned": "^2.3.2",
@@ -17068,6 +17069,21 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/nock": {
+      "version": "13.5.6",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.5.6.tgz",
+      "integrity": "sha512-o2zOYiCpzRqSzPj0Zt/dQ/DqZeYoaQ7TUonc/xUPjCGl9WeHpNbxgVvOquXYAaJzI0M9BXV3HTzG0p8IUAbBTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      }
+    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -18266,6 +18282,16 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",

--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "lint-staged": "^16.1.2",
     "lockfile-diff": "^0.1.0",
     "markdownlint-cli2": "^0.10.0",
+    "nock": "^13.5.6",
     "playwright": "^1.54.1",
     "prettier": "^3.5.3",
     "selfsigned": "^2.3.2",

--- a/tests/networkAudit.test.ts
+++ b/tests/networkAudit.test.ts
@@ -1,0 +1,26 @@
+import { globSync } from 'glob';
+import { readFileSync } from 'fs';
+
+const TEST_GLOB = '**/*.{test.ts,test.tsx,test.js,test.jsx}';
+
+function hasUnmockedNetCalls(file: string, content: string): boolean {
+  const usesNetwork = /axios\.|\bfetch\(/.test(content);
+  const hasMock = /nock|msw|fetchMock|global\.fetch|jest\.spyOn\(global,\s*'fetch'/.test(content);
+  return usesNetwork && !hasMock;
+}
+
+test('network audit', () => {
+  const offenders: string[] = [];
+  for (const file of globSync(TEST_GLOB, { ignore: ['**/node_modules/**'] })) {
+    const text = readFileSync(file, 'utf8');
+    if (hasUnmockedNetCalls(file, text)) {
+      offenders.push(file);
+    }
+  }
+  if (offenders.length) {
+    console.warn(
+      'Network audit: possible unmocked HTTP calls in:\n' + offenders.join('\n'),
+    );
+  }
+  expect(true).toBe(true);
+});

--- a/tests/setup/nock.ts
+++ b/tests/setup/nock.ts
@@ -1,0 +1,12 @@
+import nock from 'nock';
+
+nock.disableNetConnect();
+nock.enableNetConnect(/^(127\.0\.0\.1|localhost)$/);
+
+afterEach(() => {
+  const pending = nock.pendingMocks();
+  if (pending.length > 0) {
+    throw new Error(`Unused nock interceptors:\n${pending.join('\n')}`);
+  }
+  nock.cleanAll();
+});


### PR DESCRIPTION
## Summary
- block outbound network requests in Jest with a nock setup
- add network audit test to flag axios/fetch without mocks
- document requirement to mock non-localhost HTTP calls

## Testing
- `npm run format` (backend)
- `node scripts/run-jest.js tests/networkAudit.test.ts` *(fails: Missing root dependencies. Run 'npm run setup' before running tests.)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ebece9d4832dae1ca06bde423612