### PR TITLE
fix: relax octokit types for ci watchdog

### DIFF
--- a/scripts/ci_watchdog.js
+++ b/scripts/ci_watchdog.js
@@ -3,7 +3,6 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-/* eslint-disable */
 const action_1 = require("@octokit/action");
 const node_child_process_1 = require("node:child_process");
 const promises_1 = __importDefault(require("node:fs/promises"));
@@ -15,30 +14,41 @@ const MIN_HITS = 5;
 const MAX_RUNS = 25;
 const sinceIso = new Date(Date.now() - WINDOW_HOURS * 3600_000).toISOString();
 async function main() {
-    const runs = await octo.paginate(octo.rest.actions.listWorkflowRunsForRepo, {
-        owner, repo, per_page: 100, status: "failure", event: "pull_request", created: `>${sinceIso}`
+    const { data } = await octo.rest.actions.listWorkflowRunsForRepo({
+        owner,
+        repo,
+        per_page: 100,
+        status: "failure",
+        event: "pull_request",
+        created: `>${sinceIso}`,
     });
+    const runs = (data.workflow_runs ?? []).filter(Boolean);
     const clusters = {};
     for (const r of runs.slice(0, MAX_RUNS)) {
-        const log = await octo.rest.actions.downloadWorkflowRunLogs({
-            owner, repo, run_id: r.id, request: { raw: true }
-        });
-        const firstLine = Buffer.from(log.data)
-            .toString("utf8")
-            .split("\n")
-            .find(Boolean) ?? "unknown error";
+        const res = (await octo.request("GET /repos/{owner}/{repo}/actions/runs/{run_id}/logs", {
+            owner,
+            repo,
+            run_id: r.id,
+            request: { raw: true },
+        }));
+        const buf = res.data;
+        const firstLine = Buffer.from(buf).toString("utf8").split("\n").find(Boolean) ??
+            "unknown error";
         const key = firstLine.trim().slice(0, 120);
         clusters[key] ??= { msg: key, runs: [], prs: [] };
         clusters[key].runs.push(r.id);
         clusters[key].prs.push(r.pull_requests?.[0]?.number ?? -1);
     }
-    const systemic = Object.values(clusters).filter(c => c.prs.length >= MIN_HITS);
+    const systemic = Object.values(clusters).filter((c) => c.prs.length >= MIN_HITS);
     if (!systemic.length) {
         console.log("No systemic failure detected");
         return;
     }
     for (const cluster of systemic) {
-        const slug = cluster.msg.toLowerCase().replace(/[^a-z0-9]+/g, "-").slice(0, 40);
+        const slug = cluster.msg
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, "-")
+            .slice(0, 40);
         await handleCluster(slug, cluster);
     }
 }
@@ -52,7 +62,7 @@ async function handleCluster(slug, cluster) {
     }
     if (cluster.msg.includes("netlify/actions@")) {
         console.log("Fixing Netlify action path");
-        changed ||= await patchFiles(/uses:\s*netlify\/actions@v(\d+)/g, 'uses: netlify/actions/cli@v$1');
+        changed ||= await patchFiles(/uses:\s*netlify\/actions@v(\d+)/g, "uses: netlify/actions/cli@v$1");
     }
     if (cluster.msg.includes("Unauthorized: could not retrieve project")) {
         console.log("Adding secret guard to Netlify step");
@@ -75,14 +85,19 @@ fi`);
     (0, node_child_process_1.execSync)('git commit -am "ci: auto-fix systemic failure"');
     (0, node_child_process_1.execSync)(`git push -f origin ${branch}`);
     await octo.rest.pulls.create({
-        owner, repo,
-        head: branch, base: "main",
+        owner,
+        repo,
+        head: branch,
+        base: "main",
         title: `ci: auto-fix for "${cluster.msg}"`,
-        body: "This PR was opened automatically by the CI watchdog."
+        body: "This PR was opened automatically by the CI watchdog.",
     });
 }
 async function patchFiles(pattern, replacement) {
-    const files = ["Dockerfile", ...(await globWalk(".github/workflows", ".yml"))];
+    const files = [
+        "Dockerfile",
+        ...(await globWalk(".github/workflows", ".yml")),
+    ];
     let altered = false;
     for (const f of files) {
         const txt = await promises_1.default.readFile(f, "utf8");
@@ -106,14 +121,30 @@ async function globWalk(dir, ext, out = []) {
     return out;
 }
 async function upsertIssue(title, cluster) {
-    const { data: issues } = await octo.rest.issues.listForRepo({ owner, repo, state: "open", labels: "ci-watchdog" });
-    const existing = issues.find(i => i.title === title);
+    const { data: issues } = await octo.rest.issues.listForRepo({
+        owner,
+        repo,
+        state: "open",
+        labels: "ci-watchdog",
+    });
+    const existing = issues.find((i) => i.title === title);
     const body = `Detected **${cluster.prs.length} PRs** failing with:\n\n\`\`\`\n${cluster.msg}\n\`\`\``;
     if (existing) {
-        await octo.rest.issues.update({ owner, repo, issue_number: existing.number, body });
+        await octo.rest.issues.update({
+            owner,
+            repo,
+            issue_number: existing.number,
+            body,
+        });
     }
     else {
-        await octo.rest.issues.create({ owner, repo, title, body, labels: ["ci-watchdog"] });
+        await octo.rest.issues.create({
+            owner,
+            repo,
+            title,
+            body,
+            labels: ["ci-watchdog"],
+        });
     }
 }
 async function commentOnPRs(cluster) {
@@ -121,9 +152,14 @@ async function commentOnPRs(cluster) {
         if (pr < 0)
             continue;
         await octo.rest.issues.createComment({
-            owner, repo, issue_number: pr,
-            body: `Heads-up 🚦 — CI is currently failing on **all PRs** with:\n\`\`\`\n${cluster.msg}\n\`\`\`\nA fix is being prepared automatically.`
+            owner,
+            repo,
+            issue_number: pr,
+            body: `Heads-up 🚦 — CI is currently failing on **all PRs** with:\n\`\`\`\n${cluster.msg}\n\`\`\`\nA fix is being prepared automatically.`,
         });
     }
 }
-main().catch(e => { console.error(e); process.exit(1); });
+main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+});

