### PR TITLE
ci: shorten workflow timeouts

### DIFF
--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: frontend
@@ -47,6 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     needs: build
+    timeout-minutes: 5
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/check-watchdog.yml
+++ b/.github/workflows/check-watchdog.yml
@@ -15,7 +15,7 @@ jobs:
   watch:
     runs-on: ubuntu-latest
     continue-on-error: true
-    timeout-minutes: 8
+    timeout-minutes: 5
     permissions:
       checks: read
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: frontend
@@ -49,6 +50,7 @@ jobs:
 
   test-backend:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       fail-fast: true
       matrix:
@@ -92,6 +94,7 @@ jobs:
 
   test-frontend:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       fail-fast: true
       matrix:
@@ -142,6 +145,7 @@ jobs:
   test-integration:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/eslint-diagnostics.yml
+++ b/.github/workflows/eslint-diagnostics.yml
@@ -19,6 +19,7 @@ jobs:
   eslint:
     runs-on: ubuntu-latest
     continue-on-error: true
+    timeout-minutes: 5
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/frontend-dry-build.yml
+++ b/.github/workflows/frontend-dry-build.yml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
   dry-build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/frontend-local-build.yml
+++ b/.github/workflows/frontend-local-build.yml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -20,7 +20,7 @@ jobs:
     env:
       PORT: 3000
       CI_REQUIRE_EXTERNAL: '0'
-    timeout-minutes: 20
+    timeout-minutes: 15
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/openapi-lint.yml
+++ b/.github/workflows/openapi-lint.yml
@@ -17,6 +17,7 @@ concurrency:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/pipeline-deadlock-check.yml
+++ b/.github/workflows/pipeline-deadlock-check.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   deadlock:
     runs-on: ubuntu-latest
-    timeout-minutes: 1
+    timeout-minutes: 5
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/pipeline-smoke.yml
+++ b/.github/workflows/pipeline-smoke.yml
@@ -18,6 +18,7 @@ concurrency:
 jobs:
   smoke_test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       STRIPE_TEST_KEY: ${{ secrets.STRIPE_TEST_KEY }}
       DB_URL: ${{ secrets.DB_URL }}

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   lint-format:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
@@ -31,7 +31,7 @@ jobs:
       - run: npm run lint --prefix backend
   validate-wrangler:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4

--- a/.github/workflows/smoke-backend.yml
+++ b/.github/workflows/smoke-backend.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   backend-smoke:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 15
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   smoke:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       PORT: 3000
       DB_URL: postgres://user:pass@localhost:5432/testdb

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   typecheck:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- cap build and test workflow jobs at 15 minutes
- reduce preflight and script check jobs to 5 minute timeouts to free runners faster

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: interrupted)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a71bf99dfc832da40677656344c147