### PR TITLE
ci: add backend unit test early warning workflow

### DIFF
--- a/.github/workflows/jest-early-warning.yml
+++ b/.github/workflows/jest-early-warning.yml
@@ -1,0 +1,16 @@
+name: Jest Early Warning
+
+on:
+  pull_request:
+
+jobs:
+  backend-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci --prefix backend
+      - run: npm test --prefix backend -- --maxWorkers=50% --runInBand=false --silent --reporters=default


### PR DESCRIPTION
## Summary
- add Jest Early Warning workflow to run backend unit tests on pull requests

## Testing
- `npm --prefix backend run format`
- `npm test` *(fails: process terminated during dependency install)*
- `SKIP_PW_DEPS=1 npm run ci` *(interrupted during dependency install)*

------
https://chatgpt.com/codex/tasks/task_e_68a606d86b10832da5e7ab923fc18cbd