### PR TITLE
ci: add cloudflare preview workflow

### DIFF
--- a/.github/workflows/cloudflare-preview.yml
+++ b/.github/workflows/cloudflare-preview.yml
@@ -1,0 +1,37 @@
+name: Cloudflare Preview
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            frontend/package-lock.json
+      - run: npm ci && npm ci --prefix frontend && npm run build --prefix frontend
+      - name: Run wrangler pages dev
+        run: |
+          npx -y wrangler@4.31.0 pages dev frontend/dist --port=8787 --persist-to=.wrangler &
+          pid=$!
+          sleep 5
+          kill $pid || true
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cloudflare-preview
+          path: .wrangler


### PR DESCRIPTION
## Summary
- add Cloudflare Pages preview workflow to build the frontend and generate a wrangler dev artifact

## Testing
- `npm run format --prefix backend`
```
> backend@1.0.0 preformat
> node ../scripts/ensure-root-deps.js

> backend@1.0.0 format
> sh -c 'cd .. && node scripts/ensure-root-deps.js && prettier --log-level warn --write "**/*.{js,jsx,json,md}" --ignore-path .prettierignore'
```
- `npm test --prefix backend`
```
PASS tests/api.test.ts
PASS tests/additionalApi.test.js
PASS tests/analytics.test.js
PASS tests/rewards.test.js
PASS tests/textToImage.test.js
PASS tests/subscriptions.test.js
...
```
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script "lint")*
```
npm error Missing script: "lint"
```
- `SKIP_PW_DEPS=1 npm run smoke`
```
[pw] npx -y wait-on http://localhost:3000 && npx playwright test --reporter=list --trace on e2e/smoke.test.js | tee pw.log exited with code 0
--> Sending SIGTERM to other processes..
[serve] npm run serve | tee serve.log exited with code SIGTERM
```


------
https://chatgpt.com/codex/tasks/task_e_68a70daa6f84832d85fa5bc0de00318c