### PR TITLE
build: add prebuild sanity check for vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "smoke": "node scripts/run-smoke.js",
     "start:backend": "npm start --prefix backend",
     "predeploy": "node scripts/check-missing-links.js",
+    "prebuild": "test -x frontend/node_modules/.bin/vite || (echo \"vite not installed in frontend\" && exit 1)",
     "build": "npm run build --prefix frontend",
     "postbuild": "npx -y ts-node --transpile-only scripts/check-broken-symlinks-9ac8f74db5e1c32.ts",
     "load": "artillery run tests/load/models.yml",


### PR DESCRIPTION
## Summary
- fail fast if frontend lacks vite by adding `prebuild` script

## Testing
- `npm run validate-env`
- `npx --yes prettier package.json --log-level warn --write` (no output)
- `npm test --prefix backend` *(fails: Setup flag missing. Running 'npm run setup'...)*
- `npm run ci` *(fails: Dependencies missing. Installing root dependencies...)*
- `npm run smoke` *(fails: Running: bash scripts/setup-codex-9b08f7c1.sh)*

------
https://chatgpt.com/codex/tasks/task_e_68a70ee9eb14832d8a8d9826cf9ed80e