### PR TITLE
ci: add check watchdog

### DIFF
--- a/.github/workflows/check-watchdog.yml
+++ b/.github/workflows/check-watchdog.yml
@@ -1,0 +1,42 @@
+name: Check Watchdog
+
+on:
+  pull_request:
+
+jobs:
+  watch:
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    permissions:
+      checks: read
+    steps:
+      - name: Watch required checks
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          checks=("Build frontend / build" "Backend Smoke" "Cloudflare Pages")
+          deadline=$((SECONDS + 420))
+          while [ $SECONDS -lt $deadline ]; do
+            all_started=1
+            for check in "${checks[@]}"; do
+              status=$(gh api repos/${{ github.repository }}/commits/$SHA/check-runs \
+                -f check_name="$check" --jq '.check_runs[0].status' 2>/dev/null)
+              if [[ "$status" == "" || "$status" == "queued" ]]; then
+                all_started=0
+                break
+              fi
+            done
+            if [ $all_started -eq 1 ]; then
+              exit 0
+            fi
+            sleep 15
+          done
+          echo -e "Check\tStatus\tStarted At"
+          for check in "${checks[@]}"; do
+            gh api repos/${{ github.repository }}/commits/$SHA/check-runs \
+              -f check_name="$check" \
+              --jq '.check_runs[0] | [.name,.status,.started_at] | @tsv' 2>/dev/null
+          done | column -t -s $'\t'
+          echo "Jobs did not start within 7 min — likely runner queue/concurrency jam" >&2
+          exit 1


### PR DESCRIPTION
## Summary
- add watchdog workflow to ensure Build frontend / build, Backend Smoke, and Cloudflare Pages checks start within 7 minutes

## Testing
- `npm run format` (backend)
- `npm test` (backend) *(fails: Command failed: npm run setup)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Failed to run setup: Command failed: CI=1 npm run setup)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Error: Command failed: bash scripts/setup-codex-9b08f7c1.sh)*

------
https://chatgpt.com/codex/tasks/task_e_68a6586e6390832d8b7c974ff2290a9c