### PR TITLE
ci: cache seeded database for backend smoke

### DIFF
--- a/.github/workflows/smoke-backend.yml
+++ b/.github/workflows/smoke-backend.yml
@@ -21,11 +21,65 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     uses: ./.github/workflows/preflight.yml
 
-  backend-smoke:
+  db-seed:
     needs: preflight
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres" --health-interval 10s --health-timeout 5s --health-retries 5
+    steps:
+      - uses: actions/checkout@v5
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+      - name: Install dependencies
+        run: npm ci --prefix backend
+      - name: Seed database
+        env:
+          DB_URL: postgres://postgres:postgres@localhost:5432/test
+        run: npm run seed --prefix backend
+      - name: Dump database
+        env:
+          PGUSER: postgres
+          PGPASSWORD: postgres
+          PGHOST: localhost
+          PGDATABASE: test
+        run: pg_dump --format=custom -f seeded-db.dump
+      - name: Upload seeded database
+        uses: actions/upload-artifact@v4
+        with:
+          name: seeded-db
+          path: seeded-db.dump
+
+  backend-smoke:
+    needs: [preflight, db-seed]
     if: needs.preflight.outputs.run_backend == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres" --health-interval 10s --health-timeout 5s --health-retries 5
+    env:
+      DB_URL: postgres://postgres:postgres@localhost:5432/test
     steps:
       - name: Heartbeat
         run: |
@@ -48,6 +102,17 @@ jobs:
               sleep $((2**attempt))
             fi
           done
+      - name: Download seeded database
+        uses: actions/download-artifact@v4
+        with:
+          name: seeded-db
+      - name: Restore database
+        env:
+          PGUSER: postgres
+          PGPASSWORD: postgres
+          PGHOST: localhost
+          PGDATABASE: test
+        run: pg_restore --clean --no-owner -d test seeded-db.dump
       - name: Lint
         run: npm run lint --prefix backend
       - name: Healthz test


### PR DESCRIPTION
## Summary
- seed backend database once and share via artifact for smoke tests

## Testing
- `npm run format`
- `npm test` *(fails: npm ci encountered tar or filesystem errors)*
- `npm run ci` *(fails: ENOTEMPTY: directory not empty)*
- `npm run smoke` *(fails: missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a73a73de3c832db7b1e05364839d84