### PR TITLE
ci: specify bash shell for frontend build action

### DIFF
--- a/.github/actions/frontend-build/action.yml
+++ b/.github/actions/frontend-build/action.yml
@@ -8,9 +8,11 @@ runs:
         cache: npm
         cache-dependency-path: frontend/package-lock.json
     - name: Install deps
+      shell: bash
       run: npm ci
       working-directory: frontend
     - name: Build
+      shell: bash
       run: npm run build
       working-directory: frontend
     - uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- add explicit bash shell to composite frontend build action

## Testing
- `npm run format` (passed)
- `npm test` *(fails: Setup flag missing then hangs)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: dependencies missing)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html)*
- `act -W /tmp/test-workflow.yml -j build` *(fails: Couldn't get a valid docker connection)*

------
https://chatgpt.com/codex/tasks/task_e_68a737f217ec832da03f0f6b629c2d31