### PR TITLE
ci: add concurrency to push and PR workflows

### DIFF
--- a/.github/workflows/env-parity.yml
+++ b/.github/workflows/env-parity.yml
@@ -7,6 +7,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   env-parity:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add concurrency controls to lint and environment parity workflows to cancel previous runs

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend` *(incomplete - terminated after long runtime)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: npm run lint --prefix frontend not found)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a71be783ec832dbd15677e928f5b8e