### PR TITLE
ci: run Cloudflare deploy after CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,11 +1,11 @@
 name: Deploy
 
 on:
-  push:
+  workflow_run:
+    workflows: ["CI"]
     branches: [00000production]
-    paths:
-      - "frontend/**"
-      - ".github/workflows/deploy.yml"
+    types:
+      - completed
   workflow_dispatch:
 
 concurrency:
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   deploy:
-    if: vars.ENABLE_PAGES == '1'
+    if: vars.ENABLE_PAGES == '1' && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     env:
       WRANGLER_VERSION: 3.72.0
@@ -111,7 +111,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_PAGES_API_TOKEN }}
 
   pages-disabled:
-    if: vars.ENABLE_PAGES != '1'
+    if: vars.ENABLE_PAGES != '1' && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Heartbeat


### PR DESCRIPTION
## Summary
- run Cloudflare deploy workflow only after CI succeeds

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` (fails: Missing script "lint")
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68a70da76240832d89f935d98c808058