### PR TITLE
ci: add backend smoke workflow

### DIFF
--- a/.github/workflows/smoke-backend.yml
+++ b/.github/workflows/smoke-backend.yml
@@ -1,0 +1,28 @@
+name: Backend Smoke
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  backend-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+      - name: Install dependencies
+        run: npm ci --prefix backend
+      - name: Lint
+        run: npm run lint --prefix backend
+      - name: Healthz test
+        run: npm --prefix backend test -- backend/tests/healthz.test.js
+      - name: Generate API test
+        run: npm --prefix backend test -- backend/tests/api.test.js -t "POST /api/generate returns glb url"


### PR DESCRIPTION
## Summary
- add fast backend smoke check for pull requests

## Testing
- `npm run format --prefix backend`
- `CI=1 npm test --prefix backend backend/tests/healthz.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a611efb244832da96a5b9897132030