### PR TITLE
ci: update pages deployment configuration

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -18,11 +18,10 @@ jobs:
         with:
           node-version: 20
           cache: npm
-          cache-dependency-path: frontend/package-lock.json
-      - run: npm ci
-        working-directory: frontend
-      - run: npm run build
-        working-directory: frontend
+          cache-dependency-path: |
+            package-lock.json
+            frontend/package-lock.json
+      - run: npm ci && npm run build --prefix frontend
       - name: verify build
         run: |
           if [ ! -f frontend/dist/index.html ]; then
@@ -40,7 +39,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
-          url=$(npx -y wrangler@3 pages deploy frontend/dist --project-name "${{ secrets.CF_PAGES_PROJECT }}" --branch production | tee /tmp/deploy.log | grep -Eo 'https://[^ ]+' | tail -n 1)
+          url=$(npx -y wrangler pages deploy frontend/dist --project-name "${{ secrets.CF_PAGES_PROJECT }}" --branch production | tee /tmp/deploy.log | grep -Eo 'https://[^ ]+' | tail -n 1)
           echo "$url" > deploy-url.txt
           echo "url=$url" >> "$GITHUB_OUTPUT"
       - name: Job summary

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,7 +1,1 @@
-name = "mvp-website"
-
-[pages]
-# Cloudflare Pages expects a pre-built directory. Ensure the path matches
-# the frontend build output so wrangler does not try to run its own build
-# or error out with an invalid configuration.
-build_output_dir = "frontend/dist"
+pages_build_output_dir = "frontend/dist"


### PR DESCRIPTION
## Summary
- configure Cloudflare Pages output directory
- adjust Pages workflow to build and deploy with wrangler

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: husky install && tsc -p scripts/tsconfig.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f3fda7b0832d91c9745e948641bf