### PR TITLE
ci: add regression guard for lint and tests

### DIFF
--- a/.github/workflows/regression-guard.yml
+++ b/.github/workflows/regression-guard.yml
@@ -1,0 +1,20 @@
+name: regression-guard
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5.0.0
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: node scripts/check-lint-regression.js
+      - run: node scripts/check-test-regression.js

--- a/scripts/check-lint-regression.js
+++ b/scripts/check-lint-regression.js
@@ -14,11 +14,15 @@ if (fs.existsSync(baselinePath)) {
   }
 }
 
-const output = execSync("pnpm exec eslint . -f json", {
-  cwd: repoRoot,
-  encoding: "utf8",
-});
-const results = JSON.parse(output);
+const rootOutput = execSync(
+  'npx eslint "scripts/**/*.js" --no-warn-ignored -f json || true',
+  { cwd: repoRoot, encoding: "utf8" },
+);
+const backendOutput = execSync(
+  "npx eslint . --no-warn-ignored --ignore-pattern lib -f json || true",
+  { cwd: path.join(repoRoot, "backend"), encoding: "utf8" },
+);
+const results = [...JSON.parse(rootOutput || "[]"), ...JSON.parse(backendOutput || "[]")];
 const counts = results.reduce(
   (acc, r) => {
     acc.errorCount += r.errorCount || 0;

--- a/scripts/check-test-regression.js
+++ b/scripts/check-test-regression.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+const { spawnSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+const repoRoot = path.resolve(__dirname, "..");
+const baselinePath = path.join(repoRoot, "tests", "testBaseline.json");
+let baseline = { numFailedTests: 0 };
+if (fs.existsSync(baselinePath)) {
+  try {
+    baseline = JSON.parse(fs.readFileSync(baselinePath, "utf8"));
+  } catch (err) {
+    console.error("Failed to read baseline:", err);
+  }
+}
+
+const resultsPath = path.join(repoRoot, "test-results.json");
+spawnSync(
+  "node",
+  ["scripts/run-jest.js", "--json", `--outputFile=${resultsPath}`],
+  { cwd: repoRoot, stdio: "inherit" },
+);
+
+let results = { numFailedTests: Infinity };
+try {
+  results = JSON.parse(fs.readFileSync(resultsPath, "utf8"));
+} catch (err) {
+  console.error("Failed to read test results:", err);
+}
+
+if (results.numFailedTests > baseline.numFailedTests) {
+  console.error(
+    `Test failures increased. Current: ${results.numFailedTests}, baseline: ${baseline.numFailedTests}`,
+  );
+  process.exit(1);
+}
+console.log(
+  `Jest failures ${results.numFailedTests} within baseline ${baseline.numFailedTests}`,
+);

--- a/scripts/update-test-baseline.js
+++ b/scripts/update-test-baseline.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+const { spawnSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+const repoRoot = path.resolve(__dirname, "..");
+const baselinePath = path.join(repoRoot, "tests", "testBaseline.json");
+const resultsPath = path.join(repoRoot, "test-results.json");
+
+spawnSync(
+  "node",
+  ["scripts/run-jest.js", "--json", `--outputFile=${resultsPath}`],
+  { cwd: repoRoot, stdio: "inherit" },
+);
+
+const results = JSON.parse(fs.readFileSync(resultsPath, "utf8"));
+fs.writeFileSync(
+  baselinePath,
+  JSON.stringify({ numFailedTests: results.numFailedTests }, null, 2),
+);
+console.log(`Updated test baseline at ${baselinePath}`);

--- a/tests/testBaseline.json
+++ b/tests/testBaseline.json
@@ -1,0 +1,3 @@
+{
+  "numFailedTests": 0
+}


### PR DESCRIPTION
## Summary
- add regression guard workflow to freeze lint/test error counts
- script baseline comparison for ESLint and Jest

## Testing
- `npm run format`
- `node scripts/check-lint-regression.js`
- `node scripts/check-test-regression.js` *(fails: Failed to read test results)*

------
https://chatgpt.com/codex/tasks/task_e_68a615330fd0832d86fe2cad15403653