### PR TITLE
ci: shard backend tests across matrix jobs

### DIFF
--- a/.github/workflows/backend-only-ci.yml
+++ b/.github/workflows/backend-only-ci.yml
@@ -14,6 +14,10 @@ jobs:
   backend-tests:
     runs-on: ubuntu-latest
     continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [aa, ab, ac]
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
@@ -24,4 +28,9 @@ jobs:
             package-lock.json
             backend/package-lock.json
       - run: npm ci
-      - run: npm test --prefix backend
+      - run: npm ci --prefix backend
+      - name: Run backend tests
+        run: |
+          node scripts/run-jest.js backend --listTests | split -n l/3 - test-files-
+          TEST_FILES=$(cat test-files-${{ matrix.shard }} | tr '\n' ' ')
+          node scripts/run-jest.js --runTestsByPath $TEST_FILES --ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,10 @@ jobs:
 
   test-backend:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [aa, ab, ac]
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
@@ -46,15 +50,18 @@ jobs:
       - run: npm ci
       - run: npm ci --prefix backend
       - name: Run backend tests
-        run: node scripts/run-jest.js backend --ci --coverage --coverageDirectory=coverage/backend
+        run: |
+          node scripts/run-jest.js backend --listTests | split -n l/3 - test-files-
+          TEST_FILES=$(cat test-files-${{ matrix.shard }} | tr '\n' ' ')
+          node scripts/run-jest.js --runTestsByPath $TEST_FILES --ci --coverage --coverageDirectory=coverage/backend
       - uses: actions/upload-artifact@v4.3.4
         with:
-          name: junit-backend
+          name: junit-backend-${{ matrix.shard }}
           path: junit-backend.xml
           if-no-files-found: ignore
       - uses: actions/upload-artifact@v4.3.4
         with:
-          name: coverage-backend
+          name: coverage-backend-${{ matrix.shard }}
           path: coverage/backend
 
   test-frontend:
@@ -118,8 +125,9 @@ jobs:
       - run: npm ci --ignore-scripts
       - uses: actions/download-artifact@v4.1.8
         with:
-          name: coverage-backend
+          pattern: coverage-backend-*
           path: coverage/backend
+          merge-multiple: true
       - uses: actions/download-artifact@v4.1.8
         with:
           name: coverage-frontend


### PR DESCRIPTION
## Summary
- shard backend-only CI and main backend tests across three matrix jobs
- merge coverage from all backend shards using artifact pattern

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend -- backend/tests/api.test.js` *(fails: husky install command is deprecated)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f5d78338832d858a778116028ffa