### PR TITLE
ci: add npm cache validator workflow

### DIFF
--- a/.github/workflows/cache-validator.yml
+++ b/.github/workflows/cache-validator.yml
@@ -1,0 +1,31 @@
+name: NPM cache validator
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - name: frontend
+            working-directory: .
+            lockfile: package-lock.json
+          - name: backend
+            working-directory: backend
+            lockfile: backend/package-lock.json
+    steps:
+      - uses: actions/checkout@v5
+      - id: setup
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: ${{ matrix.lockfile }}
+      - run: npm ci --prefer-offline
+        working-directory: ${{ matrix.working-directory }}
+      - run: echo "cache hit: ${{ steps.setup.outputs.cache-hit }}"


### PR DESCRIPTION
## Summary
- add workflow to check npm cache hit/miss for frontend and backend

## Testing
- `npm run validate-env`
```
✅ environment OK
```
- `cd backend && npm run format`
```
> backend@1.0.0 format
> sh -c 'cd .. && node scripts/ensure-root-deps.js && prettier --log-level warn --write "**/*.{js,jsx,json,md}" --ignore-path .prettierignore'
```
- `cd backend && npm test`
```
PASS tests/analytics.test.js (9.587 s)
PASS tests/additionalApi.test.js (10.275 s)
PASS tests/api.test.js (10.487 s)
...
```


------
https://chatgpt.com/codex/tasks/task_e_68a6079fa2a8832dab9b05937beab553