### PR TITLE
ci: run frontend build explicitly

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -36,8 +36,7 @@
     "send-ops-report": "node scripts/send-ops-report.js",
     "flag-overdue-printers": "node scripts/flag-overdue-procurement-orders.js",
     "pretest": "node scripts/ensure-deps.js",
-    "format:check": "sh -c 'cd .. && prettier --log-level warn --check \"**/*.{js,jsx,json,md}\" --ignore-path .prettierignore'",
-    "postinstall": "npm --prefix .. run build"
+    "format:check": "sh -c 'cd .. && prettier --log-level warn --check \"**/*.{js,jsx,json,md}\" --ignore-path .prettierignore'"
   },
   "keywords": [],
   "author": "",

--- a/scripts/__tests__/auto-cloudflare-config-a1b2c3d4e5f6g7h.test.ts
+++ b/scripts/__tests__/auto-cloudflare-config-a1b2c3d4e5f6g7h.test.ts
@@ -26,7 +26,9 @@ describe("auto-cloudflare-config script", () => {
     });
     expect(result.status).toBe(0);
     const cfg = JSON.parse(fs.readFileSync(cfgFile, "utf8"));
-    expect(cfg.buildCommand).toBe("npm run build");
+    expect(cfg.buildCommand).toBe(
+      "npm ci --prefix frontend && npm run build --prefix frontend",
+    );
     const generated = fs
       .readdirSync(tmp)
       .find(

--- a/scripts/__tests__/auto-cloudflare-config-xvpfhoqbxmsielp.test.ts
+++ b/scripts/__tests__/auto-cloudflare-config-xvpfhoqbxmsielp.test.ts
@@ -27,7 +27,9 @@ test('adds buildCommand when framework detected', () => {
     require('../auto-cloudflare-config.ts');
   });
   logSpy.mockRestore();
-  expect(JSON.parse(mockFiles['cfg.json']).buildCommand).toBe('npm run build');
+  expect(JSON.parse(mockFiles['cfg.json']).buildCommand).toBe(
+    'npm ci --prefix frontend && npm run build --prefix frontend'
+  );
   const generated = Object.keys(mockFiles).find(f => f.startsWith('cloudflare-pages-config-') && f.endsWith('.ts'));
   expect(generated).toBeDefined();
 });

