### PR TITLE
fix: resolve TypeScript project for tests

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -14,6 +14,7 @@ module.exports = {
       extends: [
         "plugin:@typescript-eslint/recommended-requiring-type-checking",
       ],
+      rules: { "no-undef": "off" },
     },
     {
       files: ["**/*.js"],

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,6 +13,7 @@ const prettier = require("eslint-config-prettier");
 const globals = require("globals");
 const jsdoc = require("eslint-plugin-jsdoc");
 const tsParser = require("@typescript-eslint/parser");
+const tsPlugin = require("@typescript-eslint/eslint-plugin");
 const frontend = require("./eslint.frontend-87adf32bca1e546.cjs");
 const isCI = Boolean(process.env.CI);
 
@@ -37,7 +38,7 @@ module.exports = [
       "scripts/check-gh-workflow-sync-23859.ts",
       "upload/**",
       // "src/**", // removed to enable frontend linting
-  ],
+    ],
   },
   {
     files: ["**/*.{ts,tsx}"],
@@ -48,6 +49,8 @@ module.exports = [
         tsconfigRootDir: __dirname,
       },
     },
+    plugins: { "@typescript-eslint": tsPlugin },
+    rules: { "no-undef": "off" },
   },
   {
     files: ["**/*.js"],

--- a/tests/eslintTestParse.test.js
+++ b/tests/eslintTestParse.test.js
@@ -1,0 +1,28 @@
+const { spawnSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+const repoRoot = path.join(__dirname, "..");
+
+function runEslint(file) {
+  return spawnSync("npx", ["eslint", file, "-f", "json"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  });
+}
+
+describe("eslint parses test files", () => {
+  test("ts test file lints without parsing errors", () => {
+    const tmp = path.join(__dirname, "tmp-eslint.ts");
+    fs.writeFileSync(tmp, "export const num: number = 1;\n");
+    const res = runEslint(tmp);
+    fs.unlinkSync(tmp);
+    if (res.status !== 0) console.error(res.stdout || res.stderr);
+    expect(res.status).toBe(0);
+    const messages = JSON.parse(res.stdout)[0].messages;
+    const parsingErrors = messages.filter((m) =>
+      /Parsing error/i.test(m.message),
+    );
+    expect(parsingErrors).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure ts files use TypeScript plugin and disable no-undef for typed code
- verify ESLint parses test files without project errors

## Testing
- `npm run format`
- `node scripts/run-jest.js tests/eslintTestParse.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a73b91e11c832db18620799bbe4b94