### PR TITLE
ci: cache backend build output

### DIFF
--- a/.github/workflows/backend-only-ci.yml
+++ b/.github/workflows/backend-only-ci.yml
@@ -65,6 +65,12 @@ jobs:
               sleep $((2**attempt))
             fi
           done
+      - uses: actions/cache@v4
+        with:
+          path: |
+            backend/node_modules/.cache
+            backend/dist
+          key: backend-${{ hashFiles('backend/pnpm-lock.yaml') }}-${{ hashFiles('backend/tsconfig*.json','backend/src/**') }}
       - name: Run backend tests
         run: |
           node scripts/run-jest.js backend --listTests | split -n l/3 - test-files-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,12 @@ jobs:
           cache: "npm"
           cache-dependency-path: backend/package-lock.json
       - run: npm ci --prefix backend
+      - uses: actions/cache@v4
+        with:
+          path: |
+            backend/node_modules/.cache
+            backend/dist
+          key: backend-${{ hashFiles('backend/pnpm-lock.yaml') }}-${{ hashFiles('backend/tsconfig*.json','backend/src/**') }}
       - name: Run backend tests
         run: |
           node scripts/run-jest.js backend --listTests | split -n l/3 - test-files-


### PR DESCRIPTION
## Summary
- cache backend dist and cache directories in CI workflows

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci` *(fails: Missing script "lint")*
- `npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a738e0e1b4832d880c24a440f76825