### PR TITLE
ci: capture Cloudflare Pages URL

### DIFF
--- a/.github/workflows/cf-pages-preview.yml
+++ b/.github/workflows/cf-pages-preview.yml
@@ -4,9 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
-      - 'frontend/**'
-      - '!docs/**'
-      - 'package.json'
+      - "frontend/**"
+      - "!docs/**"
+      - "package.json"
 
 permissions:
   contents: read
@@ -39,7 +39,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
           set -o pipefail
-          url=$(timeout 60 npx -y wrangler pages dev frontend/dist --local false --project-name "${{ secrets.CF_PAGES_PROJECT }}" --branch "$GITHUB_HEAD_REF" 2>&1 | tee /tmp/wrangler.log | grep -Eo 'https://[^ ]+' | tail -n 1)
+          url=$(timeout 60 npx -y wrangler pages dev frontend/dist --local false --project-name "${{ secrets.CF_PAGES_PROJECT }}" --branch "$GITHUB_HEAD_REF" 2>&1 | tee /tmp/wrangler.log | grep -Eo 'https://[^ ]+\.pages\.dev' | tail -n 1)
           echo "$url" > preview-url.txt
           echo "url=$url" >> "$GITHUB_OUTPUT"
       - name: Comment preview URL

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -3,7 +3,6 @@ name: Pages Deploy
 env:
   HUSKY: 0
 
-
 on:
   push:
     branches: ["00000production"]
@@ -63,7 +62,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: |
-          url=$(npx -y wrangler pages deploy pages_dist --project-name "${{ secrets.CF_PAGES_PROJECT }}" --branch production | tee /tmp/deploy.log | grep -Eo 'https://[^ ]+' | tail -n 1)
+          url=$(npx -y wrangler pages deploy pages_dist --project-name "${{ secrets.CF_PAGES_PROJECT }}" --branch production | tee /tmp/deploy.log | grep -Eo 'https://[^ ]+\.pages\.dev' | tail -n 1)
           echo "$url" > deploy-url.txt
           echo "url=$url" >> "$GITHUB_OUTPUT"
       - name: Job summary


### PR DESCRIPTION
## Summary
- capture only Pages preview URLs in Cloudflare Pages workflows to ignore functions note

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` (backend)
- `npm test` *(fails: setup script runs and exits before tests)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: dependencies missing)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html)*

------
https://chatgpt.com/codex/tasks/task_e_68a738904c0c832da93b9a906fe767c1