### PR TITLE
ci: decouple coveralls upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,9 +93,11 @@ jobs:
       - name: Sanitize coverage for Coveralls
         run: sed -r -i 's/\x1B\[[0-9;]*[JKmsu]//g' coverage/lcov.info
 
-      - name: Upload coverage to Coveralls
-        run: npm run coveralls:retry
-        continue-on-error: true
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4.3.4
+        with:
+          name: lcov
+          path: coverage/lcov.info
 
       - name: Check bundle size
         run: npm run bundle:size

--- a/.github/workflows/coveralls-upload.yml
+++ b/.github/workflows/coveralls-upload.yml
@@ -1,0 +1,28 @@
+name: Coveralls Upload
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+
+jobs:
+  upload:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Download coverage artifact
+        uses: actions/download-artifact@v4.1.8
+        with:
+          run-id: ${{ github.event.workflow_run.id }}
+          name: lcov
+          path: .
+      - name: Upload to Coveralls
+        uses: coverallsapp/github-action@v2.2.3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: coverage/lcov.info
+          retry: true


### PR DESCRIPTION
## Summary
- move coverage upload to separate workflow
- upload coverage artifact from CI for Coveralls retry workflow

## Testing
- `npm run format`
- `npm run format` (backend)
- `npm test` (backend) *(fails: eslintIsolation.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a60797d078832dbb33c705d4152b14