### PR TITLE
ci: gate node 22 build behind label

### DIFF
--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -16,13 +16,14 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: ${{ matrix.node != 22 || contains(github.event.pull_request.labels.*.name, 'full-matrix') }}
+    continue-on-error: ${{ matrix.node == 22 }}
     defaults:
       run:
         working-directory: frontend
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest]
         node: [20, 22]
     steps:
       - name: Heartbeat


### PR DESCRIPTION
## Summary
- run frontend build on Node 22 only when `full-matrix` label is present
- treat Node 22 runs as informational to reduce required checks

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script: "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html. Run 'npm run build' and retry)*

------
https://chatgpt.com/codex/tasks/task_e_68a71a1747f0832d86bfb2037a554cc6