### PR TITLE
ci: scope Playwright cache per branch

### DIFF
--- a/.github/workflows/playwright-browsers-cache.yml
+++ b/.github/workflows/playwright-browsers-cache.yml
@@ -28,9 +28,9 @@ jobs:
           path: |
             ~/.cache/ms-playwright
             ~/.cache/ms-playwright-ffmpeg
-          key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-playwright-${{ github.head_ref }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-playwright-
+            ${{ runner.os }}-playwright-${{ github.head_ref }}-
       - run: echo "Cache key: ${{ steps.cache-playwright.outputs.cache-primary-key }}"
 
       - name: Install Playwright browsers


### PR DESCRIPTION
## Summary
- scope Playwright browsers cache per branch to avoid cross-branch cache reuse

## Testing
- `npm run format`
- `npm test` *(partial; truncated due to long runtime)*
- `SKIP_PW_DEPS=1 npm run ci` *(truncated)*
- `SKIP_PW_DEPS=1 npm run smoke` *(missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a73a81b950832daf776d359188577c