### PR TITLE
chore: add Cloudflare Pages ignore file

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,0 +1,4 @@
+node_modules
+**/*.map
+.*
+!.well-known


### PR DESCRIPTION
## Summary
- add `.cfignore` to exclude `node_modules`, source maps, and dotfiles from Cloudflare Pages uploads while preserving `.well-known`

## Testing
- `npm run format` in `backend`
- `npm test` in `backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script "lint" in frontend)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68a70f2f3eb0832da0072d1052258c45