### PR TITLE
ci: reuse build artifacts in coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,9 +22,16 @@ jobs:
       - uses: actions/setup-node@v4.4.0
         with:
           node-version: 20
-      - run: SKIP_PW_DEPS=1 npm run setup
-        env:
-          DB_URL: postgres://localhost:5432/dev
+      - name: Download backend dist
+        uses: actions/download-artifact@v4
+        with:
+          name: backend-dist
+          path: backend
+      - name: Download frontend dist
+        uses: actions/download-artifact@v4
+        with:
+          name: frontend-dist
+          path: frontend/dist
       - run: SKIP_PW_DEPS=1 npm run coverage
       - name: Coverage summary
         run: |


### PR DESCRIPTION
## Summary
- download backend and frontend dist artifacts before running coverage

## Testing
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script "lint")*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68a70db74234832d8bd208e4c96ac0d8