### PR TITLE
ci: cache Playwright browsers

### DIFF
--- a/.github/workflows/playwright-browsers-cache.yml
+++ b/.github/workflows/playwright-browsers-cache.yml
@@ -1,0 +1,23 @@
+name: Playwright browsers cache
+
+on:
+  pull_request:
+
+jobs:
+  cache-browsers:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/ms-playwright
+            ~/.cache/ms-playwright-ffmpeg
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
+
+      - name: Install Playwright browsers
+        if: runner.os == 'Linux'
+        run: npx playwright install --with-deps


### PR DESCRIPTION
## Summary
- cache Playwright browser downloads to avoid reinstalling on every PR

## Testing
- `npm run format`
- `npm test` *(fails: Playwright host dependencies missing)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Prettier found unformatted files)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68a606d2b834832d90387911bf12ba0f