### PR TITLE
test: add stripe webhook secret validation

### DIFF
--- a/backend/config.js
+++ b/backend/config.js
@@ -38,10 +38,15 @@ const requireLive =
   process.env.NODE_ENV === "production" &&
   process.env.CI_REQUIRE_EXTERNAL === "1";
 if (requireLive) {
-  if (!/^sk_live/.test(stripeKey)) {
+  const invalid = (val, prefix, mock) =>
+    typeof val !== "string" ||
+    !val.startsWith(prefix) ||
+    val === mock ||
+    /_(test|mock)/.test(val);
+  if (invalid(stripeKey, "sk_live", mockSecrets.STRIPE_SECRET_KEY)) {
     throw new Error("STRIPE_SECRET_KEY must be a live secret");
   }
-  if (!/^whsec_/.test(stripeWebhook)) {
+  if (invalid(stripeWebhook, "whsec_", mockSecrets.STRIPE_WEBHOOK_SECRET)) {
     throw new Error("STRIPE_WEBHOOK_SECRET must be a live webhook secret");
   }
 }

--- a/backend/tests/stripeSecretValidation.test.js
+++ b/backend/tests/stripeSecretValidation.test.js
@@ -1,0 +1,66 @@
+const { mockSecrets } = require("../src/lib/mockEnv");
+
+describe("Stripe webhook secret validation", () => {
+  const { env } = process;
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...env };
+    process.env.DB_URL = "postgres://user:pass@localhost/db";
+    process.env.STRIPE_SECRET_KEY = "sk_live_valid";
+  });
+
+  afterEach(() => {
+    process.env = env;
+  });
+
+  test("uses mock webhook secret in test env", () => {
+    delete process.env.STRIPE_WEBHOOK_SECRET;
+    jest.isolateModules(() => {
+      const config = require("../config");
+      expect(config.stripeWebhook).toBe(mockSecrets.STRIPE_WEBHOOK_SECRET);
+    });
+  });
+
+  describe("production", () => {
+    beforeEach(() => {
+      delete process.env.CI;
+      process.env.NODE_ENV = "production";
+      process.env.CI_REQUIRE_EXTERNAL = "1";
+    });
+
+    test("accepts real webhook secret", () => {
+      process.env.STRIPE_WEBHOOK_SECRET = "whsec_real_secret";
+      jest.isolateModules(() => {
+        const cfg = require("../config");
+        expect(cfg.stripeWebhook).toBe("whsec_real_secret");
+      });
+    });
+
+    test("fails when webhook secret missing", () => {
+      delete process.env.STRIPE_WEBHOOK_SECRET;
+      jest.isolateModules(() => {
+        expect(() => require("../config")).toThrow(
+          "STRIPE_WEBHOOK_SECRET must be a live webhook secret",
+        );
+      });
+    });
+
+    test("fails when webhook secret is mock", () => {
+      process.env.STRIPE_WEBHOOK_SECRET = mockSecrets.STRIPE_WEBHOOK_SECRET;
+      jest.isolateModules(() => {
+        expect(() => require("../config")).toThrow(
+          "STRIPE_WEBHOOK_SECRET must be a live webhook secret",
+        );
+      });
+    });
+
+    test("fails when webhook secret has wrong format", () => {
+      process.env.STRIPE_WEBHOOK_SECRET = "not_a_whsec";
+      jest.isolateModules(() => {
+        expect(() => require("../config")).toThrow(
+          "STRIPE_WEBHOOK_SECRET must be a live webhook secret",
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- tighten production Stripe webhook secret validation
- add tests for mock and real Stripe webhook secrets

## Testing
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Code style issues found; run Prettier)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*


------
https://chatgpt.com/codex/tasks/task_e_68a73b99e620832d91bd9a9bc84cc356