--- a/scripts/ci_watchdog.ts
+++ b/scripts/ci_watchdog.ts
@@ -1,4 +1,6 @@
 import { Octokit } from "@octokit/action";
+import type { OctokitResponse } from "@octokit/types";
+import type { components } from "@octokit/openapi-types";
 import { execSync } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -14,36 +16,36 @@ const sinceIso = new Date(Date.now() - WINDOW_HOURS * 3600_000).toISOString();
 
 type Cluster = { msg: string; runs: number[]; prs: number[] };
 
-type WorkflowRun = {
-  id: number;
-  pull_requests?: { number: number }[];
-};
+type WorkflowRun = components["schemas"]["workflow-run"];
+type PRRef = { number: number };
+type WR = Omit<WorkflowRun, "pull_requests"> & { pull_requests?: PRRef[] };
 
 async function main() {
-  const runs: WorkflowRun[] = await octo.paginate(
-    octo.rest.actions.listWorkflowRunsForRepo,
-    {
-      owner,
-      repo,
-      per_page: 100,
-      status: "failure",
-      event: "pull_request",
-      created: `>${sinceIso}`,
-    },
-  );
+  const { data } = await octo.rest.actions.listWorkflowRunsForRepo({
+    owner,
+    repo,
+    per_page: 100,
+    status: "failure",
+    event: "pull_request",
+    created: `>${sinceIso}`,
+  });
+  const runs: WR[] = (data.workflow_runs ?? []).filter(Boolean) as WR[];
 
   const clusters: Record<string, Cluster> = {};
 
   for (const r of runs.slice(0, MAX_RUNS)) {
-    const log: { data: ArrayBuffer } =
-      await octo.rest.actions.downloadWorkflowRunLogs({
+    const res = (await octo.request(
+      "GET /repos/{owner}/{repo}/actions/runs/{run_id}/logs",
+      {
         owner,
         repo,
         run_id: r.id,
         request: { raw: true },
-      });
+      },
+    )) as OctokitResponse<ArrayBuffer, any>;
+    const buf: ArrayBuffer = res.data as ArrayBuffer;
     const firstLine =
-      Buffer.from(log.data).toString("utf8").split("\n").find(Boolean) ??
+      Buffer.from(buf).toString("utf8").split("\n").find(Boolean) ??
       "unknown error";
     const key = firstLine.trim().slice(0, 120);
 


### PR DESCRIPTION
## Summary
- relax Octokit types in ci watchdog script to align with current API responses
- fetch workflow logs using explicit OctokitResponse casting

## Testing
- `npx prettier --log-level warn --write scripts/ci_watchdog.ts scripts/ci_watchdog.js`
- `SKIP_PW_DEPS=1 npm run format` *(fails: setup script requires Playwright browser download in this environment)*
- `PLAYWRIGHT_BROWSERS_PATH=.dummy-browser npm test` *(fails: dependencies not fully installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f74c9d28832d860a6b8af8f6f4d8