### PR TITLE
ci: restrict heavy tests to push events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,7 @@ jobs:
           path: coverage/frontend
 
   test-integration:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -104,6 +105,7 @@ jobs:
           path: coverage/integration
 
   coverage-merge:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     needs:
       - test-backend

--- a/.github/workflows/glb-tests.yml
+++ b/.github/workflows/glb-tests.yml
@@ -8,7 +8,7 @@ on:
       - 'backend/src/lib/**/*glb*.ts'
       - 'backend/src/pipeline/generateModel.*'
       - 'backend/tests/glb/**'
-  pull_request:
+  merge_group:
     branches: [main, dev]
     paths:
       - 'backend/src/lib/**glb**'

--- a/.github/workflows/smoke-backend.yml
+++ b/.github/workflows/smoke-backend.yml
@@ -1,7 +1,8 @@
 name: Backend Smoke
 
 on:
-  pull_request:
+  push:
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -1,7 +1,8 @@
 name: Server Smoke Test
 
 on:
-  pull_request:
+  push:
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
- run integration and coverage merge only on push
- trigger smoke/e2e workflows on push and merge_group instead of pull_request

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: husky install command failed)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: husky install command failed)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: setup script failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f5d3884c832da2a0fb8009542dad