### PR TITLE
ci: run lint and typecheck in pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,5 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 npm audit --audit-level=high
-bash -c "source scripts/check-env.sh && npx lint-staged"
+bash -c "source scripts/check-env.sh && npm run lint && npm run typecheck && npx lint-staged"
+


### PR DESCRIPTION
## Summary
- run lint and typecheck as part of Husky pre-commit hook to catch issues earlier

## Testing
- `npm run lint`
- `npm run typecheck`
- `(cd backend && npm run format)`
- `(cd backend && npm test)` *(fails: process interrupted with remaining suites)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: aborted after partial run)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Playwright config error)*

------
https://chatgpt.com/codex/tasks/task_e_68a6159d1960832db749dc2c81be8327