### PR TITLE
ci: add fail-fast matrix cancellation

### DIFF
--- a/.github/workflows/backend-only-ci.yml
+++ b/.github/workflows/backend-only-ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         shard: [aa, ab, ac]
     steps:

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -16,7 +16,7 @@ jobs:
       run:
         working-directory: frontend
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         os: [ubuntu-latest]
         node: [20, 22]

--- a/.github/workflows/cache-validator.yml
+++ b/.github/workflows/cache-validator.yml
@@ -14,7 +14,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         include:
           - name: root

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
   test-backend:
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         shard: [aa, ab, ac]
     steps:
@@ -80,7 +80,7 @@ jobs:
   test-frontend:
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         include:
           - shard: core

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -18,7 +18,7 @@ jobs:
       CI_REQUIRE_EXTERNAL: '0'
     timeout-minutes: 20
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         node-version: 20
 


### PR DESCRIPTION
## Summary
- enable fail-fast across workflow matrices to stop redundant jobs early

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: root eslint exits 0)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script: "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(Playwright config load error)*

------
https://chatgpt.com/codex/tasks/task_e_68a70d287878832db414be189e566cb4