### PR TITLE
ci: add frontend build workflow

### DIFF
--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -1,0 +1,29 @@
+name: Build frontend
+
+on:
+  pull_request:
+    paths:
+      - 'frontend/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20, 22]
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci
+        working-directory: frontend
+      - run: npm run build
+        working-directory: frontend
+      - run: node scripts/assert-frontend-dist.js
+      - uses: actions/upload-artifact@v4
+        with:
+          name: frontend-dist-${{ matrix.node-version }}
+          path: frontend/dist


### PR DESCRIPTION
## Summary
- add workflow to build frontend on relevant PRs and upload the dist artifact

## Testing
- `npm run format --prefix backend`
- `SKIP_PW_DEPS=1 npm test --prefix backend` *(fails: requires Playwright binaries)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: log file not found)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: log file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ebc67964832da392d7679c92d093