### PR TITLE
ci: reuse build artifacts

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,13 +7,57 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm ci --prefix backend
+      - run: npx tsc -p backend/tsconfig.build.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: frontend-dist
+          path: frontend/dist
+      - uses: actions/upload-artifact@v4
+        with:
+          name: backend-build
+          path: backend/lib
+      - uses: actions/upload-artifact@v4
+        with:
+          name: node-modules
+          path: node_modules
+      - uses: actions/upload-artifact@v4
+        with:
+          name: backend-node-modules
+          path: backend/node_modules
+
   coverage:
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - name: Heartbeat
         run: |
           while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
+      - uses: actions/download-artifact@v4
+        with:
+          name: frontend-dist
+          path: frontend/dist
+      - uses: actions/download-artifact@v4
+        with:
+          name: backend-build
+          path: backend/lib
+      - uses: actions/download-artifact@v4
+        with:
+          name: node-modules
+          path: node_modules
+      - uses: actions/download-artifact@v4
+        with:
+          name: backend-node-modules
+          path: backend/node_modules
       - name: Load Stripe env
         run: node scripts/ci-env-preflight.js
         env:
@@ -22,9 +66,6 @@ jobs:
       - uses: actions/setup-node@v4.4.0
         with:
           node-version: 20
-      - run: SKIP_PW_DEPS=1 npm run setup
-        env:
-          DB_URL: postgres://localhost:5432/dev
       - run: SKIP_PW_DEPS=1 npm run coverage
       - name: Coverage summary
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,35 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm ci --prefix backend
+      - run: npx tsc -p backend/tsconfig.build.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: frontend-dist
+          path: frontend/dist
+      - uses: actions/upload-artifact@v4
+        with:
+          name: backend-build
+          path: backend/lib
+      - uses: actions/upload-artifact@v4
+        with:
+          name: node-modules
+          path: node_modules
+      - uses: actions/upload-artifact@v4
+        with:
+          name: backend-node-modules
+          path: backend/node_modules
+
   deploy:
+    needs: build
     if: vars.ENABLE_PAGES == '1'
     runs-on: ubuntu-latest
     env:
@@ -28,6 +56,22 @@ jobs:
           while true; do date; sleep 120; done &
       - name: Checkout code
         uses: actions/checkout@v5
+      - uses: actions/download-artifact@v4
+        with:
+          name: frontend-dist
+          path: frontend/dist
+      - uses: actions/download-artifact@v4
+        with:
+          name: backend-build
+          path: backend/lib
+      - uses: actions/download-artifact@v4
+        with:
+          name: node-modules
+          path: node_modules
+      - uses: actions/download-artifact@v4
+        with:
+          name: backend-node-modules
+          path: backend/node_modules
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -43,10 +87,6 @@ jobs:
         run: |
           echo "::add-mask::$CLOUDFLARE_API_TOKEN"
           echo "::add-mask::$CLOUDFLARE_ACCOUNT_ID"
-
-      - name: Build frontend
-        working-directory: frontend
-        run: npm run build:ci
 
       - name: Verify dist output
         run: node scripts/assert-frontend-dist.js

--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -9,7 +9,35 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm ci --prefix backend
+      - run: npx tsc -p backend/tsconfig.build.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: frontend-dist
+          path: frontend/dist
+      - uses: actions/upload-artifact@v4
+        with:
+          name: backend-build
+          path: backend/lib
+      - uses: actions/upload-artifact@v4
+        with:
+          name: node-modules
+          path: node_modules
+      - uses: actions/upload-artifact@v4
+        with:
+          name: backend-node-modules
+          path: backend/node_modules
+
   smoke:
+    needs: build
     runs-on: ubuntu-latest
     env:
       PORT: 3000
@@ -20,11 +48,25 @@ jobs:
         run: |
           while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
+      - uses: actions/download-artifact@v4
+        with:
+          name: frontend-dist
+          path: frontend/dist
+      - uses: actions/download-artifact@v4
+        with:
+          name: backend-build
+          path: backend/lib
+      - uses: actions/download-artifact@v4
+        with:
+          name: node-modules
+          path: node_modules
+      - uses: actions/download-artifact@v4
+        with:
+          name: backend-node-modules
+          path: backend/node_modules
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: "npm"
-      - run: npm run setup
       - name: Start backend
         run: |
           npm run dev 2>&1 | tee /tmp/server.log &


### PR DESCRIPTION
## Summary
- reuse prebuilt frontend and backend outputs via artifacts in coverage workflow
- reuse build artifacts for smoke tests instead of rebuilding
- reuse build outputs for deploy job to avoid redundant builds

## Testing
- `npm run setup`
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: Command failed: npm run setup)*
- `npm run ci` *(terminated: Using dummy STRIPE_TEST_KEY)*
- `npm run smoke` *(terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68a70ef4527c832da52229f61aebe2a9