### PR TITLE
fix: scope wrangler config per environment

### DIFF
--- a/tests/wranglerToml.test.js
+++ b/tests/wranglerToml.test.js
@@ -1,10 +1,15 @@
 const fs = require("fs");
 const toml = require("toml");
 
+const content = fs.readFileSync("wrangler.toml", "utf8");
+const config = toml.parse(content);
+
 describe("wrangler.toml", () => {
-  test("pages_build_output_dir points to frontend/dist", () => {
-    const content = fs.readFileSync("wrangler.toml", "utf8");
-    const config = toml.parse(content);
-    expect(config.pages_build_output_dir).toBe("frontend/dist");
+  test("env.production.pages_build_output_dir points to frontend/dist", () => {
+    expect(config.env.production.pages_build_output_dir).toBe("frontend/dist");
+  });
+
+  test("env.preview.pages_build_output_dir points to frontend/dist", () => {
+    expect(config.env.preview.pages_build_output_dir).toBe("frontend/dist");
   });
 });

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,5 +1,13 @@
 name = "mvp-website"
+
+[env.production]
 pages_build_output_dir = "frontend/dist"
 
-[build]
+[env.production.build]
+command = "npm ci --prefix frontend && npm run build --prefix frontend"
+
+[env.preview]
+pages_build_output_dir = "frontend/dist"
+
+[env.preview.build]
 command = "npm ci --prefix frontend && npm run build --prefix frontend"


### PR DESCRIPTION
## Summary
- structure wrangler.toml with explicit production and preview env tables
- adjust tests to verify pages_build_output_dir in each environment

## Testing
- `npm run validate-env`
- `npm run format`
- `npm test` *(fails: npm ci encountered tar filesystem errors)*
- `npm run ci` *(fails: ENOTEMPTY rmdir)*
- `npm run smoke` *(fails: missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a71c133104832d8c16d446c7c6de98