### PR TITLE
ci: lint only changed files with cache

### DIFF
--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -23,5 +23,5 @@ jobs:
       - run: npm ci
       - run: npm ci --prefix backend
       - run: npm run format
-      - run: npm run lint
+      - run: eslint --cache --cache-location .eslintcache --max-warnings=0 $(git diff --name-only origin/$BASE_SHA... | grep -E '\\.(js|ts|tsx)$' || true)
       - run: npm run lint --prefix backend


### PR DESCRIPTION
## Summary
- run eslint with cache on changed files in preflight workflow

## Testing
- `npm run format`
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script "lint")*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68a70f120620832db12d26f8999d6dfe