### PR TITLE
fix: normalize octokit download data type

### DIFF
--- a/scripts/ci_watchdog.js
+++ b/scripts/ci_watchdog.js
@@ -3,7 +3,6 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-/* eslint-disable */
 const action_1 = require("@octokit/action");
 const node_child_process_1 = require("node:child_process");
 const promises_1 = __importDefault(require("node:fs/promises"));
@@ -15,30 +14,50 @@ const MIN_HITS = 5;
 const MAX_RUNS = 25;
 const sinceIso = new Date(Date.now() - WINDOW_HOURS * 3600_000).toISOString();
 async function main() {
-    const runs = await octo.paginate(octo.rest.actions.listWorkflowRunsForRepo, {
-        owner, repo, per_page: 100, status: "failure", event: "pull_request", created: `>${sinceIso}`
-    });
+    const runs = (await octo.paginate(octo.rest.actions.listWorkflowRunsForRepo, {
+        owner,
+        repo,
+        per_page: 100,
+        status: "failure",
+        event: "pull_request",
+        created: `>${sinceIso}`,
+    }));
     const clusters = {};
     for (const r of runs.slice(0, MAX_RUNS)) {
         const log = await octo.rest.actions.downloadWorkflowRunLogs({
-            owner, repo, run_id: r.id, request: { raw: true }
+            owner,
+            repo,
+            run_id: r.id,
+            request: { raw: true },
         });
-        const firstLine = Buffer.from(log.data)
-            .toString("utf8")
-            .split("\n")
-            .find(Boolean) ?? "unknown error";
+        const raw = log.data;
+        const buf = raw instanceof ArrayBuffer
+            ? Buffer.from(raw)
+            : Buffer.isBuffer(raw)
+                ? raw
+                : typeof raw === "string"
+                    ? Buffer.from(raw)
+                    : ArrayBuffer.isView(raw)
+                        ? Buffer.from(raw.buffer)
+                        : null;
+        if (!buf)
+            throw new Error("unexpected log data type");
+        const firstLine = buf.toString("utf8").split("\n").find(Boolean) ?? "unknown error";
         const key = firstLine.trim().slice(0, 120);
         clusters[key] ??= { msg: key, runs: [], prs: [] };
         clusters[key].runs.push(r.id);
         clusters[key].prs.push(r.pull_requests?.[0]?.number ?? -1);
     }
-    const systemic = Object.values(clusters).filter(c => c.prs.length >= MIN_HITS);
+    const systemic = Object.values(clusters).filter((c) => c.prs.length >= MIN_HITS);
     if (!systemic.length) {
         console.log("No systemic failure detected");
         return;
     }
     for (const cluster of systemic) {
-        const slug = cluster.msg.toLowerCase().replace(/[^a-z0-9]+/g, "-").slice(0, 40);
+        const slug = cluster.msg
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, "-")
+            .slice(0, 40);
         await handleCluster(slug, cluster);
     }
 }
