### PR TITLE
ci: add cache primer workflow

### DIFF
--- a/.github/workflows/cache-primer.yml
+++ b/.github/workflows/cache-primer.yml
@@ -1,0 +1,27 @@
+name: Cache primer
+
+on:
+  pull_request:
+
+jobs:
+  frontend-cache:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci --prefix frontend
+
+  backend-cache:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+      - run: npm ci --prefix backend


### PR DESCRIPTION
## Summary
- warm npm caches for frontend and backend on pull requests

## Testing
- `npm run format`
- `cd backend && SKIP_PW_DEPS=1 npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Code style issues found in 14 files)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68a606cd43b4832d830d1e205a27f530