### PR TITLE
ci: restrict frontend workflow paths

### DIFF
--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -7,7 +7,9 @@ env:
 on:
   pull_request:
     paths:
-      - "frontend/**"
+      - 'frontend/**'
+      - '!docs/**'
+      - 'package.json'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/cf-pages-preview.yml
+++ b/.github/workflows/cf-pages-preview.yml
@@ -3,6 +3,10 @@ name: Cloudflare Pages Preview
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    paths:
+      - 'frontend/**'
+      - '!docs/**'
+      - 'package.json'
 
 permissions:
   contents: read

--- a/.github/workflows/cloudflare-preview.yml
+++ b/.github/workflows/cloudflare-preview.yml
@@ -3,6 +3,10 @@ name: Cloudflare Preview
 on:
   pull_request:
     branches: [main]
+    paths:
+      - 'frontend/**'
+      - '!docs/**'
+      - 'package.json'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/frontend-dry-build.yml
+++ b/.github/workflows/frontend-dry-build.yml
@@ -6,6 +6,10 @@ env:
 
 on:
   pull_request:
+    paths:
+      - 'frontend/**'
+      - '!docs/**'
+      - 'package.json'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
- narrow frontend workflow triggers to frontend files or root package.json, ignoring docs

## Testing
- `npm run format` in backend
- `npm run test-ci` in backend
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script: "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a71a291ef0832d8b31b4d33e99967d