### PR TITLE
test: improve ESLint failure diagnostics

### DIFF
--- a/backend/tests/eslintIsolation.test.js
+++ b/backend/tests/eslintIsolation.test.js
@@ -7,10 +7,13 @@ const repoRoot = path.resolve(__dirname, "..", "..");
 const eslintBin = path.join(repoRoot, "node_modules", ".bin", "eslint");
 
 function runEslint(args) {
-  return spawnSync("node", ["--experimental-vm-modules", eslintBin, ...args], {
+  const cmd = ["node", "--experimental-vm-modules", eslintBin, ...args];
+  const res = spawnSync(cmd[0], cmd.slice(1), {
     cwd: repoRoot,
     encoding: "utf8",
   });
+  res.cmd = cmd.join(" ");
+  return res;
 }
 
 describe("isolated ESLint failures", () => {
@@ -33,6 +36,11 @@ describe("isolated ESLint failures", () => {
 
   test("typescript file parses without error", () => {
     const res = runEslint(["scripts/ci_watchdog.ts", "--no-ignore"]);
+    if (res.status !== 0) {
+      console.error(`ESLint command: ${res.cmd}`);
+      if (res.stdout) console.error(res.stdout);
+      if (res.stderr) console.error(res.stderr);
+    }
     expect(res.status).toBe(0);
   });
 
@@ -54,7 +62,11 @@ describe("isolated ESLint failures", () => {
       "--no-warn-ignored",
     ]);
     fs.rmSync(tmpDir, { recursive: true, force: true });
-    if (res.stderr) console.error(res.stderr);
+    if (res.status !== 0) {
+      console.error(`ESLint command: ${res.cmd}`);
+      if (res.stdout) console.error(res.stdout);
+      if (res.stderr) console.error(res.stderr);
+    }
     expect(res.status).toBe(0);
   });
 });

--- a/backend/tests/lintingDetailed.test.js
+++ b/backend/tests/lintingDetailed.test.js
@@ -13,10 +13,19 @@ test("detailed backend ESLint report", () => {
     fs.mkdirSync(coverageDir, { recursive: true });
     fs.writeFileSync(path.join(coverageDir, ".gitkeep"), "");
   }
-  const output = execSync(`npx eslint -f json .`, {
-    cwd: backendDir,
-    encoding: "utf8",
-  });
+  const cmd = `npx eslint -f json .`;
+  let output;
+  try {
+    output = execSync(cmd, {
+      cwd: backendDir,
+      encoding: "utf8",
+    });
+  } catch (err) {
+    console.error(`ESLint command: ${cmd}`);
+    if (err.stdout) console.error(err.stdout);
+    if (err.stderr) console.error(err.stderr);
+    throw err;
+  }
   const results = JSON.parse(output);
   const errors = results
     .flatMap((r) => r.messages.map((m) => ({ ...m, file: r.filePath })))

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -11,6 +11,7 @@
     "backend/**/*.tsx",
     "tests/**/*.ts",
     "tests/**/*.tsx",
+    "scripts/*.ts",
     "scripts/**/*.ts"
   ],
   "exclude": ["node_modules", "dist", "build", "coverage", ".next", ".cache"]


### PR DESCRIPTION
## Summary
- log ESLint command and output when isolation tests fail
- surface ESLint command and errors in detailed lint report
- include standalone script files in ESLint project config

## Testing
- `npm run format`
- `npm test`
- `npm run ci` *(interrupted: exceeded time limits)*
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68a615350110832d9b596e790c0352cd