### PR TITLE
ci: gate coverage and deploy on build success

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
   test-backend:
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         shard: [aa, ab, ac]
     steps:
@@ -80,7 +80,7 @@ jobs:
   test-frontend:
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         include:
           - shard: core
@@ -148,6 +148,7 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     needs:
+      - build
       - test-backend
       - test-frontend
       - test-integration
@@ -182,3 +183,14 @@ jobs:
         with:
           name: lcov
           path: coverage/lcov.info
+
+  deploy:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    needs:
+      - coverage-merge
+    steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
+      - run: echo 'Deploying application'


### PR DESCRIPTION
## Summary
- ensure backend and frontend test matrices fail fast
- gate coverage merge on successful build and test jobs
- add deploy job that runs only after coverage completes

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` (fails: Missing script "lint")
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68a70da47978832d8d3e223fe868f5ca