### PR TITLE
ci: add frontend dry build workflow

### DIFF
--- a/.github/workflows/frontend-dry-build.yml
+++ b/.github/workflows/frontend-dry-build.yml
@@ -1,0 +1,24 @@
+name: Frontend dry build
+
+on:
+  pull_request:
+
+jobs:
+  dry-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci
+        working-directory: frontend
+      - run: npm run build
+        working-directory: frontend
+      - run: node -e "require('fs').accessSync('frontend/dist/index.html')"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: frontend-dist
+          path: frontend/dist


### PR DESCRIPTION
## Summary
- add a workflow to dry-build the frontend without deploying

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend -- tests/api.test.js`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: process interrupted)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: process interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68a606ed6334832d98105aa017b589f8