### PR TITLE
ci: add backend typecheck to preflight

### DIFF
--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -25,3 +25,15 @@ jobs:
       - run: npm run format
       - run: npm run lint
       - run: npm run lint --prefix backend
+  typecheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm ci --prefix backend
+      - run: npx tsc --project backend/tsconfig.json --noEmit


### PR DESCRIPTION
## Summary
- add backend typecheck job to preflight workflow

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script: "lint")*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68a70f19ee14832da5d3b03793e3fe20