### PR TITLE
ci: deploy Cloudflare Pages preview from artifact

### DIFF
--- a/.github/workflows/cf-pages-preview.yml
+++ b/.github/workflows/cf-pages-preview.yml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  preview:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Heartbeat
@@ -32,14 +32,33 @@ jobs:
             package-lock.json
             frontend/package-lock.json
       - run: npm ci && npm run build --prefix frontend
-      - name: Start preview
+      - uses: actions/upload-artifact@v4.3.1
+        with:
+          name: frontend-dist
+          path: frontend/dist
+
+  preview:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
+      - uses: actions/download-artifact@v4.1.8
+        with:
+          name: frontend-dist
+          path: pages_dist
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Deploy preview
         id: preview
+        if: env.CLOUDFLARE_API_TOKEN != '' && env.CLOUDFLARE_ACCOUNT_ID != ''
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: |
-          set -o pipefail
-          url=$(timeout 60 npx -y wrangler pages dev frontend/dist --local false --project-name "${{ secrets.CF_PAGES_PROJECT }}" --branch "$GITHUB_HEAD_REF" 2>&1 | tee /tmp/wrangler.log | grep -Eo 'https://[^ ]+' | tail -n 1)
+          url=$(npx -y wrangler pages deploy pages_dist --project-name "${{ secrets.CF_PAGES_PROJECT }}" --branch "$GITHUB_HEAD_REF" 2>&1 | tee /tmp/wrangler.log | grep -Eo 'https://[^ ]+' | tail -n 1)
           echo "$url" > preview-url.txt
           echo "url=$url" >> "$GITHUB_OUTPUT"
       - name: Comment preview URL
@@ -56,7 +75,7 @@ jobs:
               issue_number: context.issue.number,
               body
             });
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v4.3.1
         if: steps.preview.outputs.url
         with:
           name: cf-pages-preview-url


### PR DESCRIPTION
## Summary
- build frontend and upload dist artifact for Cloudflare Pages previews
- deploy previews via Wrangler using uploaded artifact when CF tokens exist

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a7386c2d04832d98e23d60ffbafc95