### PR TITLE
test: add ESLint config resolution coverage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,11 @@ Thank you for helping improve this project! Please follow these steps to keep ou
 - If Playwright dependencies are already installed you can set `SKIP_PW_DEPS=1` when running setup or CI to skip the lengthy install step.
 - Mock all external HTTP calls in tests. Only `localhost` traffic is permitted; any other network access must be stubbed with tools like [nock](https://github.com/nock/nock).
 
+## ESLint configuration
+
+- The root `eslint.config.js` lints `scripts/**` and `tests/**`. Add shared rules there and update `tsconfig.eslint.json` when new TypeScript sources are introduced.
+- The `backend/` directory has its own `eslint.config.js` and `tsconfig.json`. Backend-specific rules and type settings belong in those files.
+
 ## How to run tests / lint / coverage / smoke
 
 Run the following commands from the repository root:

--- a/backend/tests/eslintIsolation.test.js
+++ b/backend/tests/eslintIsolation.test.js
@@ -7,10 +7,20 @@ const repoRoot = path.resolve(__dirname, "..", "..");
 const eslintBin = path.join(repoRoot, "node_modules", ".bin", "eslint");
 
 function runEslint(args) {
-  return spawnSync("node", ["--experimental-vm-modules", eslintBin, ...args], {
-    cwd: repoRoot,
-    encoding: "utf8",
-  });
+  const res = spawnSync(
+    "node",
+    ["--experimental-vm-modules", eslintBin, ...args],
+    {
+      cwd: repoRoot,
+      encoding: "utf8",
+      timeout: 20_000,
+      env: { ...process.env, CI: "1" },
+    },
+  );
+  if (res.error && res.error.code === "ETIMEDOUT") {
+    throw new Error(`ESLint timed out after 20s: ${args.join(" ")}`);
+  }
+  return res;
 }
 
 describe("isolated ESLint failures", () => {

--- a/tests/__snapshots__/detailedLint.test.js.snap
+++ b/tests/__snapshots__/detailedLint.test.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`eslint detailed lint granular messages controlled ts sample 1`] = `
+[
+  {
+    "message": "'unused' is assigned a value but never used.",
+    "ruleId": "no-unused-vars",
+    "severity": 2,
+  },
+]
+`;

--- a/tests/detailedLint.test.js
+++ b/tests/detailedLint.test.js
@@ -1,0 +1,45 @@
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+describe("eslint detailed lint", () => {
+  describe("granular messages", () => {
+    test("controlled ts sample", () => {
+      const prevCI = process.env.CI;
+      process.env.CI = "1";
+      const repoRoot = path.resolve(__dirname, "..");
+      const eslintPath = path.join(
+        repoRoot,
+        "node_modules",
+        "eslint",
+        "bin",
+        "eslint.js",
+      );
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "lint-"));
+      const file = path.join(tmpDir, "sample.ts");
+      fs.writeFileSync(file, "const unused=1;\n");
+      const res = spawnSync(
+        "node",
+        [
+          "--experimental-vm-modules",
+          eslintPath,
+          file,
+          "-f",
+          "json",
+          "--config",
+          path.join(repoRoot, "eslint.config.js"),
+          "--no-warn-ignored",
+        ],
+        { cwd: tmpDir, encoding: "utf8" },
+      );
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+      if (prevCI === undefined) delete process.env.CI;
+      else process.env.CI = prevCI;
+      const messages = JSON.parse(res.stdout)[0].messages.map(
+        ({ ruleId, severity, message }) => ({ ruleId, severity, message }),
+      );
+      expect(messages).toMatchSnapshot();
+    });
+  });
+});

--- a/tests/eslintConfigResolution.test.js
+++ b/tests/eslintConfigResolution.test.js
@@ -1,0 +1,53 @@
+const { spawnSync } = require("child_process");
+const path = require("path");
+
+const repoRoot = path.resolve(__dirname, "..");
+
+function runEslint(args) {
+  const res = spawnSync("pnpm", ["exec", "eslint", ...args], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    env: { ...process.env, CI: "1" },
+  });
+  if (res.stderr) console.error(res.stderr);
+  return res;
+}
+
+describe("eslint config resolution", () => {
+  test("root lint resolves typescript", () => {
+    const res = runEslint([
+      "scripts/ci_watchdog.ts",
+      "--no-ignore",
+      "-f",
+      "json",
+    ]);
+    if (res.status !== 0) console.error(res.stdout);
+    expect(res.status).toBe(0);
+    const messages = JSON.parse(res.stdout)[0].messages.filter(
+      (m) => m.severity === 2,
+    );
+    expect(messages).toHaveLength(0);
+  });
+
+  test("tests ts files parse", () => {
+    const res = runEslint([
+      "tests/runSmoke.fallback-env.test.ts",
+      "-f",
+      "json",
+    ]);
+    if (res.status !== 0) console.error(res.stdout);
+    expect(res.status).toBe(0);
+    const messages = JSON.parse(res.stdout)[0].messages.filter(
+      (m) => m.severity === 2,
+    );
+    expect(messages).toHaveLength(0);
+  });
+
+  test("root ignores backend", () => {
+    const res = runEslint(["backend"]);
+    const output = res.stdout + res.stderr;
+    expect(res.status).not.toBe(0);
+    expect(output).toMatch(/ignored/);
+    expect(output).toMatch(/backend/);
+  });
+});


### PR DESCRIPTION
## Summary
- add config-resolution tests to ensure TypeScript files parse and backend is ignored
- snapshot ESLint messages from a controlled TypeScript sample
- guard ESLint isolation tests against hangs with a timeout
- document ESLint ownership for scripts, tests, and backend

## Testing
- `npm run format --prefix backend`
- `node scripts/run-jest.js --runTestsByPath tests/eslintConfigResolution.test.js tests/detailedLint.test.js`
- `node scripts/run-jest.js --runTestsByPath backend/tests/eslintIsolation.test.js`
- `npm test --prefix backend` *(fails: parsing errors in lint baseline)*

------
https://chatgpt.com/codex/tasks/task_e_68a613381c08832d892f99ca6c52d16f