### PR TITLE
fix: align ESLint project configuration

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,6 @@
+frontend/dist
+**/dist
+**/build
+coverage
+.cache
+backend/lib

--- a/backend/eslint.config.js
+++ b/backend/eslint.config.js
@@ -5,6 +5,9 @@ const jsdoc = require("eslint-plugin-jsdoc");
 
 module.exports = [
   {
+    ignores: ["lib/**"],
+  },
+  {
     languageOptions: {
       globals: {
         ...globals.node,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,7 +13,6 @@ const prettier = require("eslint-config-prettier");
 const globals = require("globals");
 const jsdoc = require("eslint-plugin-jsdoc");
 const tsParser = require("@typescript-eslint/parser");
-const fs = require("fs");
 const frontend = require("./eslint.frontend-87adf32bca1e546.cjs");
 const isCI = Boolean(process.env.CI);
 
@@ -45,16 +44,8 @@ module.exports = [
     languageOptions: {
       parser: tsParser,
       parserOptions: {
+        project: ["./tsconfig.eslint.json"],
         tsconfigRootDir: __dirname,
-        ...(isCI
-          ? {}
-          : {
-              project: [
-                "tsconfig.json",
-                "backend/tsconfig.json",
-                "backend/tsconfig.build.json",
-              ].filter((p) => fs.existsSync(p)),
-            }),
       },
     },
   },
@@ -76,7 +67,13 @@ module.exports = [
   {
     languageOptions: {
       ecmaVersion: 2022,
-      globals: { ...globals.node, ...globals.es2021, ...globals.jest },
+      globals: { ...globals.node, ...globals.es2021 },
+    },
+  },
+  {
+    files: ["**/*.test.{ts,js}", "tests/**/*.{ts,js}"],
+    languageOptions: {
+      globals: { ...globals.jest, ...globals.node },
     },
   },
   js.configs.recommended,

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,17 +1,15 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "noEmit": true,
-    "allowJs": true,
-    "checkJs": false,
-    "types": ["node"]
+    "noEmit": true
   },
-  "include": [
-    "backend/**/*.ts",
-    "backend/**/*.tsx",
-    "tests/**/*.ts",
-    "tests/**/*.tsx",
-    "scripts/**/*.ts"
-  ],
-  "exclude": ["node_modules", "dist", "build", "coverage", ".next", ".cache"]
+  "include": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.cjs", "**/*.mjs"],
+  "exclude": [
+    "node_modules",
+    "frontend/dist",
+    "**/*.gen.*",
+    "**/coverage",
+    "**/.next",
+    "**/build"
+  ]
 }


### PR DESCRIPTION
## Summary
- configure ESLint to use dedicated `tsconfig.eslint.json`
- add test-specific environment and ignore compiled output
- keep backend build artifacts out of ESLint

## Testing
- `npm run format`
- `npm test -- tests/lintingDetailed.test.js`
- `npx eslint scripts/ci_watchdog.ts --no-ignore`
- `npx eslint .`


------
https://chatgpt.com/codex/tasks/task_e_68a6103da044832d85aa52a876f6d26e