### PR TITLE
ci: pin CodeQL version and enable uploads

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,6 +2,7 @@ name: CodeQL
 
 env:
   HUSKY: 0
+  CODEQL_ACTION_FEATURE_MULTI_LANGUAGE: false
 
 
 on:
@@ -23,6 +24,10 @@ jobs:
     if: github.event_name != 'pull_request' || startsWith(github.head_ref, 'security/')
     name: Analyze
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        codeql-version: ["2.22.4"]
     steps:
       - name: Heartbeat
         run: |
@@ -38,6 +43,7 @@ jobs:
         uses: github/codeql-action/init@v3.29.9
         with:
           languages: javascript-typescript
+          tools: ${{ matrix.codeql-version }}
       - name: Build
         run: |
           npm ci
@@ -45,3 +51,5 @@ jobs:
           npm run build
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3.29.9
+        with:
+          upload: true


### PR DESCRIPTION
## Summary
- pin CodeQL CLI version via matrix
- ensure analysis upload and disable multi-language

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend` *(failed: process did not complete)*
- `SKIP_PW_DEPS=1 npm run ci` *(failed: process terminated early)*
- `SKIP_PW_DEPS=1 npm run smoke` *(failed: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a7385886c0832dba4cb90ae635f973