### PR TITLE
test: ensure local vite binary is used

### DIFF
--- a/tests/viteLocalBinary.test.js
+++ b/tests/viteLocalBinary.test.js
@@ -1,0 +1,25 @@
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const { spawnSync } = require("child_process");
+
+test("uses local node_modules/.bin/vite", () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vite-bin-"));
+  const fakeVite = path.join(tmpDir, "vite");
+  fs.writeFileSync(fakeVite, "#!/bin/sh\necho global-vite >&2\nexit 1\n");
+  fs.chmodSync(fakeVite, 0o755);
+
+  const env = {
+    ...process.env,
+    PATH: `${tmpDir}${path.delimiter}${process.env.PATH}`,
+  };
+
+  const result = spawnSync(
+    "npm",
+    ["run", "build", "--prefix", "frontend", "--", "--help"],
+    { env, encoding: "utf8" },
+  );
+
+  expect(result.status).toBe(0);
+  expect(result.stderr || "").not.toContain("global-vite");
+});


### PR DESCRIPTION
## Summary
- add test confirming `npm run build` uses local `node_modules/.bin/vite`

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format tests/viteLocalBinary.test.js`
- `node scripts/run-jest.js tests/viteLocalBinary.test.js`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script "lint")*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68a70dc37afc832d9d721861aeeac8d8