### PR TITLE
test: add shared test resource reaper

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -2,7 +2,10 @@
 module.exports = {
   rootDir: ".",
   setupFiles: ["<rootDir>/tests/setupGlobals.js"],
-  setupFilesAfterEnv: ["<rootDir>/tests/setup.js"],
+  setupFilesAfterEnv: [
+    "<rootDir>/../tests/utils/testEnv.ts",
+    "<rootDir>/tests/setup.js",
+  ],
   globalTeardown: "<rootDir>/tests/globalTeardown.js",
   testEnvironment: "node",
   transform: {

--- a/backend/server.js
+++ b/backend/server.js
@@ -3527,5 +3527,9 @@ app.use((err, _req, res, _next) => {
   res.status(status).json({ error: message });
 });
 
+if (process.env.NODE_ENV === "test") {
+  global.__servers?.push(app.listen(0));
+}
+
 module.exports = app;
 module.exports.checkCompetitionStart = checkCompetitionStart;

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
     "<rootDir>/backend/tests/setupGlobals.js",
   ],
   setupFilesAfterEnv: [
+    "<rootDir>/tests/utils/testEnv.ts",
     "<rootDir>/test/setupAuthMiddleware.js",
     "<rootDir>/tests/setup/nock.ts",
   ],

--- a/tests/utils/reaper.ts
+++ b/tests/utils/reaper.ts
@@ -1,0 +1,66 @@
+type Server = import('http').Server;
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const nock = require('nock');
+
+interface GlobalWithResources {
+  __servers?: Server[];
+  __pgPools?: Array<{ end: () => Promise<unknown> }>;
+  __redisClients?: Array<{
+    quit?: () => Promise<unknown> | void;
+    disconnect?: () => Promise<unknown> | void;
+  }>;
+  __cleanups?: Array<() => unknown | Promise<unknown>>;
+}
+
+const g = globalThis as GlobalWithResources;
+
+declare function afterAll(fn: () => unknown | Promise<unknown>): void;
+
+function registerServer(server: Server) {
+  if (!g.__servers) g.__servers = [];
+  g.__servers.push(server);
+  return server;
+}
+
+function registerCleanup(fn: () => unknown | Promise<unknown>) {
+  if (!g.__cleanups) g.__cleanups = [];
+  g.__cleanups.push(fn);
+  return fn;
+}
+
+// Initialize arrays if not already present
+g.__servers = g.__servers || [];
+g.__pgPools = g.__pgPools || [];
+g.__redisClients = g.__redisClients || [];
+g.__cleanups = g.__cleanups || [];
+
+let mongoose: any;
+try {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  mongoose = require('mongoose');
+} catch {
+  mongoose = null;
+}
+
+afterAll(async () => {
+  for (const server of g.__servers || []) {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+  for (const pool of g.__pgPools || []) {
+    if (typeof pool.end === 'function') await pool.end();
+  }
+  if (mongoose && mongoose.connection && mongoose.connection.readyState !== 0) {
+    await mongoose.disconnect();
+  }
+  for (const client of g.__redisClients || []) {
+    if (typeof client.quit === 'function') await client.quit();
+    else if (typeof client.disconnect === 'function') await client.disconnect();
+  }
+  for (const fn of g.__cleanups || []) {
+    await fn();
+  }
+  nock.cleanAll();
+  nock.restore();
+});
+
+module.exports = { registerServer, registerCleanup };

--- a/tests/utils/testEnv.ts
+++ b/tests/utils/testEnv.ts
@@ -1,0 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+require('./reaper');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+module.exports = require('./reaper');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,10 @@
     "skipLibCheck": true,
     "types": ["node"]
   },
-  "include": ["backend/utils/generateTitle.js"],
+  "include": [
+    "backend/utils/generateTitle.js",
+    "tests/utils/reaper.ts",
+    "tests/utils/testEnv.ts"
+  ],
   "exclude": ["node_modules", "img", "models", "uploads"]
 }


### PR DESCRIPTION
## Summary
- add reaper utility to close servers and connections after tests
- hook reaper into Jest configs and backend server for test runs
- include test utilities in TypeScript project

## Testing
- `npm run format`
- `npm run lint`
- `npm test` (backend)
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68a60bbc9a50832db4ceda5a9ffdf1c0