### PR TITLE
build: add deterministic ESLint configuration

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,6 @@
+**/dist
+**/build
+coverage
+.cache
+frontend/dist
+

--- a/backend/.eslintrc.cjs
+++ b/backend/.eslintrc.cjs
@@ -1,15 +1,8 @@
-const fs = require('fs');
-const path = require('path');
-const projects = ['tsconfig.json', 'tsconfig.build.json']
-  .map((p) => path.join(__dirname, p))
-  .filter(fs.existsSync);
-
 module.exports = {
   parser: '@typescript-eslint/parser',
   parserOptions: {
-
+    project: ['../tsconfig.eslint.json'],
     tsconfigRootDir: __dirname,
-    ...(projects.length ? { project: projects } : {}),
   },
   extends: ['eslint:recommended', 'prettier'],
   env: { node: true, jest: true },
@@ -40,6 +33,5 @@ module.exports = {
       'error',
       { argsIgnorePattern: '^_', caughtErrorsIgnorePattern: '^_' },
     ],
-
   },
 };

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,7 +13,6 @@ const prettier = require("eslint-config-prettier");
 const globals = require("globals");
 const jsdoc = require("eslint-plugin-jsdoc");
 const tsParser = require("@typescript-eslint/parser");
-const fs = require("fs");
 const frontend = require("./eslint.frontend-87adf32bca1e546.cjs");
 const isCI = Boolean(process.env.CI);
 
@@ -38,23 +37,15 @@ module.exports = [
       "scripts/check-gh-workflow-sync-23859.ts",
       "upload/**",
       // "src/**", // removed to enable frontend linting
-    ],
+  ],
   },
   {
     files: ["**/*.{ts,tsx}"],
     languageOptions: {
       parser: tsParser,
       parserOptions: {
+        project: ["./tsconfig.eslint.json"],
         tsconfigRootDir: __dirname,
-        ...(isCI
-          ? {}
-          : {
-              project: [
-                "tsconfig.json",
-                "backend/tsconfig.json",
-                "backend/tsconfig.build.json",
-              ].filter((p) => fs.existsSync(p)),
-            }),
       },
     },
   },

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,17 +1,13 @@
 {
   "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "noEmit": true,
-    "allowJs": true,
-    "checkJs": false,
-    "types": ["node"]
-  },
-  "include": [
-    "backend/**/*.ts",
-    "backend/**/*.tsx",
-    "tests/**/*.ts",
-    "tests/**/*.tsx",
-    "scripts/**/*.ts"
-  ],
-  "exclude": ["node_modules", "dist", "build", "coverage", ".next", ".cache"]
+  "compilerOptions": { "noEmit": true },
+  "include": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.cjs", "**/*.mjs"],
+  "exclude": [
+    "**/dist",
+    "**/build",
+    "coverage",
+    ".cache",
+    "frontend/dist",
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- configure ESLint to use a dedicated tsconfig for consistent parsing
- point backend ESLint config at shared project config
- ignore build output and coverage directories during linting

## Testing
- `npm run format`
- `npm test`
- `npm run ci` *(fails: preformat step interrupted)*
- `npm run smoke` *(fails: stopped after env validation)*

------
https://chatgpt.com/codex/tasks/task_e_68a611413848832da732ab392c21b816