### PR TITLE
ci: specify shell for frontend build action

### DIFF
--- a/.github/actions/frontend-build/action.yml
+++ b/.github/actions/frontend-build/action.yml
@@ -8,9 +8,11 @@ runs:
         cache: npm
         cache-dependency-path: frontend/package-lock.json
     - name: Install deps
+      shell: bash
       run: npm ci
       working-directory: frontend
     - name: Build
+      shell: bash
       run: npm run build
       working-directory: frontend
     - uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- declare bash shell for run steps in frontend-build composite action

## Testing
- `npm run format`
- `npm test` *(fails: root eslint exits 0, root has few warnings, root has no errors, root and backend exit codes match, eslint detailed results, health, test-ci script)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script: "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html)*

------
https://chatgpt.com/codex/tasks/task_e_68a737f31a8c832d9f7384cc36601d14