### PR TITLE
ci: build frontend before deadlock tests

### DIFF
--- a/.github/workflows/pipeline-deadlock-check.yml
+++ b/.github/workflows/pipeline-deadlock-check.yml
@@ -15,4 +15,5 @@ jobs:
         with:
           node-version: 20
       - run: npm install --no-save yaml
+      - run: npm ci && npm run build --prefix frontend
       - run: node --test tests/ci/pipeline-deadlock-check-b1a2c3d.test.js


### PR DESCRIPTION
## Summary
- build frontend before pipeline deadlock tests to mirror production build

## Testing
- `npm run format`
- `npm test` *(fails: Command failed: npm run setup)*
- `npm run ci` *(fails: husky install && tsc errors)*
- `npm run smoke` *(fails: setup-codex script failed)*


------
https://chatgpt.com/codex/tasks/task_e_68a6f5511dc8832dbb3042f440e422f7