### PR TITLE
ci: disable husky in CI

### DIFF
--- a/.github/workflows/auto_rebase_merge_queue.yml
+++ b/.github/workflows/auto_rebase_merge_queue.yml
@@ -1,5 +1,9 @@
 name: Auto Rebase and Merge Queue
 
+env:
+  HUSKY: 0
+
+
 on:
   pull_request:
     types: [opened, synchronize, reopened]

--- a/.github/workflows/backend-only-ci.yml
+++ b/.github/workflows/backend-only-ci.yml
@@ -1,5 +1,9 @@
 name: Backend Only CI
 
+env:
+  HUSKY: 0
+
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -1,5 +1,9 @@
 name: Build frontend
 
+env:
+  HUSKY: 0
+
+
 on:
   pull_request:
     paths:

--- a/.github/workflows/cache-primer.yml
+++ b/.github/workflows/cache-primer.yml
@@ -1,5 +1,9 @@
 name: Cache primer
 
+env:
+  HUSKY: 0
+
+
 on:
   pull_request:
 

--- a/.github/workflows/cache-validator.yml
+++ b/.github/workflows/cache-validator.yml
@@ -1,5 +1,9 @@
 name: NPM cache validator
 
+env:
+  HUSKY: 0
+
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/check-watchdog.yml
+++ b/.github/workflows/check-watchdog.yml
@@ -1,5 +1,9 @@
 name: Check Watchdog
 
+env:
+  HUSKY: 0
+
+
 on:
   pull_request:
 

--- a/.github/workflows/ci-queue-monitor.yml
+++ b/.github/workflows/ci-queue-monitor.yml
@@ -1,5 +1,9 @@
 name: CI Queue Monitor
 
+env:
+  HUSKY: 0
+
+
 on:
   schedule:
     - cron: '*/15 * * * *'

--- a/.github/workflows/ci-rerun-slow.yml
+++ b/.github/workflows/ci-rerun-slow.yml
@@ -1,5 +1,9 @@
 name: Rerun Slow CI Lanes
 
+env:
+  HUSKY: 0
+
+
 on:
   workflow_dispatch:
 

--- a/.github/workflows/ci-watchdog.yml
+++ b/.github/workflows/ci-watchdog.yml
@@ -1,4 +1,8 @@
 name: CI Watchdog
+
+env:
+  HUSKY: 0
+
 on:
   workflow_run:
     workflows: ["CI", "build", "test"]

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,5 +1,9 @@
 name: CodeQL
 
+env:
+  HUSKY: 0
+
+
 on:
   push:
     branches: [dev]

--- a/.github/workflows/collect-artifacts.yml
+++ b/.github/workflows/collect-artifacts.yml
@@ -1,5 +1,9 @@
 name: Collect Failed Logs
 
+env:
+  HUSKY: 0
+
+
 on:
   workflow_run:
     workflows:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,5 +1,9 @@
 name: Coverage
 
+env:
+  HUSKY: 0
+
+
 on: [push, pull_request]
 
 concurrency:

--- a/.github/workflows/coveralls-upload.yml
+++ b/.github/workflows/coveralls-upload.yml
@@ -1,5 +1,9 @@
 name: Coveralls Upload
 
+env:
+  HUSKY: 0
+
+
 on:
   workflow_run:
     workflows: ["CI"]

--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -1,5 +1,9 @@
 name: DB Backup
 
+env:
+  HUSKY: 0
+
+
 on:
   schedule:
     - cron: '0 2 * * *'

--- a/.github/workflows/debug-queue.yml
+++ b/.github/workflows/debug-queue.yml
@@ -1,5 +1,9 @@
 name: Debug Queue
 
+env:
+  HUSKY: 0
+
+
 on:
   pull_request:
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,9 @@
 name: Deploy
 
+env:
+  HUSKY: 0
+
+
 on:
   push:
     branches: [00000production]

--- a/.github/workflows/diagnostics-dist-check.yml
+++ b/.github/workflows/diagnostics-dist-check.yml
@@ -1,5 +1,9 @@
 name: diagnostics-dist-check
 
+env:
+  HUSKY: 0
+
+
 on:
   pull_request:
 

--- a/.github/workflows/diagnostics.yml
+++ b/.github/workflows/diagnostics.yml
@@ -1,5 +1,9 @@
 name: Diagnostics
 
