### PR TITLE
ci: add nightly warm cache job

### DIFF
--- a/.github/workflows/warm-cache.yml
+++ b/.github/workflows/warm-cache.yml
@@ -1,0 +1,55 @@
+name: Warm NPM cache
+
+env:
+  HUSKY: 0
+
+on:
+  schedule:
+    - cron: '0 1 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  root-cache:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - run: npm ci
+
+  backend-cache:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+      - run: npm ci --prefix backend
+
+  frontend-cache:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - run: npm ci --prefix frontend


### PR DESCRIPTION
## Summary
- add nightly warm cache workflow to pre-populate npm caches for root, backend, and frontend

## Testing
- `npm run validate-env`
- `npm --prefix backend test` *(fails: apt-utils package is missing. Set SKIP_PW_DEPS=1 to skip Playwright dependencies.)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: dependencies missing)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a71c01699c832db64e0c6787fb5bdd