### PR TITLE
ci: guard frontend directory in workflows

### DIFF
--- a/.github/workflows/cf-pages-preview.yml
+++ b/.github/workflows/cf-pages-preview.yml
@@ -20,6 +20,8 @@ jobs:
         run: |
           while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
+      - name: Ensure frontend directory
+        run: test -d frontend
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -27,7 +29,13 @@ jobs:
           cache-dependency-path: |
             package-lock.json
             frontend/package-lock.json
-      - run: npm ci && npm run build --prefix frontend
+      - run: npm ci
+      - name: Install frontend dependencies
+        run: npm ci
+        working-directory: frontend
+      - name: Build frontend
+        run: npm run build
+        working-directory: frontend
       - name: Start preview
         id: preview
         env:

--- a/.github/workflows/ci-env.yml
+++ b/.github/workflows/ci-env.yml
@@ -18,21 +18,26 @@ jobs:
         run: |
           while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
+      - name: Ensure frontend directory
+        run: test -d frontend
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm
           cache-dependency-path: package-lock.json
       - run: npm ci
-      - run: npm ci --prefix frontend
+      - name: Install frontend dependencies
+        run: npm ci
+        working-directory: frontend
       - name: Record tool versions
+        working-directory: frontend
         run: |
-          echo "node: $(node -v)" >> versions.txt
-          echo "npm: $(npm -v)" >> versions.txt
-          echo "tsc: $(npx tsc -v)" >> versions.txt
-          echo "vite: $(npx --prefix frontend vite --version)" >> versions.txt
-          echo "eslint: $(npx eslint --version)" >> versions.txt
-          cat versions.txt
+          echo "node: $(node -v)" >> ../versions.txt
+          echo "npm: $(npm -v)" >> ../versions.txt
+          echo "tsc: $(npx tsc -v)" >> ../versions.txt
+          echo "vite: $(npx vite --version)" >> ../versions.txt
+          echo "eslint: $(npx eslint --version)" >> ../versions.txt
+          cat ../versions.txt
       - uses: actions/upload-artifact@v4.3.4
         with:
           name: tool-versions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,8 @@ jobs:
         run: |
           while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
+      - name: Ensure frontend directory
+        run: test -d frontend
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -121,9 +123,12 @@ jobs:
           path: ~/.npm
           key: npm-${{ runner.os }}-fe-${{ hashFiles('frontend/package-lock.json') }}
           restore-keys: npm-${{ runner.os }}-fe-
-      - run: npm ci --prefix frontend
+      - name: Install frontend dependencies
+        run: npm ci
+        working-directory: frontend
       - name: Run frontend tests
-        run: node scripts/run-jest.js --testPathPattern "${{ matrix.pattern }}" --ci --coverage --coverageDirectory=coverage/frontend
+        working-directory: frontend
+        run: node ../scripts/run-jest.js --testPathPattern "${{ matrix.pattern }}" --ci --coverage --coverageDirectory=coverage/frontend
       - uses: actions/upload-artifact@v4.3.4
         with:
           name: junit-frontend-${{ matrix.shard }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,6 +18,8 @@ jobs:
         run: |
           while true; do date; sleep 120; done &
       - uses: actions/checkout@v4
+      - name: Ensure frontend directory
+        run: test -d frontend
       - uses: ./.github/actions/frontend-build
       - name: Load Stripe env
         run: node scripts/ci-env-preflight.js

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,8 @@ jobs:
           while true; do date; sleep 120; done &
       - name: Checkout code
         uses: actions/checkout@v5
+      - name: Ensure frontend directory
+        run: test -d frontend
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+      - name: Ensure frontend directory
+        run: test -d frontend
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -20,8 +22,12 @@ jobs:
             backend/package-lock.json
             frontend/package-lock.json
       - run: npm ci
-      - run: npm ci --prefix frontend
+      - name: Install frontend dependencies
+        run: npm ci
+        working-directory: frontend
       - run: npm ci --prefix backend
       - run: npm run lint:root
-      - run: npm run lint --prefix frontend
+      - name: Lint frontend
+        run: npm run lint
+        working-directory: frontend
       - run: npm run lint --prefix backend

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+      - name: Ensure frontend directory
+        run: test -d frontend
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -20,6 +22,8 @@ jobs:
             backend/package-lock.json
             frontend/package-lock.json
       - run: npm ci
-      - run: npm ci --prefix frontend
+      - name: Install frontend dependencies
+        run: npm ci
+        working-directory: frontend
       - run: npm ci --prefix backend
       - run: npx tsc --noEmit

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -37,7 +37,7 @@ module.exports = [
       "scripts/check-gh-workflow-sync-23859.ts",
       "upload/**",
       // "src/**", // removed to enable frontend linting
-  ],
+    ],
   },
   {
     files: ["**/*.{ts,tsx}"],

--- a/scripts/check-lint-regression.js
+++ b/scripts/check-lint-regression.js
@@ -22,7 +22,10 @@ const backendOutput = execSync(
   "npx eslint . --no-warn-ignored --ignore-pattern lib -f json || true",
   { cwd: path.join(repoRoot, "backend"), encoding: "utf8" },
 );
-const results = [...JSON.parse(rootOutput || "[]"), ...JSON.parse(backendOutput || "[]")];
+const results = [
+  ...JSON.parse(rootOutput || "[]"),
+  ...JSON.parse(backendOutput || "[]"),
+];
 const counts = results.reduce(
   (acc, r) => {
     acc.errorCount += r.errorCount || 0;

--- a/tests/eslintCiRules.test.js
+++ b/tests/eslintCiRules.test.js
@@ -16,10 +16,7 @@ function runEslint(file) {
 describe("CI eslint regression checks", () => {
   test("flags missing jsdoc and console usage", () => {
     const tmp = path.join(repoRoot, "tmp-ci-lint.js");
-    fs.writeFileSync(
-      tmp,
-      "function demo(x){console.log(x);return x;}\n",
-    );
+    fs.writeFileSync(tmp, "function demo(x){console.log(x);return x;}\n");
     const res = runEslint(tmp);
     fs.unlinkSync(tmp);
     expect(res.status).not.toBe(0);

--- a/tests/linting.test.js
+++ b/tests/linting.test.js
@@ -36,7 +36,9 @@ test("repository passes ESLint with no warnings", () => {
       if (result.stdout) {
         try {
           const json = JSON.parse(result.stdout);
-          console.error("ESLint JSON output:\n" + JSON.stringify(json, null, 2));
+          console.error(
+            "ESLint JSON output:\n" + JSON.stringify(json, null, 2),
+          );
         } catch {
           console.error(result.stdout);
         }


### PR DESCRIPTION
## Summary
- ensure each workflow checks for the frontend directory
- run frontend-related commands from the `frontend` subdirectory

## Testing
- `npm run format`
- `npm test`
- `npm run ci` *(fails: Missing script: "lint")*
- `npm run smoke` *(fails: Missing frontend build artifact)*


------
https://chatgpt.com/codex/tasks/task_e_68a71c0be4b0832db7afe1df689659f5