### PR TITLE
ci: skip frontend workflows when absent

### DIFF
--- a/.github/workflows/cache-primer.yml
+++ b/.github/workflows/cache-primer.yml
@@ -37,6 +37,7 @@ jobs:
       - run: npm ci --prefix backend
 
   frontend-cache:
+    if: hashFiles('frontend/package.json') != ''
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/cache-validator.yml
+++ b/.github/workflows/cache-validator.yml
@@ -13,6 +13,7 @@ concurrency:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    if: matrix.name != 'frontend' || hashFiles('frontend/package.json') != ''
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/check-watchdog.yml
+++ b/.github/workflows/check-watchdog.yml
@@ -18,8 +18,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           SHA: ${{ github.event.pull_request.head.sha }}
+          HAS_FRONTEND: ${{ hashFiles('frontend/package.json') }}
         run: |
-          checks=("Build frontend / build" "Backend Smoke" "Cloudflare Pages")
+          checks=("Backend Smoke" "Cloudflare Pages")
+          if [ -n "$HAS_FRONTEND" ]; then
+            checks+=("Build frontend / build")
+          fi
           deadline=$((SECONDS + 420))
           while [ $SECONDS -lt $deadline ]; do
             all_started=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ env:
 
 jobs:
   build:
+    if: hashFiles('frontend/package.json') != ''
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -78,6 +79,7 @@ jobs:
           path: coverage/backend
 
   test-frontend:
+    if: hashFiles('frontend/package.json') != ''
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   deploy:
-    if: vars.ENABLE_PAGES == '1'
+    if: vars.ENABLE_PAGES == '1' && hashFiles('frontend/package.json') != ''
     runs-on: ubuntu-latest
     env:
       WRANGLER_VERSION: 3.72.0
@@ -111,7 +111,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_PAGES_API_TOKEN }}
 
   pages-disabled:
-    if: vars.ENABLE_PAGES != '1'
+    if: vars.ENABLE_PAGES != '1' || hashFiles('frontend/package.json') == ''
     runs-on: ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/diagnostics-dist-check.yml
+++ b/.github/workflows/diagnostics-dist-check.yml
@@ -9,6 +9,7 @@ concurrency:
 
 jobs:
   build:
+    if: hashFiles('frontend/package.json') != ''
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:

--- a/.github/workflows/frontend-dry-build.yml
+++ b/.github/workflows/frontend-dry-build.yml
@@ -9,6 +9,7 @@ concurrency:
 
 jobs:
   dry-build:
+    if: hashFiles('frontend/package.json') != ''
     runs-on: ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/frontend-local-build.yml
+++ b/.github/workflows/frontend-local-build.yml
@@ -9,6 +9,7 @@ concurrency:
 
 jobs:
   build:
+    if: hashFiles('frontend/package.json') != ''
     runs-on: ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -11,6 +11,7 @@ concurrency:
 
 jobs:
   deploy:
+    if: hashFiles('frontend/package.json') != ''
     runs-on: ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/pipeline-deadlock-check.yml
+++ b/.github/workflows/pipeline-deadlock-check.yml
@@ -19,4 +19,5 @@ jobs:
           node-version: 20
       - run: npm install --no-save yaml
       - run: npm ci && npm run build --prefix frontend
+        if: hashFiles('frontend/package.json') != ''
       - run: node --test tests/ci/pipeline-deadlock-check-b1a2c3d.test.js


### PR DESCRIPTION
## Summary
- guard frontend CI jobs and deploy steps so they run only when `frontend/package.json` exists
- adjust check watchdog to account for missing frontend checks

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup` (fails: vite not found)
- `npm run format --prefix backend`
- `npm test --prefix backend` (fails: vite not found)
- `SKIP_PW_DEPS=1 npm run ci` (fails: vite not found)
- `SKIP_PW_DEPS=1 npm run smoke` (fails: npm run setup)


------
https://chatgpt.com/codex/tasks/task_e_68a70ee6ae48832d80acb82af9f765ca