### PR TITLE
chore: disable jsdoc param rule in backend

### DIFF
--- a/backend/eslint.config.js
+++ b/backend/eslint.config.js
@@ -27,6 +27,10 @@ module.exports = [
     },
   },
   prettier,
+  {
+    files: ["lib/**/*.js", "pipeline/**/*.js"],
+    rules: { "jsdoc/require-param": "off" },
+  },
   // Disable JSDoc requirement for existing backend files
   {
     files: ["**/*", "scripts/**/*"],


### PR DESCRIPTION
## Summary
- disable jsdoc/require-param for backend/lib and backend/pipeline sources
- ensure lint script still fails on warnings

## Testing
- `npm run format` (backend)
- `npm run lint` (backend)
- `npm test` *(fails: npm run setup command failed with TypeScript errors)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: TypeScript errors in scripts/ci_watchdog.ts)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: TypeScript errors in scripts/ci_watchdog.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f536a4d0832db99b352a8758fe88