### PR TITLE
ci: add diagnostics helper scripts

### DIFF
--- a/scripts/ci/assert-dist.js
+++ b/scripts/ci/assert-dist.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+const fs = require("fs");
+const file = "frontend/dist/index.html";
+if (fs.existsSync(file)) {
+  process.exit(0);
+} else {
+  console.error(`Missing ${file}`);
+  process.exit(2);
+}

--- a/scripts/ci/print-env-safe.sh
+++ b/scripts/ci/print-env-safe.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+shopt -s nocasematch
+
+echo "Node version: $(node --version)"
+echo "npm version: $(npm --version)"
+echo "git commit: $(git rev-parse --short HEAD)"
+
+env | sort | while IFS='=' read -r name value; do
+  if [[ "$name" =~ (KEY|TOKEN|SECRET) ]]; then
+    echo "$name=***"
+  else
+    echo "$name=$value"
+  fi
+done
+
+shopt -u nocasematch

--- a/scripts/ci/tree.sh
+++ b/scripts/ci/tree.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+pwd && ls -la && du -sh frontend/* || true


### PR DESCRIPTION
## Summary
- add script to print node, npm, commit, and non-secret env vars
- add assert-dist.js to verify frontend build
- add simple tree.sh for workspace inspection

## Testing
- `npm run format`
- `npm test` (fails: "tests/eslintIsolation.test.js" and other lint tests)
- `npm run ci` (partial, interrupted)


------
https://chatgpt.com/codex/tasks/task_e_68a606dc608c832d9fbdf68a38a7967e