### PR TITLE
chore: disable jsdoc param rule for backend libs

### DIFF
--- a/backend/eslint.config.js
+++ b/backend/eslint.config.js
@@ -32,4 +32,10 @@ module.exports = [
     files: ["**/*", "scripts/**/*"],
     rules: { "jsdoc/require-jsdoc": "off" },
   },
+  // TODO: add docs for legacy lib modules
+  // Temporarily disable param checks until JSDoc is written
+  {
+    files: ["lib/**/*.js", "lib/pipeline/**/*.js"],
+    rules: { "jsdoc/require-param": "off" },
+  },
 ];


### PR DESCRIPTION
## Summary
- relax jsdoc param requirement for backend lib files
- add TODO about documenting lib modules later

## Testing
- `npm run format` (backend)
- `npm test` (backend) *(fails: husky install && tsc -p scripts/tsconfig.json)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: husky install && tsc -p scripts/tsconfig.json)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: husky install && tsc -p scripts/tsconfig.json)*


------
https://chatgpt.com/codex/tasks/task_e_68a6f3f202ec832da503e8dcadc79aa3