### PR TITLE
docs: add JSDoc param stubs

### DIFF
--- a/backend/src/lib/prepareImage.js
+++ b/backend/src/lib/prepareImage.js
@@ -7,6 +7,9 @@ const uploadS3_1 = require("./uploadS3");
 function __importDefault(mod) {
   return mod && mod.__esModule ? mod : { default: mod };
 }
+/**
+ * @param {*} image
+ */
 async function prepareImage(image) {
   if (/^https?:\/\//.test(image)) {
     return image;

--- a/backend/src/lib/preserveColors.js
+++ b/backend/src/lib/preserveColors.js
@@ -1,5 +1,8 @@
 const { NodeIO } = require("@gltf-transform/core");
 
+/**
+ * @param {*} glb
+ */
 async function preserveColors(glb) {
   const io = new NodeIO();
   const doc = await io.readBinary(glb);

--- a/backend/src/lib/storeGlb.js
+++ b/backend/src/lib/storeGlb.js
@@ -1,5 +1,8 @@
 const { S3Client, PutObjectCommand } = require("@aws-sdk/client-s3");
 
+/**
+ * @param {*} attempts
+ */
 async function storeGlb(data, attempts = 3) {
   if (data.length < 12 || data.toString("utf8", 0, 4) !== "glTF") {
     throw new Error("Invalid GLB");

--- a/backend/src/pipeline/generateModel.js
+++ b/backend/src/pipeline/generateModel.js
@@ -5,6 +5,11 @@ const { generateGlb } = require("../lib/sparc3dClient");
 const { storeGlb } = require("../lib/storeGlb");
 const logger = require("../../../src/logger");
 
+/**
+ * @param {Object} [root0]
+ * @param {*} [root0.prompt]
+ * @param {*} [root0.image]
+ */
 async function generateModel({ prompt, image } = {}) {
   logger.info(
     "🔸 generateModel called with prompt:",


### PR DESCRIPTION
## Summary
- add minimal JSDoc `@param` stubs to prepareImage, preserveColors, storeGlb, and generateModel helpers

## Testing
- `npm run format`
- `npm test` *(fails: scripts/ci_watchdog.ts type errors)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: scripts/ci_watchdog.ts type errors)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: setup-codex-9b08f7c1.sh exited with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f3f56bb4832dae1abe303c1ac4ff