### PR TITLE
ci: upload lcov artifact

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -48,3 +48,9 @@ jobs:
         continue-on-error: true
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+      - name: Upload LCOV artifact
+        if: always()
+        uses: actions/upload-artifact@v4.6.2
+        with:
+          name: lcov
+          path: coverage/lcov.info


### PR DESCRIPTION
## Summary
- ensure coverage workflow always uploads lcov artifact

## Testing
- `npm run format --prefix backend`
- `node scripts/run-jest.js --runInBand --forceExit` *(fails: process did not exit cleanly, but tests passed)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: setup triggered reinstall and hung)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: kill-port not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a70dbc1a80832db3c63de51e012a32