### PR TITLE
ci: split pages deploy into validate and deploy jobs

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -14,7 +14,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  validate:
+    name: Pages config validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Validate config
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: npx -y wrangler pages config validate --project-name "${{ secrets.CF_PAGES_PROJECT }}"
+
   deploy:
+    needs: validate
     runs-on: ubuntu-latest
     steps:
       - name: Heartbeat


### PR DESCRIPTION
## Summary
- separate Cloudflare Pages config validation into its own job
- run deployment only after validation succeeds

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `cd backend && npm run format`
- `cd backend && npm test` *(fails: eslint log missing)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend/dist/index.html)*

------
https://chatgpt.com/codex/tasks/task_e_68a71c166e60832d94be4536ab0cd66e