### PR TITLE
ci: add self-hosted fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,9 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on:
+      - self-hosted
+      - ubuntu-latest
     defaults:
       run:
         working-directory: frontend
@@ -37,8 +39,8 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: ~/.npm
-          key: npm-${{ runner.os }}-fe-${{ hashFiles('frontend/package-lock.json') }}
-          restore-keys: npm-${{ runner.os }}-fe-
+          key: npm-fe-${{ hashFiles('frontend/package-lock.json') }}
+          restore-keys: npm-fe-
       - run: npm ci && npm run lint && npm run build
       - run: test -d dist
       - if: failure()
@@ -48,7 +50,9 @@ jobs:
           path: ${{ runner.temp }}/_github_workflow/*.log
 
   test-backend:
-    runs-on: ubuntu-latest
+    runs-on:
+      - self-hosted
+      - ubuntu-latest
     strategy:
       fail-fast: true
       matrix:
@@ -91,7 +95,9 @@ jobs:
           path: ${{ runner.temp }}/_github_workflow/*.log
 
   test-frontend:
-    runs-on: ubuntu-latest
+    runs-on:
+      - self-hosted
+      - ubuntu-latest
     strategy:
       fail-fast: true
       matrix:
@@ -119,8 +125,8 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: ~/.npm
-          key: npm-${{ runner.os }}-fe-${{ hashFiles('frontend/package-lock.json') }}
-          restore-keys: npm-${{ runner.os }}-fe-
+          key: npm-fe-${{ hashFiles('frontend/package-lock.json') }}
+          restore-keys: npm-fe-
       - run: npm ci --prefix frontend
       - name: Run frontend tests
         run: node scripts/run-jest.js --testPathPattern "${{ matrix.pattern }}" --ci --coverage --coverageDirectory=coverage/frontend
@@ -141,7 +147,9 @@ jobs:
 
   test-integration:
     if: github.event_name == 'push'
-    runs-on: ubuntu-latest
+    runs-on:
+      - self-hosted
+      - ubuntu-latest
     steps:
       - name: Heartbeat
         run: |
@@ -172,7 +180,9 @@ jobs:
 
   coverage-merge:
     if: github.event_name == 'push'
-    runs-on: ubuntu-latest
+    runs-on:
+      - self-hosted
+      - ubuntu-latest
     needs:
       - test-backend
       - test-frontend


### PR DESCRIPTION
## Summary
- attempt to run CI jobs on self-hosted runner with ubuntu-latest fallback
- use OS-agnostic npm cache key for frontend installs

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script: "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*


------
https://chatgpt.com/codex/tasks/task_e_68a71be01648832d9da4f0744f4806da