### PR TITLE
ci: cache npm per workspace

### DIFF
--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: npm
+          cache-dependency-path: frontend/package-lock.json
       - run: npm ci && npm run lint && npm run build
       - run: test -d dist
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/cache-primer.yml
+++ b/.github/workflows/cache-primer.yml
@@ -29,3 +29,14 @@ jobs:
           cache: npm
           cache-dependency-path: backend/package-lock.json
       - run: npm ci --prefix backend
+
+  frontend-cache:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci --prefix frontend

--- a/.github/workflows/cache-validator.yml
+++ b/.github/workflows/cache-validator.yml
@@ -16,12 +16,15 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: frontend
+          - name: root
             working-directory: .
             lockfile: package-lock.json
           - name: backend
             working-directory: backend
             lockfile: backend/package-lock.json
+          - name: frontend
+            working-directory: frontend
+            lockfile: frontend/package-lock.json
     steps:
       - uses: actions/checkout@v5
       - id: setup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           node-version: 20
           cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
       - run: npm ci && npm run lint && npm run build
       - run: test -d dist
 
@@ -40,10 +41,13 @@ jobs:
         with:
           node-version: 20
           cache: "npm"
-          cache-dependency-path: |
-            package-lock.json
-            backend/package-lock.json
+          cache-dependency-path: package-lock.json
       - run: npm ci
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+          cache-dependency-path: backend/package-lock.json
       - run: npm ci --prefix backend
       - name: Run backend tests
         run: node scripts/run-jest.js backend --ci --coverage --coverageDirectory=coverage/backend
@@ -65,10 +69,14 @@ jobs:
         with:
           node-version: 20
           cache: "npm"
-          cache-dependency-path: |
-            package-lock.json
-            frontend/package-lock.json
+          cache-dependency-path: package-lock.json
       - run: npm ci
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci --prefix frontend
       - name: Run frontend tests
         run: node scripts/run-jest.js frontend --ci --coverage --coverageDirectory=coverage/frontend
       - uses: actions/upload-artifact@v4.3.4
@@ -115,6 +123,7 @@ jobs:
         with:
           node-version: 20
           cache: "npm"
+          cache-dependency-path: package-lock.json
       - run: npm ci --ignore-scripts
       - uses: actions/download-artifact@v4.1.8
         with:

--- a/.github/workflows/diagnostics-dist-check.yml
+++ b/.github/workflows/diagnostics-dist-check.yml
@@ -18,6 +18,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
       - name: Install frontend dependencies
         run: npm ci --prefix frontend
       - name: Build frontend


### PR DESCRIPTION
## Summary
- cache npm dependencies separately for root, backend, and frontend workflows
- add frontend caching to primer and validator workflows
- ensure diagnostics and build jobs use frontend lockfile cache

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: Command failed: npm run setup)*
- `npm run ci` *(fails: husky install && tsc -p scripts/tsconfig.json)*
- `npm run smoke` *(fails: Command failed: bash scripts/setup-codex-9b08f7c1.sh)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f5603a64832db192cea512679b9c