### PR TITLE
ci: use self-hosted runners for heavy jobs

### DIFF
--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -15,14 +15,13 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     defaults:
       run:
         working-directory: frontend
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest]
         node: [20, 22]
     steps:
       - name: Heartbeat

--- a/.github/workflows/ci-rerun-slow.yml
+++ b/.github/workflows/ci-rerun-slow.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     outputs:
       duration: ${{ steps.duration.outputs.value }}
     steps:
@@ -41,7 +41,7 @@ jobs:
         run: echo "value=$(( ${{ steps.end.outputs.end }} - ${{ steps.start.outputs.start }} ))" >> "$GITHUB_OUTPUT"
 
   e2e:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     env:
       PORT: 3000
       DB_URL: postgres://user:pass@localhost:5432/testdb

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/frontend-dry-build.yml
+++ b/.github/workflows/frontend-dry-build.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   dry-build:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/frontend-local-build.yml
+++ b/.github/workflows/frontend-local-build.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/glb-ci-alerts-938dhf.yml
+++ b/.github/workflows/glb-ci-alerts-938dhf.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   notify:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     env:
       PORT: 3000
       DB_URL: postgres://user:pass@localhost:5432/testdb

--- a/.github/workflows/glb-tests.yml
+++ b/.github/workflows/glb-tests.yml
@@ -25,8 +25,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  unit-tests:
-    runs-on: ubuntu-latest
+    unit-tests:
+      runs-on: ubuntu-latest
     steps:
       - name: Heartbeat
         run: |
@@ -47,9 +47,9 @@ jobs:
       - name: Run unit tests
         run: npm run test:unit --prefix backend
 
-  e2e-tests:
-    needs: unit-tests
-    runs-on: ubuntu-latest
+    e2e-tests:
+      needs: unit-tests
+      runs-on: [self-hosted, linux, x64]
     env:
       PORT: 3000
       DB_URL: postgres://user:pass@localhost:5432/testdb

--- a/.github/workflows/playwright-browsers-cache.yml
+++ b/.github/workflows/playwright-browsers-cache.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   cache-browsers:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/smoke-backend.yml
+++ b/.github/workflows/smoke-backend.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   backend-smoke:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 5
     steps:
       - name: Heartbeat

--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   smoke:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     env:
       PORT: 3000
       DB_URL: postgres://user:pass@localhost:5432/testdb


### PR DESCRIPTION
## Summary
- run frontend build workflows on self-hosted runners
- move smoke, coverage, and Playwright jobs to self-hosted infrastructure

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: ESLint reports numerous errors, test-ci script mismatch)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: npm run lint missing script)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a719f4975c832da1a949d65813b647