### PR TITLE
ci: comment on unstarted checks

### DIFF
--- a/.github/workflows/check-watchdog.yml
+++ b/.github/workflows/check-watchdog.yml
@@ -3,7 +3,6 @@ name: Check Watchdog
 env:
   HUSKY: 0
 
-
 on:
   pull_request:
 
@@ -23,6 +22,7 @@ jobs:
         run: |
           while true; do date; sleep 120; done &
       - name: Watch required checks
+        id: watch
         env:
           GH_TOKEN: ${{ github.token }}
           SHA: ${{ github.event.pull_request.head.sha }}
@@ -46,14 +46,38 @@ jobs:
             sleep $backoff
             backoff=$((backoff < 60 ? backoff * 2 : 60))
           done
-          echo -e "Check\tStatus\tStarted At"
+          > checks.txt
           for check in "${checks[@]}"; do
-            gh api repos/${{ github.repository }}/commits/$SHA/check-runs \
-              -f check_name="$check" \
-              --jq '.check_runs[0] | [.name,.status,.started_at] | @tsv' 2>/dev/null || true
-          done | column -t -s $'\t'
-          echo
-          echo "Recent workflow runs:"
-          gh run list --limit 5 || true
+            status=$(gh api repos/${{ github.repository }}/commits/$SHA/check-runs \
+              -f check_name="$check" --jq '.check_runs[0].status' 2>/dev/null || true)
+            if [[ "$status" == "" ]]; then
+              echo "- $check: limit" >> checks.txt
+            elif [[ "$status" == "queued" ]]; then
+              echo "- $check: queued" >> checks.txt
+            fi
+          done
+          cat checks.txt
+          echo >> checks.txt
+          echo "Recent workflow runs:" >> checks.txt
+          gh run list --limit 5 >> checks.txt || true
           echo "Jobs did not start within 5 min — likely runner queue/concurrency jam" >&2
           exit 1
+      - name: Comment missing checks
+        if: steps.watch.outcome == 'failure'
+        uses: actions/github-script@v7.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const pr = context.payload.pull_request?.number;
+            if (!pr) {
+              core.info('No pull request associated with this run.');
+              return;
+            }
+            const body = fs.readFileSync('checks.txt', 'utf8');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr,
+              body,
+            });


### PR DESCRIPTION
## Summary
- comment on pull requests when required checks never start and classify each as queued or limit

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` (fails: process interrupted)
- `SKIP_PW_DEPS=1 npm run smoke` (fails: Missing frontend build artifact)


------
https://chatgpt.com/codex/tasks/task_e_68a738688fd4832d85baae3389acfc4b