### PR TITLE
ci: comment artifact paths and add separate caches

### DIFF
--- a/.github/workflows/backend-only-ci.yml
+++ b/.github/workflows/backend-only-ci.yml
@@ -27,10 +27,13 @@ jobs:
         with:
           node-version: 20
           cache: npm
-          cache-dependency-path: |
-            package-lock.json
-            backend/package-lock.json
+          cache-dependency-path: package-lock.json
       - run: npm ci
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
       - run: npm ci --prefix backend
       - name: Run backend tests
         run: |

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -12,9 +12,6 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: frontend
     strategy:
       fail-fast: false
       matrix:
@@ -29,10 +26,22 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
           cache: npm
+          cache-dependency-path: package-lock.json
+      - run: npm ci
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+      - run: npm ci --prefix backend
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
           cache-dependency-path: frontend/package-lock.json
-      - run: npm ci && npm run lint && npm run build
-      - run: test -d dist
-      - run: node ../scripts/assert-frontend-dist.js
+      - run: npm ci --prefix frontend && npm run lint --prefix frontend && npm run build --prefix frontend
+      - run: test -d frontend/dist
+      - run: node scripts/assert-frontend-dist.js
       - uses: actions/upload-artifact@v4
         with:
           name: frontend-dist-${{ matrix.node }}
@@ -53,7 +62,38 @@ jobs:
       - run: |
           tar -czf frontend-dist.tar.gz -C frontend/dist .
           tar -tvf frontend-dist.tar.gz | tee frontend-dist-filetree.txt
+          find frontend/dist -type f -exec du -h {} + | sort -h > frontend-dist-sizes.txt
       - uses: actions/upload-artifact@v4
         with:
           name: frontend-dist-filetree
           path: frontend-dist-filetree.txt
+      - uses: actions/upload-artifact@v4
+        with:
+          name: frontend-dist-sizes
+          path: frontend-dist-sizes.txt
+      - name: Comment artifact contents
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7.0.1
+        with:
+          script: |
+            const fs = require('fs');
+            const lines = fs.readFileSync('frontend-dist-sizes.txt', 'utf8')
+              .trim()
+              .split('\n');
+            const body = [
+              '### Artifact contents',
+              '',
+              '| Size | Path |',
+              '| --- | --- |',
+              ...lines.map(l => {
+                const [size, ...pathParts] = l.trim().split(/\s+/);
+                const path = pathParts.join(' ');
+                return `| ${size} | ${path} |`;
+              })
+            ].join('\n');
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body
+            });

--- a/.github/workflows/frontend-local-build.yml
+++ b/.github/workflows/frontend-local-build.yml
@@ -20,7 +20,19 @@ jobs:
           node-version: 20
           cache: npm
           cache-dependency-path: package-lock.json
-      - run: npm ci && npm run build
+      - run: npm ci
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+      - run: npm ci --prefix backend
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci --prefix frontend && npm run build --prefix frontend
       - run: node scripts/assert-frontend-dist.js
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- comment frontend build artifacts on PRs
- cache root, backend, and frontend dependencies separately in build workflows

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script "lint" in frontend)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68a70efa6bf0832db64389a1e41b8676