### PR TITLE
ci: collect failed run logs

### DIFF
--- a/.github/workflows/collect-artifacts.yml
+++ b/.github/workflows/collect-artifacts.yml
@@ -1,0 +1,40 @@
+name: Collect Failed Logs
+
+on:
+  workflow_run:
+    workflows:
+      - CI
+      - Build frontend
+      - Node CI
+      - Full Pipeline Smoke Test
+      - Server Smoke Test
+    types:
+      - completed
+
+jobs:
+  collect-logs:
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download job logs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          run_id=${{ github.event.workflow_run.id }}
+          mkdir logs
+          curl -L \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "${{ github.api_url }}/repos/${{ github.repository }}/actions/runs/$run_id/jobs?per_page=100" \
+            | jq -r '.jobs[].id' | while read job_id; do
+              curl -L \
+                -H "Authorization: Bearer $GITHUB_TOKEN" \
+                -H "Accept: application/vnd.github+json" \
+                "${{ github.api_url }}/repos/${{ github.repository }}/actions/jobs/$job_id/logs" \
+                -o logs/$job_id.log
+            done
+      - name: Upload logs artifact
+        uses: actions/upload-artifact@v4.3.1
+        with:
+          name: failed-logs-${{ github.event.workflow_run.id }}
+          path: logs


### PR DESCRIPTION
## Summary
- add auxiliary workflow to capture logs from failed CI runs

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(partial run; interrupted due to time)*
- `SKIP_PW_DEPS=1 npm run smoke` *(Playwright warning, exited 0)*

------
https://chatgpt.com/codex/tasks/task_e_68a606e97318832da332f2a2867a884a