### PR TITLE
ci: pin pnpm version in workflows

### DIFF
--- a/.github/workflows/pipeline-smoke.yml
+++ b/.github/workflows/pipeline-smoke.yml
@@ -43,8 +43,10 @@ jobs:
         with:
           node-version: 20
 
-      - name: Install pnpm
-        run: npm install -g pnpm
+      - name: Setup pnpm
+        run: |
+          corepack enable
+          pnpm set version 9.15.9
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/verify-lockfile.yml
+++ b/.github/workflows/verify-lockfile.yml
@@ -31,6 +31,11 @@ jobs:
         with:
           node-version: 20
 
+      - name: Setup pnpm
+        run: |
+          corepack enable
+          pnpm set version 9.15.9
+
       # Install dependencies without auditing and without funding messages
       - run: npm install --no-audit --no-fund
 
@@ -45,9 +50,6 @@ jobs:
             git diff package-lock.json >&2
             exit 1
           fi
-
-      - name: Install pnpm
-        run: npm install -g pnpm
 
       - name: Regenerate pnpm lockfile
         run: pnpm install --lockfile-only


### PR DESCRIPTION
## Summary
- use corepack with a pinned pnpm version in smoke test workflow
- ensure lockfile verification uses pinned pnpm via corepack

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: scripts/ci_watchdog.ts error)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: setup script errors)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: setup script errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f55ba044832dafc29428952bf3f7