### PR TITLE
ci: sanitize symlinks before pages deploy

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -34,6 +34,10 @@ jobs:
             fi
             exit 1
           fi
+      - name: sanitize symlinks
+        run: |
+          find frontend/dist -type l -exec bash -c 't=$(mktemp); cp -L "{}" "$t" && mv "$t" "{}"' \;
+          find frontend/dist -type l -exec rm -f {} +
       - name: Deploy to Cloudflare Pages
         id: deploy
         env:


### PR DESCRIPTION
## Summary
- sanitize symlinks in `frontend/dist` before Cloudflare Pages deployment

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup` *(fails: scripts/ci_watchdog.ts type errors)*
- `npm run diagnose` *(fails: missing backend dependencies)*
- `cd backend && npm run format`
- `cd backend && npm test` *(fails: setup failed)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: setup failed)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: setup script failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f76f61d4832d813e1841ed5d0668