### PR TITLE
ci: add concurrency and retries

### DIFF
--- a/.github/workflows/backend-only-ci.yml
+++ b/.github/workflows/backend-only-ci.yml
@@ -7,6 +7,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -30,8 +34,28 @@ jobs:
           cache-dependency-path: |
             package-lock.json
             backend/package-lock.json
-      - run: npm ci
-      - run: npm ci --prefix backend
+      - name: Install root dependencies
+        run: |
+          for attempt in 1 2; do
+            if npm ci; then
+              break
+            elif [ $attempt -eq 2 ]; then
+              exit 1
+            else
+              sleep $((2**attempt))
+            fi
+          done
+      - name: Install backend dependencies
+        run: |
+          for attempt in 1 2; do
+            if npm ci --prefix backend; then
+              break
+            elif [ $attempt -eq 2 ]; then
+              exit 1
+            else
+              sleep $((2**attempt))
+            fi
+          done
       - name: Run backend tests
         run: |
           node scripts/run-jest.js backend --listTests | split -n l/3 - test-files-

--- a/.github/workflows/check-watchdog.yml
+++ b/.github/workflows/check-watchdog.yml
@@ -3,6 +3,10 @@ name: Check Watchdog
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   watch:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-queue-monitor.yml
+++ b/.github/workflows/ci-queue-monitor.yml
@@ -5,6 +5,10 @@ on:
     - cron: '*/15 * * * *'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   monitor:
     runs-on: ubuntu-latest

--- a/.github/workflows/debug-queue.yml
+++ b/.github/workflows/debug-queue.yml
@@ -3,6 +3,10 @@ name: Debug Queue
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/pipeline-deadlock-check.yml
+++ b/.github/workflows/pipeline-deadlock-check.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   deadlock:
     runs-on: ubuntu-latest
@@ -17,6 +20,27 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - run: npm install --no-save yaml
-      - run: npm ci && npm run build --prefix frontend
+      - name: Install yaml
+        run: |
+          for attempt in 1 2; do
+            if npm install --no-save yaml; then
+              break
+            elif [ $attempt -eq 2 ]; then
+              exit 1
+            else
+              sleep $((2**attempt))
+            fi
+          done
+      - name: Install dependencies
+        run: |
+          for attempt in 1 2; do
+            if npm ci; then
+              break
+            elif [ $attempt -eq 2 ]; then
+              exit 1
+            else
+              sleep $((2**attempt))
+            fi
+          done
+      - run: npm run build --prefix frontend
       - run: node --test tests/ci/pipeline-deadlock-check-b1a2c3d.test.js

--- a/.github/workflows/queue-probe.yml
+++ b/.github/workflows/queue-probe.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:

--- a/.github/workflows/regression-guard.yml
+++ b/.github/workflows/regression-guard.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   guard:
     runs-on: ubuntu-latest
@@ -19,6 +23,16 @@ jobs:
           node-version: 20
           cache: npm
           cache-dependency-path: package-lock.json
-      - run: npm ci
+      - name: Install dependencies
+        run: |
+          for attempt in 1 2; do
+            if npm ci; then
+              break
+            elif [ $attempt -eq 2 ]; then
+              exit 1
+            else
+              sleep $((2**attempt))
+            fi
+          done
       - run: node scripts/check-lint-regression.js
       - run: node scripts/check-test-regression.js

--- a/.github/workflows/smoke-backend.yml
+++ b/.github/workflows/smoke-backend.yml
@@ -4,6 +4,10 @@ on:
   push:
   merge_group:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -23,7 +27,16 @@ jobs:
           cache: npm
           cache-dependency-path: backend/package-lock.json
       - name: Install dependencies
-        run: npm ci --prefix backend
+        run: |
+          for attempt in 1 2; do
+            if npm ci --prefix backend; then
+              break
+            elif [ $attempt -eq 2 ]; then
+              exit 1
+            else
+              sleep $((2**attempt))
+            fi
+          done
       - name: Lint
         run: npm run lint --prefix backend
       - name: Healthz test


### PR DESCRIPTION
## Summary
- add concurrency groups to workflows so new pushes cancel running jobs
- wrap npm installs with 2-attempt exponential backoff

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: sh: 1: vite: not found)*
- `npm run ci` *(fails: vite: not found)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: setup script error)*


------
https://chatgpt.com/codex/tasks/task_e_68a70f395958832d8e92928aad1a8e64