### PR TITLE
fix: improve missing dist diagnostics

### DIFF
--- a/scripts/assert-dist.mjs
+++ b/scripts/assert-dist.mjs
@@ -1,5 +1,6 @@
 import { access } from "fs/promises";
 import { resolve } from "path";
+import { execSync } from "child_process";
 
 const output = resolve("frontend/dist/index.html");
 
@@ -7,5 +8,13 @@ try {
   await access(output);
 } catch {
   console.error(`Missing build output: ${output}`);
+  try {
+    const rev = execSync("git rev-parse --short HEAD").toString().trim();
+    console.error(rev);
+  } catch {}
+  try {
+    const ls = execSync("ls -la frontend/dist").toString().trim();
+    console.error(ls);
+  } catch {}
   process.exit(1);
 }

--- a/scripts/ci/assert-dist.js
+++ b/scripts/ci/assert-dist.js
@@ -1,9 +1,18 @@
 const fs = require("fs");
 const path = require("path");
+const { execSync } = require("child_process");
 
 const distPath = path.resolve("frontend/dist/index.html");
 if (!fs.existsSync(distPath)) {
   console.error(`Missing ${distPath}`);
+  try {
+    const rev = execSync("git rev-parse --short HEAD").toString().trim();
+    console.error(rev);
+  } catch {}
+  try {
+    const ls = execSync("ls -la frontend/dist").toString().trim();
+    console.error(ls);
+  } catch {}
   process.exit(1);
 }
 console.log(`Found ${distPath}`);


### PR DESCRIPTION
## Summary
- improve missing dist check to output commit and dist contents

## Testing
- `npm run format` (backend)
- `npm test` (backend) *(fails: Setup flag missing. Running 'npm run setup'...)*
- `npm run ci` *(fails: ENOTEMPTY: directory not empty)*
- `npm run smoke` *(fails: npm ci encountered tar or filesystem errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f55498f4832dae9c96d586bccdbb