### PR TITLE
chore: add missing JSDoc param tags

### DIFF
--- a/backend/src/lib/prepareImage.js
+++ b/backend/src/lib/prepareImage.js
@@ -4,11 +4,21 @@ exports.prepareImage = void 0;
 const fs_1 = __importDefault(require("fs"));
 const path_1 = __importDefault(require("path"));
 const uploadS3_1 = require("./uploadS3");
+/**
+ * Wraps CommonJS modules for ESModule interop.
+ *
+ * @param {unknown} mod - Module to normalize.
+ * @returns {{ default: unknown }} Normalized module.
+ * @private
+ */
 function __importDefault(mod) {
   return mod && mod.__esModule ? mod : { default: mod };
 }
 /**
- * @param {*} image
+ * Upload an image (path, data URL or remote URL) to S3 if needed.
+ *
+ * @param {string} image - Image path, data URL, or HTTP URL.
+ * @returns {Promise<string>} Publicly accessible image URL.
  */
 async function prepareImage(image) {
   if (/^https?:\/\//.test(image)) {

--- a/backend/src/lib/preserveColors.js
+++ b/backend/src/lib/preserveColors.js
@@ -1,7 +1,10 @@
 const { NodeIO } = require("@gltf-transform/core");
 
 /**
- * @param {*} glb
+ * Ensure that vertex colors encoded in extras are preserved on the mesh.
+ *
+ * @param {Uint8Array|Buffer} glb - Binary GLB data.
+ * @returns {Promise<Uint8Array>} GLB with color attributes applied.
  */
 async function preserveColors(glb) {
   const io = new NodeIO();

--- a/backend/src/lib/storeGlb.js
+++ b/backend/src/lib/storeGlb.js
@@ -1,7 +1,11 @@
 const { S3Client, PutObjectCommand } = require("@aws-sdk/client-s3");
 
 /**
- * @param {*} attempts
+ * Store generated GLB data in S3 and return a public URL.
+ *
+ * @param {Buffer} data - Binary GLB contents.
+ * @param {number} [attempts=3] - Number of retry attempts on failure.
+ * @returns {Promise<string>} URL of the uploaded model.
  */
 async function storeGlb(data, attempts = 3) {
   if (data.length < 12 || data.toString("utf8", 0, 4) !== "glTF") {

--- a/backend/src/pipeline/generateModel.js
+++ b/backend/src/pipeline/generateModel.js
@@ -6,9 +6,12 @@ const { storeGlb } = require("../lib/storeGlb");
 const logger = require("../../../src/logger");
 
 /**
- * @param {Object} [root0]
- * @param {*} [root0.prompt]
- * @param {*} [root0.image]
+ * Generate a 3D model from a prompt and/or reference image.
+ *
+ * @param {Object} [root0] - Options for generation.
+ * @param {string} [root0.prompt] - Text prompt describing the model.
+ * @param {string} [root0.image] - Image path or URL used for guidance.
+ * @returns {Promise<string>} Public URL to the generated GLB model.
  */
 async function generateModel({ prompt, image } = {}) {
   logger.info(


### PR DESCRIPTION
## Summary
- add missing JSDoc for internal ES module wrapper and document prepareImage parameters
- document GLB storage helper and pipeline model generator
- clarify vertex color preservation helper

## Testing
- `npx prettier backend/src/lib/prepareImage.js backend/src/lib/preserveColors.js backend/src/lib/storeGlb.js backend/src/pipeline/generateModel.js -w`
- `npm test` *(fails: setup script re-invokes and does not complete due to missing dependencies)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: `npm ci` ENOTEMPTY rmdir lodash-es)*

------
https://chatgpt.com/codex/tasks/task_e_68a70f0e9f90832d9d9ca0b287fda5ac