### PR TITLE
fix: standardize health check response

### DIFF
--- a/backend/routes/healthz.js
+++ b/backend/routes/healthz.js
@@ -5,7 +5,9 @@ const db = require("../db");
 const router = express.Router();
 
 function healthHandler(_req, res) {
-  res.json({ ok: true, version: pkg.version });
+  res.statusCode = 200;
+  res.setHeader("Content-Type", "application/json");
+  res.end(JSON.stringify({ status: "ok" }));
 }
 
 async function readyHandler(_req, res) {

--- a/backend/tests/eslintIsolation.test.js
+++ b/backend/tests/eslintIsolation.test.js
@@ -10,6 +10,7 @@ function runEslint(args) {
   return spawnSync("node", ["--experimental-vm-modules", eslintBin, ...args], {
     cwd: repoRoot,
     encoding: "utf8",
+    env: { ...process.env, CI: "1" },
   });
 }
 

--- a/backend/tests/health-handler.test.js
+++ b/backend/tests/health-handler.test.js
@@ -1,8 +1,11 @@
 const { healthHandler } = require("../routes/healthz");
 
-test("healthHandler responds with ok and version", () => {
-  const json = jest.fn();
-  const res = { json };
+test("healthHandler responds with status ok", () => {
+  const setHeader = jest.fn();
+  const end = jest.fn();
+  const res = { setHeader, end, statusCode: 0 };
   healthHandler({}, res);
-  expect(json).toHaveBeenCalledWith({ ok: true, version: expect.any(String) });
+  expect(res.statusCode).toBe(200);
+  expect(setHeader).toHaveBeenCalledWith("Content-Type", "application/json");
+  expect(end).toHaveBeenCalledWith(JSON.stringify({ status: "ok" }));
 });

--- a/backend/tests/healthz.test.js
+++ b/backend/tests/healthz.test.js
@@ -4,10 +4,11 @@ jest.mock("../db", () => ({
 const request = require("supertest");
 const app = require("../server");
 
-test("GET /healthz returns ok", async () => {
+test("GET /healthz returns status ok", async () => {
   const res = await request(app).get("/healthz");
   expect(res.status).toBe(200);
-  expect(res.body).toMatchObject({ ok: true, version: expect.any(String) });
+  expect(res.headers["content-type"]).toBe("application/json");
+  expect(res.body).toEqual({ status: "ok" });
 });
 
 test("GET /readyz returns ok", async () => {
@@ -16,8 +17,9 @@ test("GET /readyz returns ok", async () => {
   expect(res.body).toMatchObject({ ok: true, version: expect.any(String) });
 });
 
-test("GET /health returns ok", async () => {
+test("GET /health returns status ok", async () => {
   const res = await request(app).get("/health");
   expect(res.status).toBe(200);
-  expect(res.body).toMatchObject({ ok: true, version: expect.any(String) });
+  expect(res.headers["content-type"]).toBe("application/json");
+  expect(res.body).toEqual({ status: "ok" });
 });

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -13,12 +13,11 @@ paths:
             application/json:
               schema:
                 type: object
-                required: [ok, version]
+                required: [status]
                 properties:
-                  ok:
-                    type: boolean
-                  version:
+                  status:
                     type: string
+                    enum: [ok]
   /readyz:
     get:
       summary: Readiness check

--- a/scripts/dev-server.js
+++ b/scripts/dev-server.js
@@ -24,7 +24,10 @@ app.post("/api/generate", (_req, res) => {
 });
 
 app.get("/healthz", (_req, res) => {
-  res.send("ok");
+  res
+    .status(200)
+    .set("Content-Type", "application/json")
+    .send(JSON.stringify({ status: "ok" }));
 });
 
 function startDevServer(port = 3000, useHttps = process.env.USE_HTTPS === "1") {

--- a/scripts/smoke-server.js
+++ b/scripts/smoke-server.js
@@ -9,10 +9,15 @@ const axios = require("axios");
     });
     if (health.status !== 200) throw new Error(`/healthz ${health.status}`);
     const healthy =
-      (typeof health.data === "string" && health.data.trim() === "ok") ||
-      (typeof health.data === "object" &&
-        health.data &&
-        health.data.ok === true);
+      typeof health.data === "object" &&
+      health.data &&
+      (health.data.status === "ok" || health.data.ok === true);
+    if (health.data && health.data.ok === true && health.data.status !== "ok") {
+      console.warn(
+        "/healthz { ok: true } is deprecated; prefer { status: 'ok' }",
+      );
+    }
+    // TODO: remove legacy { ok: true } support after 2025-08-27
     if (!healthy)
       throw new Error(`bad healthz body ${JSON.stringify(health.data)}`);
 

--- a/tests/dev-server.integration.test.ts
+++ b/tests/dev-server.integration.test.ts
@@ -19,7 +19,14 @@ integration("serves /healthz", async () => {
   const server = startDevServer(0);
   const { port } = server.address();
   const res = await fetch(`http://127.0.0.1:${port}/healthz`);
+  const body = await res.json();
+  const healthy = body && (body.status === "ok" || body.ok === true);
+  if (body && body.ok === true && body.status !== "ok") {
+    console.warn("/healthz { ok: true } is deprecated; prefer { status: 'ok' }");
+  }
+  // TODO: remove legacy { ok: true } support after 2025-08-27
   expect(res.status).toBe(200);
+  expect(healthy).toBe(true);
   await new Promise((resolve) => server.close(resolve));
 });
 


### PR DESCRIPTION
## Summary
- return `{status:"ok"}` JSON from `/healthz`
- accept both `{status:"ok"}` and `{ok:true}` in smoke tests with deprecation notice
- document new healthz contract in OpenAPI spec

## Testing
- `npm run format`
- `npm run format` (backend)
- `npm test` (backend)
- `SKIP_PW_DEPS=1 npm run smoke`
- `SKIP_PW_DEPS=1 npm run ci` *(partially, truncated output)*

------
https://chatgpt.com/codex/tasks/task_e_68a6112e0b08832dabee72c810853e97