### PR TITLE
ci: split smoke workflow into backend and frontend check

### DIFF
--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -3,7 +3,6 @@ name: Server Smoke Test
 env:
   HUSKY: 0
 
-
 on:
   push:
   merge_group:
@@ -13,7 +12,23 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  smoke:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      frontend: ${{ steps.filter.outputs.frontend }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - id: filter
+        uses: dorny/paths-filter@v3.0.2
+        with:
+          filters: |
+            frontend:
+              - 'frontend/**'
+
+  backend-smoke:
+    needs: changes
     runs-on: ubuntu-latest
     env:
       PORT: 3000
@@ -24,11 +39,10 @@ jobs:
         run: |
           while true; do date; sleep 120; done &
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/frontend-build
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: "npm"
+          cache: npm
       - run: npm run setup
       - name: Start backend
         run: |
@@ -47,3 +61,15 @@ jobs:
           sleep 5
           cat /tmp/server.log || true
         shell: bash
+
+  frontend-artifact-check:
+    needs: [changes, backend-smoke]
+    if: needs.changes.outputs.frontend == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/frontend-build
+      - run: test -f frontend/dist/index.html


### PR DESCRIPTION
## Summary
- split smoke_test workflow into separate backend-smoke and frontend-artifact-check jobs
- skip frontend build unless frontend code changes

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend -- backend/tests/healthz.test.js` *(fails: coverage thresholds not met)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: missing script: "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html. Run 'npm run build' and retry)*


------
https://chatgpt.com/codex/tasks/task_e_68a7385f2358832db20c42497f883046