### PR TITLE
ci: validate wrangler config during preflight

### DIFF
--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -25,3 +25,14 @@ jobs:
       - run: npm run format
       - run: npm run lint
       - run: npm run lint --prefix backend
+  validate-wrangler:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: mkdir -p frontend/dist
+      - run: npx -y wrangler pages project validate frontend/dist --config wrangler.toml


### PR DESCRIPTION
## Summary
- add validate-wrangler job to preflight workflow
- validate wrangler config via `wrangler pages project validate`

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: Setup flag missing. Running 'npm run setup'... APT repositories unreachable)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: process terminated)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68a70ef02ae0832d913547fc6f1a3f1f