### PR TITLE
build: pin vite and enable corepack

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,6 @@
     "preview": "vite preview"
   },
   "devDependencies": {
-    "vite": "^5.3.0"
+    "vite": "^5.4.19"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "perf-events": "node scripts/perf-events.js",
-    "preinstall": "node scripts/check-node-version.js",
+    "preinstall": "corepack enable && node scripts/check-node-version.js",
     "lhci": "lhci autorun",
     "prepare": "husky install",
     "prepare:dev": "husky install && tsc -p scripts/tsconfig.json",
@@ -99,6 +99,7 @@
     "node": ">=20 <21"
   },
   "type": "commonjs",
+  "packageManager": "pnpm@10.11.0",
   "prettier": {},
   "devDependencies": {
     "@axe-core/cli": "^4.10.2",


### PR DESCRIPTION
## Summary
- pin frontend Vite dev dependency to a stable v5
- enable Corepack and declare pnpm package manager

## Testing
- `npm run validate-env`
- `curl -I https://registry.npmjs.org`
- `curl -I https://cdn.playwright.dev`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: terminated)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: terminated)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: missing frontend build artifact)*


------
https://chatgpt.com/codex/tasks/task_e_68a71c08d838832d932621fe11a01974