### PR TITLE
ci: guard against symlinks in frontend dist

### DIFF
--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -3,7 +3,7 @@ name: Build frontend
 on:
   pull_request:
     paths:
-      - 'frontend/**'
+      - "frontend/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -11,7 +11,6 @@ concurrency:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -28,6 +27,7 @@ jobs:
           cache: npm
       - run: npm ci && npm run lint && npm run build
       - run: test -d dist
+      - run: node ../scripts/assert-frontend-dist.js
       - uses: actions/upload-artifact@v4
         with:
           name: frontend-dist-${{ matrix.node }}

--- a/.github/workflows/frontend-local-build.yml
+++ b/.github/workflows/frontend-local-build.yml
@@ -18,8 +18,8 @@ jobs:
           cache: npm
           cache-dependency-path: package-lock.json
       - run: npm ci && npm run build
-      - run: node -e "require('fs').accessSync('dist/index.html')"
+      - run: node scripts/assert-frontend-dist.js
       - uses: actions/upload-artifact@v4
         with:
           name: frontend-dist
-          path: dist
+          path: frontend/dist

--- a/scripts/assert-frontend-dist.js
+++ b/scripts/assert-frontend-dist.js
@@ -9,4 +9,39 @@ const indexFile = path.join(distDir, "index.html");
 if (!fs.existsSync(indexFile)) {
   throw new Error(`Missing index.html in ${distDir}`);
 }
+
+/**
+ * Recursively collect symlinks inside a directory.
+ * @param {string} dir
+ * @param {string[]} acc
+ * @returns {string[]}
+ */
+function collectSymlinks(dir, acc = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isSymbolicLink()) {
+      acc.push(full);
+    } else if (entry.isDirectory()) {
+      collectSymlinks(full, acc);
+    }
+  }
+  return acc;
+}
+
+let symlinks = collectSymlinks(distDir);
+if (symlinks.length) {
+  const tmpDir = path.join(path.dirname(distDir), "dist_nolinks");
+  fs.cpSync(distDir, tmpDir, { recursive: true, dereference: true });
+  fs.rmSync(distDir, { recursive: true, force: true });
+  fs.renameSync(tmpDir, distDir);
+  symlinks = collectSymlinks(distDir);
+  if (symlinks.length) {
+    console.error("Symlinks found in dist:");
+    for (const link of symlinks) console.error(" -", link);
+  } else {
+    console.error("Symlinks were found and replaced with copies.");
+  }
+  process.exit(1);
+}
+
 console.log("Found frontend build output:", indexFile);


### PR DESCRIPTION
## Summary
- ensure scripts/assert-frontend-dist.js checks for symlinks and replaces them with real files before failing
- enforce symlink check in frontend build workflows

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup` *(fails: Type '{ total_count: number; workflow_runs: ... } is not assignable to type 'WorkflowRun[]')*
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: husky install && tsc -p scripts/tsconfig.json)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: husky install && tsc -p scripts/tsconfig.json)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: husky install && tsc -p scripts/tsconfig.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f404a0e8832db7243d538e05fb76