### PR TITLE
build: constrain node engine

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,9 @@
   "name": "frontend",
   "version": "1.0.0",
   "private": true,
+  "engines": {
+    "node": ">=20 <21"
+  },
   "scripts": {
     "build": "mkdir -p dist && echo '<!doctype html><html><head><meta charset=\"utf-8\"><title>frontend</title></head><body></body></html>' > dist/index.html",
     "build:ci": "npm ci && npm run build"

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
   "author": "",
   "license": "ISC",
   "engines": {
-    "node": ">=20"
+    "node": ">=20 <21"
   },
   "type": "commonjs",
   "prettier": {},


### PR DESCRIPTION
## Summary
- restrict Node.js to >=20 <21 in root package.json
- enforce same Node range in frontend package.json

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: scripts/ci_watchdog.ts type errors)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: scripts/ci_watchdog.ts type errors)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: setup-codex script error)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f57c2010832d8739e6501ad61d53