### PR TITLE
test: add healthz probe diagnostic

### DIFF
--- a/tests/diagnostics/healthz_probe.test.js
+++ b/tests/diagnostics/healthz_probe.test.js
@@ -1,0 +1,13 @@
+const { startDevServer } = require("../../scripts/dev-server");
+
+test("logs /healthz response", async () => {
+  const server = startDevServer(0);
+  const { port } = server.address();
+  const res = await fetch(`http://127.0.0.1:${port}/healthz`);
+  const body = await res.text();
+  const headers = Object.fromEntries(res.headers.entries());
+  console.log("/healthz headers", headers);
+  console.log("/healthz body", body);
+  await new Promise((resolve) => server.close(resolve));
+  expect(true).toBe(true);
+});


### PR DESCRIPTION
## Summary
- add diagnostics healthz probe test that logs the /healthz body and headers without failing

## Testing
- `npm run format` (backend)
- `npm test` (backend)
- `node scripts/run-jest.js tests/diagnostics/healthz_probe.test.js`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68a606e1d194832d91d10457566b886a