### PR TITLE
Add netconnect sentinel diagnostic test

### DIFF
--- a/tests/diagnostics/netconnect_sentinel.test.js
+++ b/tests/diagnostics/netconnect_sentinel.test.js
@@ -1,0 +1,21 @@
+const nock = require("nock");
+const http = require("http");
+
+describe("netconnect sentinel", () => {
+  it("warns on unmatched external requests", async () => {
+    nock.disableNetConnect();
+    nock.enableNetConnect("127.0.0.1");
+
+    nock.emitter.on("no match", (req) => {
+      console.warn("nock no match:", req);
+    });
+
+    await new Promise((resolve) => {
+      http
+        .get("http://127.0.0.1", () => resolve())
+        .on("error", () => resolve());
+    });
+
+    expect(true).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- log unmatched external network requests in a new diagnostic test

## Testing
- `npm run format` (backend)
- `npm test` (backend) *(fails: repository has numerous eslint/test failures)*
- `node scripts/run-jest.js tests/diagnostics/netconnect_sentinel.test.js`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: aborted after persistent lint errors)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68a606e65044832d897373923435d333