### PR TITLE
test: split smoke test stages

### DIFF
--- a/tests/smokeStages.test.js
+++ b/tests/smokeStages.test.js
@@ -1,0 +1,73 @@
+const { execSync } = require("child_process");
+
+const TIMEOUT = 5 * 60 * 1000;
+const runStage = process.env.RUN_SMOKE_STAGES ? test : test.skip;
+
+function run(command) {
+  const env = {
+    ...process.env,
+    HF_TOKEN: "test",
+    AWS_ACCESS_KEY_ID: "id",
+    AWS_SECRET_ACCESS_KEY: "secret",
+    DB_URL: "postgres://user:pass@localhost/db",
+    STRIPE_SECRET_KEY: "sk_test",
+    STRIPE_WEBHOOK_SECRET: "whsec",
+    CLOUDFRONT_MODEL_DOMAIN: "cdn.test",
+    SKIP_PW_DEPS: "1",
+    SKIP_NET_CHECKS: "1",
+    SKIP_DB_CHECK: "1",
+  };
+  delete env.npm_config_http_proxy;
+  delete env.npm_config_https_proxy;
+  execSync(command, { stdio: "inherit", env });
+}
+
+describe("smoke stages", () => {
+  runStage(
+    "install",
+    () => {
+      run("npm ci");
+    },
+    TIMEOUT,
+  );
+
+  runStage(
+    "build",
+    () => {
+      run("npm run build");
+    },
+    TIMEOUT,
+  );
+
+  runStage(
+    "lint",
+    () => {
+      run("npm run lint");
+    },
+    TIMEOUT,
+  );
+
+  runStage(
+    "typecheck",
+    () => {
+      run("npm run typecheck");
+    },
+    TIMEOUT,
+  );
+
+  runStage(
+    "unit",
+    () => {
+      run("npm test --prefix backend");
+    },
+    TIMEOUT,
+  );
+
+  runStage(
+    "integration",
+    () => {
+      run("npm run smoke");
+    },
+    TIMEOUT,
+  );
+});


### PR DESCRIPTION
## Summary
- add smoke stage tests for install/build/lint/typecheck/unit/integration

## Testing
- `npm run format` *(fails: ENOENT: no such file or directory, rename '/root/.npm/_cacache/tmp/fe7846f7')*
- `node scripts/run-jest.js tests/smokeStages.test.js` *(fails: Dependencies missing. Installing root dependencies...)*


------
https://chatgpt.com/codex/tasks/task_e_68a70d9c6d7c832d9bec478fb164d1bd