### PR TITLE
ci: add frontend local build workflow

### DIFF
--- a/.github/workflows/frontend-local-build.yml
+++ b/.github/workflows/frontend-local-build.yml
@@ -1,0 +1,21 @@
+name: Frontend dist local build
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci --prefix frontend && npm run build --prefix frontend
+      - run: node -e "require('fs').accessSync('frontend/dist/index.html')"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: frontend-dist
+          path: frontend/dist


### PR DESCRIPTION
## Summary
- add workflow to build frontend locally and upload the `dist` artifact

## Testing
- `npm run format` (backend)
- `npm test` (backend)
- `SKIP_PW_DEPS=1 npm run ci` *(partial; terminated after tests due to environment constraints)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68a60793b32c832d9f50de1762d97d2d