### PR TITLE
test: retry flaky jest tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,6 +6,7 @@ module.exports = {
   setupFilesAfterEnv: [
     "<rootDir>/test/setupAuthMiddleware.js",
     "<rootDir>/tests/setup/nock.ts",
+    "<rootDir>/tests/setup/retries.ts",
   ],
   coverageThreshold: {
     global: {

--- a/tests/setup/retries.ts
+++ b/tests/setup/retries.ts
@@ -1,0 +1,1 @@
+jest.retryTimes(2, { logErrorsBeforeRetry: true });


### PR DESCRIPTION
## Summary
- retry failed Jest tests twice globally

## Testing
- `npm run format`
- `npm test tests/health.test.js`
- `node scripts/run-jest.js tests/gitignore.test.js`
- `SKIP_PW_DEPS=1 npm run smoke`
- `SKIP_PW_DEPS=1 npm run ci` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68a6120ef3f0832db4929bab3a964d3d