### PR TITLE
ci: skip jest coverage on PRs

### DIFF
--- a/.github/workflows/jest-early-warning.yml
+++ b/.github/workflows/jest-early-warning.yml
@@ -13,5 +13,8 @@ concurrency:
 jobs:
   backend-tests:
     uses: ./.github/workflows/_setup.yml
+    env:
+      CI: true
+      JEST_SKIP_COVERAGE: true
     with:
       run: npm test --prefix backend -- --maxWorkers=50% --runInBand=false --silent --reporters=default

--- a/jest.config.js
+++ b/jest.config.js
@@ -13,6 +13,7 @@ module.exports = {
   maxWorkers: "50%",
   detectOpenHandles: true,
   forceExit: true,
+  collectCoverage: process.env.JEST_SKIP_COVERAGE !== "true",
   coverageThreshold: {
     global: {
       lines: 80,


### PR DESCRIPTION
## Summary
- avoid collecting coverage in Jest early warning job
- allow coverage collection to be skipped via `JEST_SKIP_COVERAGE`

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: process hung, manual interrupt)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script: "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a738c35fbc832d9ab610cb48540d77