### PR TITLE
ci: upload Cloudflare Pages build artifacts on failure

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -51,3 +51,9 @@ jobs:
         with:
           name: pages-deploy-url
           path: deploy-url.txt
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: frontend-dist
+          path: frontend/dist
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary
- always capture frontend build output when Cloudflare Pages deploy fails

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: Command failed: npm run setup)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Command failed: CI=1 npm run setup)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Command failed: bash scripts/setup-codex-9b08f7c1.sh)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f5e61368832da34cf6be7b4a423f