### PR TITLE
ci: add backend test notice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,11 +78,14 @@ jobs:
         run: |
           node scripts/run-jest.js backend --listTests | split -n l/3 - test-files-
           TEST_FILES=$(cat test-files-${{ matrix.shard }} | tr '\n' ' ')
-          node scripts/run-jest.js --runTestsByPath $TEST_FILES --ci --coverage --coverageDirectory=coverage/backend
+          node scripts/run-jest.js --runTestsByPath $TEST_FILES --ci --coverage --coverageDirectory=coverage/backend --json --outputFile=junit.json
+      - name: Backend test notice
+        if: always()
+        run: echo "::notice title=Backend Tests::$(jq '.numFailedTests' junit.json) failed"
       - uses: actions/upload-artifact@v4.3.4
         with:
           name: junit-backend-${{ matrix.shard }}
-          path: junit-backend.xml
+          path: junit.json
           if-no-files-found: ignore
       - uses: actions/upload-artifact@v4.3.4
         with:


### PR DESCRIPTION
## Summary
- surface backend test failures in CI job summary with a `::notice`

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script: "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a73a4b625c832dbc2b84db489bc0b1