### PR TITLE
ci: comment Pages preview link on PRs

### DIFF
--- a/.github/workflows/pages-url-comment.yml
+++ b/.github/workflows/pages-url-comment.yml
@@ -1,0 +1,47 @@
+name: Pages URL Comment
+
+on:
+  workflow_run:
+    workflows: ["Deploy"]
+    types: [completed]
+
+jobs:
+  comment:
+    if: ${{ github.event.workflow_run.conclusion != 'cancelled' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Download Pages URL
+        id: download
+        uses: actions/download-artifact@v4.1.8
+        with:
+          name: pages-url
+          run-id: ${{ github.event.workflow_run.id }}
+          path: artifact
+        continue-on-error: true
+      - name: Read Pages URL
+        id: read
+        if: steps.download.outcome == 'success'
+        run: echo "url=$(cat artifact/pages-url.txt)" >> "$GITHUB_OUTPUT"
+      - name: Comment on PR
+        if: steps.read.outputs.url != ''
+        uses: actions/github-script@v7.0.1
+        env:
+          URL: ${{ steps.read.outputs.url }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = context.payload.workflow_run.pull_requests[0];
+            if (!pr) {
+              core.info('No pull request associated with this workflow run.');
+              return;
+            }
+            const body = `Cloudflare Pages preview: ${process.env.URL}`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body
+            });


### PR DESCRIPTION
## Summary
- comment Cloudflare Pages preview link on PRs when Deploy workflow completes

## Testing
- `npm run format` (backend)
- `npm test` (backend, abort: setup flag missing)
- `npm run ci` (failed: dependencies missing)
- `npm run smoke` (environment OK)


------
https://chatgpt.com/codex/tasks/task_e_68a70dacf9b4832d92411d0cb93b1d86