@@ -52,7 +71,7 @@ async function handleCluster(slug, cluster) {
     }
     if (cluster.msg.includes("netlify/actions@")) {
         console.log("Fixing Netlify action path");
-        changed ||= await patchFiles(/uses:\s*netlify\/actions@v(\d+)/g, 'uses: netlify/actions/cli@v$1');
+        changed ||= await patchFiles(/uses:\s*netlify\/actions@v(\d+)/g, "uses: netlify/actions/cli@v$1");
     }
     if (cluster.msg.includes("Unauthorized: could not retrieve project")) {
         console.log("Adding secret guard to Netlify step");
@@ -75,14 +94,19 @@ fi`);
     (0, node_child_process_1.execSync)('git commit -am "ci: auto-fix systemic failure"');
     (0, node_child_process_1.execSync)(`git push -f origin ${branch}`);
     await octo.rest.pulls.create({
-        owner, repo,
-        head: branch, base: "main",
+        owner,
+        repo,
+        head: branch,
+        base: "main",
         title: `ci: auto-fix for "${cluster.msg}"`,
-        body: "This PR was opened automatically by the CI watchdog."
+        body: "This PR was opened automatically by the CI watchdog.",
     });
 }
 async function patchFiles(pattern, replacement) {
-    const files = ["Dockerfile", ...(await globWalk(".github/workflows", ".yml"))];
+    const files = [
+        "Dockerfile",
+        ...(await globWalk(".github/workflows", ".yml")),
+    ];
     let altered = false;
     for (const f of files) {
         const txt = await promises_1.default.readFile(f, "utf8");
@@ -106,14 +130,30 @@ async function globWalk(dir, ext, out = []) {
     return out;
 }
 async function upsertIssue(title, cluster) {
-    const { data: issues } = await octo.rest.issues.listForRepo({ owner, repo, state: "open", labels: "ci-watchdog" });
-    const existing = issues.find(i => i.title === title);
+    const { data: issues } = await octo.rest.issues.listForRepo({
+        owner,
+        repo,
+        state: "open",
+        labels: "ci-watchdog",
+    });
+    const existing = issues.find((i) => i.title === title);
     const body = `Detected **${cluster.prs.length} PRs** failing with:\n\n\`\`\`\n${cluster.msg}\n\`\`\``;
     if (existing) {
-        await octo.rest.issues.update({ owner, repo, issue_number: existing.number, body });
+        await octo.rest.issues.update({
+            owner,
+            repo,
+            issue_number: existing.number,
+            body,
+        });
     }
     else {
-        await octo.rest.issues.create({ owner, repo, title, body, labels: ["ci-watchdog"] });
+        await octo.rest.issues.create({
+            owner,
+            repo,
+            title,
+            body,
+            labels: ["ci-watchdog"],
+        });
     }
 }
 async function commentOnPRs(cluster) {
@@ -121,9 +161,14 @@ async function commentOnPRs(cluster) {
         if (pr < 0)
             continue;
         await octo.rest.issues.createComment({
-            owner, repo, issue_number: pr,
-            body: `Heads-up 🚦 — CI is currently failing on **all PRs** with:\n\`\`\`\n${cluster.msg}\n\`\`\`\nA fix is being prepared automatically.`
+            owner,
+            repo,
+            issue_number: pr,
+            body: `Heads-up 🚦 — CI is currently failing on **all PRs** with:\n\`\`\`\n${cluster.msg}\n\`\`\`\nA fix is being prepared automatically.`,
         });
     }
 }
-main().catch(e => { console.error(e); process.exit(1); });
+main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+});

--- a/scripts/ci_watchdog.ts
+++ b/scripts/ci_watchdog.ts
@@ -16,11 +16,11 @@ type Cluster = { msg: string; runs: number[]; prs: number[] };
 
 type WorkflowRun = {
   id: number;
-  pull_requests?: { number: number }[];
+  pull_requests?: { number: number }[] | null;
 };
 
 async function main() {
-  const runs: WorkflowRun[] = await octo.paginate(
+  const runs = (await octo.paginate(
     octo.rest.actions.listWorkflowRunsForRepo,
     {
       owner,
@@ -30,21 +30,32 @@ async function main() {
       event: "pull_request",
       created: `>${sinceIso}`,
     },
-  );
+  )) as WorkflowRun[];
 
   const clusters: Record<string, Cluster> = {};
 
   for (const r of runs.slice(0, MAX_RUNS)) {
-    const log: { data: ArrayBuffer } =
+    const log: { data: unknown } =
       await octo.rest.actions.downloadWorkflowRunLogs({
         owner,
         repo,
         run_id: r.id,
         request: { raw: true },
       });
+    const raw = log.data;
+    const buf =
+      raw instanceof ArrayBuffer
+        ? Buffer.from(raw)
+        : Buffer.isBuffer(raw)
+        ? raw
+        : typeof raw === "string"
+        ? Buffer.from(raw)
+        : ArrayBuffer.isView(raw)
+        ? Buffer.from(raw.buffer)
+        : null;
+    if (!buf) throw new Error("unexpected log data type");
     const firstLine =
-      Buffer.from(log.data).toString("utf8").split("\n").find(Boolean) ??
-      "unknown error";
+      buf.toString("utf8").split("\n").find(Boolean) ?? "unknown error";
     const key = firstLine.trim().slice(0, 120);
 
     clusters[key] ??= { msg: key, runs: [], prs: [] };


### PR DESCRIPTION
## Summary
- handle null pull_requests and unknown log data types in ci watchdog
- guard Octokit log downloads and normalize ArrayBuffer to Buffer

## Testing
- `npm run setup`
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: Setup flag missing. Running 'npm run setup'...)*
- `npm run ci` *(fails: npm error process terminated signal SIGINT)*
- `npm run smoke` *(fails: Running: bash scripts/setup-codex-9b08f7c1.sh)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f5747914832d819b43a848bed4de