### PR TITLE
tests: assert no global vite/tsc in CI

### DIFF
--- a/tests/noGlobalViteTsc.test.js
+++ b/tests/noGlobalViteTsc.test.js
@@ -1,0 +1,20 @@
+const { execSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+describe("no hidden global dependencies", () => {
+  test("vite is not installed globally", () => {
+    expect(() => execSync("which vite")).toThrow();
+  });
+
+  test("tsc is installed locally and not globally", () => {
+    expect(() =>
+      execSync("which tsc", { env: { PATH: "/usr/bin:/bin" } }),
+    ).toThrow();
+    const repoRoot = execSync("git rev-parse --show-toplevel")
+      .toString()
+      .trim();
+    const localTsc = path.join(repoRoot, "node_modules", ".bin", "tsc");
+    expect(fs.existsSync(localTsc)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add test verifying vite is absent globally and tsc is provided via local node_modules

## Testing
- `npm run format`
- `node scripts/run-jest.js tests/noGlobalViteTsc.test.js`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a70d372228832da912f7ae9764b3c2