### PR TITLE
ci: build frontend output for Pages deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,14 +20,14 @@ jobs:
 
       - name: Install deps
         run: npm ci
+        working-directory: frontend
 
       - name: Build frontend
-        run: npm run build:frontend
+        run: npm run build
+        working-directory: frontend
 
       - name: Assert build output
-        run: |
-          test -d frontend/dist
-          test -f frontend/dist/index.html
+        run: node scripts/assert-dist.mjs
 
       - name: Deploy with Wrangler
         env:

--- a/scripts/assert-dist.mjs
+++ b/scripts/assert-dist.mjs
@@ -1,0 +1,11 @@
+import { access } from "fs/promises";
+import { resolve } from "path";
+
+const output = resolve("frontend/dist/index.html");
+
+try {
+  await access(output);
+} catch {
+  console.error(`Missing build output: ${output}`);
+  process.exit(1);
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,2 +1,0 @@
-name = "mvp-website"
-pages_build_output_dir = "frontend/dist"


### PR DESCRIPTION
## Summary
- build frontend in `frontend` dir on deploy
- fail deploy if `frontend/dist` missing
- simplify Cloudflare Pages deploy config

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68a604ec85d8832d96e9a3cb6b9d5a61