### PR TITLE
ci: add deterministic node caches

### DIFF
--- a/.github/workflows/ci-watchdog.yml
+++ b/.github/workflows/ci-watchdog.yml
@@ -29,8 +29,17 @@ jobs:
           while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
+        id: setup-node
         with:
           node-version: 20
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            frontend/package-lock.json
+            backend/package-lock.json
+            backend/dalle_server/package-lock.json
+            pnpm-lock.yaml
+      - run: echo "cache-hit: ${{ steps.setup-node.outputs.cache-hit }}"
       - run: npm install --no-audit --no-fund
       - run: node scripts/ci_watchdog.js
         env:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,10 +28,18 @@ jobs:
         run: |
           while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
-      - uses: actions/setup-node@v4.4.0
+      - uses: actions/setup-node@v4
+        id: setup-node
         with:
           node-version: 20
-          cache: 'npm'
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            frontend/package-lock.json
+            backend/package-lock.json
+            backend/dalle_server/package-lock.json
+            pnpm-lock.yaml
+      - run: echo "cache-hit: ${{ steps.setup-node.outputs.cache-hit }}"
       - name: Verify code scanning enabled
         run: node scripts/check-code-scanning.js
       - name: Initialize CodeQL

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,9 +24,18 @@ jobs:
         env:
           STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
           STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
-      - uses: actions/setup-node@v4.4.0
+      - uses: actions/setup-node@v4
+        id: setup-node
         with:
           node-version: 20
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            frontend/package-lock.json
+            backend/package-lock.json
+            backend/dalle_server/package-lock.json
+            pnpm-lock.yaml
+      - run: echo "cache-hit: ${{ steps.setup-node.outputs.cache-hit }}"
       - uses: actions/download-artifact@v4
         with:
           name: backend-dist

--- a/.github/workflows/diagnostics.yml
+++ b/.github/workflows/diagnostics.yml
@@ -32,9 +32,17 @@ jobs:
           echo 'DIAGNOSTIC: strict lint'
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
+        id: setup-node
         with:
           node-version: 20
-          cache: "npm"
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            frontend/package-lock.json
+            backend/package-lock.json
+            backend/dalle_server/package-lock.json
+            pnpm-lock.yaml
+      - run: echo "cache-hit: ${{ steps.setup-node.outputs.cache-hit }}"
       - run: npm ci
       - name: Lint
         run: npm run lint
@@ -53,9 +61,17 @@ jobs:
           echo 'DIAGNOSTIC: dependency audit'
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
+        id: setup-node
         with:
           node-version: 20
-          cache: "npm"
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            frontend/package-lock.json
+            backend/package-lock.json
+            backend/dalle_server/package-lock.json
+            pnpm-lock.yaml
+      - run: echo "cache-hit: ${{ steps.setup-node.outputs.cache-hit }}"
       - run: npm ci
       - name: Audit root
         run: npm audit --audit-level=high
@@ -78,9 +94,17 @@ jobs:
           echo 'DIAGNOSTIC: Stripe/Cloudflare smoke'
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
+        id: setup-node
         with:
           node-version: 20
-          cache: "npm"
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            frontend/package-lock.json
+            backend/package-lock.json
+            backend/dalle_server/package-lock.json
+            pnpm-lock.yaml
+      - run: echo "cache-hit: ${{ steps.setup-node.outputs.cache-hit }}"
       - run: npm ci
       - name: Cloudflare readiness
         run: npm run test:cf-readiness

--- a/.github/workflows/ensure_server_boots_185ecc2b50.yml
+++ b/.github/workflows/ensure_server_boots_185ecc2b50.yml
@@ -42,13 +42,19 @@ jobs:
         env:
           STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
           STRIPE_WEBHOOK_SECRET: ${{ secrets.STRIPE_WEBHOOK_SECRET }}
-
       - name: Setup Node.js
         uses: actions/setup-node@v4
+        id: setup-node
         with:
           node-version: 20
