### PR TITLE
ci: add Cloudflare Pages deploy workflow

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -1,0 +1,53 @@
+name: Pages Deploy
+
+on:
+  push:
+    branches: ["00000production"]
+  workflow_dispatch:
+
+concurrency:
+  group: pages-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci
+        working-directory: frontend
+      - run: npm run build
+        working-directory: frontend
+      - name: verify build
+        run: |
+          if [ ! -f frontend/dist/index.html ]; then
+            echo "frontend/dist/index.html is missing"
+            if command -v tree >/dev/null; then
+              tree frontend/dist
+            else
+              find frontend/dist -maxdepth 2 -print
+            fi
+            exit 1
+          fi
+      - name: Deploy to Cloudflare Pages
+        id: deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          url=$(npx -y wrangler@3 pages deploy frontend/dist --project-name "${{ secrets.CF_PAGES_PROJECT }}" --branch production | tee /tmp/deploy.log | grep -Eo 'https://[^ ]+' | tail -n 1)
+          echo "$url" > deploy-url.txt
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+      - name: Job summary
+        if: steps.deploy.outputs.url
+        run: echo "Deployed to ${{ steps.deploy.outputs.url }}" >> "$GITHUB_STEP_SUMMARY"
+      - uses: actions/upload-artifact@v4
+        if: steps.deploy.outputs.url
+        with:
+          name: pages-deploy-url
+          path: deploy-url.txt


### PR DESCRIPTION
## Summary
- add standalone Cloudflare Pages deployment workflow

## Testing
- `npm run setup` *(fails: husky install command is deprecated)*
- `npm run format` *(fails: husky install command is deprecated)*
- `npm test` *(fails: husky install command is deprecated)*

------
https://chatgpt.com/codex/tasks/task_e_68a658625100832d95c5a9fd9faa6865