### PR TITLE
test: add stall diagnostics and ensure cleanup

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -14,7 +14,7 @@ module.exports = {
   testMatch: ["**/?(*.)+(spec|test).[jt]s?(x)"],
   moduleFileExtensions: ["ts", "js", "json"],
   testTimeout: 120000,
-  maxWorkers: "50%",
+  maxWorkers: 1,
   detectOpenHandles: true,
   forceExit: true,
   coverageDirectory: "coverage",

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,7 +10,7 @@ module.exports = {
     "<rootDir>/tests/setup/teardown.ts",
   ],
   testTimeout: 60000,
-  maxWorkers: "50%",
+  maxWorkers: 1,
   detectOpenHandles: true,
   forceExit: true,
   coverageThreshold: {

--- a/scripts/run-coverage.js
+++ b/scripts/run-coverage.js
@@ -40,7 +40,7 @@ if (extraArgs.includes("--help") || extraArgs.includes("-h")) {
 const jestArgs = [
   "--ci",
   "--coverage",
-  "--maxWorkers=2",
+  "--runInBand",
   "--detectOpenHandles",
   "--forceExit",
   "--coverageReporters=text-lcov",

--- a/tests/setup/teardown.ts
+++ b/tests/setup/teardown.ts
@@ -5,4 +5,15 @@ afterAll(async () => {
   }
 
   await (globalThis as any).__DB_POOL__?.end?.();
+
+  const stripeMock =
+    (globalThis as any).__STRIPE_MOCK__ ||
+    (globalThis as any).__STRIPE_PROCESS__;
+  if (stripeMock) {
+    if (typeof stripeMock.close === "function") {
+      await new Promise((resolve) => stripeMock.close(resolve));
+    } else if (typeof stripeMock.kill === "function") {
+      stripeMock.kill("SIGTERM");
+    }
+  }
 });

--- a/tests/smoke-atomic/apiGenerate_fallback.test.ts
+++ b/tests/smoke-atomic/apiGenerate_fallback.test.ts
@@ -21,5 +21,5 @@ test('POST /api/generate returns fallback when externals fail', async () => {
   expect(typeof body.glb_url).toBe('string');
   expect(body.fallback).toBe(true);
   expect(body.reason).toBe('external_unavailable');
-  server.close();
+  await new Promise<void>((resolve) => server.close(() => resolve()));
 });

--- a/tests/smoke-hang-diagnostics-a1b2c3.test.js
+++ b/tests/smoke-hang-diagnostics-a1b2c3.test.js
@@ -28,7 +28,7 @@ describe.skip("insecure http fetch; https unavailable", () => {
     test("npm run serve binds to port 3000", async () => {
       const server = startDevServer(3000);
       await waitPort(3000);
-      server.close();
+      await new Promise((r) => server.close(r));
     });
 
     test("homepage responds at /", async () => {
@@ -36,7 +36,7 @@ describe.skip("insecure http fetch; https unavailable", () => {
       const port = server.address().port;
       await waitPort(port);
       const res = await fetch(`http://127.0.0.1:${port}/`);
-      server.close();
+      await new Promise((r) => server.close(r));
       expect(res.status).toBe(200);
     });
 
@@ -50,7 +50,7 @@ describe.skip("insecure http fetch; https unavailable", () => {
       const port = server.address().port;
       await waitPort(port);
       const res = await fetch(`http://127.0.0.1:${port}/img/box%20logo.png`);
-      server.close();
+      await new Promise((r) => server.close(r));
       expect(res.status).toBe(200);
     });
 
@@ -59,7 +59,7 @@ describe.skip("insecure http fetch; https unavailable", () => {
       const server = startDevServer(0);
       const port = server.address().port;
       await waitPort(port);
-      server.close();
+      await new Promise((r) => server.close(r));
       expect(Date.now() - t).toBeLessThan(3000);
     });
 

--- a/tests/utils/testEnv.ts
+++ b/tests/utils/testEnv.ts
@@ -1,4 +1,24 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-require('./reaper');
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-module.exports = require('./reaper');
+const reaper = require('./reaper');
+
+const STALL_MS = 10_000;
+let stallTimer: NodeJS.Timeout | null = null;
+
+beforeEach(() => {
+  const name = expect.getState().currentTestName;
+  stallTimer = setTimeout(() => {
+    const handles = (process as any)._getActiveHandles?.() || [];
+    console.error(
+      `Test "${name}" has not finished after ${STALL_MS}ms; open handles: ${handles.length}`,
+    );
+  }, STALL_MS);
+});
+
+afterEach(() => {
+  if (stallTimer) {
+    clearTimeout(stallTimer);
+    stallTimer = null;
+  }
+});
+
+module.exports = reaper;


### PR DESCRIPTION
## Summary
- add per-test stall timers
- close DB, HTTP server, and stripe mock in teardown
- run Jest in-band with open handle detection and fix async cleanup

## Testing
- `npm run format`
- `npm test` *(hangs at exit; tests themselves pass)*
- `npm test --prefix backend` *(hangs at exit)*

------
https://chatgpt.com/codex/tasks/task_e_68a73b9c438c832da35ee763bd621780