### PR TITLE
fix: validate frontend build in wrangler

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,10 +4,10 @@ name = "mvp-website"
 pages_build_output_dir = "frontend/dist"
 
 [env.production.build]
-command = "npm ci --prefix frontend && npm run build --prefix frontend"
+command = "npm ci --prefix frontend && npm run build --prefix frontend && node scripts/assert-frontend-dist.js"
 
 [env.preview]
 pages_build_output_dir = "frontend/dist"
 
 [env.preview.build]
-command = "npm ci --prefix frontend && npm run build --prefix frontend"
+command = "npm ci --prefix frontend && npm run build --prefix frontend && node scripts/assert-frontend-dist.js"


### PR DESCRIPTION
## Summary
- ensure Cloudflare Pages builds verify frontend output and symlinks

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: expect(received).toBe(expected))*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script: "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(Playwright stack trace, exited 0)*

------
https://chatgpt.com/codex/tasks/task_e_68a7383a8d38832d8e1e85031b7b1599