### PR TITLE
ci: add queue probe workflow

### DIFF
--- a/.github/workflows/queue-probe.yml
+++ b/.github/workflows/queue-probe.yml
@@ -1,0 +1,14 @@
+name: Queue Probe
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - run: echo "hello $GITHUB_RUN_ID"


### PR DESCRIPTION
### Summary
- add Queue Probe workflow that echoes run ID on PRs and manual dispatch

### Testing
- `npm run format` (passed)
- `npm test` (failed: scripts/ci_watchdog.ts type error)
- `npm run ci` (failed: scripts/ci_watchdog.ts type error)
- `npm run smoke` (failed: scripts/ci_watchdog.ts type error)


------
https://chatgpt.com/codex/tasks/task_e_68a658351524832d9e5d2949720662f0