### PR TITLE
ci: replace pnpm with npm in workflows

### DIFF
--- a/.github/workflows/pipeline-smoke.yml
+++ b/.github/workflows/pipeline-smoke.yml
@@ -3,7 +3,6 @@ name: Full Pipeline Smoke Test
 env:
   HUSKY: 0
 
-
 on:
   push:
     branches:
@@ -49,39 +48,36 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-
-      - name: Setup pnpm
-        run: |
-          corepack enable
-          pnpm set version 9.15.9
-
       - name: Install dependencies
-        run: pnpm install
+        run: |
+          npm ci
+          npm ci --prefix frontend
+          npm run build --prefix frontend
 
       - name: Ensure frontend build output exists
         run: test -f frontend/dist/index.html
 
       - name: Run smoke tests
-        run: pnpm run smoke
+        run: npm run smoke
 
       - name: Start backend
-        run: pnpm dev &
+        run: npm run dev &
         shell: bash
 
       - name: Wait for backend
         run: npx wait-on http://localhost:3000 --timeout 300000
 
       - name: Test generate endpoint
-        run: pnpm run test:generate
+        run: npm run test:generate
       - name: Test Stripe webhook
         if: env.CI_REQUIRE_EXTERNAL == '1'
-        run: pnpm run test:webhook
+        run: npm run test:webhook
 
       - name: Stop backend
         run: pkill -f "node backend/server.js" || true
 
       - name: Run diagnostics
-        run: pnpm diagnose
+        run: npm run diagnose
 
       - name: Collect logs
         if: always()

--- a/.github/workflows/verify-lockfile.yml
+++ b/.github/workflows/verify-lockfile.yml
@@ -40,11 +40,6 @@ jobs:
         with:
           node-version: 20
 
-      - name: Setup pnpm
-        run: |
-          corepack enable
-          pnpm set version 9.15.9
-
       # Install dependencies without auditing and without funding messages
       - run: npm install --no-audit --no-fund
 
@@ -57,16 +52,5 @@ jobs:
           if ! git diff --quiet package-lock.json; then
             echo "::error::package-lock.json is out of sync. Please run 'npm install' and commit the updated lock file." >&2
             git diff package-lock.json >&2
-            exit 1
-          fi
-
-      - name: Regenerate pnpm lockfile
-        run: pnpm install --lockfile-only --ignore-workspace-root-check
-
-      - name: Ensure pnpm lockfile is up to date
-        run: |
-          if ! git diff --quiet pnpm-lock.yaml; then
-            echo "::error::pnpm-lock.yaml is out of sync. Please run 'pnpm install' and commit the updated lock file." >&2
-            git diff pnpm-lock.yaml >&2
             exit 1
           fi


### PR DESCRIPTION
## Summary
- replace pnpm commands in pipeline-smoke workflow with npm equivalents
- remove pnpm lockfile regeneration from verify-lockfile workflow

## Testing
- `npm ci`
- `npm run format` *(fails: Playwright setup needed)*
- `npm test` *(fails: dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a7380b26b4832d9bffe05c24308afb