### PR TITLE
build: configure wrangler for pages

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,1 +1,5 @@
+name = "mvp-website"
 pages_build_output_dir = "frontend/dist"
+
+[build]
+command = "npm ci --prefix frontend && npm run build --prefix frontend"


### PR DESCRIPTION
## Summary
- configure Cloudflare Pages wrangler build command and output directory

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format --prefix backend`
- `npm test --prefix backend` *(hangs after tests run)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(Playwright version warning)*

------
https://chatgpt.com/codex/tasks/task_e_68a70bd145b4832dab45e954a740a4b1