### PR TITLE
ci: build frontend before pipeline deadlock check

### DIFF
--- a/.github/workflows/pipeline-deadlock-check.yml
+++ b/.github/workflows/pipeline-deadlock-check.yml
@@ -14,5 +14,5 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - run: npm install --no-save yaml
+      - run: npm ci && npm run build --prefix frontend
       - run: node --test tests/ci/pipeline-deadlock-check-b1a2c3d.test.js


### PR DESCRIPTION
## Summary
- build frontend assets before running the pipeline deadlock test to satisfy artifact check

## Testing
- `npm run validate-env`
- `npm run setup` (fails: husky install command is deprecated)
- `npm run format --prefix backend`
- `npm test --prefix backend` (fails: husky install command is deprecated)
- `SKIP_PW_DEPS=1 npm run ci` (fails: husky install command is deprecated)
- `SKIP_PW_DEPS=1 npm run smoke` (fails: husky install command is deprecated)

------
https://chatgpt.com/codex/tasks/task_e_68a6f40ad3c4832d8456cfb572902e21