### PR TITLE
backend: remove root build from postinstall

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -36,8 +36,7 @@
     "send-ops-report": "node scripts/send-ops-report.js",
     "flag-overdue-printers": "node scripts/flag-overdue-procurement-orders.js",
     "pretest": "node scripts/ensure-deps.js",
-    "format:check": "sh -c 'cd .. && prettier --log-level warn --check \"**/*.{js,jsx,json,md}\" --ignore-path .prettierignore'",
-    "postinstall": "npm --prefix .. run build"
+    "format:check": "sh -c 'cd .. && prettier --log-level warn --check \"**/*.{js,jsx,json,md}\" --ignore-path .prettierignore'"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- prevent backend postinstall from building the root project

## Testing
- `npm run format` *(fails: Dependencies missing. Installing root dependencies...)*
- `npm test` *(fails: Setup flag missing. Running 'npm run setup'...)*
- `npm run ci` *(fails: Dependencies missing. Installing root dependencies...)*
- `npm run smoke` *(fails: npm warn tarball data ... seems to be corrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68a70cb6a0a0832d91181ac7d59cc2a5