### PR TITLE
ci: collapse frontend build matrix

### DIFF
--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     paths:
       - "frontend/**"
+  workflow_dispatch:
+  schedule:
+    - cron: '0 3 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -15,15 +18,13 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     defaults:
       run:
         working-directory: frontend
     strategy:
       fail-fast: true
-      matrix:
-        os: [ubuntu-latest]
-        node: [20, 22]
+      matrix: ${{ fromJSON(github.event_name == 'pull_request' && '{"os":["ubuntu-latest"],"node":[20]}' || '{"os":["ubuntu-latest","windows-latest"],"node":[20,22]}') }}
     steps:
       - name: Heartbeat
         run: |
@@ -40,7 +41,7 @@ jobs:
       - run: node ../scripts/assert-frontend-dist.js
       - uses: actions/upload-artifact@v4
         with:
-          name: frontend-dist-${{ matrix.node }}
+          name: frontend-dist-${{ matrix.os }}-${{ matrix.node }}
           path: frontend/dist
 
   artifact-lister:
@@ -53,7 +54,7 @@ jobs:
           while true; do date; sleep 120; done &
       - uses: actions/download-artifact@v4
         with:
-          name: frontend-dist-20
+          name: frontend-dist-ubuntu-latest-20
           path: frontend/dist
       - run: |
           tar -czf frontend-dist.tar.gz -C frontend/dist .


### PR DESCRIPTION
## Summary
- run frontend build with single Ubuntu/Node 20 lane on PRs
- enable full 2x2 OS/Node matrix via manual trigger or nightly schedule

## Testing
- `npm run format` (backend)
```
> backend@1.0.0 preformat
> node ../scripts/ensure-root-deps.js

> backend@1.0.0 format
> sh -c 'cd .. && node scripts/ensure-root-deps.js && prettier --log-level warn --write "**/*.{js,jsx,json,md}" --ignore-path .prettierignore'
```
- `npm test` (backend)
```
PASS tests/additionalApi.test.js
PASS tests/analytics.test.js
```
- `SKIP_PW_DEPS=1 npm run ci` (fails: Missing script "lint")
- `SKIP_PW_DEPS=1 npm run smoke` (fails: Missing frontend build artifact)
- `SKIP_PW_DEPS=1 npm run diagnose` (fails: testCleanupValidator mismatch)


------
https://chatgpt.com/codex/tasks/task_e_68a71bf578dc832d878796b3f874e1fa