### PR TITLE
ci: restrict heavy workflows to production

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,11 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [00000production]
   pull_request:
-    branches: [main]
+    types: [labeled, opened, synchronize, reopened]
+  schedule:
+    - cron: '0 0 * * *'
   workflow_dispatch:
 
 concurrency:
@@ -16,6 +18,7 @@ env:
 
 jobs:
   build:
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-full')
     runs-on:
       - self-hosted
       - ubuntu-latest
@@ -50,6 +53,7 @@ jobs:
           path: ${{ runner.temp }}/_github_workflow/*.log
 
   test-backend:
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-full')
     runs-on:
       - self-hosted
       - ubuntu-latest
@@ -95,6 +99,7 @@ jobs:
           path: ${{ runner.temp }}/_github_workflow/*.log
 
   test-frontend:
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-full')
     runs-on:
       - self-hosted
       - ubuntu-latest
@@ -146,7 +151,7 @@ jobs:
           path: ${{ runner.temp }}/_github_workflow/*.log
 
   test-integration:
-    if: github.event_name == 'push'
+    if: (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-full')) && github.event_name == 'push'
     runs-on:
       - self-hosted
       - ubuntu-latest
@@ -179,7 +184,7 @@ jobs:
           path: ${{ runner.temp }}/_github_workflow/*.log
 
   coverage-merge:
-    if: github.event_name == 'push'
+    if: (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-full')) && github.event_name == 'push'
     runs-on:
       - self-hosted
       - ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,8 +6,11 @@ env:
 
 on:
   push:
-    branches: [dev]
+    branches: [00000production]
   pull_request:
+    types: [labeled, opened, synchronize, reopened]
+  schedule:
+    - cron: '0 0 * * *'
 
 permissions:
   actions: read
@@ -20,7 +23,7 @@ concurrency:
 
 jobs:
   analyze:
-    if: github.event_name != 'pull_request' || startsWith(github.head_ref, 'security/')
+    if: github.event_name != 'pull_request' || startsWith(github.head_ref, 'security/') || contains(github.event.pull_request.labels.*.name, 'run-full')
     name: Analyze
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/glb-tests.yml
+++ b/.github/workflows/glb-tests.yml
@@ -6,19 +6,21 @@ env:
 
 on:
   push:
-    branches: [main, dev]
+    branches: [00000production]
     paths:
       - 'backend/src/lib/**glb**'
       - 'backend/src/lib/**/*glb*.ts'
       - 'backend/src/pipeline/generateModel.*'
       - 'backend/tests/glb/**'
-  merge_group:
-    branches: [main, dev]
+  pull_request:
+    types: [labeled, opened, synchronize, reopened]
     paths:
       - 'backend/src/lib/**glb**'
       - 'backend/src/lib/**/*glb*.ts'
       - 'backend/src/pipeline/generateModel.*'
       - 'backend/tests/glb/**'
+  schedule:
+    - cron: '0 0 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -26,6 +28,7 @@ concurrency:
 
 jobs:
   unit-tests:
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-full')
     runs-on: ubuntu-latest
     steps:
       - name: Heartbeat
@@ -53,6 +56,7 @@ jobs:
     env:
       PORT: 3000
       DB_URL: postgres://user:pass@localhost:5432/testdb
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-full')
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/smoke-backend.yml
+++ b/.github/workflows/smoke-backend.yml
@@ -4,10 +4,12 @@ env:
   HUSKY: 0
 
 on:
-  workflow_run:
-    workflows: ["Preflight"]
-    types:
-      - completed
+  push:
+    branches: [00000production]
+  pull_request:
+    types: [labeled, opened, synchronize, reopened]
+  schedule:
+    - cron: '0 0 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -18,12 +20,12 @@ permissions:
 
 jobs:
   preflight:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-full')
     uses: ./.github/workflows/preflight.yml
 
   backend-smoke:
     needs: preflight
-    if: needs.preflight.outputs.run_backend == 'true'
+    if: needs.preflight.outputs.run_backend == 'true' && (github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-full'))
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -6,14 +6,19 @@ env:
 
 on:
   push:
-  merge_group:
-
+    branches: [00000production]
+  pull_request:
+    types: [labeled, opened, synchronize, reopened]
+  schedule:
+    - cron: '0 0 * * *'
+  
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   smoke:
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-full')
     runs-on: ubuntu-latest
     env:
       PORT: 3000


### PR DESCRIPTION
## Summary
- limit heavy CI workflows to production pushes, nightly schedule, or run-full label
- gate GLB tests and smoke checks behind the same conditions
- scope CodeQL analysis to production, nightly, or run-full/ security branches

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a738e59eec832d99d1ea94d1308c44