### PR TITLE
fix: harden smoke health checks

### DIFF
--- a/scripts/smoke-server.js
+++ b/scripts/smoke-server.js
@@ -1,40 +1,67 @@
 const axios = require("axios");
 
+const timer = setTimeout(() => {
+  console.error("❌ server smoke failed: timeout");
+  process.exit(1);
+}, 90_000);
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function checkHealth(base) {
+  let last;
+  for (let i = 0; i < 10; i++) {
+    try {
+      const res = await axios.get(`${base}/healthz`, {
+        validateStatus: () => true,
+      });
+      const healthy =
+        (typeof res.data === "string" && res.data.trim() === "ok") ||
+        (typeof res.data === "object" && res.data && res.data.ok === true);
+      if (res.status === 200 && healthy) return;
+      last = res;
+    } catch (err) {
+      last = {
+        status: err.response?.status || err.code || "ERR",
+        data: err.response?.data || err.message,
+      };
+    }
+    await sleep(500 + Math.random() * 500);
+  }
+  throw new Error(
+    `/healthz status=${last?.status} body=${JSON.stringify(last?.data)}`,
+  );
+}
+
 (async () => {
   try {
     const base = process.env.SMOKE_BASE_URL || "http://localhost:3000";
 
-    const health = await axios.get(`${base}/healthz`, {
-      validateStatus: () => true,
-    });
-    if (health.status !== 200) throw new Error(`/healthz ${health.status}`);
-    const healthy =
-      (typeof health.data === "string" && health.data.trim() === "ok") ||
-      (typeof health.data === "object" &&
-        health.data &&
-        health.data.ok === true);
-    if (!healthy)
-      throw new Error(`bad healthz body ${JSON.stringify(health.data)}`);
+    await checkHealth(base);
 
     const ready = await axios.get(`${base}/readyz`, {
       validateStatus: () => true,
     });
-    if (ready.status !== 200) throw new Error(`/readyz ${ready.status}`);
-    if (!ready.data.ok)
-      throw new Error(`bad readyz body ${JSON.stringify(ready.data)}`);
+    if (ready.status !== 200 || !ready.data?.ok)
+      throw new Error(
+        `/readyz status=${ready.status} body=${JSON.stringify(ready.data)}`,
+      );
 
     const gen = await axios.post(
       `${base}/api/generate`,
       { prompt: "test" },
       { validateStatus: () => true },
     );
-    if (gen.status !== 200) throw new Error(`/api/generate ${gen.status}`);
-    if (typeof gen.data.glb_url !== "string")
-      throw new Error(`bad generate body ${JSON.stringify(gen.data)}`);
+    if (gen.status !== 200 || typeof gen.data.glb_url !== "string")
+      throw new Error(
+        `/api/generate status=${gen.status} body=${JSON.stringify(gen.data)}`,
+      );
 
+    clearTimeout(timer);
     console.log("✅ server smoke passed");
   } catch (err) {
-    console.error("❌ server smoke failed:", err.message);
+    console.error(`❌ server smoke failed: ${err.message}`);
     process.exit(1);
   }
 })();


### PR DESCRIPTION
## Summary
- retry server health check with bounded backoff
- enforce 90s timeout and clearer error messages for smoke script

## Testing
- `npm run format`
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: tests/eslintIsolation.test.js, tests/lintingDetailed.test.js, tests/linting.test.js, __tests__/health.test.js)*
- `SKIP_PW_DEPS=1 npm run ci` *(terminated due to time)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68a6117c125c832db1b11f7bcfb696c9