### PR TITLE
ci: add concurrency and paths to workflows

### DIFF
--- a/.github/workflows/_setup.yml
+++ b/.github/workflows/_setup.yml
@@ -8,6 +8,10 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   run:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,26 @@ name: CI
 on:
   push:
     branches: [main]
+    paths:
+      - frontend/**
+      - backend/**
+      - package.json
+      - package-lock.json
+      - frontend/package-lock.json
+      - backend/package-lock.json
+      - pnpm-lock.yaml
+      - .github/workflows/**
   pull_request:
     branches: [main]
+    paths:
+      - frontend/**
+      - backend/**
+      - package.json
+      - package-lock.json
+      - frontend/package-lock.json
+      - backend/package-lock.json
+      - pnpm-lock.yaml
+      - .github/workflows/**
   workflow_dispatch:
 
 concurrency:
@@ -55,6 +73,7 @@ jobs:
       - ubuntu-latest
     strategy:
       fail-fast: true
+      max-parallel: 2
       matrix:
         shard: [aa, ab, ac]
     steps:
@@ -100,6 +119,7 @@ jobs:
       - ubuntu-latest
     strategy:
       fail-fast: true
+      max-parallel: 2
       matrix:
         include:
           - shard: core

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,8 +3,22 @@ name: Lint
 on:
   push:
     branches: [main]
+    paths:
+      - frontend/**
+      - backend/**
+      - package.json
+      - package-lock.json
+      - pnpm-lock.yaml
+      - .github/workflows/**
   pull_request:
     branches: [main]
+    paths:
+      - frontend/**
+      - backend/**
+      - package.json
+      - package-lock.json
+      - pnpm-lock.yaml
+      - .github/workflows/**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -7,8 +7,22 @@ env:
 on:
   push:
     branches: [main]
+    paths:
+      - frontend/**
+      - backend/**
+      - package.json
+      - package-lock.json
+      - pnpm-lock.yaml
+      - .github/workflows/**
   pull_request:
     branches: [main]
+    paths:
+      - frontend/**
+      - backend/**
+      - package.json
+      - package-lock.json
+      - pnpm-lock.yaml
+      - .github/workflows/**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -6,14 +6,28 @@ env:
 on:
   push:
     branches: [main]
+    paths:
+      - backend/**
+      - package.json
+      - package-lock.json
+      - .github/workflows/**
   pull_request:
     branches: [main]
+    paths:
+      - backend/**
+      - package.json
+      - package-lock.json
+      - .github/workflows/**
   merge_group:
   workflow_call:
     outputs:
       run_backend:
         description: Run backend jobs
         value: ${{ jobs.changed.outputs.backend }}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   changed:


### PR DESCRIPTION
## Summary
- add top-level concurrency block to reusable setup and preflight workflows
- limit CI, lint, and node workflows to relevant paths
- restrict CI matrix jobs to two concurrent shards

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a738185450832d812e305a6cb3df44