### PR TITLE
ci: build frontend before Pages deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,8 +39,7 @@ jobs:
           echo "::add-mask::$CLOUDFLARE_ACCOUNT_ID"
 
       - name: Build frontend
-        working-directory: frontend
-        run: npm run build:ci
+        run: npm ci && npm run build --prefix frontend
 
       - name: Verify dist output
         run: node scripts/assert-frontend-dist.js

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -18,11 +18,8 @@ jobs:
         with:
           node-version: 20
           cache: npm
-          cache-dependency-path: frontend/package-lock.json
-      - run: npm ci
-        working-directory: frontend
-      - run: npm run build
-        working-directory: frontend
+          cache-dependency-path: package-lock.json
+      - run: npm ci && npm run build --prefix frontend
       - name: verify build
         run: |
           if [ ! -f frontend/dist/index.html ]; then

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,7 +1,1 @@
-name = "mvp-website"
-
-[pages]
-# Cloudflare Pages expects a pre-built directory. Ensure the path matches
-# the frontend build output so wrangler does not try to run its own build
-# or error out with an invalid configuration.
-build_output_dir = "frontend/dist"
+pages_build_output_dir = "frontend/dist"


### PR DESCRIPTION
## Summary
- configure Wrangler for Pages with `frontend/dist`
- run `npm ci && npm run build --prefix frontend` before deploying Pages
- build frontend in main Pages workflow before running Wrangler deploy

## Testing
- `npm run setup` *(fails: scripts/ci_watchdog.ts compile errors)*
- `SKIP_PW_DEPS=1 npm run diagnose` *(fails: missing module 'cors')*
- `npm run format` *(pass)*
- `npm test` *(fails: Command failed: npm run setup)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: husky install & TypeScript errors)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: husky install & TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f53c03fc832d89190e6c3e168b68