### PR TITLE
ci: add reusable setup workflow

### DIFF
--- a/.github/workflows/_setup.yml
+++ b/.github/workflows/_setup.yml
@@ -1,0 +1,30 @@
+name: Setup
+
+on:
+  workflow_call:
+    inputs:
+      run:
+        description: Command to execute after dependencies install
+        required: true
+        type: string
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            backend/package-lock.json
+            frontend/package-lock.json
+      - run: npm ci
+      - run: npm ci --prefix frontend
+      - run: npm ci --prefix backend
+      - run: ${{ inputs.run }}

--- a/.github/workflows/jest-early-warning.yml
+++ b/.github/workflows/jest-early-warning.yml
@@ -3,7 +3,6 @@ name: Jest Early Warning
 env:
   HUSKY: 0
 
-
 on:
   pull_request:
 
@@ -13,16 +12,6 @@ concurrency:
 
 jobs:
   backend-tests:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Heartbeat
-        run: |
-          while true; do date; sleep 120; done &
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-          cache-dependency-path: backend/package-lock.json
-      - run: npm ci --prefix backend
-      - run: npm test --prefix backend -- --maxWorkers=50% --runInBand=false --silent --reporters=default
+    uses: ./.github/workflows/_setup.yml
+    with:
+      run: npm test --prefix backend -- --maxWorkers=50% --runInBand=false --silent --reporters=default

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,20 +8,9 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-          cache-dependency-path: |
-            package-lock.json
-            backend/package-lock.json
-            frontend/package-lock.json
-      - run: npm ci
-      - run: npm ci --prefix frontend
-      - run: npm ci --prefix backend
-      - run: npm run lint:root
-      - run: npm run lint --prefix frontend
-      - run: npm run lint --prefix backend
+    uses: ./.github/workflows/_setup.yml
+    with:
+      run: |
+        npm run lint:root
+        npm run lint --prefix frontend
+        npm run lint --prefix backend

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -8,18 +8,6 @@ on:
 
 jobs:
   typecheck:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-          cache-dependency-path: |
-            package-lock.json
-            backend/package-lock.json
-            frontend/package-lock.json
-      - run: npm ci
-      - run: npm ci --prefix frontend
-      - run: npm ci --prefix backend
-      - run: npx tsc --noEmit
+    uses: ./.github/workflows/_setup.yml
+    with:
+      run: npx tsc --noEmit


### PR DESCRIPTION
## Summary
- create reusable setup workflow
- call reusable setup from lint, typecheck, and jest-early-warning

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup` *(fails: install steps hang, aborted)*
- `npm run format --prefix backend` *(fails: missing dependencies)*
- `npm test --prefix backend` *(fails: missing dependencies)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: missing dependencies)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: missing frontend build artifact)*


------
https://chatgpt.com/codex/tasks/task_e_68a71bfe8370832d9ad54adb743b0ebe