### PR TITLE
ci: log queue context

### DIFF
--- a/.github/workflows/queue-probe.yml
+++ b/.github/workflows/queue-probe.yml
@@ -15,7 +15,17 @@ concurrency:
 permissions: {}
 
 jobs:
+  context:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Print queue context
+        run: |
+          echo "Queue started: $(date)"
+          echo "Runner: ${{ runner.name }}"
+          echo "OS: ${{ runner.os }}"
+
   probe:
+    needs: context
     runs-on: ubuntu-latest
     continue-on-error: true
     timeout-minutes: 5


### PR DESCRIPTION
## Summary
- add an initial job in queue probe workflow to print runner details and start time

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format`
```
> backend@1.0.0 preformat
> node ../scripts/ensure-root-deps.js

> backend@1.0.0 format
> sh -c 'cd .. && node scripts/ensure-root-deps.js && prettier --log-level warn --write "**/*.{js,jsx,json,md}" --ignore-path .prettierignore'
```
- `npm test`
```
PASS tests/api.test.js (5.266 s)
```
- `SKIP_PW_DEPS=1 npm run ci` (fails: Missing script: "lint")
- `SKIP_PW_DEPS=1 npm run smoke` (fails: Missing frontend build artifact)


------
https://chatgpt.com/codex/tasks/task_e_68a73a9be7d8832d8f4817792589cc0d