### PR TITLE
test: retry flaky e2e

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -13,6 +13,9 @@ module.exports = {
   maxWorkers: "50%",
   detectOpenHandles: true,
   forceExit: true,
+  testEnvironment: "node",
+  testRunner: "jest-circus/runner",
+  retryTimes: 2,
   coverageThreshold: {
     global: {
       lines: 80,


### PR DESCRIPTION
## Summary
- retry flaky e2e tests by configuring Jest with jest-circus runner and retries

## Testing
- `npm run format` (backend)
- `npm test` (backend)
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Playwright browsers not installed)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*
- `node scripts/run-jest.js tests/linting.test.js` *(fails: Missing backend dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a73a5fba14832dadd53bbbd1db5c43