### PR TITLE
ci: run heavy jobs on self-hosted runners

### DIFF
--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -15,14 +15,13 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     defaults:
       run:
         working-directory: frontend
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest]
         node: [20, 22]
     steps:
       - name: Heartbeat

--- a/.github/workflows/ci-rerun-slow.yml
+++ b/.github/workflows/ci-rerun-slow.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     outputs:
       duration: ${{ steps.duration.outputs.value }}
     steps:
@@ -41,7 +41,7 @@ jobs:
         run: echo "value=$(( ${{ steps.end.outputs.end }} - ${{ steps.start.outputs.start }} ))" >> "$GITHUB_OUTPUT"
 
   e2e:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     env:
       PORT: 3000
       DB_URL: postgres://user:pass@localhost:5432/testdb

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/frontend-dry-build.yml
+++ b/.github/workflows/frontend-dry-build.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   dry-build:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/frontend-local-build.yml
+++ b/.github/workflows/frontend-local-build.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/glb-ci-alerts-938dhf.yml
+++ b/.github/workflows/glb-ci-alerts-938dhf.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   notify:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     env:
       PORT: 3000
       DB_URL: postgres://user:pass@localhost:5432/testdb

--- a/.github/workflows/glb-tests.yml
+++ b/.github/workflows/glb-tests.yml
@@ -49,7 +49,7 @@ jobs:
 
   e2e-tests:
     needs: unit-tests
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     env:
       PORT: 3000
       DB_URL: postgres://user:pass@localhost:5432/testdb

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     env:
       PORT: 3000
       CI_REQUIRE_EXTERNAL: '0'

--- a/.github/workflows/pipeline-smoke.yml
+++ b/.github/workflows/pipeline-smoke.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   smoke_test:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     env:
       STRIPE_TEST_KEY: ${{ secrets.STRIPE_TEST_KEY }}
       DB_URL: ${{ secrets.DB_URL }}

--- a/.github/workflows/playwright-browsers-cache.yml
+++ b/.github/workflows/playwright-browsers-cache.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   cache-browsers:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     env:
       PORT: 3000
     steps:

--- a/.github/workflows/smoke-backend.yml
+++ b/.github/workflows/smoke-backend.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   backend-smoke:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 5
     steps:
       - name: Heartbeat

--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   smoke:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     env:
       PORT: 3000
       DB_URL: postgres://user:pass@localhost:5432/testdb


### PR DESCRIPTION
## Summary
- use self-hosted linux x64 runners for frontend builds
- move backend smoke tests to self-hosted runner
- run coverage and Playwright-based workflows on self-hosted runners

## Testing
- `npm run format` (backend)
- `npm test` *(fails: eslint log missing)*
- `npm run ci` *(fails: Missing script: "lint")*
- `npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a719f4975c832da1a949d65813b647