### PR TITLE
test: fix CodeQL SARIF glob

### DIFF
--- a/tests/codeqlSecurityCheck_d5e9f4.test.ts
+++ b/tests/codeqlSecurityCheck_d5e9f4.test.ts
@@ -1,5 +1,6 @@
 const fs = require("fs");
 const path = require("path");
+const glob = require("glob");
 
 function severityOf(result) {
   return (
@@ -21,11 +22,14 @@ function severityOf(result) {
 }
 
 describe("codeql security output", () => {
+  const defaultSarif =
+    glob.sync(path.join(__dirname, "..", "codeql-results", "*.sarif"))[0] ||
+    path.join(__dirname, "..", "codeql-results.sarif");
   const logFile =
     process.env.CODEQL_OUTPUT ||
     process.env.CODEQL_LOG ||
     process.env.CODEQL_ANNOTATIONS ||
-    path.join(__dirname, "..", "codeql-results.sarif");
+    defaultSarif;
 
   const run = fs.existsSync(logFile) ? test : test.skip;
 


### PR DESCRIPTION
## Summary
- glob CodeQL results to avoid hard-coded `codeql-results.sarif`

## Testing
- `npm run format` *(fails: scripts/ci_watchdog.ts TypeScript errors)*
- `npm test` *(fails: scripts/ci_watchdog.ts TypeScript errors)*
- `npm run ci` *(fails: scripts/ci_watchdog.ts TypeScript errors)*
- `npm run smoke` *(fails: scripts/ci_watchdog.ts TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f5687f1c832d8ea56a508fe53d03