### PR TITLE
tests: add wrangler.toml parse check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,6 +71,7 @@
         "selfsigned": "^2.3.2",
         "size-limit": "^11.2.0",
         "stripe": "^14.25.0",
+        "toml": "^3.0.0",
         "tsconfig-strictest": "^1.0.0-beta.1",
         "tslib": "^2.8.1",
         "typescript": "^5.8.3",
@@ -78,7 +79,7 @@
         "yaml": "^2.8.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=20 <21"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -21131,6 +21132,13 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/toml": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tough-cookie": {
       "version": "2.5.0",

--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
     "selfsigned": "^2.3.2",
     "size-limit": "^11.2.0",
     "stripe": "^14.25.0",
+    "toml": "^3.0.0",
     "tsconfig-strictest": "^1.0.0-beta.1",
     "tslib": "^2.8.1",
     "typescript": "^5.8.3",

--- a/tests/wranglerToml.test.js
+++ b/tests/wranglerToml.test.js
@@ -1,0 +1,10 @@
+const fs = require("fs");
+const toml = require("toml");
+
+describe("wrangler.toml", () => {
+  test("pages_build_output_dir points to frontend/dist", () => {
+    const content = fs.readFileSync("wrangler.toml", "utf8");
+    const config = toml.parse(content);
+    expect(config.pages_build_output_dir).toBe("frontend/dist");
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest test to parse wrangler.toml and assert Cloudflare build output directory
- include `toml` dependency for config parsing

## Testing
- `npm run format`
- `npm run format --prefix backend`
- `node scripts/run-jest.js tests/wranglerToml.test.js`
- `npm test --prefix backend` *(fails: long-running suite did not complete)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: missing lint script in frontend)
- `SKIP_PW_DEPS=1 npm run smoke` *(warnings from Playwright; command exited)*

------
https://chatgpt.com/codex/tasks/task_e_68a70d3b89b8832d9a0ee2ee413734da