### PR TITLE
ci: make CodeQL neutral on PRs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   analyze:
+    if: github.event_name != 'pull_request' || startsWith(github.head_ref, 'security/')
     name: Analyze
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- skip CodeQL analysis on regular pull requests to avoid blocking

## Testing
- `npm run format`
```
> backend@1.0.0 preformat
> node ../scripts/ensure-root-deps.js

> backend@1.0.0 format
> sh -c 'cd .. && node scripts/ensure-root-deps.js && prettier --log-level warn --write "**/*.{js,jsx,json,md}" --ignore-path .prettierignore'
```
- `npm test` (fails to complete setup)
```
> backend@1.0.0 pretest
> node scripts/ensure-deps.js

✅ network OK
Setup flag missing. Running 'npm run setup'...

> mvp-website@1.0.0 setup
> bash scripts/setup.sh

scripts/ci_watchdog.ts(23,9): error TS2322: Type '{ total_count: number; workflow_runs: { id: number; ...  }[]; } & { ...; }[]' is not assignable to type 'WorkflowRun[]'.
...
npm error code 2
```
- `npm run ci` (fails: process terminated with SIGINT)
- `npm run smoke` (setup script ran, then aborted)


------
https://chatgpt.com/codex/tasks/task_e_68a6f56c7b7c832d98e0244b52eb25df