### PR TITLE
ci: cache frontend deps

### DIFF
--- a/.github/actions/frontend-build/action.yml
+++ b/.github/actions/frontend-build/action.yml
@@ -5,11 +5,15 @@ runs:
     - uses: actions/setup-node@v4
       with:
         node-version: '20'
-        cache: npm
-        cache-dependency-path: frontend/package-lock.json
+    - name: Cache frontend deps
+      uses: actions/cache@v4
+      with:
+        path: frontend/node_modules
+        key: fe-${{ runner.os }}-${{ hashFiles('frontend/package-lock.json') }}
+        restore-keys: |
+          fe-${{ runner.os }}-
     - name: Install deps
-      run: npm ci
-      working-directory: frontend
+      run: npm ci --prefix frontend
     - name: Build
       run: npm run build
       working-directory: frontend


### PR DESCRIPTION
## Summary
- cache frontend node_modules in composite frontend-build action

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` (in backend/)
- `npm test` (in backend/)
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a7382585c0832da43af46383ed8c64