+env:
+  HUSKY: 0
+
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,5 +1,9 @@
 name: Docker Build
 
+env:
+  HUSKY: 0
+
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/endpoint-health.yml
+++ b/.github/workflows/endpoint-health.yml
@@ -1,5 +1,9 @@
 name: Endpoint Health
 
+env:
+  HUSKY: 0
+
+
 on:
   schedule:
     - cron: '*/15 * * * *'

--- a/.github/workflows/ensure_server_boots_185ecc2b50.yml
+++ b/.github/workflows/ensure_server_boots_185ecc2b50.yml
@@ -1,5 +1,9 @@
 name: Ensure Server Boots
 
+env:
+  HUSKY: 0
+
+
 on:
   workflow_dispatch:
   pull_request:

--- a/.github/workflows/eslint-diagnostics.yml
+++ b/.github/workflows/eslint-diagnostics.yml
@@ -1,5 +1,9 @@
 name: ESLint Diagnostics
 
+env:
+  HUSKY: 0
+
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/frontend-dry-build.yml
+++ b/.github/workflows/frontend-dry-build.yml
@@ -1,5 +1,9 @@
 name: Frontend dry build
 
+env:
+  HUSKY: 0
+
+
 on:
   pull_request:
 

--- a/.github/workflows/frontend-local-build.yml
+++ b/.github/workflows/frontend-local-build.yml
@@ -1,5 +1,9 @@
 name: Frontend dist local build
 
+env:
+  HUSKY: 0
+
+
 on:
   workflow_dispatch:
 

--- a/.github/workflows/glb-ci-alerts-938dhf.yml
+++ b/.github/workflows/glb-ci-alerts-938dhf.yml
@@ -1,5 +1,9 @@
 name: Playwright Failure Alerts
 
+env:
+  HUSKY: 0
+
+
 on:
   push:
     branches: [main, dev]

--- a/.github/workflows/glb-tests.yml
+++ b/.github/workflows/glb-tests.yml
@@ -1,5 +1,9 @@
 name: GLB Tests
 
+env:
+  HUSKY: 0
+
+
 on:
   push:
     branches: [main, dev]

--- a/.github/workflows/healthz-contract.yml
+++ b/.github/workflows/healthz-contract.yml
@@ -1,5 +1,9 @@
 name: Healthz Contract
 
+env:
+  HUSKY: 0
+
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/jest-early-warning.yml
+++ b/.github/workflows/jest-early-warning.yml
@@ -1,5 +1,9 @@
 name: Jest Early Warning
 
+env:
+  HUSKY: 0
+
+
 on:
   pull_request:
 

--- a/.github/workflows/jest-open-handles.yml
+++ b/.github/workflows/jest-open-handles.yml
@@ -1,5 +1,9 @@
 name: Jest open handles
 
+env:
+  HUSKY: 0
+
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,4 +1,8 @@
 name: Sync Labels
+
+env:
+  HUSKY: 0
+
 on:
   push:
     paths:

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,5 +1,9 @@
 name: Lighthouse
 
+env:
+  HUSKY: 0
+
+
 on:
   deployment_status:
     types: [success]

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -1,5 +1,9 @@
 name: Load Test
 
+env:
+  HUSKY: 0
+
+
 on:
   workflow_dispatch:
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,5 +1,9 @@
 name: Nightly CI
 
+env:
+  HUSKY: 0
+
+
 on:
   schedule:
     - cron: '0 3 * * *'

--- a/.github/workflows/nock-report.yml
+++ b/.github/workflows/nock-report.yml
@@ -1,5 +1,9 @@
 name: nock report
 
+env:
+  HUSKY: 0
+
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -1,5 +1,9 @@
 name: Node CI
 
+env:
+  HUSKY: 0
+
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/openapi-lint.yml
+++ b/.github/workflows/openapi-lint.yml
@@ -1,5 +1,9 @@
 name: OpenAPI Lint
 
+env:
+  HUSKY: 0
+
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/ops-report.yml
+++ b/.github/workflows/ops-report.yml
@@ -1,5 +1,9 @@
 name: Weekly Operations Report
 
+env:
+  HUSKY: 0
+
+
 on:
   schedule:
     - cron: '0 6 * * 1'

--- a/.github/workflows/package-helm.yml
+++ b/.github/workflows/package-helm.yml
@@ -1,5 +1,9 @@
 name: Package Helm Chart
 
