### PR TITLE
ci: throttle load test concurrency

### DIFF
--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -4,7 +4,8 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Limit load tests to a single runner across all refs to avoid saturating runner capacity
+  group: load-test
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
- throttle load-test workflow by grouping all runs into a single concurrency slot

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: husky install && tsc -p scripts/tsconfig.json)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: husky install && tsc -p scripts/tsconfig.json)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: husky install && tsc -p scripts/tsconfig.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a655c3f274832db3adc803b03be76e