### PR TITLE
ci: lint and typecheck on pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,7 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 npm audit --audit-level=high
-bash -c "source scripts/check-env.sh && npx lint-staged"
+npm run validate-env
+npx lint-staged
+npx eslint . --ext .ts,.tsx,.js --max-warnings=0
+npx tsc --noEmit

--- a/tests/preCommit.test.js
+++ b/tests/preCommit.test.js
@@ -7,7 +7,15 @@ test("pre-commit validates env before lint-staged", () => {
     l.includes("npm run validate-env"),
   );
   const idxLint = lines.findIndex((l) => l.includes("npx lint-staged"));
+  const idxEslint = lines.findIndex((l) =>
+    l.includes("npx eslint . --ext .ts,.tsx,.js --max-warnings=0"),
+  );
+  const idxTsc = lines.findIndex((l) => l.includes("npx tsc --noEmit"));
   expect(idxValidate).toBeGreaterThan(-1);
   expect(idxLint).toBeGreaterThan(-1);
+  expect(idxEslint).toBeGreaterThan(-1);
+  expect(idxTsc).toBeGreaterThan(-1);
   expect(idxValidate).toBeLessThan(idxLint);
+  expect(idxLint).toBeLessThan(idxEslint);
+  expect(idxEslint).toBeLessThan(idxTsc);
 });


### PR DESCRIPTION
## Summary
- run `npm run validate-env`, ESLint, and TypeScript checks in pre-commit
- test pre-commit script for new lint and typecheck commands

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `node scripts/run-jest.js tests/preCommit.test.js`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68a611fb815c832d87a060663bfc0a17