### PR TITLE
ci: silence pnpm lock warnings

### DIFF
--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: npm
+          cache-dependency-path: frontend/package-lock.json
       - run: npm ci && npm run lint && npm run build
       - run: test -d dist
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/eslint-diagnostics.yml
+++ b/.github/workflows/eslint-diagnostics.yml
@@ -21,6 +21,9 @@ jobs:
         with:
           node-version: 20
           cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            backend/package-lock.json
       - run: npm ci
       - run: npm ci --prefix backend
       - name: Lint root

--- a/.github/workflows/jest-early-warning.yml
+++ b/.github/workflows/jest-early-warning.yml
@@ -16,5 +16,6 @@ jobs:
         with:
           node-version: 20
           cache: npm
+          cache-dependency-path: backend/package-lock.json
       - run: npm ci --prefix backend
       - run: npm test --prefix backend -- --maxWorkers=50% --runInBand=false --silent --reporters=default

--- a/.github/workflows/nock-report.yml
+++ b/.github/workflows/nock-report.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           node-version: 20
           cache: npm
+          cache-dependency-path: package-lock.json
       - run: npm ci
       - run: node scripts/run-jest.js tests/diagnostics/nock_reporter.test.js
       - name: upload netconnect report

--- a/.github/workflows/regression-guard.yml
+++ b/.github/workflows/regression-guard.yml
@@ -15,6 +15,7 @@ jobs:
         with:
           node-version: 20
           cache: npm
+          cache-dependency-path: package-lock.json
       - run: npm ci
       - run: node scripts/check-lint-regression.js
       - run: node scripts/check-test-regression.js

--- a/.github/workflows/verify-lockfile.yml
+++ b/.github/workflows/verify-lockfile.yml
@@ -50,7 +50,7 @@ jobs:
         run: npm install -g pnpm
 
       - name: Regenerate pnpm lockfile
-        run: pnpm install --lockfile-only
+        run: pnpm install --lockfile-only --ignore-workspace-root-check
 
       - name: Ensure pnpm lockfile is up to date
         run: |


### PR DESCRIPTION
## Summary
- ensure pnpm lock regeneration ignores workspace root check
- pin npm caching to package-lock.json to avoid pnpm warnings

## Testing
- `npm run format --prefix backend`
- `npm run setup` *(fails: husky install && tsc -p scripts/tsconfig.json)*
- `npm test --prefix backend` *(fails: husky install && tsc -p scripts/tsconfig.json)*
- `npm run ci` *(fails: husky install && tsc -p scripts/tsconfig.json)*
- `npm run smoke` *(fails: husky install && tsc -p scripts/tsconfig.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f5f4effc832db82ac2c1d7f5bcde