### PR TITLE
ci: install frontend deps before prebuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "smoke": "node scripts/run-smoke.js",
     "start:backend": "npm start --prefix backend",
     "predeploy": "node scripts/check-missing-links.js",
-    "prebuild": "test -x frontend/node_modules/.bin/vite || (echo \"vite not installed in frontend\" && exit 1)",
+    "prebuild": "node -e \"require('./scripts/run-npm-ci').runNpmCi('frontend')\" && test -x frontend/node_modules/.bin/vite || (echo \\\"vite not installed in frontend\\\" && exit 1)",
     "build": "npm run build --prefix frontend",
     "postbuild": "npx -y ts-node --transpile-only scripts/check-broken-symlinks-9ac8f74db5e1c32.ts",
     "load": "artillery run tests/load/models.yml",


### PR DESCRIPTION
## Summary
- ensure prebuild runs npm ci for frontend to make vite available

## Testing
- `npm run validate-env`
- `npx prettier --log-level warn --write package.json`
- `npm test --prefix backend` *(fails: tarball data seems to be corrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68a738774448832d822c37c092091a85