### PR TITLE
ci: scope concurrency and set job timeouts

### DIFF
--- a/.github/workflows/ci-queue-monitor.yml
+++ b/.github/workflows/ci-queue-monitor.yml
@@ -5,9 +5,14 @@ on:
     - cron: '*/15 * * * *'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.ref }}-ci
+  cancel-in-progress: false
+
 jobs:
   monitor:
     runs-on: ubuntu-latest
+    timeout-minutes: 12
     permissions:
       actions: write
       pull-requests: write

--- a/.github/workflows/ci-rerun-slow.yml
+++ b/.github/workflows/ci-rerun-slow.yml
@@ -4,12 +4,13 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.ref }}-ci
+  cancel-in-progress: false
 
 jobs:
   coverage:
     runs-on: ubuntu-latest
+    timeout-minutes: 12
     outputs:
       duration: ${{ steps.duration.outputs.value }}
     steps:
@@ -35,6 +36,7 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
+    timeout-minutes: 12
     env:
       PORT: 3000
       DB_URL: postgres://user:pass@localhost:5432/testdb
@@ -79,6 +81,7 @@ jobs:
 
   timings:
     runs-on: ubuntu-latest
+    timeout-minutes: 12
     needs: [coverage, e2e]
     steps:
       - run: |

--- a/.github/workflows/ci-watchdog.yml
+++ b/.github/workflows/ci-watchdog.yml
@@ -12,13 +12,14 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.ref }}-ci
+  cancel-in-progress: false
 
 jobs:
   scan:
     if: ${{ github.repository_owner == 'print3git' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 12
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,13 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.ref }}-ci
+  cancel-in-progress: false
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 12
     defaults:
       run:
         working-directory: frontend
@@ -34,6 +35,7 @@ jobs:
 
   test-backend:
     runs-on: ubuntu-latest
+    timeout-minutes: 12
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
@@ -59,6 +61,7 @@ jobs:
 
   test-frontend:
     runs-on: ubuntu-latest
+    timeout-minutes: 12
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
@@ -83,6 +86,7 @@ jobs:
 
   test-integration:
     runs-on: ubuntu-latest
+    timeout-minutes: 12
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
@@ -105,6 +109,7 @@ jobs:
 
   coverage-merge:
     runs-on: ubuntu-latest
+    timeout-minutes: 12
     needs:
       - test-backend
       - test-frontend


### PR DESCRIPTION
## Summary
- scope CI workflows with cross-workflow concurrency using `${{ github.ref }}-ci`
- add 12-minute timeouts to CI jobs

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup` *(fails: TypeScript error in scripts/ci_watchdog.ts)*
- `npm run format` (in backend)
- `npm test` *(fails: TypeScript error in scripts/ci_watchdog.ts)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: TypeScript error in scripts/ci_watchdog.ts)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: TypeScript error in scripts/ci_watchdog.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f563fd10832da17055276b93ee8e