### PR TITLE
ci: install frontend deps before builds

### DIFF
--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -21,16 +21,21 @@ jobs:
         os: [ubuntu-latest]
         node: [20, 22]
     steps:
+      - uses: actions/checkout@v4
       - name: Heartbeat
         run: |
           while true; do date; sleep 120; done &
-      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
           cache: npm
           cache-dependency-path: frontend/package-lock.json
-      - run: npm ci && npm run lint && npm run build
+      - name: Install frontend deps
+        run: npm ci
+      - name: Lint frontend
+        run: npm run lint
+      - name: Build frontend
+        run: npm run build
       - run: test -d dist
       - run: node ../scripts/assert-frontend-dist.js
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,19 +24,24 @@ jobs:
       PORT: 3000
       CI_REQUIRE_EXTERNAL: "0"
     steps:
+      - uses: actions/checkout@v4
       - name: Heartbeat
         run: |
           while true; do date; sleep 120; done &
       - name: REQUIRED
         run: |
           echo 'REQUIRED: production build'
-      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: "npm"
           cache-dependency-path: frontend/package-lock.json
-      - run: npm ci && npm run lint && npm run build
+      - name: Install frontend deps
+        run: npm ci
+      - name: Lint frontend
+        run: npm run lint
+      - name: Build frontend
+        run: npm run build
       - run: test -d dist
 
   test-backend:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Heartbeat
         run: |
           while true; do date; sleep 120; done &
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4.4.0
         with:
           node-version: 20
@@ -38,6 +38,7 @@ jobs:
         run: |
           npm ci
           npm --prefix backend ci
+          npm ci --prefix frontend
           npm run build
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3.29.9

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,21 +20,17 @@ jobs:
       WRANGLER_VERSION: 3.72.0
 
     steps:
-
-      - name: Heartbeat
-
-        run: |
-
-          while true; do date; sleep 120; done &
       - name: Checkout code
-        uses: actions/checkout@v5
-
+        uses: actions/checkout@v4
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm
-          cache-dependency-path: package-lock.json
+          cache-dependency-path: frontend/package-lock.json
 
       - name: Mask secrets
         env:
@@ -43,6 +39,10 @@ jobs:
         run: |
           echo "::add-mask::$CLOUDFLARE_API_TOKEN"
           echo "::add-mask::$CLOUDFLARE_ACCOUNT_ID"
+
+      - name: Install frontend deps
+        run: npm ci
+        working-directory: frontend
 
       - name: Build frontend
         working-directory: frontend

--- a/.github/workflows/diagnostics-dist-check.yml
+++ b/.github/workflows/diagnostics-dist-check.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Heartbeat
         run: |
           while true; do date; sleep 120; done &
-      - name: Checkout
-        uses: actions/checkout@v4
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -24,9 +24,11 @@ jobs:
           cache: npm
           cache-dependency-path: frontend/package-lock.json
       - name: Install frontend dependencies
-        run: npm ci --prefix frontend
+        run: npm ci
+        working-directory: frontend
       - name: Build frontend
-        run: npm run build --prefix frontend
+        run: npm run build
+        working-directory: frontend
       - name: Print workspace structure
         run: |
           pwd

--- a/.github/workflows/frontend-dry-build.yml
+++ b/.github/workflows/frontend-dry-build.yml
@@ -11,19 +11,25 @@ jobs:
   dry-build:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - name: Heartbeat
         run: |
           while true; do date; sleep 120; done &
-      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm
-          cache-dependency-path: package-lock.json
-      - run: npm ci
-      - run: npm run build
-      - run: node -e "require('fs').accessSync('dist/index.html')"
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install frontend deps
+        run: npm ci
+        working-directory: frontend
+      - name: Build frontend
+        run: npm run build
+        working-directory: frontend
+      - name: Verify build
+        run: node -e "require('fs').accessSync('dist/index.html')"
+        working-directory: frontend
       - uses: actions/upload-artifact@v4
         with:
           name: frontend-dist
-          path: dist
+          path: frontend/dist

--- a/.github/workflows/frontend-local-build.yml
+++ b/.github/workflows/frontend-local-build.yml
@@ -11,16 +11,21 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - name: Heartbeat
         run: |
           while true; do date; sleep 120; done &
-      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm
-          cache-dependency-path: package-lock.json
-      - run: npm ci && npm run build
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install frontend deps
+        run: npm ci
+        working-directory: frontend
+      - name: Build frontend
+        run: npm run build
+        working-directory: frontend
       - run: node scripts/assert-frontend-dist.js
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -13,18 +13,21 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - name: Heartbeat
         run: |
           while true; do date; sleep 120; done &
-      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm
-          cache-dependency-path: |
-            package-lock.json
-            frontend/package-lock.json
-      - run: npm ci && npm run build --prefix frontend
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install frontend deps
+        run: npm ci
+        working-directory: frontend
+      - name: Build frontend
+        run: npm run build
+        working-directory: frontend
       - name: verify build
         run: |
           if [ ! -f frontend/dist/index.html ]; then

--- a/.github/workflows/pipeline-deadlock-check.yml
+++ b/.github/workflows/pipeline-deadlock-check.yml
@@ -10,13 +10,20 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 1
     steps:
+      - uses: actions/checkout@v4
       - name: Heartbeat
         run: |
           while true; do date; sleep 120; done &
-      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
       - run: npm install --no-save yaml
-      - run: npm ci && npm run build --prefix frontend
+      - name: Install frontend deps
+        run: npm ci
+        working-directory: frontend
+      - name: Build frontend
+        run: npm run build
+        working-directory: frontend
       - run: node --test tests/ci/pipeline-deadlock-check-b1a2c3d.test.js


### PR DESCRIPTION
## Summary
- install frontend dependencies before running builds in CI workflows
- move frontend build steps after checkout
- ensure codeql and deadlock checks also set up frontend deps

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run smoke`
- `npm run ci` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68a70bbfd744832d9c19fd8f3a74ff1c