### PR TITLE
fix: prevent backend postinstall cross-builds

### DIFF
--- a/backend/scripts/ensure-deps.js
+++ b/backend/scripts/ensure-deps.js
@@ -139,7 +139,7 @@ if (!fs.existsSync(expressPath)) {
   if (!canReachRegistry()) process.exit(1);
   console.log("Express not found. Installing root dependencies...");
   try {
-    runNpmCi(repoRoot);
+    runNpmCi(repoRoot, { ignoreScripts: true });
   } catch (err) {
     console.error("Failed to install root dependencies:", err.message);
     process.exit(1);
@@ -151,7 +151,7 @@ if (!fs.existsSync(pwPath)) {
   if (!canReachRegistry()) process.exit(1);
   console.log("@playwright/test not found. Installing root dependencies...");
   try {
-    runNpmCi(repoRoot);
+    runNpmCi(repoRoot, { ignoreScripts: true });
   } catch (err) {
     console.error("Failed to install root dependencies:", err.message);
     process.exit(1);
@@ -171,7 +171,7 @@ if (!fs.existsSync(jestPath)) {
     process.exit(1);
   }
   try {
-    runNpmCi();
+    runNpmCi(".", { ignoreScripts: true });
   } catch (err) {
     console.warn(
       "npm ci failed, retrying after cleaning node_modules:",
@@ -183,7 +183,7 @@ if (!fs.existsSync(jestPath)) {
       // ignore errors removing node_modules
     }
     try {
-      execSync("npm ci", { stdio: "inherit" });
+      execSync("npm ci --ignore-scripts", { stdio: "inherit" });
     } catch (err2) {
       console.error("Failed to install dependencies:", err2.message);
       process.exit(1);

--- a/scripts/assert-setup.js
+++ b/scripts/assert-setup.js
@@ -107,7 +107,7 @@ function rootDepsInstalled() {
 if (!rootDepsInstalled()) {
   console.log("Root dependencies missing. Installing...");
   try {
-    runNpmCi();
+    runNpmCi(".", { ignoreScripts: true });
   } catch (err) {
     const msg = String(err.message || err);
     if (msg.includes("EUSAGE")) {
@@ -205,7 +205,7 @@ function pluginInstalled() {
 if (!jestInstalled() || !pluginInstalled()) {
   console.log("Dependencies missing. Installing root dependencies...");
   try {
-    runNpmCi();
+    runNpmCi(".", { ignoreScripts: true });
   } catch (err) {
     console.error("Failed to install dependencies:", err.message);
     process.exit(1);

--- a/scripts/ensure-root-deps.js
+++ b/scripts/ensure-root-deps.js
@@ -139,14 +139,17 @@ if (!requiredPaths.every((p) => fs.existsSync(p))) {
   }
   const install = () => {
     try {
-      const r = spawnSync("npm", ["ci"], { stdio: "inherit", env: getEnv() });
+      const r = spawnSync("npm", ["ci", "--ignore-scripts"], {
+        stdio: "inherit",
+        env: getEnv(),
+      });
       if (r.status === 0) return true;
       throw new Error("npm ci failed");
     } catch (err) {
       const msg = String(err.message || err);
       if (msg.includes("EUSAGE")) {
         console.warn("npm ci failed, falling back to 'npm install'");
-        const res = spawnSync("npm", ["install"], {
+        const res = spawnSync("npm", ["install", "--ignore-scripts"], {
           stdio: "inherit",
           env: getEnv(),
         });

--- a/scripts/run-npm-ci.js
+++ b/scripts/run-npm-ci.js
@@ -29,17 +29,20 @@ function cleanupNpmCache() {
   }
 }
 
-function runNpmCi(dir = ".") {
+function runNpmCi(dir = ".", opts = {}) {
   const options = { stdio: "inherit" };
   if (dir !== ".") options.cwd = dir;
+  const ignoreScripts = opts.ignoreScripts || process.env.NPM_IGNORE_SCRIPTS;
+  const ciCmd = `npm ci --no-audit --no-fund${ignoreScripts ? " --ignore-scripts" : ""}`;
   try {
-    execSync("npm ci --no-audit --no-fund", options);
+    execSync(ciCmd, options);
   } catch (err) {
     const output = String(err.stderr || err.stdout || err.message || "");
     if (output.includes("EUSAGE")) {
       console.warn(`npm ci failed in ${dir}, falling back to 'npm install'`);
-      execSync("npm install --no-audit --no-fund", options);
-      execSync("npm ci --no-audit --no-fund", options);
+      const installCmd = `npm install --no-audit --no-fund${ignoreScripts ? " --ignore-scripts" : ""}`;
+      execSync(installCmd, options);
+      execSync(ciCmd, options);
     } else if (
       /TAR_ENTRY_ERROR|ENOENT|ENOTEMPTY|tarball .*corrupted/.test(output)
     ) {
@@ -51,7 +54,7 @@ function runNpmCi(dir = ".") {
         recursive: true,
         force: true,
       });
-      execSync("npm ci --no-audit --no-fund", options);
+      execSync(ciCmd, options);
     } else {
       throw err;
     }

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -136,13 +136,13 @@ run_ci() {
   local attempt=1
   local max_attempts=3
   while [ $attempt -le $max_attempts ]; do
-    if npm ci $extra --no-audit --no-fund 2>ci.log; then
+    if npm ci $extra --no-audit --no-fund --ignore-scripts 2>ci.log; then
       rm -f ci.log
       return 0
     fi
     if grep -q "EUSAGE" ci.log; then
       echo "npm ci failed in $dir due to lock mismatch. Running npm install..." >&2
-      npm install $extra --no-audit --no-fund
+      npm install $extra --no-audit --no-fund --ignore-scripts
     elif grep -E -q "TAR_ENTRY_ERROR|ENOENT|ENOTEMPTY|tarball .*corrupted" ci.log; then
       echo "npm ci encountered tar or filesystem errors in $dir. Cleaning cache and retrying ($attempt/$max_attempts)..." >&2
       cleanup_npm_cache
@@ -154,7 +154,7 @@ run_ci() {
     fi
     attempt=$((attempt + 1))
   done
-  npm ci $extra --no-audit --no-fund
+  npm ci $extra --no-audit --no-fund --ignore-scripts
   rm -f ci.log
 }
 


### PR DESCRIPTION
## Summary
- guard dependency installers with `--ignore-scripts` so backend installs don't run root/frontend builds
- ensure setup and helper scripts use the new option to avoid cross-package side effects

## Testing
- `npm run format`
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script: "lint")*
- `npm run build --prefix frontend`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68a71c0fe6f0832d9bbace7f3685f273