### PR TITLE
fix: define browser globals for frontend lint

### DIFF
--- a/eslint.frontend-87adf32bca1e546.cjs
+++ b/eslint.frontend-87adf32bca1e546.cjs
@@ -6,6 +6,7 @@ const tsParser = require('@typescript-eslint/parser');
 const htmlPlugin = require('@html-eslint/eslint-plugin');
 const htmlParser = require('@html-eslint/parser');
 const frontendRules = require('./scripts/eslint-frontend-rules');
+const globals = require('globals');
 
 module.exports = [
   {
@@ -20,6 +21,7 @@ module.exports = [
         project: ['./tsconfig.base.json'],
         tsconfigRootDir: __dirname,
       },
+      globals: { ...globals.browser },
     },
     plugins: {
       react,


### PR DESCRIPTION
## Summary
- declare browser globals in frontend ESLint config to avoid undefined DOM identifiers

## Testing
- `npm run format`
- `npm run lint:root` *(fails: @typescript-eslint/no-var-requires rule not found)*
- `node scripts/run-jest.js tests/frontend` *(fails: dependency check spec)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: prettier check)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a73853e224832dab73cd471e15ee5f