### PR TITLE
smoke: build frontend dist if missing

### DIFF
--- a/scripts/run-smoke.js
+++ b/scripts/run-smoke.js
@@ -155,6 +155,10 @@ function main() {
     if (!process.env.SKIP_PW_DEPS) {
       run("npx -y playwright install --with-deps");
     }
+    if (!fs.existsSync("frontend/dist/index.html")) {
+      execSync("npm ci --prefix frontend", { stdio: "inherit" });
+      execSync("npm run build --prefix frontend", { stdio: "inherit" });
+    }
     const waitArgs = process.env.WAIT_ON_TIMEOUT
       ? `-t ${process.env.WAIT_ON_TIMEOUT} `
       : "";


### PR DESCRIPTION
## Summary
- build frontend within smoke runner when dist/index.html is absent

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run smoke`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script "lint" and Playwright config warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a70c93c020832d8076ace3f6b32814