### PR TITLE
ci: build frontend explicitly

### DIFF
--- a/.github/workflows/backend-only-ci.yml
+++ b/.github/workflows/backend-only-ci.yml
@@ -29,8 +29,10 @@ jobs:
           cache: npm
           cache-dependency-path: |
             package-lock.json
+            frontend/package-lock.json
             backend/package-lock.json
       - run: npm ci
+      - run: npm run build:frontend
       - run: npm ci --prefix backend
       - name: Run backend tests
         run: |

--- a/.github/workflows/cache-primer.yml
+++ b/.github/workflows/cache-primer.yml
@@ -33,8 +33,11 @@ jobs:
         with:
           node-version: 20
           cache: npm
-          cache-dependency-path: backend/package-lock.json
-      - run: npm ci --prefix backend
+          cache-dependency-path: |
+            frontend/package-lock.json
+            backend/package-lock.json
+      - run: npm run build:frontend
+      - run: npm ci --prefix backend --ignore-scripts
 
   frontend-cache:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-rerun-slow.yml
+++ b/.github/workflows/ci-rerun-slow.yml
@@ -59,10 +59,13 @@ jobs:
         with:
           node-version: 20
           cache: npm
-          cache-dependency-path: package-lock.json
+          cache-dependency-path: |
+            package-lock.json
+            frontend/package-lock.json
       - name: Install dependencies
         run: |
           npm ci
+          npm run build:frontend
           npm ci --prefix backend
       - name: Cache Playwright browsers
         uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,11 @@ jobs:
         with:
           node-version: 20
           cache: "npm"
-          cache-dependency-path: package-lock.json
+          cache-dependency-path: |
+            package-lock.json
+            frontend/package-lock.json
       - run: npm ci
+      - run: npm run build:frontend
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/eslint-diagnostics.yml
+++ b/.github/workflows/eslint-diagnostics.yml
@@ -26,8 +26,10 @@ jobs:
           cache: npm
           cache-dependency-path: |
             package-lock.json
+            frontend/package-lock.json
             backend/package-lock.json
       - run: npm ci
+      - run: npm run build:frontend
       - run: npm ci --prefix backend
       - name: Lint root
         id: lint-root

--- a/.github/workflows/glb-ci-alerts-938dhf.yml
+++ b/.github/workflows/glb-ci-alerts-938dhf.yml
@@ -26,9 +26,14 @@ jobs:
         with:
           node-version: 20
           cache: 'npm'
+          cache-dependency-path: |
+            package-lock.json
+            frontend/package-lock.json
+            backend/package-lock.json
       - name: Install dependencies
         run: |
           npm ci
+          npm run build:frontend
           npm ci --prefix backend
       - name: Install Playwright browsers
         run: npx playwright install --with-deps

--- a/.github/workflows/glb-tests.yml
+++ b/.github/workflows/glb-tests.yml
@@ -37,7 +37,10 @@ jobs:
         with:
           node-version: 20
           cache: 'npm'
-          cache-dependency-path: 'backend/package-lock.json'
+          cache-dependency-path: |
+            frontend/package-lock.json
+            backend/package-lock.json
+      - run: npm run build:frontend
       - name: Install dependencies
         run: npm ci --prefix backend
       - name: Run unit tests
@@ -63,10 +66,13 @@ jobs:
         with:
           node-version: 20
           cache: 'npm'
-          cache-dependency-path: 'package-lock.json'
+          cache-dependency-path: |
+            package-lock.json
+            frontend/package-lock.json
       - name: Install dependencies
         run: |
           npm ci
+          npm run build:frontend
           npm ci --prefix backend
       - name: Cache Playwright browsers
         uses: actions/cache@v4

--- a/.github/workflows/jest-early-warning.yml
+++ b/.github/workflows/jest-early-warning.yml
@@ -19,6 +19,9 @@ jobs:
         with:
           node-version: 20
           cache: npm
-          cache-dependency-path: backend/package-lock.json
+          cache-dependency-path: |
+            frontend/package-lock.json
+            backend/package-lock.json
+      - run: npm run build:frontend
       - run: npm ci --prefix backend
       - run: npm test --prefix backend -- --maxWorkers=50% --runInBand=false --silent --reporters=default

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -20,7 +20,12 @@ jobs:
         with:
           node-version: 20
           cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            frontend/package-lock.json
+            backend/package-lock.json
       - run: npm ci
+      - run: npm run build:frontend
       - run: npm ci --prefix backend
       - run: npm run format
       - run: npm run lint

--- a/.github/workflows/smoke-backend.yml
+++ b/.github/workflows/smoke-backend.yml
@@ -21,7 +21,10 @@ jobs:
         with:
           node-version: 20
           cache: npm
-          cache-dependency-path: backend/package-lock.json
+          cache-dependency-path: |
+            frontend/package-lock.json
+            backend/package-lock.json
+      - run: npm run build:frontend
       - name: Install dependencies
         run: npm ci --prefix backend
       - name: Lint

--- a/backend/package.json
+++ b/backend/package.json
@@ -37,7 +37,7 @@
     "flag-overdue-printers": "node scripts/flag-overdue-procurement-orders.js",
     "pretest": "node scripts/ensure-deps.js",
     "format:check": "sh -c 'cd .. && prettier --log-level warn --check \"**/*.{js,jsx,json,md}\" --ignore-path .prettierignore'",
-    "postinstall": "npm --prefix .. run build"
+    "postinstall": "npm ci --prefix ../frontend && npm run build --prefix ../frontend"
   },
   "keywords": [],
   "author": "",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "dev": "node backend/server.js",
     "validate-env": "bash scripts/validate-env.sh",
     "setup": "bash scripts/setup.sh",
-    "build:frontend": "npm --prefix frontend ci && npm --prefix frontend run build",
+    "build:frontend": "npm ci --prefix frontend && npm run build --prefix frontend",
     "e2e": "playwright test",
     "test:e2e": "playwright test",
     "test:unit": "npm test --prefix backend",

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -159,6 +159,8 @@ run_ci() {
 }
 
 run_ci ""
+run_ci frontend
+npm run build --prefix frontend
 run_ci backend
 run_ci backend/dalle_server
 


### PR DESCRIPTION
## Summary
- run frontend install and build explicitly in workflows
- update build scripts to use npm ci --prefix frontend && npm run build --prefix frontend
- invoke frontend build during setup and backend postinstall

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_68a70ede3870832d94a2fe5d604c010b