### PR TITLE
ci: disable matrix fail fast

### DIFF
--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -17,6 +17,7 @@ jobs:
       run:
         working-directory: frontend
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         node: [20, 22]

--- a/.github/workflows/cache-validator.yml
+++ b/.github/workflows/cache-validator.yml
@@ -14,6 +14,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         include:
           - name: frontend

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -18,6 +18,7 @@ jobs:
       CI_REQUIRE_EXTERNAL: '0'
     timeout-minutes: 20
     strategy:
+      fail-fast: false
       matrix:
         node-version: 20
 


### PR DESCRIPTION
## Summary
- ensure matrix jobs keep running by setting `fail-fast: false`

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: scripts/ci_watchdog.ts TypeScript error)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: scripts/ci_watchdog.ts TypeScript error)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: husky install && tsc error)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f546bcc0832d9b2feee1c1115412