### PR TITLE
ci: snapshot health endpoint contract

### DIFF
--- a/.github/workflows/healthz-contract.yml
+++ b/.github/workflows/healthz-contract.yml
@@ -1,0 +1,24 @@
+name: Healthz Contract
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: node scripts/run-jest.js tests/diagnostics/healthz_contract.test.js
+      - uses: actions/upload-artifact@v4
+        with:
+          name: healthz.json
+          path: .artifacts/healthz.json

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ infra/*.tfstate*
 infra/AWSCLIV2.pkg
 infra/awscliv2.zip
 test-results/
+
+.artifacts/

--- a/tests/diagnostics/healthz_contract.test.js
+++ b/tests/diagnostics/healthz_contract.test.js
@@ -1,0 +1,29 @@
+const fs = require("fs");
+const path = require("path");
+
+const ARTIFACTS_DIR = path.join(__dirname, "..", "..", ".artifacts");
+
+async function snapshotHealthz() {
+  const url = "http://localhost:3000/healthz";
+  const result = { url };
+  try {
+    const res = await fetch(url);
+    const body = await res.text();
+    const headers = Object.fromEntries(res.headers.entries());
+    console.log("healthz body:", body);
+    console.log("healthz headers:", headers);
+    Object.assign(result, { status: res.status, headers, body });
+  } catch (err) {
+    console.log("healthz fetch error:", err.message);
+    result.error = err.message;
+  }
+  fs.mkdirSync(ARTIFACTS_DIR, { recursive: true });
+  fs.writeFileSync(
+    path.join(ARTIFACTS_DIR, "healthz.json"),
+    JSON.stringify(result, null, 2),
+  );
+}
+
+test("healthz contract snapshot", async () => {
+  await snapshotHealthz();
+});


### PR DESCRIPTION
## Summary
- capture `/healthz` contract in a diagnostic Jest test
- upload health snapshot via dedicated workflow
- ignore generated `.artifacts` directory

## Testing
- `npm run format`
- `npm test` (fails: eslintIsolation, lintingDetailed, linting)
- `node scripts/run-jest.js tests/diagnostics/healthz_contract.test.js`
- `SKIP_PW_DEPS=1 npm run ci` (incomplete)
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68a6079f9760832d98f67c7b319e6ba3