### PR TITLE
ci: add post-mortem reporter workflow

### DIFF
--- a/.github/workflows/post-mortem-report.yml
+++ b/.github/workflows/post-mortem-report.yml
@@ -1,0 +1,30 @@
+name: Post-mortem reporter
+
+on:
+  pull_request:
+
+jobs:
+  fail-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Intentionally fail
+        id: fail_step
+        run: |
+          echo "This step fails"
+          exit 1
+      - name: Upload logs
+        if: failure()
+        id: upload_logs
+        uses: actions/upload-artifact@v4.3.4
+        with:
+          name: ${{ github.job }}-logs
+          path: ${{ runner.temp }}/_github_workflow/*.log
+      - name: Capture log url
+        if: failure()
+        id: logs
+        run: echo "url=${{ steps.upload_logs.outputs.artifact-url }}" >> "$GITHUB_OUTPUT"
+      - name: Comment on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh pr comment ${{ github.event.pull_request.number }} --body "❌ ${{ github.job }} failed at ${{ steps.fail_step.id }}. Logs: ${{ steps.logs.outputs.url }}"


### PR DESCRIPTION
## Summary
- add workflow to comment on failing jobs with log links

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` (backend)
- `npm test` (backend)
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script: "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html)*

------
https://chatgpt.com/codex/tasks/task_e_68a73a898d14832d8aa25c309652c287