### PR TITLE
build: remove backend postinstall build step

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "backend",
       "version": "1.0.0",
-      "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.842.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -36,8 +36,7 @@
     "send-ops-report": "node scripts/send-ops-report.js",
     "flag-overdue-printers": "node scripts/flag-overdue-procurement-orders.js",
     "pretest": "node scripts/ensure-deps.js",
-    "format:check": "sh -c 'cd .. && prettier --log-level warn --check \"**/*.{js,jsx,json,md}\" --ignore-path .prettierignore'",
-    "postinstall": "npm --prefix .. run build"
+    "format:check": "sh -c 'cd .. && prettier --log-level warn --check \"**/*.{js,jsx,json,md}\" --ignore-path .prettierignore'"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- remove backend postinstall that triggered a root build
- update backend lockfile to drop its install script flag

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: setup tries to download Playwright browsers and terminates)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: dependency installation interrupted)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: frontend build missing vite)*

------
https://chatgpt.com/codex/tasks/task_e_68a70ee110f4832d80fe44e5d48a1b2a