### PR TITLE
ci: fix dependency cache paths

### DIFF
--- a/.github/workflows/cache-primer.yml
+++ b/.github/workflows/cache-primer.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 jobs:
-  frontend-cache:
+  root-cache:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -12,8 +12,8 @@ jobs:
         with:
           node-version: 20
           cache: npm
-          cache-dependency-path: frontend/package-lock.json
-      - run: npm ci --prefix frontend
+          cache-dependency-path: package-lock.json
+      - run: npm ci
 
   backend-cache:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           node-version: 20
           cache: npm
-          cache-dependency-path: frontend/package-lock.json
+          cache-dependency-path: package-lock.json
 
       - name: Mask secrets
         env:

--- a/.github/workflows/frontend-dry-build.yml
+++ b/.github/workflows/frontend-dry-build.yml
@@ -12,13 +12,11 @@ jobs:
         with:
           node-version: 20
           cache: npm
-          cache-dependency-path: frontend/package-lock.json
+          cache-dependency-path: package-lock.json
       - run: npm ci
-        working-directory: frontend
       - run: npm run build
-        working-directory: frontend
-      - run: node -e "require('fs').accessSync('frontend/dist/index.html')"
+      - run: node -e "require('fs').accessSync('dist/index.html')"
       - uses: actions/upload-artifact@v4
         with:
           name: frontend-dist
-          path: frontend/dist
+          path: dist

--- a/.github/workflows/frontend-local-build.yml
+++ b/.github/workflows/frontend-local-build.yml
@@ -12,10 +12,10 @@ jobs:
         with:
           node-version: 20
           cache: npm
-          cache-dependency-path: frontend/package-lock.json
-      - run: npm ci --prefix frontend && npm run build --prefix frontend
-      - run: node -e "require('fs').accessSync('frontend/dist/index.html')"
+          cache-dependency-path: package-lock.json
+      - run: npm ci && npm run build
+      - run: node -e "require('fs').accessSync('dist/index.html')"
       - uses: actions/upload-artifact@v4
         with:
           name: frontend-dist
-          path: frontend/dist
+          path: dist


### PR DESCRIPTION
## Summary
- fix invalid package-lock paths in dependency caching workflows
- ensure root dependencies are cached during primer and build jobs

## Testing
- `npm run format` (backend)
- `npm test` *(fails: backend tests skipped after setup)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Playwright browsers not installed, setup reran)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: exited after environment setup)*

------
https://chatgpt.com/codex/tasks/task_e_68a615963c0c832da696e5991756fd54