### PR TITLE
ci: add workflow to report tool versions

### DIFF
--- a/.github/workflows/ci-env.yml
+++ b/.github/workflows/ci-env.yml
@@ -1,0 +1,39 @@
+name: CI environment versions
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  versions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - run: npm ci
+      - run: npm ci --prefix frontend
+      - name: Record tool versions
+        run: |
+          echo "node: $(node -v)" >> versions.txt
+          echo "npm: $(npm -v)" >> versions.txt
+          echo "tsc: $(npx tsc -v)" >> versions.txt
+          echo "vite: $(npx --prefix frontend vite --version)" >> versions.txt
+          echo "eslint: $(npx eslint --version)" >> versions.txt
+          cat versions.txt
+      - uses: actions/upload-artifact@v4.3.4
+        with:
+          name: tool-versions
+          path: versions.txt


### PR DESCRIPTION
## Summary
- add ci-env workflow to log versions of node, npm, tsc, vite and eslint

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: process hung, manually interrupted)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script: "lint")*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68a70dc07224832db4e9ddcab7a83f8a