--- a/scripts/auto-cloudflare-config.ts
+++ b/scripts/auto-cloudflare-config.ts
@@ -79,7 +79,8 @@ ensureRequired({
 if (!cfg.buildCommand) {
   const fw = detectFramework();
   if (fw) {
-    cfg.buildCommand = "npm run build";
+    cfg.buildCommand =
+      "npm ci --prefix frontend && npm run build --prefix frontend";
   }
 }
 

--- a/scripts/dependency-stability.js
+++ b/scripts/dependency-stability.js
@@ -55,14 +55,22 @@ function runNpmCi() {
   }
 }
 
+function runFrontendCi() {
+  run(
+    "npm ci --prefix frontend --no-audit --no-fund",
+    "npm ci frontend failed",
+  );
+}
+
 function runBuild() {
-  run("npm run build", "npm run build failed");
+  run("npm run build --prefix frontend", "npm run build failed");
 }
 
 function checkAll() {
   verifyLockfileSync();
   checkDeprecatedDependencies();
   runNpmCi();
+  runFrontendCi();
   runBuild();
   console.log("Dependency installation stability check passed.");
 }

--- a/scripts/run-smoke.js
+++ b/scripts/run-smoke.js
@@ -155,11 +155,13 @@ function main() {
     if (!process.env.SKIP_PW_DEPS) {
       run("npx -y playwright install --with-deps");
     }
+    run("npm ci --prefix frontend");
+    run("npm run build --prefix frontend");
     const waitArgs = process.env.WAIT_ON_TIMEOUT
       ? `-t ${process.env.WAIT_ON_TIMEOUT} `
       : "";
     console.log("WAIT_ON_TIMEOUT:", process.env.WAIT_ON_TIMEOUT || "default");
-    const serve = "npm run serve | tee serve.log";
+    const serve = "node scripts/dev-server.js | tee serve.log";
     const test = `npx -y wait-on ${waitArgs}http://localhost:3000 && npx playwright test --reporter=list --trace on e2e/smoke.test.js | tee pw.log`;
     const cmd = `npx -y concurrently -k -s first --verbose -n serve,pw "${serve}" "${test}"`;
     try {

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -159,8 +159,11 @@ run_ci() {
 }
 
 run_ci ""
+run_ci frontend
 run_ci backend
 run_ci backend/dalle_server
+
+npm run build --prefix frontend
 
 cleanup_npm_cache
 

--- a/tests/ci/backend-lib-build-check-abc123.test.ts
+++ b/tests/ci/backend-lib-build-check-abc123.test.ts
@@ -8,12 +8,22 @@ describe("backend build artifacts", () => {
   const libDir = path.join(backendDir, "lib");
 
   test("TypeScript output exists after build", () => {
-    const result = spawnSync("npm", ["run", "build"], {
+    spawnSync("npm", ["ci", "--prefix", "frontend"], {
       cwd: repoRoot,
       stdio: "inherit",
     });
+    const result = spawnSync(
+      "npm",
+      ["run", "build", "--prefix", "frontend"],
+      {
+        cwd: repoRoot,
+        stdio: "inherit",
+      },
+    );
     if (result.status !== 0) {
-      throw new Error(`npm run build exited with code ${result.status}`);
+      throw new Error(
+        `npm run build --prefix frontend exited with code ${result.status}`,
+      );
     }
     if (!fs.existsSync(libDir)) {
       throw new Error(

--- a/tests/ci/build-pipeline-diagnostic-6b7f9e18c3d2a4b1.test.ts
+++ b/tests/ci/build-pipeline-diagnostic-6b7f9e18c3d2a4b1.test.ts
@@ -26,7 +26,8 @@ describe("build pipeline diagnostics", () => {
 
   test("build command emits expected artifacts", () => {
     rmSync(buildDir, { recursive: true, force: true });
-    run("npm run build", "Build");
+    run("npm ci --prefix frontend", "npm ci frontend");
+    run("npm run build --prefix frontend", "Build");
     if (!existsSync(buildDir)) {
       throw new Error(`Build output directory missing: ${path.relative(repoRoot, buildDir)}`);
     }

--- a/tests/ci/test-cloudflare-deployment-readiness-4c7a3f2e1b0d9c8.test.ts
+++ b/tests/ci/test-cloudflare-deployment-readiness-4c7a3f2e1b0d9c8.test.ts
@@ -62,7 +62,8 @@ describe("cloudflare deployment readiness", () => {
   const outputDir = getOutputDir();
 
   test("build succeeds and output valid", () => {
-    execSync("npm run build", { cwd: repoRoot, stdio: "inherit" });
+    execSync("npm ci --prefix frontend", { cwd: repoRoot, stdio: "inherit" });
+    execSync("npm run build --prefix frontend", { cwd: repoRoot, stdio: "inherit" });
     expect(fs.existsSync(outputDir)).toBe(true);
     const entries = fs.readdirSync(outputDir);
     expect(entries.length).toBeGreaterThan(0);

--- a/tests/dependencyInstallationStability.test.js
+++ b/tests/dependencyInstallationStability.test.js
@@ -5,6 +5,7 @@ const {
   verifyLockfileSync,
   checkDeprecatedDependencies,
   runNpmCi,
+  runFrontendCi,
   checkAll,
 } = require("../scripts/dependency-stability");
 
@@ -53,6 +54,7 @@ describe("dependency installation stability", () => {
       .mockReturnValueOnce("")
       .mockReturnValueOnce("")
       .mockReturnValueOnce("")
+      .mockReturnValueOnce("")
       .mockReturnValueOnce("");
     checkAll();
     expect(execSync.mock.calls.map((c) => c[0])).toEqual([
@@ -60,7 +62,8 @@ describe("dependency installation stability", () => {
       "git diff --name-only package.json package-lock.json",
       "npm ls",
       "npm ci --no-audit --no-fund",
-      "npm run build",
+      "npm ci --prefix frontend --no-audit --no-fund",
+      "npm run build --prefix frontend",
     ]);
   });
 });

--- a/tests/smoke-atomic/frontendBuild_c9d0e1f2.test.js
+++ b/tests/smoke-atomic/frontendBuild_c9d0e1f2.test.js
@@ -3,7 +3,10 @@ const fs = require("fs");
 const path = require("path");
 
 test("npm run build succeeds and js folder exists", () => {
-  const result = spawnSync("npm", ["run", "build"], { encoding: "utf8" });
+  spawnSync("npm", ["ci", "--prefix", "frontend"], { encoding: "utf8" });
+  const result = spawnSync("npm", ["run", "build", "--prefix", "frontend"], {
+    encoding: "utf8",
+  });
   expect(result.status).toBe(0);
   const jsDir = path.join(__dirname, "..", "..", "js");
   expect(fs.existsSync(jsDir)).toBe(true);

--- a/tests/test-cloudflare-output-dir-integrity-hgt5k1m9r2c4p8b.test.ts
+++ b/tests/test-cloudflare-output-dir-integrity-hgt5k1m9r2c4p8b.test.ts
@@ -22,7 +22,8 @@ function walk(dir, list = []) {
 }
 
 test("Cloudflare build output has no dangling links", () => {
-  execSync("npm run build", { stdio: "inherit" });
+  execSync("npm ci --prefix frontend", { stdio: "inherit" });
+  execSync("npm run build --prefix frontend", { stdio: "inherit" });
 
   const root = path.resolve(__dirname, "..");
   const outputDir = fs.existsSync(path.join(root, "dist"))

--- a/tests/validate-static-assets-xaf83joemtr9k6z.ts
+++ b/tests/validate-static-assets-xaf83joemtr9k6z.ts
@@ -4,7 +4,8 @@ import { execSync } from "child_process";
 
 describe("static asset validation", () => {
   test("build output contains required files", () => {
-    execSync("npm run build", { stdio: "inherit" });
+    execSync("npm ci --prefix frontend", { stdio: "inherit" });
+    execSync("npm run build --prefix frontend", { stdio: "inherit" });
 
     const buildDir = path.resolve(__dirname, "..");
     const indexPath = path.join(buildDir, "index.html");


### PR DESCRIPTION
## Summary
- run `npm ci --prefix frontend` and `npm run build --prefix frontend` directly instead of relying on backend postinstall
- build frontend explicitly in setup, smoke, and dependency stability scripts
- update tests and Cloudflare config to use explicit frontend build sequence

## Testing
- `npm run format`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run smoke`
- `SKIP_PW_DEPS=1 npm run ci`

------
https://chatgpt.com/codex/tasks/task_e_68a70bd8fea8832d866d2a608ea65180