### PR TITLE
ci: add manual workflow for slow lanes

### DIFF
--- a/.github/workflows/ci-rerun-slow.yml
+++ b/.github/workflows/ci-rerun-slow.yml
@@ -1,0 +1,87 @@
+name: Rerun Slow CI Lanes
+
+on:
+  workflow_dispatch:
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    outputs:
+      duration: ${{ steps.duration.outputs.value }}
+    steps:
+      - id: start
+        run: echo "start=$(date +%s)" >> "$GITHUB_OUTPUT"
+      - uses: actions/checkout@v5
+      - name: Load Stripe env
+        run: node scripts/ci-env-preflight.js
+        env:
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+          STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version: 20
+      - run: SKIP_PW_DEPS=1 npm run setup
+        env:
+          DB_URL: postgres://localhost:5432/dev
+      - run: SKIP_PW_DEPS=1 npm run coverage
+      - id: end
+        run: echo "end=$(date +%s)" >> "$GITHUB_OUTPUT"
+      - id: duration
+        run: echo "value=$(( ${{ steps.end.outputs.end }} - ${{ steps.start.outputs.start }} ))" >> "$GITHUB_OUTPUT"
+
+  e2e:
+    runs-on: ubuntu-latest
+    env:
+      PORT: 3000
+      DB_URL: postgres://user:pass@localhost:5432/testdb
+    outputs:
+      duration: ${{ steps.duration.outputs.value }}
+    steps:
+      - id: start
+        run: echo "start=$(date +%s)" >> "$GITHUB_OUTPUT"
+      - uses: actions/checkout@v5
+      - name: Load Stripe env
+        run: node scripts/ci-env-preflight.js
+        env:
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+          STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - name: Install dependencies
+        run: |
+          npm ci
+          npm ci --prefix backend
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
+      - name: Install Playwright browsers
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
+        run: npx playwright install --with-deps
+      - name: Start server and run e2e tests
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
+        run: |
+          npx -y concurrently -k -s first "npm run serve" "npx wait-on http://localhost:3000 --timeout 300000 && npx playwright test e2e/*.test.js"
+      - id: end
+        run: echo "end=$(date +%s)" >> "$GITHUB_OUTPUT"
+      - id: duration
+        run: echo "value=$(( ${{ steps.end.outputs.end }} - ${{ steps.start.outputs.start }} ))" >> "$GITHUB_OUTPUT"
+
+  timings:
+    runs-on: ubuntu-latest
+    needs: [coverage, e2e]
+    steps:
+      - run: |
+          echo "coverage: ${{ needs.coverage.outputs.duration }}s" >> timings.txt
+          echo "e2e: ${{ needs.e2e.outputs.duration }}s" >> timings.txt
+          cat timings.txt >> "$GITHUB_STEP_SUMMARY"
+      - uses: actions/upload-artifact@v4.3.3
+        with:
+          name: timing-summary
+          path: timings.txt


### PR DESCRIPTION
## Summary
- add workflow to rerun coverage and e2e lanes on demand
- upload duration summary for coverage and e2e runs

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68a607adcef8832da1aa93a90b1794f0