### PR TITLE
ci: add ESLint changed-files job

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -1,0 +1,34 @@
+name: ESLint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            backend/package-lock.json
+      - run: npm ci
+      - run: npm ci --prefix backend
+      - uses: tj-actions/eslint-changed-files@v25.3.2
+        with:
+          extra_args: '--cache --cache-location .eslintcache --max-warnings 0'
+          ignore_path: .eslintignore


### PR DESCRIPTION
## Summary
- run ESLint only on changed files via tj-actions/eslint-changed-files

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: sh: 1: vite: not found)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Playwright browsers not installed)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: terminated early)*

------
https://chatgpt.com/codex/tasks/task_e_68a70db842a0832da2aedd0ab516d5c9