### PR TITLE
chore: disable jsdoc require-param for backend

### DIFF
--- a/backend/.eslintrc.json
+++ b/backend/.eslintrc.json
@@ -1,0 +1,10 @@
+{
+  "overrides": [
+    {
+      "files": ["**/*.js", "**/*.ts"],
+      "rules": {
+        "jsdoc/require-param": "off"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- disable jsdoc `require-param` rule for backend linting

## Testing
- `npm run format`
- `npm test` *(fails: Setup flag missing. Running 'npm run setup'...)*
- `npm run ci` *(fails: Playwright browsers not installed)*
- `npm run smoke` *(fails: npm ci encountered tar or filesystem errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f75693d4832db02caf41d988caa3