+env:
+  HUSKY: 0
+
+
 on:
   push:
     tags:

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -1,5 +1,9 @@
 name: Pages Deploy
 
+env:
+  HUSKY: 0
+
+
 on:
   push:
     branches: ["00000production"]

--- a/.github/workflows/pipeline-deadlock-check.yml
+++ b/.github/workflows/pipeline-deadlock-check.yml
@@ -1,5 +1,9 @@
 name: Pipeline Deadlock Check
 
+env:
+  HUSKY: 0
+
+
 on:
   pull_request:
   push:

--- a/.github/workflows/pipeline-smoke.yml
+++ b/.github/workflows/pipeline-smoke.yml
@@ -1,5 +1,9 @@
 name: Full Pipeline Smoke Test
 
+env:
+  HUSKY: 0
+
+
 on:
   push:
     branches:

--- a/.github/workflows/playwright-browsers-cache.yml
+++ b/.github/workflows/playwright-browsers-cache.yml
@@ -1,5 +1,9 @@
 name: Playwright browsers cache
 
+env:
+  HUSKY: 0
+
+
 on:
   pull_request:
 

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -1,5 +1,9 @@
 name: Preflight
 
+env:
+  HUSKY: 0
+
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -1,5 +1,9 @@
 name: Preview Deploy
 
+env:
+  HUSKY: 0
+
+
 on:
   pull_request:
     branches: [main]

--- a/.github/workflows/printclub-reminders.yml
+++ b/.github/workflows/printclub-reminders.yml
@@ -1,5 +1,9 @@
 name: print2 Pro Reminders
 
+env:
+  HUSKY: 0
+
+
 on:
   schedule:
     - cron: '0 5 * * *'

--- a/.github/workflows/queue-probe.yml
+++ b/.github/workflows/queue-probe.yml
@@ -1,5 +1,9 @@
 name: Queue Probe
 
+env:
+  HUSKY: 0
+
+
 on:
   pull_request:
   workflow_dispatch:

--- a/.github/workflows/regression-guard.yml
+++ b/.github/workflows/regression-guard.yml
@@ -1,5 +1,9 @@
 name: regression-guard
 
+env:
+  HUSKY: 0
+
+
 on:
   pull_request:
   push:

--- a/.github/workflows/reset-credits.yml
+++ b/.github/workflows/reset-credits.yml
@@ -1,5 +1,9 @@
 name: Reset Credits
 
+env:
+  HUSKY: 0
+
+
 on:
   schedule:
     - cron: '0 4 * * 1'

--- a/.github/workflows/schedule-check.yml
+++ b/.github/workflows/schedule-check.yml
@@ -1,5 +1,9 @@
 name: Check HF Space Sleep
 
+env:
+  HUSKY: 0
+
+
 on:
   schedule:
     - cron: '0 0 * * *'

--- a/.github/workflows/smoke-backend.yml
+++ b/.github/workflows/smoke-backend.yml
@@ -1,5 +1,9 @@
 name: Backend Smoke
 
+env:
+  HUSKY: 0
+
+
 on:
   push:
   merge_group:

--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -1,5 +1,9 @@
 name: Server Smoke Test
 
+env:
+  HUSKY: 0
+
+
 on:
   push:
   merge_group:

--- a/.github/workflows/sync-space.yml
+++ b/.github/workflows/sync-space.yml
@@ -1,5 +1,9 @@
 name: Sync HF Space
 
+env:
+  HUSKY: 0
+
+
 on:
   push:
     branches: [ dev ]          # ← adjust target branch if needed

--- a/.github/workflows/update_locks.yml
+++ b/.github/workflows/update_locks.yml
@@ -1,5 +1,9 @@
 name: Update Locks
 
+env:
+  HUSKY: 0
+
+
 on:
   push:
     branches: [main]

--- a/.github/workflows/verify-lockfile.yml
+++ b/.github/workflows/verify-lockfile.yml
@@ -1,5 +1,9 @@
 name: Verify Lockfile
 
+env:
+  HUSKY: 0
+
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
## Summary
- ensure all workflow jobs skip Husky by setting `HUSKY=0`

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup` *(fails: vite not found)*
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: vite not found)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: vite not found)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a70c9c81a8832dbec273b53b405505