### PR TITLE
fix: inline eslint ignores and guard browser globals

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,0 @@
-**/dist
-**/build
-coverage
-.cache
-frontend/dist
-

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -37,7 +37,12 @@ module.exports = [
       "scripts/check-gh-workflow-sync-23859.ts",
       "upload/**",
       // "src/**", // removed to enable frontend linting
-  ],
+      "**/dist",
+      "**/build",
+      "coverage",
+      ".cache",
+      "frontend/dist",
+    ],
   },
   {
     files: ["**/*.{ts,tsx}"],

--- a/eslint.frontend-87adf32bca1e546.cjs
+++ b/eslint.frontend-87adf32bca1e546.cjs
@@ -6,6 +6,7 @@ const tsParser = require('@typescript-eslint/parser');
 const htmlPlugin = require('@html-eslint/eslint-plugin');
 const htmlParser = require('@html-eslint/parser');
 const frontendRules = require('./scripts/eslint-frontend-rules');
+const globals = require('globals');
 
 module.exports = [
   {
@@ -20,6 +21,7 @@ module.exports = [
         project: ['./tsconfig.base.json'],
         tsconfigRootDir: __dirname,
       },
+      globals: { ...globals.browser },
     },
     plugins: {
       react,
@@ -39,7 +41,7 @@ module.exports = [
   },
   {
     files: ['*.html'],
-    languageOptions: { parser: htmlParser },
+    languageOptions: { parser: htmlParser, globals: { ...globals.browser } },
     plugins: {
       html: htmlPlugin,
       'no-inline-styles': noInlineStyles,

--- a/js/applyColorScheme.js
+++ b/js/applyColorScheme.js
@@ -1,7 +1,10 @@
-(function () {
-  try {
-    if (localStorage.getItem("colorScheme") === "light") {
-      document.documentElement.classList.add("light");
-    }
-  } catch {}
-})();
+/* eslint-env browser */
+if (typeof window !== "undefined") {
+  (function () {
+    try {
+      if (localStorage.getItem("colorScheme") === "light") {
+        document.documentElement.classList.add("light");
+      }
+    } catch {}
+  })();
+}

--- a/js/profileSaved.js
+++ b/js/profileSaved.js
@@ -1,37 +1,40 @@
+/* eslint-env browser */
 import { getSaved, removeSaved } from "./saveList.js";
 
-function render() {
-  const list = document.getElementById("saved-items-list");
-  if (!list) return;
-  list.innerHTML = "";
-  const items = getSaved();
-  if (!items.length) {
-    list.innerHTML =
-      '<p class="text-white text-center col-span-2">No saved items</p>';
-    return;
-  }
-  items.forEach((it) => {
-    const div = document.createElement("div");
-    div.className = "relative group";
-    const img = document.createElement("img");
-    img.src = it.snapshot || it.modelUrl || "";
-    img.alt = it.title || "Model";
-    img.className =
-      "w-24 h-24 object-cover rounded-lg bg-[#2A2A2E] border border-white/20";
-    const btn = document.createElement("button");
-    btn.type = "button";
-    btn.className =
-      "remove absolute bottom-1 right-1 text-xs px-2 py-1 bg-red-600 rounded opacity-80 group-hover:opacity-100";
-    btn.textContent = "Remove";
-    btn.addEventListener("click", (e) => {
-      e.stopPropagation();
-      removeSaved(it.id);
-      render();
+if (typeof window !== "undefined") {
+  function render() {
+    const list = document.getElementById("saved-items-list");
+    if (!list) return;
+    list.innerHTML = "";
+    const items = getSaved();
+    if (!items.length) {
+      list.innerHTML =
+        '<p class="text-white text-center col-span-2">No saved items</p>';
+      return;
+    }
+    items.forEach((it) => {
+      const div = document.createElement("div");
+      div.className = "relative group";
+      const img = document.createElement("img");
+      img.src = it.snapshot || it.modelUrl || "";
+      img.alt = it.title || "Model";
+      img.className =
+        "w-24 h-24 object-cover rounded-lg bg-[var(--color-surface)] border border-white/20";
+      const btn = document.createElement("button");
+      btn.type = "button";
+      btn.className =
+        "remove absolute bottom-1 right-1 text-xs px-2 py-1 bg-red-600 rounded opacity-80 group-hover:opacity-100";
+      btn.textContent = "Remove";
+      btn.addEventListener("click", (e) => {
+        e.stopPropagation();
+        removeSaved(it.id);
+        render();
+      });
+      div.appendChild(img);
+      div.appendChild(btn);
+      list.appendChild(div);
     });
-    div.appendChild(img);
-    div.appendChild(btn);
-    list.appendChild(div);
-  });
-}
+  }
 
-document.addEventListener("DOMContentLoaded", render);
+  document.addEventListener("DOMContentLoaded", render);
+}


### PR DESCRIPTION
## Summary
- inline `.eslintignore` patterns into `eslint.config.js`
- enable browser globals for frontend linting
- guard DOM access and swap hardcoded colors for CSS tokens

## Testing
- `npm run format`
- `npm test` *(fails: SIGINT during setup)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: ENOTEMPTY directory rmdir)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a738445630832dae14a796bfad464d