### PR TITLE
ci: deploy pages dist without symlinks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Verify dist output
         run: node scripts/assert-frontend-dist.js
 
+      - name: Copy dist without symlinks
+        run: cp -aL frontend/dist/. pages_dist/
+
       - name: Assert Pages project has no build config
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -79,7 +82,7 @@ jobs:
           set +e
           for attempt in 1 2 3; do
             echo "Attempt $attempt"
-            npx wrangler@${{ env.WRANGLER_VERSION }} pages deploy frontend/dist --project-name mvp-website 2>&1 | tee deploy.log
+            npx wrangler@${{ env.WRANGLER_VERSION }} pages deploy pages_dist --project-name mvp-website 2>&1 | tee deploy.log
             status=${PIPESTATUS[0]}
             if [ $status -eq 0 ]; then
               break
@@ -105,7 +108,7 @@ jobs:
       - name: Publish to Cloudflare Pages
         run: |
           npx wrangler@${{ env.WRANGLER_VERSION }} --version
-          npx wrangler@${{ env.WRANGLER_VERSION }} pages deploy frontend/dist --project-name ${{ secrets.CF_PAGES_PROJECT }}
+          npx wrangler@${{ env.WRANGLER_VERSION }} pages deploy pages_dist --project-name ${{ secrets.CF_PAGES_PROJECT }}
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_PAGES_API_TOKEN }}

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -36,17 +36,15 @@ jobs:
             fi
             exit 1
           fi
-      - name: sanitize symlinks
-        run: |
-          find frontend/dist -type l -exec bash -c 't=$(mktemp); cp -L "{}" "$t" && mv "$t" "{}"' \;
-          find frontend/dist -type l -exec rm -f {} +
+      - name: copy dist without symlinks
+        run: cp -aL frontend/dist/. pages_dist/
       - name: Deploy to Cloudflare Pages
         id: deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
-          url=$(npx -y wrangler pages deploy frontend/dist --project-name "${{ secrets.CF_PAGES_PROJECT }}" --branch production | tee /tmp/deploy.log | grep -Eo 'https://[^ ]+' | tail -n 1)
+          url=$(npx -y wrangler pages deploy pages_dist --project-name "${{ secrets.CF_PAGES_PROJECT }}" --branch production | tee /tmp/deploy.log | grep -Eo 'https://[^ ]+' | tail -n 1)
           echo "$url" > deploy-url.txt
           echo "url=$url" >> "$GITHUB_OUTPUT"
       - name: Job summary
@@ -60,6 +58,6 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: frontend-dist
-          path: frontend/dist
+          name: pages-dist
+          path: pages_dist
           if-no-files-found: ignore


### PR DESCRIPTION
## Summary
- copy frontend build to `pages_dist` to remove symlinks before Cloudflare Pages deploy
- deploy `pages_dist` in pages-deploy and deploy workflows

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script: "lint")*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68a70f2ab210832dbae1f7bf8e5ba295