### PR TITLE
test: log ESLint JSON on failure

### DIFF
--- a/tests/linting.test.js
+++ b/tests/linting.test.js
@@ -33,6 +33,14 @@ test("repository passes ESLint with no warnings", () => {
     );
 
     if (result.status !== 0) {
+      if (result.stdout) {
+        try {
+          const json = JSON.parse(result.stdout);
+          console.error("ESLint JSON output:\n" + JSON.stringify(json, null, 2));
+        } catch {
+          console.error(result.stdout);
+        }
+      }
       if (result.stderr) console.error(result.stderr);
     }
     expect(result.status).toBe(0);


### PR DESCRIPTION
## Summary
- show full ESLint JSON output when linting test fails

## Testing
- `npm --prefix backend run format`
- `npm --prefix backend test`
- `node scripts/run-jest.js tests/linting.test.js --runTestsByPath`
- `SKIP_PW_DEPS=1 npm run smoke`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: command hung, aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68a70db1181c832d9a3042946ad19900