### PR TITLE
feat: add readiness endpoint and tests

### DIFF
--- a/backend/routes/healthz.js
+++ b/backend/routes/healthz.js
@@ -1,14 +1,29 @@
 const express = require("express");
+const pkg = require("../package.json");
+const db = require("../db");
 
 const router = express.Router();
 
-router.get("/healthz", (_req, res) => {
-  res.json({ ok: true });
-});
+function healthHandler(_req, res) {
+  res.json({ ok: true, version: pkg.version });
+}
+
+async function readyHandler(_req, res) {
+  try {
+    await db.query("SELECT 1");
+    res.json({ ok: true, version: pkg.version });
+  } catch {
+    res.status(500).json({ ok: false, version: pkg.version });
+  }
+}
+
+router.get("/healthz", healthHandler);
 
 // Allow legacy /health endpoint for compatibility
-router.get("/health", (_req, res) => {
-  res.json({ ok: true });
-});
+router.get("/health", healthHandler);
+
+router.get("/readyz", readyHandler);
 
 module.exports = router;
+module.exports.healthHandler = healthHandler;
+module.exports.readyHandler = readyHandler;

--- a/backend/tests/health-handler.test.js
+++ b/backend/tests/health-handler.test.js
@@ -1,0 +1,8 @@
+const { healthHandler } = require("../routes/healthz");
+
+test("healthHandler responds with ok and version", () => {
+  const json = jest.fn();
+  const res = { json };
+  healthHandler({}, res);
+  expect(json).toHaveBeenCalledWith({ ok: true, version: expect.any(String) });
+});

--- a/backend/tests/healthz.test.js
+++ b/backend/tests/healthz.test.js
@@ -1,14 +1,23 @@
+jest.mock("../db", () => ({
+  query: jest.fn().mockResolvedValue({ rows: [] }),
+}));
 const request = require("supertest");
 const app = require("../server");
 
 test("GET /healthz returns ok", async () => {
   const res = await request(app).get("/healthz");
   expect(res.status).toBe(200);
-  expect(res.body).toEqual({ ok: true });
+  expect(res.body).toMatchObject({ ok: true, version: expect.any(String) });
+});
+
+test("GET /readyz returns ok", async () => {
+  const res = await request(app).get("/readyz");
+  expect(res.status).toBe(200);
+  expect(res.body).toMatchObject({ ok: true, version: expect.any(String) });
 });
 
 test("GET /health returns ok", async () => {
   const res = await request(app).get("/health");
   expect(res.status).toBe(200);
-  expect(res.body).toEqual({ ok: true });
+  expect(res.body).toMatchObject({ ok: true, version: expect.any(String) });
 });

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -9,4 +9,30 @@ paths:
       responses:
         '200':
           description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [ok, version]
+                properties:
+                  ok:
+                    type: boolean
+                  version:
+                    type: string
+  /readyz:
+    get:
+      summary: Readiness check
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [ok, version]
+                properties:
+                  ok:
+                    type: boolean
+                  version:
+                    type: string
 components: {}

--- a/e2e/wait-for-backend-a3f9X2.test.js
+++ b/e2e/wait-for-backend-a3f9X2.test.js
@@ -12,12 +12,19 @@ async function main() {
   });
   try {
     await waitOn({
-      resources: ["http://localhost:3000/healthz"],
+      resources: [
+        "http://localhost:3000/healthz",
+        "http://localhost:3000/readyz",
+      ],
       timeout: 120000,
     });
-    const res = await fetch("http://localhost:3000/healthz");
-    if (!res.ok) {
-      throw new Error(`Expected 200 from /healthz, got ${res.status}`);
+    const health = await fetch("http://localhost:3000/healthz");
+    if (!health.ok) {
+      throw new Error(`Expected 200 from /healthz, got ${health.status}`);
+    }
+    const ready = await fetch("http://localhost:3000/readyz");
+    if (!ready.ok) {
+      throw new Error(`Expected 200 from /readyz, got ${ready.status}`);
     }
     console.log("Server responded within timeout");
   } catch (err) {

--- a/scripts/smoke-server.js
+++ b/scripts/smoke-server.js
@@ -8,8 +8,15 @@ const axios = require("axios");
       validateStatus: () => true,
     });
     if (health.status !== 200) throw new Error(`/healthz ${health.status}`);
-    if (health.data.status !== "ok")
+    if (!health.data.ok)
       throw new Error(`bad healthz body ${JSON.stringify(health.data)}`);
+
+    const ready = await axios.get(`${base}/readyz`, {
+      validateStatus: () => true,
+    });
+    if (ready.status !== 200) throw new Error(`/readyz ${ready.status}`);
+    if (!ready.data.ok)
+      throw new Error(`bad readyz body ${JSON.stringify(ready.data)}`);
 
     const gen = await axios.post(
       `${base}/api/generate`,

--- a/tests/serverBootSmoke_c63b9e.test.ts
+++ b/tests/serverBootSmoke_c63b9e.test.ts
@@ -16,7 +16,10 @@ describe("backend server boot", () => {
     proc = spawn(process.execPath, [serverPath], { stdio: "ignore" });
     try {
       await waitOn({
-        resources: ["http://localhost:3000/healthz"],
+        resources: [
+          "http://localhost:3000/healthz",
+          "http://localhost:3000/readyz",
+        ],
         timeout: 5000,
       });
     } catch (err) {


### PR DESCRIPTION
## Summary
- add `/readyz` endpoint that checks database connectivity
- return app version in health responses and document in OpenAPI
- test health handlers and update smoke tests for readiness

## Testing
- `npm test --prefix backend backend/tests/health-handler.test.js backend/tests/healthz.test.js`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68a6050645e8832dad69d8d4d23d8aae