### PR TITLE
ci: add fast ci test lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,53 @@ jobs:
       - run: npm ci && npm run lint && npm run build
       - run: test -d dist
 
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+      - run: npm ci
+      - run: npm run format:check
+      - run: npm run lint
+      - run: npm run i18n:lint
+
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+      - run: npm ci
+      - run: npm run typecheck
+
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Load Stripe env
+        run: node scripts/ci-env-preflight.js
+        env:
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+          STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+      - run: SKIP_PW_DEPS=1 npm run setup
+        env:
+          DB_URL: postgres://localhost:5432/dev
+      - run: SKIP_PW_DEPS=1 npm run coverage
+      - name: Sanitize coverage for Coveralls
+        run: sed -r -i 's/\x1B\[[0-9;]*[JKmsu]//g' coverage/lcov.info
+      - name: Upload coverage to Coveralls
+        run: npm run coveralls:retry
+        continue-on-error: true
+
   tests:
     runs-on: ubuntu-latest
     env:
@@ -69,9 +116,7 @@ jobs:
         run: npx playwright install --with-deps
       - name: Prepare test env
         run: |
-
           echo "DB_URL=postgres://user:pass@localhost/db" > .env.test
-
       - name: Loader precedence preflight
         env:
           STRIPE_SECRET_KEY: sk_live_xxx
@@ -82,40 +127,28 @@ jobs:
           STRIPE_WEBHOOK_SECRET=
           EOF
           node scripts/env-loader-preflight.js /tmp/ci.env
-
-      - name: Run CI
+      - name: Run tests
         env:
           PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "0"
-        run: npm run ci
-
-      - name: Run coverage
-        run: SKIP_PW_DEPS=1 npm run coverage
-
-      - name: Sanitize coverage for Coveralls
-        run: sed -r -i 's/\x1B\[[0-9;]*[JKmsu]//g' coverage/lcov.info
-
-      - name: Upload coverage to Coveralls
-        run: npm run coveralls:retry
-        continue-on-error: true
-
+        run: npm run test:ci:fast
+      - name: Run a11y tests
+        run: npm run test:a11y
+      - name: Run UI tests
+        run: npm run test:ui
       - name: Check bundle size
         run: npm run bundle:size
-
       - name: Check for duplicate packages
         run: npm run deps:dedupe-check
-
       - name: Run Lighthouse CI
         if: github.event_name == 'pull_request'
         run: npm run lhci
-
       - name: Verify lockfiles
         run: |
           npm run deps:check
           git diff --exit-code package-lock.json
           git diff --exit-code backend/package-lock.json
           git diff --exit-code backend/hunyuan_server/package-lock.json
-
       - name: Audit dependencies
         run: |
           npm audit --audit-level=high
@@ -123,7 +156,6 @@ jobs:
           if [ -f backend/hunyuan_server/package.json ]; then
             npm audit --prefix backend/hunyuan_server --audit-level=high
           fi
-
       - name: Validate Snyk token
         if: ${{ secrets.SNYK_TOKEN }}
         env:
@@ -131,33 +163,30 @@ jobs:
         run: |
           echo "Validating SNYK_TOKEN..."
           npx snyk auth --token=$SNYK_TOKEN
-
       - name: Snyk scan backend
         if: success() && secrets.SNYK_TOKEN
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         run: npx snyk test --severity-threshold=high --file=backend/package.json
-
       - name: Fallback to npm audit
         if: ${{ !secrets.SNYK_TOKEN }}
         run: |
           echo "⚠️ SNYK_TOKEN missing or invalid; running npm audit instead"
           npm audit --audit-level=high --prefix backend
-
       - name: Snyk scan hunyuan_server
         if: success() && secrets.SNYK_TOKEN && fileExists('backend/hunyuan_server/package.json')
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         run: npx snyk test --severity-threshold=high --file=backend/hunyuan_server/package.json
-
       - name: Run visual tests
         if: ${{ secrets.PERCY_TOKEN }}
         env:
           PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "0"
-        run: npm run test:ci
+        run: npm run test:ci:fast
       - name: Run smoke tests
         env:
           PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "0"
         run: npm run smoke
+

--- a/package.json
+++ b/package.json
@@ -78,7 +78,8 @@
     "test:webhook": "node scripts/test-webhook.js",
     "check:code-scanning": "node scripts/check-code-scanning.js",
     "commitlint": "commitlint --from=HEAD~1",
-    "lint:md": "markdownlint-cli2 \"**/*.md\""
+    "lint:md": "markdownlint-cli2 \"**/*.md\"",
+    "test:ci:fast": "sh -c \"if [ -z \\\"$CI\\\" ]; then echo 'test:ci:fast is CI-only' >&2; exit 1; fi; node scripts/run-jest.js --runInBand --bail=1 --detectOpenHandles --testTimeout=20000 --logHeapUsage --maxWorkers=2\""
   },
   "babel": {
     "presets": [

--- a/scripts/run-coverage.js
+++ b/scripts/run-coverage.js
@@ -109,7 +109,10 @@ if (result.status) {
     console.error("\n\u26d4 Jest output (last 50 lines):\n");
     console.error(snippet);
     try {
-      const failLog = path.join(repoRoot, "coverage", "failed.log");
+      const workerId = process.env.JEST_WORKER_ID
+        ? `.${process.env.JEST_WORKER_ID}`
+        : "";
+      const failLog = path.join(repoRoot, "coverage", `failed${workerId}.log`);
       fs.mkdirSync(path.dirname(failLog), { recursive: true });
       fs.writeFileSync(failLog, combined);
       console.error(`Full output written to ${failLog}`);


### PR DESCRIPTION
## Summary
- run Jest via new `test:ci:fast` script when `CI` is set
- parallelize lint, typecheck and coverage in CI workflow
- avoid coverage log contention by including `JEST_WORKER_ID` in failure logs

## Testing
- `npm test` *(fails: isolated ESLint failures and detailed lint report)*
- `npm run format`
- `SKIP_PW_DEPS=1 npm run ci` *(partial output shown; command interrupted)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68a60bca275c832db64b76256b23f20b