### PR TITLE
ci: upload job logs on failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,11 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
       - run: npm ci && npm run lint && npm run build
       - run: test -d dist
+      - if: failure()
+        uses: actions/upload-artifact@v4.3.4
+        with:
+          name: ${{ github.job }}-logs
+          path: ${{ runner.temp }}/_github_workflow/*.log
 
   test-backend:
     runs-on: ubuntu-latest
@@ -76,6 +81,11 @@ jobs:
         with:
           name: coverage-backend-${{ matrix.shard }}
           path: coverage/backend
+      - if: failure()
+        uses: actions/upload-artifact@v4.3.4
+        with:
+          name: ${{ github.job }}-logs
+          path: ${{ runner.temp }}/_github_workflow/*.log
 
   test-frontend:
     runs-on: ubuntu-latest
@@ -117,6 +127,11 @@ jobs:
         with:
           name: coverage-frontend-${{ matrix.shard }}
           path: coverage/frontend
+      - if: failure()
+        uses: actions/upload-artifact@v4.3.4
+        with:
+          name: ${{ github.job }}-logs
+          path: ${{ runner.temp }}/_github_workflow/*.log
 
   test-integration:
     if: github.event_name == 'push'
@@ -143,6 +158,11 @@ jobs:
         with:
           name: coverage-integration
           path: coverage/integration
+      - if: failure()
+        uses: actions/upload-artifact@v4.3.4
+        with:
+          name: ${{ github.job }}-logs
+          path: ${{ runner.temp }}/_github_workflow/*.log
 
   coverage-merge:
     if: github.event_name == 'push'
@@ -182,3 +202,8 @@ jobs:
         with:
           name: lcov
           path: coverage/lcov.info
+      - if: failure()
+        uses: actions/upload-artifact@v4.3.4
+        with:
+          name: ${{ github.job }}-logs
+          path: ${{ runner.temp }}/_github_workflow/*.log


### PR DESCRIPTION
## Summary
- upload job log files as artifacts when CI steps fail

## Testing
- `npm run format`
- `npm test` *(fails: setup re-ran and exited early)*
- `npm run ci` *(fails: ENOTEMPTY during npm ci)*
- `npm run smoke` *(stops after environment setup)*

------
https://chatgpt.com/codex/tasks/task_e_68a70d0144f4832d8855a84d30f713ef