### PR TITLE
fix: accept text health in smoke test

### DIFF
--- a/scripts/smoke-server.js
+++ b/scripts/smoke-server.js
@@ -8,7 +8,12 @@ const axios = require("axios");
       validateStatus: () => true,
     });
     if (health.status !== 200) throw new Error(`/healthz ${health.status}`);
-    if (health.data.status !== "ok")
+    const healthy =
+      (typeof health.data === "string" && health.data.trim() === "ok") ||
+      (typeof health.data === "object" &&
+        health.data &&
+        health.data.ok === true);
+    if (!healthy)
       throw new Error(`bad healthz body ${JSON.stringify(health.data)}`);
 
     const gen = await axios.post(


### PR DESCRIPTION
## Summary
- allow smoke-server to treat /healthz responses of `"ok"` or `{ ok: true }` as healthy

## Testing
- `npm run format`
- `npm test` (backend) *(fails: eslintIsolation.test.js parse errors)*
- `SKIP_PW_DEPS=1 npm run ci` *(partial, terminated early)*
- `SKIP_PW_DEPS=1 npm run smoke`
- `node scripts/ci-health.js`
- `node scripts/smoke-server.js`


------
https://chatgpt.com/codex/tasks/task_e_68a60500dd0c832dae6620f42ff9b33c