### PR TITLE
ci: add timeout and heartbeat to pages deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,8 +16,16 @@ jobs:
   deploy:
     if: vars.ENABLE_PAGES == '1'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
+      - name: Start heartbeat
+        run: |
+          while true; do
+            echo "heartbeat"
+            sleep 300
+          done &
+          echo $! > heartbeat.pid
       - name: Checkout code
         uses: actions/checkout@v5
 
@@ -104,6 +112,10 @@ jobs:
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_PAGES_API_TOKEN }}
+
+      - name: Stop heartbeat
+        if: always()
+        run: kill $(cat heartbeat.pid) || true
 
   pages-disabled:
     if: vars.ENABLE_PAGES != '1'


### PR DESCRIPTION
## Summary
- ensure Pages deploy job times out after 15 minutes
- emit a heartbeat during Pages deploy to avoid indefinite queueing

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: scripts/ci_watchdog.ts type errors)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: scripts/ci_watchdog.ts type errors)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: scripts/ci_watchdog.ts type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a656bb1798832d81efb8b11866e59a