### PR TITLE
test: log commit and dist listing on pipeline failure

### DIFF
--- a/tests/ci/pipeline-deadlock-check-b1a2c3d.test.js
+++ b/tests/ci/pipeline-deadlock-check-b1a2c3d.test.js
@@ -1,5 +1,6 @@
 const fs = require("fs/promises");
 const path = require("path");
+const { execSync } = require("child_process");
 const { test } = require("node:test");
 
 const repoRoot = path.resolve(__dirname, "../..");
@@ -62,7 +63,24 @@ test("pipeline configuration avoids common deadlocks", async () => {
   }
 
   if (errors.length) {
-    await appendSummary(`### CI/CD pipeline issues\n${errors.map((e) => `- ${e}`).join("\n")}`);
+    let commitSha = "unknown";
+    let distListing = "";
+    try {
+      commitSha = execSync("git rev-parse HEAD", { cwd: repoRoot })
+        .toString()
+        .trim();
+    } catch {}
+    try {
+      distListing = execSync("ls -la frontend/dist", { cwd: repoRoot }).toString();
+    } catch (err) {
+      distListing = `ls failed: ${err.message}`;
+    }
+    console.error(`Commit ${commitSha}\n${distListing}`);
+    await appendSummary(
+      `### CI/CD pipeline issues\n${errors
+        .map((e) => `- ${e}`)
+        .join("\n")}\nCommit ${commitSha}\n${distListing}`,
+    );
     throw new Error(errors.join("; "));
   }
 


### PR DESCRIPTION
## Summary
- log git commit SHA and `ls -la frontend/dist` output when pipeline deadlock check fails

## Testing
- `npm run format` *(fails: husky install/tsc compile error)*
- `npm test` *(fails: husky install/tsc compile error)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: husky install/tsc compile error)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: husky install/tsc compile error)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f40ecc08832d84a96e520dd8ed73