### PR TITLE
ci: add heartbeat logging to workflows

### DIFF
--- a/.github/workflows/auto_rebase_merge_queue.yml
+++ b/.github/workflows/auto_rebase_merge_queue.yml
@@ -17,6 +17,9 @@ jobs:
     if: ${{ !startsWith(github.event.pull_request.head.ref, 'codex/') }}
     runs-on: ubuntu-latest
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - name: Rebase
         if: ${{ !startsWith(github.head_ref, 'codex/') }}
         id: rebase
@@ -45,6 +48,9 @@ jobs:
     if: ${{ needs.rebase.result == 'success' || needs.rebase.result == 'skipped' }}
     runs-on: ubuntu-latest
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - name: Queue for merge
         uses: autifyhq/merge-queue-action@v0.1.0
         env:

--- a/.github/workflows/backend-only-ci.yml
+++ b/.github/workflows/backend-only-ci.yml
@@ -15,6 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -21,6 +21,9 @@ jobs:
         os: [ubuntu-latest]
         node: [20, 22]
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
@@ -37,6 +40,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - uses: actions/download-artifact@v4
         with:
           name: frontend-dist-20

--- a/.github/workflows/cache-primer.yml
+++ b/.github/workflows/cache-primer.yml
@@ -11,6 +11,9 @@ jobs:
   root-cache:
     runs-on: ubuntu-latest
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
@@ -22,6 +25,9 @@ jobs:
   backend-cache:
     runs-on: ubuntu-latest
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/cache-validator.yml
+++ b/.github/workflows/cache-validator.yml
@@ -23,6 +23,9 @@ jobs:
             working-directory: backend
             lockfile: backend/package-lock.json
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
       - id: setup
         uses: actions/setup-node@v4

--- a/.github/workflows/check-watchdog.yml
+++ b/.github/workflows/check-watchdog.yml
@@ -10,6 +10,9 @@ jobs:
     permissions:
       checks: read
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - name: Watch required checks
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/ci-queue-monitor.yml
+++ b/.github/workflows/ci-queue-monitor.yml
@@ -13,6 +13,9 @@ jobs:
       pull-requests: write
       contents: read
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - name: Check CI queue and cancel obsolete runs
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/ci-rerun-slow.yml
+++ b/.github/workflows/ci-rerun-slow.yml
@@ -13,6 +13,9 @@ jobs:
     outputs:
       duration: ${{ steps.duration.outputs.value }}
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - id: start
         run: echo "start=$(date +%s)" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@v5
@@ -41,6 +44,9 @@ jobs:
     outputs:
       duration: ${{ steps.duration.outputs.value }}
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - id: start
         run: echo "start=$(date +%s)" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@v5
@@ -81,6 +87,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [coverage, e2e]
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - run: |
           echo "coverage: ${{ needs.coverage.outputs.duration }}s" >> timings.txt
           echo "e2e: ${{ needs.e2e.outputs.duration }}s" >> timings.txt

--- a/.github/workflows/ci-watchdog.yml
+++ b/.github/workflows/ci-watchdog.yml
@@ -20,6 +20,9 @@ jobs:
     if: ${{ github.repository_owner == 'print3git' }}
     runs-on: ubuntu-latest
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
       PORT: 3000
       CI_REQUIRE_EXTERNAL: "0"
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - name: REQUIRED
         run: |
           echo 'REQUIRED: production build'
@@ -35,6 +38,9 @@ jobs:
   test-backend:
     runs-on: ubuntu-latest
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
@@ -60,6 +66,9 @@ jobs:
   test-frontend:
     runs-on: ubuntu-latest
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
@@ -84,6 +93,9 @@ jobs:
   test-integration:
     runs-on: ubuntu-latest
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
@@ -110,6 +122,9 @@ jobs:
       - test-frontend
       - test-integration
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,6 +19,9 @@ jobs:
     name: Analyze
     runs-on: ubuntu-latest
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4.4.0
         with:

--- a/.github/workflows/collect-artifacts.yml
+++ b/.github/workflows/collect-artifacts.yml
@@ -20,6 +20,9 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
     runs-on: ubuntu-latest
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - name: Download job logs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,6 +10,9 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
       - name: Load Stripe env
         run: node scripts/ci-env-preflight.js

--- a/.github/workflows/coveralls-upload.yml
+++ b/.github/workflows/coveralls-upload.yml
@@ -18,6 +18,9 @@ jobs:
       actions: read
       contents: read
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - name: Download coverage artifact
         uses: actions/download-artifact@v4.1.8
         with:

--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -13,6 +13,9 @@ jobs:
   backup:
     runs-on: ubuntu-latest
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
       - name: Run backup script
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,12 @@ jobs:
       WRANGLER_VERSION: 3.72.0
 
     steps:
+
+      - name: Heartbeat
+
+        run: |
+
+          while true; do date; sleep 120; done &
       - name: Checkout code
         uses: actions/checkout@v5
 
@@ -108,4 +114,7 @@ jobs:
     if: vars.ENABLE_PAGES != '1'
     runs-on: ubuntu-latest
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - run: echo "Pages deploy is disabled for PRs; enable via repo variable."

--- a/.github/workflows/diagnostics-dist-check.yml
+++ b/.github/workflows/diagnostics-dist-check.yml
@@ -12,6 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Node

--- a/.github/workflows/diagnostics.yml
+++ b/.github/workflows/diagnostics.yml
@@ -20,6 +20,9 @@ jobs:
     timeout-minutes: 5
     continue-on-error: true
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - name: DIAGNOSTIC
         run: |
           echo 'DIAGNOSTIC: strict lint'
@@ -38,6 +41,9 @@ jobs:
     timeout-minutes: 5
     continue-on-error: true
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - name: DIAGNOSTIC
         run: |
           echo 'DIAGNOSTIC: dependency audit'
@@ -60,6 +66,9 @@ jobs:
     env:
       CI_REQUIRE_EXTERNAL: "0"
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - name: DIAGNOSTIC
         run: |
           echo 'DIAGNOSTIC: Stripe/Cloudflare smoke'

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -16,6 +16,9 @@ jobs:
     env:
       SKIP_TESTS: 0
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
       - run: echo "Using npm"
       - name: Build Docker image

--- a/.github/workflows/endpoint-health.yml
+++ b/.github/workflows/endpoint-health.yml
@@ -12,5 +12,8 @@ jobs:
   probe:
     runs-on: ubuntu-latest
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - name: Check homepage
         run: curl -fsS https://print2.io/ > /dev/null

--- a/.github/workflows/ensure_server_boots_185ecc2b50.yml
+++ b/.github/workflows/ensure_server_boots_185ecc2b50.yml
@@ -27,6 +27,9 @@ jobs:
       PORT: 3000
       CI_REQUIRE_EXTERNAL: '0'
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - name: Checkout code
         uses: actions/checkout@v5
 

--- a/.github/workflows/eslint-diagnostics.yml
+++ b/.github/workflows/eslint-diagnostics.yml
@@ -16,6 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/frontend-dry-build.yml
+++ b/.github/workflows/frontend-dry-build.yml
@@ -11,6 +11,9 @@ jobs:
   dry-build:
     runs-on: ubuntu-latest
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/frontend-local-build.yml
+++ b/.github/workflows/frontend-local-build.yml
@@ -11,6 +11,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/glb-ci-alerts-938dhf.yml
+++ b/.github/workflows/glb-ci-alerts-938dhf.yml
@@ -18,6 +18,9 @@ jobs:
       PORT: 3000
       DB_URL: postgres://user:pass@localhost:5432/testdb
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/glb-tests.yml
+++ b/.github/workflows/glb-tests.yml
@@ -24,6 +24,9 @@ jobs:
   unit-tests:
     runs-on: ubuntu-latest
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
       - name: Load Stripe env
         run: node scripts/ci-env-preflight.js
@@ -47,6 +50,9 @@ jobs:
       PORT: 3000
       DB_URL: postgres://user:pass@localhost:5432/testdb
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
       - name: Load Stripe env
         run: node scripts/ci-env-preflight.js

--- a/.github/workflows/healthz-contract.yml
+++ b/.github/workflows/healthz-contract.yml
@@ -15,6 +15,9 @@ jobs:
   snapshot:
     runs-on: ubuntu-latest
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/jest-early-warning.yml
+++ b/.github/workflows/jest-early-warning.yml
@@ -11,6 +11,9 @@ jobs:
   backend-tests:
     runs-on: ubuntu-latest
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/jest-open-handles.yml
+++ b/.github/workflows/jest-open-handles.yml
@@ -16,6 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -13,6 +13,9 @@ jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
       - uses: EndBug/label-sync@v2
         with:

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -13,6 +13,9 @@ jobs:
     if: ${{ github.event.deployment_status.environment == 'preview' }}
     runs-on: ubuntu-latest
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -12,6 +12,9 @@ jobs:
   load:
     runs-on: ubuntu-latest
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/nock-report.yml
+++ b/.github/workflows/nock-report.yml
@@ -15,6 +15,9 @@ jobs:
   nock-report:
     runs-on: ubuntu-latest
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - uses: actions/checkout@v5.0.0
       - uses: actions/setup-node@v4.4.0
         with:

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -22,6 +22,12 @@ jobs:
         node-version: 20
 
     steps:
+
+      - name: Heartbeat
+
+        run: |
+
+          while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
 
       - name: Load Stripe env

--- a/.github/workflows/openapi-lint.yml
+++ b/.github/workflows/openapi-lint.yml
@@ -14,6 +14,9 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ops-report.yml
+++ b/.github/workflows/ops-report.yml
@@ -13,6 +13,9 @@ jobs:
   report:
     runs-on: ubuntu-latest
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/package-helm.yml
+++ b/.github/workflows/package-helm.yml
@@ -13,6 +13,9 @@ jobs:
   package:
     runs-on: ubuntu-latest
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
       - uses: azure/setup-helm@v4
       - name: Package chart

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -13,6 +13,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/pipeline-deadlock-check.yml
+++ b/.github/workflows/pipeline-deadlock-check.yml
@@ -10,6 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 1
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/pipeline-smoke.yml
+++ b/.github/workflows/pipeline-smoke.yml
@@ -29,6 +29,9 @@ jobs:
       PORT: 3000
       CI_REQUIRE_EXTERNAL: "0"
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - name: Checkout code
         uses: actions/checkout@v5
 

--- a/.github/workflows/playwright-browsers-cache.yml
+++ b/.github/workflows/playwright-browsers-cache.yml
@@ -11,6 +11,9 @@ jobs:
   cache-browsers:
     runs-on: ubuntu-latest
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - name: Checkout
         uses: actions/checkout@v5
 

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -15,6 +15,9 @@ jobs:
     env:
       PORT: 3000
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/printclub-reminders.yml
+++ b/.github/workflows/printclub-reminders.yml
@@ -13,6 +13,9 @@ jobs:
   remind:
     runs-on: ubuntu-latest
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/queue-probe.yml
+++ b/.github/workflows/queue-probe.yml
@@ -11,4 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - run: echo "hello $GITHUB_RUN_ID"

--- a/.github/workflows/regression-guard.yml
+++ b/.github/workflows/regression-guard.yml
@@ -10,6 +10,9 @@ jobs:
   guard:
     runs-on: ubuntu-latest
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - uses: actions/checkout@v5.0.0
       - uses: actions/setup-node@v4.4.0
         with:

--- a/.github/workflows/reset-credits.yml
+++ b/.github/workflows/reset-credits.yml
@@ -13,6 +13,9 @@ jobs:
   reset:
     runs-on: ubuntu-latest
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/schedule-check.yml
+++ b/.github/workflows/schedule-check.yml
@@ -12,6 +12,9 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
       - name: Verify sleep_after
         env:

--- a/.github/workflows/smoke-backend.yml
+++ b/.github/workflows/smoke-backend.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -15,6 +15,9 @@ jobs:
       DB_URL: postgres://user:pass@localhost:5432/testdb
       CI_REQUIRE_EXTERNAL: "0"
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/sync-space.yml
+++ b/.github/workflows/sync-space.yml
@@ -17,6 +17,12 @@ jobs:
       DB_URL: postgres://user:pass@localhost:5432/testdb
 
     steps:
+
+      - name: Heartbeat
+
+        run: |
+
+          while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
       - name: Load Stripe env
         run: node scripts/ci-env-preflight.js

--- a/.github/workflows/update_locks.yml
+++ b/.github/workflows/update_locks.yml
@@ -14,6 +14,9 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
         with:
           persist-credentials: true

--- a/.github/workflows/verify-lockfile.yml
+++ b/.github/workflows/verify-lockfile.yml
@@ -14,6 +14,9 @@ jobs:
   verify:
     runs-on: ubuntu-latest
     steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       # Checkout the repository's code
       - uses: actions/checkout@v5
 


### PR DESCRIPTION
## Summary
- log a periodic heartbeat in all GitHub Actions jobs to show the runner is alive

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup` *(fails: husky install && tsc -p scripts/tsconfig.json)*
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: husky install && tsc -p scripts/tsconfig.json)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: husky install && tsc -p scripts/tsconfig.json)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: husky install && tsc -p scripts/tsconfig.json)*
- `npm run diagnose` *(fails: Cannot find module 'cors')*

------
https://chatgpt.com/codex/tasks/task_e_68a6f5c8af10832da73d2fec686d2ab3