### PR TITLE
ci: harden Pages deploy pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,16 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Mask secrets
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          echo "::add-mask::$CLOUDFLARE_API_TOKEN"
+          echo "::add-mask::$CLOUDFLARE_ACCOUNT_ID"
 
       - name: Install deps
         run: npm ci
@@ -29,11 +39,73 @@ jobs:
           test -d frontend/dist
           test -f frontend/dist/index.html
 
-      - name: Deploy with Wrangler
+      - name: Wrangler version
+        run: npx wrangler --version
+
+      - name: Assert Pages project has no build config
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: npx wrangler pages deploy frontend/dist --project-name mvp-website
+        run: |
+          info=$(npx wrangler pages project info mvp-website --output json)
+          build_command=$(echo "$info" | jq -r '.deployment_configs.production.build_config.build_command')
+          root_dir=$(echo "$info" | jq -r '.deployment_configs.production.build_config.root_dir')
+          if [ "$build_command" != "null" ] && [ -n "$build_command" ]; then
+            echo "Pages-side build command configured: $build_command"
+            exit 1
+          fi
+          if [ "$root_dir" != "null" ] && [ -n "$root_dir" ]; then
+            echo "Pages-side root_dir configured: $root_dir"
+            exit 1
+          fi
+
+      - name: Deploy with Wrangler
+        id: deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set +e
+          for attempt in 1 2 3; do
+            echo "Attempt $attempt"
+            npx wrangler pages deploy frontend/dist --project-name mvp-website 2>&1 | tee deploy.log
+            status=${PIPESTATUS[0]}
+            if [ $status -eq 0 ]; then
+              break
+            fi
+            if grep -q "5[0-9][0-9]" deploy.log && [ $attempt -lt 3 ]; then
+              echo "5xx error detected, retrying..."
+              sleep 5
+            else
+              exit $status
+            fi
+          done
+          url=$(grep -o 'https://[^ ]*' deploy.log | tail -n1)
+          echo "url=$url" >> $GITHUB_OUTPUT
+          echo "$url" > pages-url.txt
+
+      - name: Upload Pages URL
+        if: steps.deploy.outputs.url != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: pages-url
+          path: pages-url.txt
+
+      - name: Comment with Pages URL
+        if: steps.deploy.outputs.url != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const url = process.env.URL;
+            const sha = context.sha;
+            await github.repos.createCommitComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: sha,
+              body: `Cloudflare Pages preview: ${url}`
+            });
+        env:
+          URL: ${{ steps.deploy.outputs.url }}
 
   pages-disabled:
     if: vars.ENABLE_PAGES != '1'

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,10 @@
+# Continuous integration
+
+This repository builds the frontend within CI and deploys the pre-built assets to Cloudflare Pages.
+Cloudflare Pages' own build step is intentionally disabled; the Pages project must not have a
+`build_command` or `root_dir` configured. The deploy workflow asserts this by inspecting the
+project with `wrangler pages project info` and will fail if a Pages-side build is detected.
+
+During deployment the workflow caches `~/.npm` for the `frontend` package via `actions/setup-node`
+and publishes the site using `wrangler pages deploy`. The resulting preview URL is uploaded as an
+artifact and commented on the commit for easy reference.


### PR DESCRIPTION
## Summary
- cache frontend dependencies and mask secrets in deploy workflow
- surface Pages preview URL and verify Pages project lacks build config
- document CI strategy around Pages builds

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend tests/api.test.ts`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68a604f02d1c832d8cc082ae086d3a87