### PR TITLE
chore: loosen watchdog tsconfig

### DIFF
--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -6,7 +6,9 @@
     "types": ["node"],
     "strict": true,
     "noImplicitAny": true,
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "skipLibCheck": true,
+    "noEmitOnError": false
   },
   "files": ["ci_watchdog.ts", "auto-cloudflare-config.ts"]
 }


### PR DESCRIPTION
## Summary
- allow scripts TypeScript to skip library checks and emit despite errors

## Testing
- `npm run setup` *(fails: husky install && tsc -p scripts/tsconfig.json)*
- `npm run format` (from backend)
- `npm test` *(fails: husky install && tsc -p scripts/tsconfig.json)*
- `npm run ci` *(fails: husky install && tsc -p scripts/tsconfig.json)*
- `npm run smoke` *(fails: husky install && tsc -p scripts/tsconfig.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f522a918832d8be91af257258b6d