### PR TITLE
ci: wait for backend health in boot check

### DIFF
--- a/.github/workflows/ensure_server_boots_185ecc2b50.yml
+++ b/.github/workflows/ensure_server_boots_185ecc2b50.yml
@@ -41,20 +41,37 @@ jobs:
       - name: Install dependencies
         run: npm run setup
 
-      - name: Start server
+      - name: Start backend
+        env:
+          STRIPE_TEST_KEY: ${{ env.STRIPE_TEST_KEY }}
+          DB_URL: ${{ env.DB_URL }}
+          HF_API_KEY: ${{ env.HF_API_KEY }}
+          CLOUDFRONT_MODEL_DOMAIN: ${{ env.CLOUDFRONT_MODEL_DOMAIN }}
+          SPARC3D_ENDPOINT: ${{ env.SPARC3D_ENDPOINT }}
+          SPARC3D_TOKEN: ${{ env.SPARC3D_TOKEN }}
+          STABILITY_KEY: ${{ env.STABILITY_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ env.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ env.AWS_SECRET_ACCESS_KEY }}
+          S3_BUCKET: ${{ env.S3_BUCKET }}
+          HF_TOKEN: ${{ env.HF_TOKEN }}
+          PORT: ${{ env.PORT }}
+          CI_REQUIRE_EXTERNAL: ${{ env.CI_REQUIRE_EXTERNAL }}
         run: |
-          npm run dev 2>&1 | tee /tmp/server.log &
+          npm run start:backend 2>&1 | tee /tmp/server.log &
           echo $! > /tmp/server.pid
         shell: bash
 
-      - name: Wait for server
+      - name: Wait for backend
         run: |
-          npx wait-on http://localhost:3000 --timeout 300000 || {
+          npx wait-on http://localhost:3000/healthz --timeout 90000 || {
             echo "Server failed to start";
             cat /tmp/server.log;
             exit 1;
           }
         shell: bash
+
+      - name: Probe health endpoint
+        run: curl -fsS http://localhost:3000/healthz | jq -e '.ok==true'
 
       - name: Run backend tests
         run: npm test --prefix backend

--- a/backend/__tests__/health.test.js
+++ b/backend/__tests__/health.test.js
@@ -12,5 +12,5 @@ afterAll(() => {
 test("GET /health returns ok", async () => {
   const res = await request(app).get("/health");
   expect(res.status).toBe(200);
-  expect(res.body).toEqual({ status: "ok" });
+  expect(res.body).toEqual({ ok: true });
 });

--- a/backend/routes/healthz.js
+++ b/backend/routes/healthz.js
@@ -2,13 +2,13 @@ const express = require("express");
 
 const router = express.Router();
 
-router.get("/healthz", (req, res) => {
-  res.json({ status: "ok" });
+router.get("/healthz", (_req, res) => {
+  res.json({ ok: true });
 });
 
 // Allow legacy /health endpoint for compatibility
-router.get("/health", (req, res) => {
-  res.json({ status: "ok" });
+router.get("/health", (_req, res) => {
+  res.json({ ok: true });
 });
 
 module.exports = router;

--- a/backend/tests/healthz.test.js
+++ b/backend/tests/healthz.test.js
@@ -4,11 +4,11 @@ const app = require("../server");
 test("GET /healthz returns ok", async () => {
   const res = await request(app).get("/healthz");
   expect(res.status).toBe(200);
-  expect(res.body).toEqual({ status: "ok" });
+  expect(res.body).toEqual({ ok: true });
 });
 
 test("GET /health returns ok", async () => {
   const res = await request(app).get("/health");
   expect(res.status).toBe(200);
-  expect(res.body).toEqual({ status: "ok" });
+  expect(res.body).toEqual({ ok: true });
 });

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "coveralls:retry": "node scripts/coveralls-retry.js",
     "serve": "npm run build && node scripts/dev-server.js",
     "smoke": "node scripts/run-smoke.js",
+    "start:backend": "npm start --prefix backend",
     "predeploy": "node scripts/check-missing-links.js",
     "build": "tsc -p backend/tsconfig.build.json",
     "postbuild": "npx -y ts-node --transpile-only scripts/check-broken-symlinks-9ac8f74db5e1c32.ts",


### PR DESCRIPTION
## Summary
- start backend in boot check with test env and wait on /healthz
- expose /healthz endpoint returning `{ok:true}` and update tests
- add start:backend script for workflow use

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: NetConnectNotAllowedError and other e2e failures)*
- `SKIP_PW_DEPS=1 npm run ci` *(incomplete: interrupted)*
- `SKIP_PW_DEPS=1 npm run smoke` *(interrupted by SIGINT)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ebcda19c832d8dffa1d3a25090be