### PR TITLE
cloudflare: add name + pages_build_output_dir

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,1 +1,5 @@
+name = "mvp-website"
 pages_build_output_dir = "frontend/dist"
+
+[build]
+command = "npm ci --prefix frontend && npm run build --prefix frontend"


### PR DESCRIPTION
## Summary
- set Cloudflare Pages project name and build output directory
- define build command for producing frontend assets

## Testing
- `npm run validate-env`
- `curl -I https://registry.npmjs.org`
- `curl -I https://cdn.playwright.dev`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` (backend)
- `npm test` (backend)
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script "lint")*
- `npm run format` (root)
- `SKIP_PW_DEPS=1 npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_68a70ca50c70832db9e810ae227f076e