### PR TITLE
ci: speed up jest early warning on PRs

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -1,0 +1,78 @@
+name: Backend Tests
+
+env:
+  HUSKY: 0
+
+on:
+  pull_request:
+  push:
+    branches:
+      - 00000production
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  changed-tests:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - name: Run changed tests
+        run: |
+          corepack enable
+          pnpm i --frozen-lockfile --ignore-scripts
+          pnpm jest --ci --runInBand --reporters=default \
+            --silent --noStackTrace \
+            --changedSince=origin/00000production \
+            --passWithNoTests
+
+  full-suite:
+    if: github.ref_name == '00000production'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        shard: [aa, ab, ac]
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            backend/package-lock.json
+      - name: Install root dependencies
+        run: |
+          for attempt in 1 2; do
+            if npm ci; then
+              break
+            elif [ $attempt -eq 2 ]; then
+              exit 1
+            else
+              sleep $((2**attempt))
+            fi
+          done
+      - name: Install backend dependencies
+        run: |
+          for attempt in 1 2; do
+            if npm ci --prefix backend; then
+              break
+            elif [ $attempt -eq 2 ]; then
+              exit 1
+            else
+              sleep $((2**attempt))
+            fi
+          done
+      - name: Run backend tests
+        run: |
+          node scripts/run-jest.js backend --listTests | split -n l/3 - test-files-
+          TEST_FILES=$(cat test-files-${{ matrix.shard }} | tr '\n' ' ')
+          node scripts/run-jest.js --runTestsByPath $TEST_FILES --ci --coverage

--- a/.github/workflows/jest-early-warning.yml
+++ b/.github/workflows/jest-early-warning.yml
@@ -12,6 +12,4 @@ concurrency:
 
 jobs:
   backend-tests:
-    uses: ./.github/workflows/_setup.yml
-    with:
-      run: npm test --prefix backend -- --maxWorkers=50% --runInBand=false --silent --reporters=default
+    uses: ./.github/workflows/backend-tests.yml


### PR DESCRIPTION
## Summary
- run changed backend tests with pnpm and a 5-minute timeout on pull requests
- keep sharded full-suite backend tests for `00000production`
- route Jest Early Warning through the new backend-tests workflow

## Testing
- `npm run format`
```
> backend@1.0.0 preformat
> node ../scripts/ensure-root-deps.js

> backend@1.0.0 format
> sh -c 'cd .. && node scripts/ensure-root-deps.js && prettier --log-level warn --write "**/*.{js,jsx,json,md}" --ignore-path .prettierignore'
```
- `npm test`
```
PASS tests/stripe-route-types.test.ts
PASS tests/frontend/modelViewerLoader.test.js
PASS tests/queue/printWorker.test.js
PASS tests/saleCredits.test.js
PASS tests/apiModels.test.js
PASS __tests__/server-endpoints.test.ts
PASS tests/frontend/flashBanner.test.js
PASS tests/frontend/index.test.js
PASS tests/textToImage.test.ts
PASS tests/envValidation.test.js
```
- `npm run ci` *(fails: Missing script "lint")*
```
npm error Missing script: "lint"
```
- `npm run smoke` *(fails: Missing frontend build artifact)*
```
Missing frontend build artifact: frontend/dist/index.html. Run 'npm run build' and retry
```


------
https://chatgpt.com/codex/tasks/task_e_68a738b090a4832da4b3aba4f55a10fe