### PR TITLE
ci: shard frontend tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,16 @@ jobs:
 
   test-frontend:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shard: core
+            pattern: 'frontend[^_]'
+          - shard: gen-a
+            pattern: 'generated_frontend_[0-7]'
+          - shard: gen-b
+            pattern: 'generated_frontend_[8-f]'
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
@@ -70,15 +80,15 @@ jobs:
             frontend/package-lock.json
       - run: npm ci
       - name: Run frontend tests
-        run: node scripts/run-jest.js frontend --ci --coverage --coverageDirectory=coverage/frontend
+        run: node scripts/run-jest.js --testPathPattern "${{ matrix.pattern }}" --ci --coverage --coverageDirectory=coverage/frontend
       - uses: actions/upload-artifact@v4.3.4
         with:
-          name: junit-frontend
+          name: junit-frontend-${{ matrix.shard }}
           path: junit-frontend.xml
           if-no-files-found: ignore
       - uses: actions/upload-artifact@v4.3.4
         with:
-          name: coverage-frontend
+          name: coverage-frontend-${{ matrix.shard }}
           path: coverage/frontend
 
   test-integration:
@@ -122,8 +132,9 @@ jobs:
           path: coverage/backend
       - uses: actions/download-artifact@v4.1.8
         with:
-          name: coverage-frontend
+          pattern: coverage-frontend-*
           path: coverage/frontend
+          merge-multiple: true
       - uses: actions/download-artifact@v4.1.8
         with:
           name: coverage-integration


### PR DESCRIPTION
## Summary
- split frontend Jest suite into three shards to run tests in parallel
- collect coverage from all frontend shards during merge

## Testing
- `npm run setup`
- `npm run format`
- `SKIP_PW_DEPS=1 npm test` *(fails: process terminated)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: tar or filesystem errors)*
- `npm run smoke` *(fails: cleanup ENOTEMPTY and SIGINT)*


------
https://chatgpt.com/codex/tasks/task_e_68a6f5daf5e4832dbfb2dff3f38d3cb0