### PR TITLE
ci: comment when required checks stall

### DIFF
--- a/.github/workflows/check-watchdog.yml
+++ b/.github/workflows/check-watchdog.yml
@@ -26,6 +26,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           SHA: ${{ github.event.pull_request.head.sha }}
+          PR: ${{ github.event.pull_request.number }}
         run: |
           checks=("Build frontend / build" "Backend Smoke" "Cloudflare Pages")
           deadline=$((SECONDS + 300))
@@ -33,8 +34,8 @@ jobs:
           while [ $SECONDS -lt $deadline ]; do
             all_started=1
             for check in "${checks[@]}"; do
-              status=$(gh api repos/${{ github.repository }}/commits/$SHA/check-runs \
-                -f check_name="$check" --jq '.check_runs[0].status' 2>/dev/null || true)
+              read -r status conclusion <<< $(gh api repos/${{ github.repository }}/commits/$SHA/check-runs \
+                -f check_name="$check" --jq '.check_runs[0] | [.status,.conclusion] | @tsv' 2>/dev/null || echo '')
               if [[ "$status" == "" || "$status" == "queued" ]]; then
                 all_started=0
                 break
@@ -46,14 +47,17 @@ jobs:
             sleep $backoff
             backoff=$((backoff < 60 ? backoff * 2 : 60))
           done
-          echo -e "Check\tStatus\tStarted At"
-          for check in "${checks[@]}"; do
+          summary=$(for check in "${checks[@]}"; do
             gh api repos/${{ github.repository }}/commits/$SHA/check-runs \
               -f check_name="$check" \
-              --jq '.check_runs[0] | [.name,.status,.started_at] | @tsv' 2>/dev/null || true
-          done | column -t -s $'\t'
+              --jq '.check_runs[0] | [.name,.status,.conclusion,.started_at] | @tsv' 2>/dev/null || true
+          done | column -t -s $'\t')
+          echo -e "Check\tStatus\tConclusion\tStarted At\n$summary"
+          runs=$(gh run list --limit 5 2>/dev/null || true)
           echo
           echo "Recent workflow runs:"
-          gh run list --limit 5 || true
+          echo "$runs"
+          gh pr comment "$PR" --body $'### ⏱ Check start gate failed\n\n```
+'"Check\tStatus\tConclusion\tStarted At\n$summary"$'\n```\n\nRecent workflow runs:\n```\n'$runs$'\n```\n' || true
           echo "Jobs did not start within 5 min — likely runner queue/concurrency jam" >&2
           exit 1


### PR DESCRIPTION
## Summary
- comment on PRs when required checks fail to start within 5 minutes
- gather check status and recent runs to help diagnose queue jams

## Testing
- `npm run setup` *(fails: process terminated with SIGINT)*
- `npm run format` *(fails: Dependencies missing. Installing root dependencies...)*
- `npm test` *(fails: process terminated; APT repositories unreachable)*
- `npm run ci` *(fails: ENOTEMPTY directory not empty)*
- `npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a73865a8a0832d92b49cde7ae3f569