### PR TITLE
ci: add workflow dispatch to preview deploy

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -3,6 +3,7 @@ name: Preview Deploy
 on:
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
- allow manually triggering the preview deploy workflow

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup` (failed: TypeScript compile error)
- `npm run format --prefix backend`
- `npm test --prefix backend` (failed: husky install & tsc error)
- `SKIP_PW_DEPS=1 npm run ci` (failed: npm ci ENOTEMPTY)
- `SKIP_PW_DEPS=1 npm run smoke` (failed: npm ci tar errors)


------
https://chatgpt.com/codex/tasks/task_e_68a6584ac564832d9b14567523b11afe