### PR TITLE
ci: build frontend with node matrix and lint

### DIFF
--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -7,23 +7,30 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    concurrency:
+      group: build-frontend-${{ github.ref }}-${{ matrix.os }}-${{ matrix.node }}
+      cancel-in-progress: true
     strategy:
       matrix:
-        node-version: [20, 22]
+        os: [ubuntu-latest]
+        node: [20, 22]
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ matrix.node }}
           cache: npm
           cache-dependency-path: frontend/package-lock.json
       - run: npm ci
         working-directory: frontend
+      - run: npm run lint
+        working-directory: frontend
+      - run: npx tsc -p frontend
       - run: npm run build
         working-directory: frontend
       - run: node scripts/assert-frontend-dist.js
       - uses: actions/upload-artifact@v4
         with:
-          name: frontend-dist-${{ matrix.node-version }}
+          name: frontend-dist-${{ matrix.node }}
           path: frontend/dist


### PR DESCRIPTION
## Summary
- run frontend build for Node 20 and 22 on ubuntu with concurrency limits
- upload build output per node version for downstream jobs
- add ESLint and TypeScript checks to the frontend build

## Testing
- `npm run format --prefix backend`
  ```
  > backend@1.0.0 preformat
  > node ../scripts/ensure-root-deps.js
  
  > backend@1.0.0 format
  > sh -c 'cd .. && node scripts/ensure-root-deps.js && prettier --log-level warn --write "**/*.{js,jsx,json,md}" --ignore-path .prettierignore'
  ```
- `npm test --prefix backend` *(fails: ENOTEMPTY)*
  ```
  npm error ENOTEMPTY: directory not empty, rmdir '/workspace/MVP-website/backend/node_modules/lodash-es'
  Failed to install dependencies: Command failed: npm ci
  ```
- `npm run ci` *(aborted: environment limitations)*
  ```
  Checking AWS_ACCESS_KEY_ID: your-aws-access-key-id
  npm warn deprecated lodash.isequal@4.5.0
  npm warn deprecated lodash.get@4.4.2
  ```
- `npm run smoke` *(TypeScript errors)*
  ```
  npm error ENOTEMPTY: directory not empty, rmdir '/workspace/MVP-website/backend/node_modules/z-schema/src'
  backend/src/routes/stripe/create-checkout-session.ts(3,8): error TS6133: 'NextFunction' is declared but its value is never read.
  ```

------
https://chatgpt.com/codex/tasks/task_e_68a604fe9744832da9c31de2b060d93b