### PR TITLE
ci: add pipeline deadlock guard

### DIFF
--- a/.github/workflows/pipeline-deadlock-check.yml
+++ b/.github/workflows/pipeline-deadlock-check.yml
@@ -1,0 +1,18 @@
+name: Pipeline Deadlock Check
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  deadlock:
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm install --no-save yaml
+      - run: node --test tests/ci/pipeline-deadlock-check-b1a2c3d.test.js

--- a/tests/ci/pipeline-deadlock-check-b1a2c3d.test.js
+++ b/tests/ci/pipeline-deadlock-check-b1a2c3d.test.js
@@ -1,0 +1,70 @@
+const fs = require("fs/promises");
+const path = require("path");
+const { test } = require("node:test");
+
+const repoRoot = path.resolve(__dirname, "../..");
+const workflowsDir = path.join(repoRoot, ".github", "workflows");
+
+function appendSummary(message) {
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (!summaryPath) return Promise.resolve();
+  return fs.appendFile(summaryPath, `${message}\n`);
+}
+
+test("pipeline configuration avoids common deadlocks", async () => {
+  const errors = [];
+  const files = await fs.readdir(workflowsDir);
+
+  for (const file of files) {
+    if (!file.endsWith(".yml") && !file.endsWith(".yaml")) continue;
+    const content = await fs.readFile(path.join(workflowsDir, file), "utf8");
+
+    if (/concurrency:\s*\n\s*group:\s*ci-\$\{\{\s*github.ref\s*\}\}/.test(content)) {
+      errors.push(`${file}: uses broad concurrency group ci-\${{ github.ref }}`);
+    }
+
+    const lines = content.split(/\r?\n/);
+    const jobNames = new Set();
+    let inJobs = false;
+    for (const line of lines) {
+      if (/^jobs:\s*$/.test(line)) inJobs = true;
+      else if (inJobs) {
+        const m = /^\s{2}([A-Za-z0-9_-]+):\s*$/.exec(line);
+        if (m) jobNames.add(m[1]);
+      }
+    }
+
+    for (let i = 0; i < lines.length; i++) {
+      const m = /^\s+needs:\s*(.*)$/.exec(lines[i]);
+      if (!m) continue;
+      let deps = [];
+      if (m[1] && m[1] !== "") {
+        deps = m[1].replace(/[\[\]]/g, "").split(/,\s*/);
+      } else {
+        let j = i + 1;
+        while (j < lines.length && /^\s+-\s*(\S+)/.test(lines[j])) {
+          deps.push(lines[j].trim().replace(/^-[\s]*/, ""));
+          j++;
+        }
+      }
+      for (const dep of deps) {
+        if (dep && !jobNames.has(dep)) {
+          errors.push(`${file}: job needs missing job '${dep}'`);
+        }
+      }
+    }
+  }
+
+  try {
+    await fs.access(path.join(repoRoot, "frontend", "dist", "index.html"));
+  } catch {
+    errors.push("Missing frontend build artifact: frontend/dist/index.html");
+  }
+
+  if (errors.length) {
+    await appendSummary(`### CI/CD pipeline issues\n${errors.map((e) => `- ${e}`).join("\n")}`);
+    throw new Error(errors.join("; "));
+  }
+
+  await appendSummary("### CI/CD pipeline checks\nAll checks passed.");
+});


### PR DESCRIPTION
## Summary
- add deadlock check test ensuring concurrency groups and needs dependencies are sane
- wire up fast GitHub Action to run the deadlock checks

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup` *(fails: Type '{ id: number; name?: string | null | undefined; node_id: string; check_suite_id?: number | undefined; check_suite_node_id?: string | undefined; head_branch: string | null; ... 29 more ...; display_title: string; }[]' is not assignable to type 'WorkflowRun[]')*
- `npm test --prefix backend` *(fails: husky - pre-commit script failed)*
- `node --test tests/ci/pipeline-deadlock-check-b1a2c3d.test.js`
- `npm run format --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_68a655bc2c4c832d800208e6e34d2930