### PR TITLE
docs: add missing JSDoc param tags

### DIFF
--- a/backend/src/lib/prepareImage.js
+++ b/backend/src/lib/prepareImage.js
@@ -7,6 +7,10 @@ const uploadS3_1 = require("./uploadS3");
 function __importDefault(mod) {
   return mod && mod.__esModule ? mod : { default: mod };
 }
+/**
+ * @param {string} image
+ * @returns {Promise<string>}
+ */
 async function prepareImage(image) {
   if (/^https?:\/\//.test(image)) {
     return image;

--- a/backend/src/lib/preserveColors.js
+++ b/backend/src/lib/preserveColors.js
@@ -1,5 +1,9 @@
 const { NodeIO } = require("@gltf-transform/core");
 
+/**
+ * @param {Uint8Array} glb
+ * @returns {Promise<Uint8Array>}
+ */
 async function preserveColors(glb) {
   const io = new NodeIO();
   const doc = await io.readBinary(glb);

--- a/backend/src/lib/storeGlb.js
+++ b/backend/src/lib/storeGlb.js
@@ -1,5 +1,10 @@
 const { S3Client, PutObjectCommand } = require("@aws-sdk/client-s3");
 
+/**
+ * @param {Buffer} data
+ * @param {number} [attempts=3]
+ * @returns {Promise<string>}
+ */
 async function storeGlb(data, attempts = 3) {
   if (data.length < 12 || data.toString("utf8", 0, 4) !== "glTF") {
     throw new Error("Invalid GLB");

--- a/backend/src/pipeline/generateModel.js
+++ b/backend/src/pipeline/generateModel.js
@@ -5,6 +5,12 @@ const { generateGlb } = require("../lib/sparc3dClient");
 const { storeGlb } = require("../lib/storeGlb");
 const logger = require("../../../src/logger");
 
+/**
+ * @param {object} [root0={}]
+ * @param {string} [root0.prompt]
+ * @param {string} [root0.image]
+ * @returns {Promise<string>}
+ */
 async function generateModel({ prompt, image } = {}) {
   logger.info(
     "🔸 generateModel called with prompt:",


### PR DESCRIPTION
## Summary
- document image parameter in prepareImage
- add glb parameter docs for preserveColors
- include attempts parameter docs for storeGlb
- document prompt and image options for generateModel

## Testing
- `npm run format`
- `npm test` *(fails: Command failed: npm run setup)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Command failed: CI=1 npm run setup)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Command failed: bash scripts/setup-codex-9b08f7c1.sh)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f53268b0832d8cd9673004e25c7e