### PR TITLE
test: clean up async handles after tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,7 +6,9 @@ module.exports = {
   setupFilesAfterEnv: [
     "<rootDir>/test/setupAuthMiddleware.js",
     "<rootDir>/tests/setup/nock.ts",
+    "<rootDir>/tests/setup/cleanupHandles.ts",
   ],
+  detectOpenHandles: true,
   coverageThreshold: {
     global: {
       branches: 55,

--- a/tests/setup/cleanupHandles.ts
+++ b/tests/setup/cleanupHandles.ts
@@ -1,0 +1,29 @@
+import { afterEach } from '@jest/globals';
+
+function closeHandle(handle: any) {
+  if (typeof handle?.close === 'function') {
+    try {
+      handle.close();
+    } catch {}
+  } else if (typeof handle?.destroy === 'function') {
+    try {
+      handle.destroy();
+    } catch {}
+  }
+  if (typeof handle?.unref === 'function') {
+    try {
+      handle.unref();
+    } catch {}
+  }
+}
+
+afterEach(() => {
+  jest.clearAllTimers();
+  for (const handle of process._getActiveHandles()) {
+    const name = handle.constructor?.name;
+    if (name === 'TTYWrap' || name === 'ReadStream' || name === 'WriteStream') {
+      continue;
+    }
+    closeHandle(handle);
+  }
+});


### PR DESCRIPTION
## Summary
- detect open handles in Jest and load cleanup script
- automatically close timers and handles after each test

## Testing
- `npm run format`
- `npm run format --prefix backend`
- `node scripts/run-jest.js tests/dummy.test.js`
- `npm test --prefix backend backend/tests/assertSetup.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a615984e9c832dac6532404aa968c4