### PR TITLE
ci: tighten workflow path filters

### DIFF
--- a/.github/workflows/backend-only-ci.yml
+++ b/.github/workflows/backend-only-ci.yml
@@ -7,8 +7,28 @@ env:
 on:
   push:
     branches: [main]
+    paths:
+      - 'backend/**'
+      # shared files that affect both backend and frontend
+      - '.github/**'
+      - 'scripts/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'pnpm-lock.yaml'
+    paths-ignore:
+      - 'frontend/**'
   pull_request:
     branches: [main]
+    paths:
+      - 'backend/**'
+      # shared files that affect both backend and frontend
+      - '.github/**'
+      - 'scripts/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'pnpm-lock.yaml'
+    paths-ignore:
+      - 'frontend/**'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -7,7 +7,15 @@ env:
 on:
   pull_request:
     paths:
-      - "frontend/**"
+      - 'frontend/**'
+      # shared files that affect both backend and frontend
+      - '.github/**'
+      - 'scripts/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'pnpm-lock.yaml'
+    paths-ignore:
+      - 'backend/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/frontend-dry-build.yml
+++ b/.github/workflows/frontend-dry-build.yml
@@ -6,6 +6,16 @@ env:
 
 on:
   pull_request:
+    paths:
+      - 'frontend/**'
+      # shared files that affect both backend and frontend
+      - '.github/**'
+      - 'scripts/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'pnpm-lock.yaml'
+    paths-ignore:
+      - 'backend/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/smoke-backend.yml
+++ b/.github/workflows/smoke-backend.yml
@@ -6,7 +6,27 @@ env:
 
 on:
   push:
+    paths:
+      - 'backend/**'
+      # shared files that affect both backend and frontend
+      - '.github/**'
+      - 'scripts/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'pnpm-lock.yaml'
+    paths-ignore:
+      - 'frontend/**'
   merge_group:
+    paths:
+      - 'backend/**'
+      # shared files that affect both backend and frontend
+      - '.github/**'
+      - 'scripts/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'pnpm-lock.yaml'
+    paths-ignore:
+      - 'frontend/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
- restrict backend-only workflows to backend paths and explicit shared files
- run frontend workflows only for frontend paths plus shared files
- document shared file list for clearer workflow triggers

## Testing
- `npm run format --prefix backend`
- `SKIP_PW_DEPS=1 npm test --prefix backend` *(exits after running setup; tests did not execute)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: npm could not find husky bin)*
- `npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a71bf152cc832db62ee23ad4b81d08