### PR TITLE
ci: guard missing frontend dist

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,8 +38,8 @@ jobs:
           npm ci
           npm run build
 
-      - name: Verify build output
-        run: ls -al frontend/dist && test -f frontend/dist/index.html
+      - name: Guard frontend build output
+        run: node scripts/assert-frontend-dist.js
 
 
       - name: Assert Pages project has no build config

--- a/.github/workflows/diagnostics-dist-check.yml
+++ b/.github/workflows/diagnostics-dist-check.yml
@@ -22,8 +22,8 @@ jobs:
           pwd
           ls -la
           find frontend -maxdepth 2 -type d -print
-      - name: Assert dist index
-        run: node scripts/ci/assert-dist.js
+      - name: Ensure frontend dist
+        run: node scripts/assert-frontend-dist.js
       - name: Upload dist artifact
         uses: actions/upload-artifact@v4
         with:

--- a/scripts/assert-frontend-dist.js
+++ b/scripts/assert-frontend-dist.js
@@ -3,10 +3,14 @@ const path = require("path");
 
 const distDir = path.join(__dirname, "..", "frontend", "dist");
 if (!fs.existsSync(distDir)) {
-  throw new Error(`Missing build output directory: ${distDir}`);
+  throw new Error(
+    `Missing build output directory: ${distDir}. Run \`npm run build --prefix frontend\` first.`,
+  );
 }
 const indexFile = path.join(distDir, "index.html");
 if (!fs.existsSync(indexFile)) {
-  throw new Error(`Missing index.html in ${distDir}`);
+  throw new Error(
+    `Missing index.html in ${distDir}. Ensure the frontend build completed successfully.`,
+  );
 }
 console.log("Found frontend build output:", indexFile);

--- a/scripts/ci/assert-dist.js
+++ b/scripts/ci/assert-dist.js
@@ -1,9 +1,0 @@
-const fs = require("fs");
-const path = require("path");
-
-const distPath = path.resolve("frontend/dist/index.html");
-if (!fs.existsSync(distPath)) {
-  console.error(`Missing ${distPath}`);
-  process.exit(1);
-}
-console.log(`Found ${distPath}`);


### PR DESCRIPTION
## Summary
- verify frontend build output exists before deploy to avoid missing dist errors
- reuse dist check in diagnostics workflow and remove obsolete script

## Testing
- `npm run format`
- `npm test` *(fails: isolated ESLint and lintingDetailed tests)*
- `SKIP_PW_DEPS=1 npm run ci` *(partially ran; not all tests completed)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68a6159ed944832d835d90c37e1d2cdd