### PR TITLE
ci: introduce reusable frontend build action

### DIFF
--- a/.github/actions/frontend-build/action.yml
+++ b/.github/actions/frontend-build/action.yml
@@ -1,0 +1,19 @@
+name: Frontend Build
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        cache: npm
+        cache-dependency-path: frontend/package-lock.json
+    - name: Install deps
+      run: npm ci
+      working-directory: frontend
+    - name: Build
+      run: npm run build
+      working-directory: frontend
+    - uses: actions/upload-artifact@v4
+      with:
+        name: frontend-dist
+        path: frontend/dist


### PR DESCRIPTION
## Summary
- add composite action for building the frontend

## Testing
- `npm run format` (backend)
- `npm test` (backend) *(fails: Setup flag missing, no tests run)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Playwright browsers not installed)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: process terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68a70c8406cc832d85cf33454f42f7b4