### PR TITLE
ci: avoid duplicate lint in build jobs

### DIFF
--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: npm
-      - run: npm ci && npm run lint && npm run build
+      - run: npm ci && npm run build
       - run: test -d dist
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           node-version: 20
           cache: "npm"
-      - run: npm ci && npm run lint && npm run build
+      - run: npm ci && npm run build
       - run: test -d dist
 
   test-backend:


### PR DESCRIPTION
## Summary
- run frontend workflow builds without redundant lint step
- trim lint from CI build job

## Testing
- `npm run setup` (failed: scripts/ci_watchdog.ts TypeScript error)
- `npm run format` in `backend/`
- `npm test` in `backend/` (failed: husky install && tsc scripts/ci_watchdog.ts)
- `npm run ci` (failed: husky install && tsc scripts/ci_watchdog.ts)
- `npm run smoke` (failed: setup script)


------
https://chatgpt.com/codex/tasks/task_e_68a6f5295ba8832d84788aa40dbf4c36