### PR TITLE
fix: remove backend postinstall build trigger

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -36,8 +36,7 @@
     "send-ops-report": "node scripts/send-ops-report.js",
     "flag-overdue-printers": "node scripts/flag-overdue-procurement-orders.js",
     "pretest": "node scripts/ensure-deps.js",
-    "format:check": "sh -c 'cd .. && prettier --log-level warn --check \"**/*.{js,jsx,json,md}\" --ignore-path .prettierignore'",
-    "postinstall": "npm --prefix .. run build"
+    "format:check": "sh -c 'cd .. && prettier --log-level warn --check \"**/*.{js,jsx,json,md}\" --ignore-path .prettierignore'"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- prevent backend install from triggering root build by removing postinstall script

## Testing
- `npm run format` (backend)
- `npm test` (backend)
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a70bb35138832da9b74a8dda2ebf0c