### PR TITLE
fix: clarify lint scripts

### DIFF
--- a/scripts/assert-frontend-dist.js
+++ b/scripts/assert-frontend-dist.js
@@ -12,9 +12,9 @@ if (!fs.existsSync(indexFile)) {
 
 /**
  * Recursively collect symlinks inside a directory.
- * @param {string} dir
- * @param {string[]} acc
- * @returns {string[]}
+ * @param {string} dir Directory to scan for symlinks.
+ * @param {string[]} acc Accumulator for discovered symlink paths.
+ * @returns {string[]} List of symlink paths found.
  */
 function collectSymlinks(dir, acc = []) {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {

--- a/scripts/ci/assert-dist.js
+++ b/scripts/ci/assert-dist.js
@@ -8,11 +8,15 @@ if (!fs.existsSync(distPath)) {
   try {
     const rev = execSync("git rev-parse --short HEAD").toString().trim();
     console.error(rev);
-  } catch {}
+  } catch {
+    // ignore errors fetching current revision
+  }
   try {
     const ls = execSync("ls -la frontend/dist").toString().trim();
     console.error(ls);
-  } catch {}
+  } catch {
+    // ignore errors listing frontend/dist
+  }
   process.exit(1);
 }
 console.log(`Found ${distPath}`);


### PR DESCRIPTION
## Summary
- document symlink helper parameters
- ignore errors in dist assertion script

## Testing
- `npm run format`
- `npm test -- --runTestsByPath tests/api.test.ts --coverage=false`
- `node scripts/check-lint-regression.js`


------
https://chatgpt.com/codex/tasks/task_e_68a73847a8b8832d912527ae18e37cfe