### PR TITLE
test: add network guard test

### DIFF
--- a/tests/internal/net-guard.test.ts
+++ b/tests/internal/net-guard.test.ts
@@ -1,0 +1,21 @@
+import nock from "nock";
+import axios from "axios";
+
+describe("network guard", () => {
+  test("blocks external requests", async () => {
+    await expect(axios.get("https://example.com/")).rejects.toThrow(
+      /Nock: Disallowed net connect/,
+    );
+  });
+
+  test("allows localhost requests", async () => {
+    const scope = nock("http://localhost:3000")
+      .get("/api/ping")
+      .reply(200, { ok: true });
+
+    const res = await axios.get("http://localhost:3000/api/ping");
+    expect(res.status).toBe(200);
+    expect(res.data).toEqual({ ok: true });
+    expect(scope.isDone()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- verify external requests are blocked and localhost is allowed by the network guard

## Testing
- `npm run format`
```
> mvp-website@1.0.0 preformat
> cross-env SKIP_NET_CHECKS=1 SKIP_PW_DEPS=1 node scripts/assert-setup.js
Skipping network check due to SKIP_NET_CHECKS
Playwright host dependencies already satisfied.
Playwright host dependencies already satisfied.

> mvp-website@1.0.0 format
> prettier --log-level warn --write "**/*.{js,jsx,json,md,html}"
```
- `node scripts/run-jest.js tests/internal/net-guard.test.ts`
```
✓ blocks external requests (101 ms)
✓ allows localhost requests (19 ms)

Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
Snapshots:   0 total
Time:        1.56 s
```


------
https://chatgpt.com/codex/tasks/task_e_68a60bc68360832d97fe222c4a0970f3