### PR TITLE
build: remove symlinks from frontend dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "start:backend": "npm start --prefix backend",
     "predeploy": "node scripts/check-missing-links.js",
     "build": "tsc -p backend/tsconfig.build.json",
-    "postbuild": "npx -y ts-node --transpile-only scripts/check-broken-symlinks-9ac8f74db5e1c32.ts",
+    "postbuild": "bash scripts/remove-dist-symlinks.sh && npx -y ts-node --transpile-only scripts/check-broken-symlinks-9ac8f74db5e1c32.ts",
     "load": "artillery run tests/load/models.yml",
     "visual-test": "percy exec -- npm run e2e",
     "test:a11y": "node scripts/assert-setup.js && bash scripts/install-playwright.sh chromium && playwright test e2e/a11y.test.js",

--- a/scripts/remove-dist-symlinks.sh
+++ b/scripts/remove-dist-symlinks.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -d frontend/dist ] && find frontend/dist -type l | grep . >/dev/null; then
+  cp -aLR frontend/dist frontend/dist_real && rm -rf frontend/dist && mv frontend/dist_real frontend/dist
+fi


### PR DESCRIPTION
## Summary
- remove any symlinks inside `frontend/dist` post-build to avoid deployment issues
- wire cleanup script into the `postbuild` step

## Testing
- `npm run validate-env`
- `npm run net:check`
- `SKIP_PW_DEPS=1 npm run setup` *(fails: process hung and was terminated)*
- `npm run format` *(fails: TypeScript errors during dependency install)*
- `npm test` *(fails: setup step hung and was terminated)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: TypeScript errors in scripts/ci_watchdog.ts)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: process hung and was terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f54223e0832da12cbfa959c1c437