### PR TITLE
feat: abort long-running Jest tests

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -2,7 +2,10 @@
 module.exports = {
   rootDir: ".",
   setupFiles: ["<rootDir>/tests/setupGlobals.js"],
-  setupFilesAfterEnv: ["<rootDir>/tests/setup.js"],
+  setupFilesAfterEnv: [
+    "<rootDir>/tests/setup.js",
+    "<rootDir>/../tests/setup/abort-on-timeout.js",
+  ],
   globalTeardown: "<rootDir>/tests/globalTeardown.js",
   testEnvironment: "node",
   transform: {

--- a/backend/package.json
+++ b/backend/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "main": "server.js",
   "scripts": {
-    "test": "jest",
-    "test-ci": "jest --ci --coverage --maxWorkers=2 --forceExit",
+    "test": "jest --detectOpenHandles",
+    "test-ci": "jest --ci --coverage --maxWorkers=2 --detectOpenHandles",
     "test:unit": "npm test",
     "coverage": "node ../scripts/run-coverage.js",
     "start": "node server.js",

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,6 +6,7 @@ module.exports = {
   setupFilesAfterEnv: [
     "<rootDir>/test/setupAuthMiddleware.js",
     "<rootDir>/tests/setup/nock.ts",
+    "<rootDir>/tests/setup/abort-on-timeout.js",
   ],
   coverageThreshold: {
     global: {

--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -55,6 +55,9 @@ function runJest(args) {
   if (!jestArgs.includes("--runInBand")) {
     jestArgs.push("--runInBand");
   }
+  if (!jestArgs.includes("--detectOpenHandles")) {
+    jestArgs.push("--detectOpenHandles");
+  }
 
   const fileArgs = jestArgs.filter((arg) => !arg.startsWith("-"));
   const runFromRoot = fileArgs.some((arg) => {

--- a/tests/setup/abort-on-timeout.js
+++ b/tests/setup/abort-on-timeout.js
@@ -1,0 +1,37 @@
+const MAX_TEST_DURATION = 10 * 60 * 1000; // 10 minutes
+const util = require('util');
+let timer;
+
+function dumpHandles() {
+  const handles = process._getActiveHandles();
+  if (handles.length) {
+    console.error('\nActive handles:');
+    handles.forEach((h, i) => {
+      console.error(`${i + 1}:`, util.inspect(h));
+    });
+  }
+  const requests = process._getActiveRequests();
+  if (requests.length) {
+    console.error('\nActive requests:');
+    requests.forEach((r, i) => {
+      console.error(`${i + 1}:`, util.inspect(r));
+    });
+  }
+}
+
+beforeEach(() => {
+  clearTimeout(timer);
+  timer = setTimeout(() => {
+    console.error(`\n❌ Test exceeded ${MAX_TEST_DURATION}ms`);
+    dumpHandles();
+    console.error(new Error('Test timeout exceeded').stack);
+    // Ensure non-zero exit so CI fails
+    process.exit(1);
+  }, MAX_TEST_DURATION);
+  // Allow process to exit naturally when tests finish
+  if (timer.unref) timer.unref();
+});
+
+afterEach(() => {
+  clearTimeout(timer);
+});


### PR DESCRIPTION
## Summary
- abort tests that exceed ten minutes and dump active handles
- always run Jest with `--detectOpenHandles`
- enable open-handle detection in backend test scripts

## Testing
- `npm run format --prefix backend` *(fails: Dependencies missing. Installing root dependencies...)*
- `npm test` *(fails: Dependencies missing. Installing root dependencies...)*

------
https://chatgpt.com/codex/tasks/task_e_68a6152ebcd4832daedf6d22dd8cc49c