### PR TITLE
ci: limit parallelism for heavy jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,11 +50,10 @@ jobs:
           path: ${{ runner.temp }}/_github_workflow/*.log
 
   test-backend:
-    runs-on:
-      - self-hosted
-      - ubuntu-latest
+    runs-on: ubuntu-latest-XXL
     strategy:
       fail-fast: true
+      max-parallel: 2
       matrix:
         shard: [aa, ab, ac]
     steps:
@@ -100,6 +99,7 @@ jobs:
       - ubuntu-latest
     strategy:
       fail-fast: true
+      max-parallel: 2
       matrix:
         include:
           - shard: core

--- a/.github/workflows/ensure_server_boots_185ecc2b50.yml
+++ b/.github/workflows/ensure_server_boots_185ecc2b50.yml
@@ -14,7 +14,9 @@ concurrency:
 
 jobs:
   boot_check:
-    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 2
+    runs-on: ubuntu-latest-XXL
     env:
       STRIPE_TEST_KEY: ${{ secrets.STRIPE_TEST_KEY }}
       # Fallback DB connection so check-env.sh passes


### PR DESCRIPTION
## Summary
- restrict heavy jobs to two concurrent runs
- run boot check and backend tests on larger XXL runners

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*


------
https://chatgpt.com/codex/tasks/task_e_68a738823db4832db95eb1892ad76813