### PR TITLE
ci: reuse build artifacts in coverage job

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,9 +22,14 @@ jobs:
       - uses: actions/setup-node@v4.4.0
         with:
           node-version: 20
-      - run: SKIP_PW_DEPS=1 npm run setup
-        env:
-          DB_URL: postgres://localhost:5432/dev
+      - uses: actions/download-artifact@v4
+        with:
+          name: backend-dist
+          path: backend/dist
+      - uses: actions/download-artifact@v4
+        with:
+          name: frontend-dist
+          path: frontend/dist
       - run: SKIP_PW_DEPS=1 npm run coverage
       - name: Coverage summary
         run: |


### PR DESCRIPTION
## Summary
- reuse backend and frontend build artifacts in coverage workflow

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script: "lint")*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68a70d2077cc832d803d4b182dcf4146