### PR TITLE
ci: add priority gate workflow

### DIFF
--- a/.github/workflows/priority.yml
+++ b/.github/workflows/priority.yml
@@ -1,0 +1,64 @@
+name: Priority
+
+env:
+  HUSKY: 0
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint-fast:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            backend/package-lock.json
+            frontend/package-lock.json
+      - run: npm ci
+      - run: npm ci --prefix backend
+      - run: npm ci --prefix frontend || true
+      - run: npm run lint:fast
+
+  smoke-api:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            backend/package-lock.json
+      - run: npm ci
+      - run: npm ci --prefix backend
+      - run: npm run smoke:api
+
+  gate:
+    name: Gate
+    runs-on: ubuntu-latest
+    needs: [lint-fast, smoke-api]
+    if: ${{ always() }}
+    steps:
+      - name: Evaluate gate
+        run: |
+          if [ "${{ needs.lint-fast.result }}" != "success" ] || [ "${{ needs.smoke-api.result }}" != "success" ]; then
+            echo "Required checks failed"
+            exit 1
+          fi
+          echo "All required checks passed"


### PR DESCRIPTION
## Summary
- add a priority workflow running lint:fast and smoke:api with a composite Gate status

## Testing
- `npm run validate-env`
- `curl -I https://registry.npmjs.org`
- `curl -I https://cdn.playwright.dev`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: process hung after tests; terminated)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script: "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*


------
https://chatgpt.com/codex/tasks/task_e_68a71be44acc832db7bc2d44e6571e5a