### PR TITLE
ci: support skip-heavy label

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -16,3 +16,6 @@
 - name: question
   color: d876e3
   description: Further information requested
+- name: ci:skip-heavy
+  color: 8e44ad
+  description: Run only lint and smoke tests

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci:skip-heavy') }}
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -44,6 +45,7 @@ jobs:
           path: frontend/dist
 
   artifact-lister:
+    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci:skip-heavy') }}
     runs-on: ubuntu-latest
     continue-on-error: true
     needs: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ env:
 
 jobs:
   build:
+    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci:skip-heavy') }}
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -48,6 +49,7 @@ jobs:
           path: ${{ runner.temp }}/_github_workflow/*.log
 
   test-backend:
+    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci:skip-heavy') }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
@@ -91,6 +93,7 @@ jobs:
           path: ${{ runner.temp }}/_github_workflow/*.log
 
   test-frontend:
+    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci:skip-heavy') }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
@@ -140,7 +143,7 @@ jobs:
           path: ${{ runner.temp }}/_github_workflow/*.log
 
   test-integration:
-    if: github.event_name == 'push'
+    if: ${{ (github.event_name == 'push') && (github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci:skip-heavy')) }}
     runs-on: ubuntu-latest
     steps:
       - name: Heartbeat
@@ -171,7 +174,7 @@ jobs:
           path: ${{ runner.temp }}/_github_workflow/*.log
 
   coverage-merge:
-    if: github.event_name == 'push'
+    if: ${{ (github.event_name == 'push') && (github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci:skip-heavy')) }}
     runs-on: ubuntu-latest
     needs:
       - test-backend

--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -7,6 +7,8 @@ env:
 on:
   push:
   merge_group:
+  pull_request:
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -14,6 +16,7 @@ concurrency:
 
 jobs:
   smoke:
+    if: ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'ci:skip-heavy') }}
     runs-on: ubuntu-latest
     env:
       PORT: 3000

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   typecheck:
+    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci:skip-heavy') }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
### Summary
- add `ci:skip-heavy` label so pull requests can opt into a light pipeline
- skip build and test workflows when PR has the label
- allow smoke tests to run for labeled pull requests

### Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(exited after lint step)*
- `SKIP_PW_DEPS=1 npm run smoke` *(missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a71c1d397c832d9e5cf9dafeb79e13