### PR TITLE
test: add reaper smoke test

### DIFF
--- a/tests/internal/reaper-smoke.test.ts
+++ b/tests/internal/reaper-smoke.test.ts
@@ -1,0 +1,32 @@
+import http from "http";
+
+// Simple resource reaper that tracks cleanup callbacks.
+const cleanup: Array<() => void> = [];
+
+function registerServer(server: http.Server) {
+  cleanup.push(() => new Promise((resolve) => server.close(resolve)) as any);
+}
+
+function registerTimer(timer: NodeJS.Timeout) {
+  cleanup.push(() => clearInterval(timer));
+}
+
+async function reap() {
+  for (const fn of cleanup.splice(0)) {
+    await fn();
+  }
+}
+
+test("reaper handles server and timer", (done) => {
+  const server = http.createServer((_req, res) => res.end("ok"));
+  server.listen(0, () => {
+    const timer = setInterval(() => {}, 50);
+    registerServer(server);
+    registerTimer(timer);
+    done();
+  });
+});
+
+afterAll(async () => {
+  await reap();
+});


### PR DESCRIPTION
## Summary
- add smoke test covering a tiny http server and timer registration with a simple reaper

## Testing
- `npm run format`
- `node scripts/run-jest.js tests/internal/reaper-smoke.test.ts`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: command terminated due to manual interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68a60bc036c8832dbea2feec51231b75