### PR TITLE
ci: list frontend build artifacts

### DIFF
--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -32,3 +32,19 @@ jobs:
         with:
           name: frontend-dist-${{ matrix.node }}
           path: frontend/dist
+
+  artifact-lister:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: frontend-dist-20
+          path: frontend/dist
+      - run: |
+          tar -czf frontend-dist.tar.gz -C frontend/dist .
+          tar -tvf frontend-dist.tar.gz | tee frontend-dist-filetree.txt
+      - uses: actions/upload-artifact@v4
+        with:
+          name: frontend-dist-filetree
+          path: frontend-dist-filetree.txt


### PR DESCRIPTION
## Summary
- add artifact-lister job to build-frontend workflow that archives the built frontend and uploads a file listing

## Testing
- `npm run format`
- `npm test` *(fails: TypeScript errors in scripts/ci_watchdog.ts)*
- `npm run ci` *(fails: TypeScript errors in scripts/ci_watchdog.ts)*
- `npm run smoke` *(fails: TypeScript errors in scripts/ci_watchdog.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68a656ad2ed4832db582a2a4f55babad