### PR TITLE
ci: allow diagnostics to fail

### DIFF
--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -35,6 +35,7 @@ jobs:
 
   artifact-lister:
     runs-on: ubuntu-latest
+    continue-on-error: true
     needs: build
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/check-watchdog.yml
+++ b/.github/workflows/check-watchdog.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   watch:
     runs-on: ubuntu-latest
+    continue-on-error: true
     timeout-minutes: 8
     permissions:
       checks: read

--- a/.github/workflows/queue-probe.yml
+++ b/.github/workflows/queue-probe.yml
@@ -9,6 +9,7 @@ permissions: {}
 jobs:
   probe:
     runs-on: ubuntu-latest
+    continue-on-error: true
     timeout-minutes: 5
     steps:
       - run: echo "hello $GITHUB_RUN_ID"


### PR DESCRIPTION
## Summary
- allow artifact-lister to fail without blocking
- allow queue probe to fail without blocking
- allow watchdog to fail without blocking

## Testing
- `npm run validate-env`
- `npm run setup` (fails: TypeScript errors in scripts/ci_watchdog.ts)
- `npm run format --prefix backend`
- `npm test --prefix backend` (fails: husky install & tsc error)
- `SKIP_PW_DEPS=1 npm run ci` (fails: husky install & tsc error)
- `SKIP_PW_DEPS=1 npm run smoke` (fails: husky install & tsc error)


------
https://chatgpt.com/codex/tasks/task_e_68a6f54be3dc832db228411b2df55366