### PR TITLE
ci: scope deploy workflow to frontend changes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,10 @@ name: Deploy
 on:
   push:
     branches: [00000production]
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/deploy.yml'
+  workflow_dispatch:
 
 jobs:
   deploy:


### PR DESCRIPTION
## Summary
- trigger Cloudflare deploy workflow only on frontend changes or manual dispatch

## Testing
- `npm run validate-env`
- `curl -I https://registry.npmjs.org`
- `curl -I https://cdn.playwright.dev`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: repository has lint/test failures)*
- `SKIP_PW_DEPS=1 npm run ci` *(interrupted after format check)*
- `SKIP_PW_DEPS=1 npm run smoke` *(interrupted during serve step)*

------
https://chatgpt.com/codex/tasks/task_e_68a6117727c8832dbf453e8530137cf1