### PR TITLE
ci: add concurrency gates to setup and preflight workflows

### DIFF
--- a/.github/workflows/_setup.yml
+++ b/.github/workflows/_setup.yml
@@ -8,6 +8,10 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   run:
     runs-on: ubuntu-latest

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -15,6 +15,10 @@ on:
         description: Run backend jobs
         value: ${{ jobs.changed.outputs.backend }}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   changed:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- ensure Setup workflow cancels prior runs via concurrency group
- ensure Preflight workflow cancels prior runs via concurrency group

## Testing
- `npm run format` *(backend)*
- `npm test` *(backend) - failed: Setup flag missing and reran npm run setup*
- `SKIP_PW_DEPS=1 npm run ci` *(failed: ENOTEMPTY rmdir .../es-abstract/2015)*
- `SKIP_PW_DEPS=1 npm run smoke` *(failed: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a73a33abd4832db779e1b3eddadcc0