### PR TITLE
fix: handle ArrayBuffer log data

### DIFF
--- a/scripts/ci_watchdog.ts
+++ b/scripts/ci_watchdog.ts
@@ -20,30 +20,32 @@ type WorkflowRun = {
 };
 
 async function main() {
-  const runs: WorkflowRun[] = await octo.paginate(
-    octo.rest.actions.listWorkflowRunsForRepo,
-    {
-      owner,
-      repo,
-      per_page: 100,
-      status: "failure",
-      event: "pull_request",
-      created: `>${sinceIso}`,
-    },
-  );
+  const runs = (await octo.paginate(octo.rest.actions.listWorkflowRunsForRepo, {
+    owner,
+    repo,
+    per_page: 100,
+    status: "failure",
+    event: "pull_request",
+    created: `>${sinceIso}`,
+  })) as WorkflowRun[];
 
   const clusters: Record<string, Cluster> = {};
 
   for (const r of runs.slice(0, MAX_RUNS)) {
-    const log: { data: ArrayBuffer } =
-      await octo.rest.actions.downloadWorkflowRunLogs({
-        owner,
-        repo,
-        run_id: r.id,
-        request: { raw: true },
-      });
+    const log = await octo.rest.actions.downloadWorkflowRunLogs({
+      owner,
+      repo,
+      run_id: r.id,
+      request: { raw: true },
+    });
+    const arr =
+      log.data instanceof ArrayBuffer
+        ? log.data
+        : await (
+            log.data as { arrayBuffer: () => Promise<ArrayBuffer> }
+          ).arrayBuffer();
     const firstLine =
-      Buffer.from(log.data).toString("utf8").split("\n").find(Boolean) ??
+      Buffer.from(arr).toString("utf8").split("\n").find(Boolean) ??
       "unknown error";
     const key = firstLine.trim().slice(0, 120);
 


### PR DESCRIPTION
## Summary
- handle downloadWorkflowRunLogs response as unknown and narrow to ArrayBuffer or via arrayBuffer()
- cast paginated workflow runs to local type

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` (backend)
- `npm test` (backend)
- `SKIP_PW_DEPS=1 npm run ci` *(fails: missing ESLint rules)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68a6f41674b4832d849bc75c9ab6af06