-          cache: 'npm'
-
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            frontend/package-lock.json
+            backend/package-lock.json
+            backend/dalle_server/package-lock.json
+            pnpm-lock.yaml
+      - run: echo "cache-hit: ${{ steps.setup-node.outputs.cache-hit }}"
       - name: Install dependencies
         run: npm run setup
 

--- a/.github/workflows/env-parity.yml
+++ b/.github/workflows/env-parity.yml
@@ -16,8 +16,17 @@ jobs:
           while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
+        id: setup-node
         with:
           node-version: 20
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            frontend/package-lock.json
+            backend/package-lock.json
+            backend/dalle_server/package-lock.json
+            pnpm-lock.yaml
+      - run: echo "cache-hit: ${{ steps.setup-node.outputs.cache-hit }}"
       - name: Record environment
         run: |
           {

--- a/.github/workflows/glb-ci-alerts-938dhf.yml
+++ b/.github/workflows/glb-ci-alerts-938dhf.yml
@@ -27,9 +27,17 @@ jobs:
           while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
+        id: setup-node
         with:
           node-version: 20
-          cache: 'npm'
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            frontend/package-lock.json
+            backend/package-lock.json
+            backend/dalle_server/package-lock.json
+            pnpm-lock.yaml
+      - run: echo "cache-hit: ${{ steps.setup-node.outputs.cache-hit }}"
       - name: Install dependencies
         run: |
           npm ci

--- a/.github/workflows/healthz-contract.yml
+++ b/.github/workflows/healthz-contract.yml
@@ -24,9 +24,17 @@ jobs:
           while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
+        id: setup-node
         with:
           node-version: 20
-          cache: 'npm'
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            frontend/package-lock.json
+            backend/package-lock.json
+            backend/dalle_server/package-lock.json
+            pnpm-lock.yaml
+      - run: echo "cache-hit: ${{ steps.setup-node.outputs.cache-hit }}"
       - run: npm ci
       - run: node scripts/run-jest.js tests/diagnostics/healthz_contract.test.js
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/jest-open-handles.yml
+++ b/.github/workflows/jest-open-handles.yml
@@ -25,9 +25,17 @@ jobs:
           while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
+        id: setup-node
         with:
           node-version: 20
-          cache: "npm"
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            frontend/package-lock.json
+            backend/package-lock.json
+            backend/dalle_server/package-lock.json
+            pnpm-lock.yaml
+      - run: echo "cache-hit: ${{ steps.setup-node.outputs.cache-hit }}"
       - name: Run Jest with open handles
         run: |
           npm test --prefix backend -- --detectOpenHandles --listTests --maxWorkers=50% 2>jest-stderr.log

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -22,9 +22,17 @@ jobs:
           while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
+        id: setup-node
         with:
           node-version: 20
-          cache: 'npm'
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            frontend/package-lock.json
+            backend/package-lock.json
+            backend/dalle_server/package-lock.json
+            pnpm-lock.yaml
+      - run: echo "cache-hit: ${{ steps.setup-node.outputs.cache-hit }}"
       - run: npm install --no-audit --no-fund
       - name: Run Lighthouse CI
         env:

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -21,9 +21,17 @@ jobs:
           while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
+        id: setup-node
         with:
           node-version: 20
-          cache: 'npm'
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            frontend/package-lock.json
+            backend/package-lock.json
+            backend/dalle_server/package-lock.json
+            pnpm-lock.yaml
+      - run: echo "cache-hit: ${{ steps.setup-node.outputs.cache-hit }}"
       - run: npm install --no-audit --no-fund
       - run: npm run load -- -o artillery-report.json
       - name: Upload Artillery report

--- a/.github/workflows/openapi-lint.yml
+++ b/.github/workflows/openapi-lint.yml
@@ -23,8 +23,17 @@ jobs:
           while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
+        id: setup-node
         with:
           node-version: 20
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            frontend/package-lock.json
+            backend/package-lock.json
+            backend/dalle_server/package-lock.json
+            pnpm-lock.yaml
+      - run: echo "cache-hit: ${{ steps.setup-node.outputs.cache-hit }}"
       - run: npm install --no-audit --no-fund
       - run: npm run lint:md
       - run: npx @ibm/openapi-validator docs/openapi.yaml

--- a/.github/workflows/pipeline-deadlock-check.yml
+++ b/.github/workflows/pipeline-deadlock-check.yml
@@ -22,8 +22,17 @@ jobs:
           while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
+        id: setup-node
         with:
           node-version: 20
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            frontend/package-lock.json
+            backend/package-lock.json
+            backend/dalle_server/package-lock.json
+            pnpm-lock.yaml
+      - run: echo "cache-hit: ${{ steps.setup-node.outputs.cache-hit }}"
       - name: Install yaml
         run: |
           for attempt in 1 2; do

--- a/.github/workflows/pipeline-smoke.yml
+++ b/.github/workflows/pipeline-smoke.yml
@@ -47,8 +47,17 @@ jobs:
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
+        id: setup-node
         with:
           node-version: 20
+          cache: pnpm
+          cache-dependency-path: |
+            package-lock.json
+            frontend/package-lock.json
+            backend/package-lock.json
+            backend/dalle_server/package-lock.json
+            pnpm-lock.yaml
+      - run: echo "cache-hit: ${{ steps.setup-node.outputs.cache-hit }}"
 
       - name: Setup pnpm
         run: |

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -21,9 +21,17 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
+        id: setup-node
         with:
           node-version: 20
           cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            frontend/package-lock.json
+            backend/package-lock.json
+            backend/dalle_server/package-lock.json
+            pnpm-lock.yaml
+      - run: echo "cache-hit: ${{ steps.setup-node.outputs.cache-hit }}"
       - run: npm ci
       - run: npm ci --prefix backend
       - run: npm run format
@@ -35,8 +43,16 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
+        id: setup-node
         with:
           node-version: 20
           cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            frontend/package-lock.json
+            backend/package-lock.json
+            backend/dalle_server/package-lock.json
+            pnpm-lock.yaml
+      - run: echo "cache-hit: ${{ steps.setup-node.outputs.cache-hit }}"
       - run: mkdir -p frontend/dist
       - run: npx -y wrangler pages project validate frontend/dist --config wrangler.toml

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -24,9 +24,17 @@ jobs:
           while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
+        id: setup-node
         with:
           node-version: 20
-          cache: "npm"
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            frontend/package-lock.json
+            backend/package-lock.json
+            backend/dalle_server/package-lock.json
+            pnpm-lock.yaml
+      - run: echo "cache-hit: ${{ steps.setup-node.outputs.cache-hit }}"
       - run: npm install --no-audit --no-fund
       - run: npm install --no-audit --no-fund --prefix backend
       - run: |

--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -26,9 +26,17 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/frontend-build
       - uses: actions/setup-node@v4
+        id: setup-node
         with:
           node-version: 20
-          cache: "npm"
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            frontend/package-lock.json
+            backend/package-lock.json
+            backend/dalle_server/package-lock.json
+            pnpm-lock.yaml
+      - run: echo "cache-hit: ${{ steps.setup-node.outputs.cache-hit }}"
       - run: npm run setup
       - name: Start backend
         run: |

--- a/.github/workflows/verify-lockfile.yml
+++ b/.github/workflows/verify-lockfile.yml
@@ -24,22 +24,19 @@ jobs:
       # Checkout the repository's code
       - uses: actions/checkout@v5
 
-      # Cache npm dependencies for faster installs
-      - name: Cache npm
-        id: cache-npm
-        uses: actions/cache@v4
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-npm-
-      - run: echo "Cache key: ${{ steps.cache-npm.outputs.cache-primary-key }}"
-
       # Setup Node.js 20.x (>=16 required)
       - uses: actions/setup-node@v4
+        id: setup-node
         with:
           node-version: 20
-
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            frontend/package-lock.json
+            backend/package-lock.json
+            backend/dalle_server/package-lock.json
+            pnpm-lock.yaml
+      - run: echo "cache-hit: ${{ steps.setup-node.outputs.cache-hit }}"
       - name: Setup pnpm
         run: |
           corepack enable


### PR DESCRIPTION
## Summary
- use setup-node caching across workflows with deterministic cache keys

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script: "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a71c064f04832db5bb4eb400db5b43