### PR TITLE
Add nock external-call reporter and workflow

### DIFF
--- a/.github/workflows/nock-report.yml
+++ b/.github/workflows/nock-report.yml
@@ -1,0 +1,26 @@
+name: nock report
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  nock-report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5.0.0
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: node scripts/run-jest.js tests/diagnostics/nock_reporter.test.js
+      - name: upload netconnect report
+        if: always()
+        uses: actions/upload-artifact@v4.6.2
+        with:
+          name: netconnect
+          path: .artifacts/netconnect.json

--- a/tests/diagnostics/nock_reporter.test.js
+++ b/tests/diagnostics/nock_reporter.test.js
@@ -1,0 +1,33 @@
+const fs = require("fs");
+const path = require("path");
+const nock = require("nock");
+
+describe("nock external call reporter", () => {
+  const offenders = [];
+
+  beforeAll(() => {
+    nock.disableNetConnect();
+    nock.enableNetConnect(/^(127\.0\.0\.1|localhost)$/);
+
+    nock.emitter.on("no match", (req) => {
+      offenders.push({
+        method: req.method,
+        host: req.hostname || req.host,
+        path: req.path,
+      });
+    });
+  });
+
+  afterAll(() => {
+    const artifactPath = path.resolve(
+      __dirname,
+      "../../.artifacts/netconnect.json",
+    );
+    fs.mkdirSync(path.dirname(artifactPath), { recursive: true });
+    fs.writeFileSync(artifactPath, JSON.stringify(offenders, null, 2));
+  });
+
+  it("reports unexpected network connections", () => {
+    expect(true).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add diagnostic test that disables external network connections and records unmatched requests
- introduce CI workflow to run the reporter test and upload its artifact

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `node scripts/run-jest.js tests/diagnostics/nock_reporter.test.js`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Code style issues found in generated files)*
- `SKIP_PW_DEPS=1 npm run smoke` *(stack trace printed but exits 0)*

------
https://chatgpt.com/codex/tasks/task_e_68a607a3a660832da8fd937e11a7a74f