### PR TITLE
ci: add preflight workflow for lint and format

### DIFF
--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -1,0 +1,27 @@
+name: Preflight
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint-format:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm ci --prefix backend
+      - run: npm run format
+      - run: npm run lint
+      - run: npm run lint --prefix backend


### PR DESCRIPTION
## Summary
- add a lightweight Preflight workflow that runs npm run format and npm run lint
- note: mark Preflight workflow as required in branch protection for fast feedback

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: scripts/ci_watchdog.ts TS2322)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: scripts/ci_watchdog.ts TS2322)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: scripts/ci_watchdog.ts TS2322)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f5d024e4832dbf1d1d2d56409d04