### PR TITLE
ci: add env parity job (local vs ci)

### DIFF
--- a/.github/workflows/env-parity.yml
+++ b/.github/workflows/env-parity.yml
@@ -1,0 +1,33 @@
+name: Environment parity
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  env-parity:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Record environment
+        run: |
+          {
+            echo "node: $(node -v)"
+            echo "npm: $(npm -v)"
+            echo "vite: $(which vite || echo 'not found')"
+            echo "tsc: $(which tsc || echo 'not found')"
+          } > env-summary.txt
+      - uses: actions/upload-artifact@v4.3.4
+        with:
+          name: env-summary
+          path: env-summary.txt
+          if-no-files-found: error


### PR DESCRIPTION
## Summary
- add env-parity workflow to publish versions for Node/npm and locations of vite/tsc

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script "lint")*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68a70d2f8498832d8c5eb2adb018200a