### PR TITLE
ci: upload diagnostics logs and detect flaky tests

### DIFF
--- a/.github/workflows/pipeline-smoke.yml
+++ b/.github/workflows/pipeline-smoke.yml
@@ -66,3 +66,17 @@ jobs:
 
       - name: Run diagnostics
         run: pnpm diagnose
+
+      - name: Collect logs
+        if: always()
+        run: |
+          tail -n 200 /tmp/server.log > /tmp/server-tail.log || true
+
+      - name: Upload diagnostics artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: diagnostics
+          path: |
+            /tmp/diagnostics.log
+            /tmp/server-tail.log

--- a/scripts/diagnose.sh
+++ b/scripts/diagnose.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+LOG_FILE=${DIAG_LOG:-/tmp/diagnostics.log}
+SERVER_LOG=${SERVER_LOG:-/tmp/server.log}
+exec > >(tee -a "$LOG_FILE") 2>&1
+
 if [[ -f .env ]]; then
   while IFS='=' read -r key value; do
     [[ "$key" =~ ^\s*# || -z "$key" ]] && continue
@@ -14,12 +18,25 @@ banner() {
   echo -e "\n==============================\n$1\n==============================";
 }
 
+timings=()
+time_stage() {
+  local name=$1
+  shift
+  local start=$(date +%s)
+  "$@"
+  local status=$?
+  local end=$(date +%s)
+  timings+=("$name:$((end-start))")
+  return $status
+}
+
 banner "Running environment validation"
 # Source validate-env so exported variables persist in this script
-source scripts/validate-env.sh
+time_stage "validate_env" source scripts/validate-env.sh
 
 banner "Starting dev server"
-pnpm dev &
+start=$(date +%s)
+pnpm dev &> "$SERVER_LOG" &
 SERVER_PID=$!
 trap 'kill $SERVER_PID' EXIT
 
@@ -28,14 +45,26 @@ for i in {1..30}; do
   if nc -z localhost 3000; then break; fi
   sleep 1
 done
+timings+=("server_start:$(( $(date +%s)-start ))")
 
 set +e
-node scripts/test-full-pipeline.js
+time_stage "pipeline" node scripts/test-full-pipeline.js
 PIPELINE_STATUS=$?
 
-node scripts/run-jest.js tests/**/*.js tests/**/*.ts --runInBand
+JEST_JSON=/tmp/jest-results.json
+time_stage "tests" node scripts/run-jest.js --json --outputFile "$JEST_JSON" tests/**/*.js tests/**/*.ts --runInBand
 TEST_STATUS=$?
+node scripts/flaky-test-detector.js "$JEST_JSON" || true
 set -e
+
+banner "Stage timings"
+for t in "${timings[@]}"; do
+  IFS=":" read -r name dur <<< "$t"
+  echo "$name took ${dur}s"
+done
+
+banner "Last 200 lines of server log"
+tail -n 200 "$SERVER_LOG" || true
 
 if [[ $PIPELINE_STATUS -eq 0 && $TEST_STATUS -eq 0 ]]; then
   banner "DIAGNOSTICS PASSED"

--- a/scripts/flaky-test-detector.js
+++ b/scripts/flaky-test-detector.js
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+const fs = require("fs");
+
+const file = process.argv[2];
+if (!file || !fs.existsSync(file)) {
+  console.error(`Test result file not found: ${file}`);
+  process.exit(1);
+}
+
+const data = JSON.parse(fs.readFileSync(file, "utf8"));
+const durations = [];
+for (const tr of data.testResults || []) {
+  const perf = tr.perfStats || {};
+  const runtime =
+    typeof perf.runtime === "number" ? perf.runtime : perf.end - perf.start;
+  if (runtime) {
+    durations.push({ name: tr.name, duration: runtime });
+  }
+}
+if (!durations.length) process.exit(0);
+
+durations.sort((a, b) => a.duration - b.duration);
+const idx = Math.floor(durations.length * 0.9);
+const threshold = durations[idx].duration;
+const slow = durations.filter((d) => d.duration >= threshold);
+console.log(`90th percentile duration: ${threshold}ms`);
+if (slow.length) {
+  console.log("Potentially flaky tests:");
+  for (const s of slow) {
+    console.log(` - ${s.name} (${s.duration}ms)`);
+  }
+}

--- a/tests/flaky-test-detector.test.js
+++ b/tests/flaky-test-detector.test.js
@@ -1,0 +1,20 @@
+const fs = require("fs");
+const path = require("path");
+const { execSync } = require("child_process");
+
+test("reports tests above 90th percentile", () => {
+  const file = path.join(__dirname, "sample-jest.json");
+  const data = {
+    testResults: [
+      { name: "a.test.js", perfStats: { start: 0, end: 10 } },
+      { name: "b.test.js", perfStats: { start: 0, end: 100 } },
+      { name: "c.test.js", perfStats: { start: 0, end: 20 } },
+    ],
+  };
+  fs.writeFileSync(file, JSON.stringify(data));
+  const out = execSync(
+    `node ${path.join(__dirname, "..", "scripts", "flaky-test-detector.js")} ${file}`,
+    { encoding: "utf8" },
+  );
+  expect(out).toMatch(/b\.test\.js/);
+});


### PR DESCRIPTION
## Summary
- record diagnostics output and server log tail
- report stage timings and flaky tests over the 90th percentile
- upload diagnostics and server logs from pipeline smoke test

## Testing
- `npm run format`
- `npm test`
- `node scripts/run-jest.js tests/flaky-test-detector.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a6050ffb10832db63121cbded8a9c9