### PR TITLE
ci: skip build on doc changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,14 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
   workflow_dispatch:
 
 concurrency:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Only two GitHub Action jobs are required to merge changes:
 - **Production build** – runs the exact build command that ships to users.
 - **Intent/behavior tests** – exercises the application to verify user flows.
 
+Documentation-only changes (e.g., edits to `*.md` files or anything under `docs/`) are ignored by CI and will not trigger builds.
+
 Additional checks such as strict linting, dependency audits, and Stripe/Cloudflare smoke tests run in a separate diagnostics workflow. These jobs use `continue-on-error: true` so they surface issues without blocking merges.
 
 ## 🤖 Codex Integration


### PR DESCRIPTION
## Summary
- ignore markdown and docs path changes in CI workflow
- note that docs-only updates do not trigger CI builds

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format --prefix backend`
- `SKIP_PW_DEPS=1 npm test --prefix backend` *(fails: setup reruns and tests did not execute)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: tar or filesystem errors in cache)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a73a675a18832dbb71d710dda9cde8