### PR TITLE
ci: validate dist/index.html before smoke

### DIFF
--- a/.github/workflows/pipeline-smoke.yml
+++ b/.github/workflows/pipeline-smoke.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Ensure frontend build output exists
+        run: test -f frontend/dist/index.html
+
       - name: Run smoke tests
         run: pnpm run smoke
 

--- a/.github/workflows/sync-space.yml
+++ b/.github/workflows/sync-space.yml
@@ -59,5 +59,8 @@ jobs:
       - name: Run backend tests
         run: npm run coverage --prefix backend
 
+      - name: Ensure frontend build output exists
+        run: test -f frontend/dist/index.html
+
       - name: Run smoke tests
         run: npm run smoke


### PR DESCRIPTION
## Summary
- Fail fast when frontend build output is missing before running smoke tests.

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: process terminated, SIGINT)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: interrupted)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: interrupted)*

```
> backend@1.0.0 preformat
> node ../scripts/ensure-root-deps.js

> backend@1.0.0 format
> sh -c 'cd .. && node scripts/ensure-root-deps.js && prettier --log-level warn --write "**/*.{js,jsx,json,md}" --ignore-path .prettierignore'
```

```
npm warn deprecated lodash.get@4.4.2: This package is deprecated. Use the optional chaining (?.) operator instead.
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm error process terminated
npm error signal SIGINT
```


------
https://chatgpt.com/codex/tasks/task_e_68a70d193318832db5bf34e33e50f623