### PR TITLE
test: configure jsdom for frontend tests

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  testEnvironment: "jsdom",
+  setupFiles: ["<rootDir>/test/setupDom.ts"],
+};

--- a/frontend/test/setupDom.ts
+++ b/frontend/test/setupDom.ts
@@ -1,0 +1,13 @@
+import { TextEncoder, TextDecoder } from 'util';
+
+if (typeof globalThis.TextEncoder === 'undefined') {
+  // @ts-ignore
+  globalThis.TextEncoder = TextEncoder;
+}
+
+if (typeof globalThis.TextDecoder === 'undefined') {
+  // @ts-ignore
+  globalThis.TextDecoder = TextDecoder as any;
+}
+
+// add additional DOM polyfills here if required

--- a/js/ModelViewer.js
+++ b/js/ModelViewer.js
@@ -7,18 +7,22 @@ export default function ModelViewer({ url }) {
   const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
-    if (error) {
-      document.body.dataset.viewerReady = "error";
-    } else if (loaded) {
-      document.body.dataset.viewerReady = "true";
-    } else {
-      delete document.body.dataset.viewerReady;
+    if (typeof document !== "undefined") {
+      if (error) {
+        document.body.dataset.viewerReady = "error";
+      } else if (loaded) {
+        document.body.dataset.viewerReady = "true";
+      } else {
+        delete document.body.dataset.viewerReady;
+      }
     }
   }, [loaded, error]);
 
   useEffect(
     () => () => {
-      delete document.body.dataset.viewerReady;
+      if (typeof document !== "undefined") {
+        delete document.body.dataset.viewerReady;
+      }
     },
     [],
   );


### PR DESCRIPTION
## Summary
- add frontend jest config using jsdom and setup file
- polyfill minimal DOM APIs for frontend tests
- guard document usage in ModelViewer

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup` *(terminated: hung during dependency install)*
- `npm run format`
- `npm test` *(failed: setup script hung)*
- `SKIP_PW_DEPS=1 npm run ci` *(failed: ENOTEMPTY directory not empty)*
- `SKIP_PW_DEPS=1 npm run smoke` *(failed: Missing frontend build artifact)*


------
https://chatgpt.com/codex/tasks/task_e_68a7384fb2ec832d9d8378f8c0b29e3e