### PR TITLE
test: add long-op warning test

### DIFF
--- a/tests/internal/long-op-warning.test.ts
+++ b/tests/internal/long-op-warning.test.ts
@@ -1,0 +1,15 @@
+const defaultTimeout = 5000; // Jest's default per-test timeout
+jest.setTimeout(defaultTimeout + 1000); // allow a little extra time
+
+const run = process.env.CI_ONLY === "1" ? test : test.skip;
+
+run("warns when long operations hit the per-test timeout", async () => {
+  const start = Date.now();
+  await new Promise((resolve) => setTimeout(resolve, defaultTimeout));
+  const elapsed = Date.now() - start;
+  if (elapsed >= defaultTimeout) {
+    console.warn(
+      `Long operation hit per-test timeout of ${defaultTimeout}ms (elapsed ${elapsed}ms)`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- add CI-only long operation test

## Testing
- `npm run format`
- `npm test --prefix backend`
- `CI_ONLY=1 node scripts/run-jest.js tests/internal/long-op-warning.test.ts`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68a60be700cc832d9346f626389b184b