### PR TITLE
test: enforce network mocks in ci

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,7 +5,7 @@ module.exports = {
   ],
   setupFilesAfterEnv: [
     "<rootDir>/test/setupAuthMiddleware.js",
-    "<rootDir>/tests/setup/nock.ts",
+    ...(process.env.CI ? ["<rootDir>/tests/setup/nock.ts"] : []),
   ],
   coverageThreshold: {
     global: {

--- a/tests/setup/nock.ts
+++ b/tests/setup/nock.ts
@@ -1,12 +1,47 @@
-import nock from 'nock';
+import nock from "nock";
 
+/**
+ * Block all outgoing network connections except localhost to ensure tests
+ * explicitly mock external services.
+ */
 nock.disableNetConnect();
-nock.enableNetConnect(/^(127\.0\.0\.1|localhost)$/);
+nock.enableNetConnect("127.0.0.1|localhost");
+
+const unmatched: string[] = [];
+
+// Capture any requests that do not have an active mock so we can fail the test
+nock.emitter.on("no match", (req) => {
+  const method = req.method;
+  const { protocol = "http:", host, path } = req.options || ({} as any);
+  unmatched.push(`${method} ${protocol}//${host}${path}`);
+});
+
+export const mockStability = () => nock("https://api.stability.ai");
+export const mockStripe = () => nock("https://api.stripe.com");
+export const mockS3 = (bucket = process.env.S3_UPLOAD_BUCKET || "") =>
+  nock(`https://${bucket}.s3.amazonaws.com`);
+
+declare global {
+  // eslint-disable-next-line no-var
+  var mockStability: typeof mockStability;
+  // eslint-disable-next-line no-var
+  var mockStripe: typeof mockStripe;
+  // eslint-disable-next-line no-var
+  var mockS3: typeof mockS3;
+}
+
+global.mockStability = mockStability;
+global.mockStripe = mockStripe;
+global.mockS3 = mockS3;
 
 afterEach(() => {
   const pending = nock.pendingMocks();
   if (pending.length > 0) {
-    throw new Error(`Unused nock interceptors:\n${pending.join('\n')}`);
+    throw new Error(`Unused nock interceptors:\n${pending.join("\n")}`);
   }
+  if (unmatched.length > 0) {
+    throw new Error(`Unmocked requests:\n${unmatched.join("\n")}`);
+  }
+  unmatched.length = 0;
   nock.cleanAll();
 });


### PR DESCRIPTION
## Summary
- guard tests from unintended network access with a CI-only nock setup
- expose mock helpers for Stability, Stripe, and S3

## Testing
- `npm run format`
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: isolated ESLint test reports lint error)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68a60bc32bd0832db3d1f198c6f10e96