### PR TITLE
ci: add optional self-hosted runner

### DIFF
--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -17,7 +17,8 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository == 'your-org/prod-repo' && fromJSON('["self-hosted","linux"]') || 'ubuntu-latest' }}
+    # No effect until you connect a machine, but prevents queue hell long-term.
     if: ${{ matrix.node != 22 || contains(github.event.pull_request.labels.*.name, 'full-matrix') }}
     continue-on-error: ${{ matrix.node == 22 }}
     defaults:
@@ -47,7 +48,8 @@ jobs:
           path: frontend/dist
 
   artifact-lister:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.repository == 'your-org/prod-repo' && fromJSON('["self-hosted","linux"]') || 'ubuntu-latest' }}
+    # No effect until you connect a machine, but prevents queue hell long-term.
     continue-on-error: true
     needs: build
     steps:

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Only two GitHub Action jobs are required to merge changes:
 
 - **Production build** – runs the exact build command that ships to users.
 - **Intent/behavior tests** – exercises the application to verify user flows.
+- Attach a self-hosted runner for queue-free builds.
 
 Additional checks such as strict linting, dependency audits, and Stripe/Cloudflare smoke tests run in a separate diagnostics workflow. These jobs use `continue-on-error: true` so they surface issues without blocking merges.
 


### PR DESCRIPTION
## Summary
- conditionally run frontend build workflow on self-hosted runner when targeting `your-org/prod-repo`
- document attaching a self-hosted runner for queue‑free builds

## Testing
- `npm run format`
- `npm test`
- `npm run ci` *(fails: Missing script: "lint")*
- `npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html)*

------
https://chatgpt.com/codex/tasks/task_e_68a73a43dbb4832d9287ccce515a06d3