### PR TITLE
ci: pin wrangler version in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,8 @@ jobs:
   deploy:
     if: vars.ENABLE_PAGES == '1'
     runs-on: ubuntu-latest
+    env:
+      WRANGLER_VERSION: 3.72.0
 
     steps:
       - name: Checkout code
@@ -52,7 +54,8 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
-          info=$(npx wrangler pages project info mvp-website --output json)
+          npx wrangler@${{ env.WRANGLER_VERSION }} --version
+          info=$(npx wrangler@${{ env.WRANGLER_VERSION }} pages project info mvp-website --output json)
           build_command=$(echo "$info" | jq -r '.deployment_configs.production.build_config.build_command')
           root_dir=$(echo "$info" | jq -r '.deployment_configs.production.build_config.root_dir')
           if [ "$build_command" != "null" ] && [ -n "$build_command" ]; then
@@ -70,10 +73,11 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
+          npx wrangler@${{ env.WRANGLER_VERSION }} --version
           set +e
           for attempt in 1 2 3; do
             echo "Attempt $attempt"
-            npx wrangler pages deploy frontend/dist --project-name mvp-website 2>&1 | tee deploy.log
+            npx wrangler@${{ env.WRANGLER_VERSION }} pages deploy frontend/dist --project-name mvp-website 2>&1 | tee deploy.log
             status=${PIPESTATUS[0]}
             if [ $status -eq 0 ]; then
               break
@@ -100,7 +104,9 @@ jobs:
         run: node scripts/assert-frontend-dist.js
 
       - name: Publish to Cloudflare Pages
-        run: npx wrangler@3 pages deploy frontend/dist --project-name ${{ secrets.CF_PAGES_PROJECT }}
+        run: |
+          npx wrangler@${{ env.WRANGLER_VERSION }} --version
+          npx wrangler@${{ env.WRANGLER_VERSION }} pages deploy frontend/dist --project-name ${{ secrets.CF_PAGES_PROJECT }}
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_PAGES_API_TOKEN }}


### PR DESCRIPTION
## Summary
- pin Cloudflare Wrangler to version 3.72.0 in deploy workflow
- log Wrangler version before project info, deploy, and publish steps

## Testing
- `npm run validate-env`
- `curl -I https://registry.npmjs.org`
- `curl -I https://cdn.playwright.dev`
- `SKIP_PW_DEPS=1 npm run setup` *(fails: process terminated)*
- `npm run format` *(fails: TypeScript errors)*
- `npm test` *(fails: setup hung)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: ENOTEMPTY)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: hung)*

------
https://chatgpt.com/codex/tasks/task_e_68a656b1f9f4832da870905f0a21979f