### PR TITLE
ci: kill leftover e2e processes

### DIFF
--- a/.github/workflows/ci-rerun-slow.yml
+++ b/.github/workflows/ci-rerun-slow.yml
@@ -86,6 +86,11 @@ jobs:
           PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
         run: |
           npx -y concurrently -k -s first "npm run serve" "npx wait-on http://localhost:3000 --timeout 300000 && npx playwright test e2e/*.test.js"
+      - name: Cleanup Playwright processes
+        if: always()
+        run: |
+          pkill -9 node || true
+          pkill -9 chromium || true
       - id: end
         run: echo "end=$(date +%s)" >> "$GITHUB_OUTPUT"
       - id: duration

--- a/.github/workflows/glb-tests.yml
+++ b/.github/workflows/glb-tests.yml
@@ -90,3 +90,8 @@ jobs:
           PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
         run: |
           npx -y concurrently -k -s first "npm run serve" "npx wait-on http://localhost:3000 --timeout 300000 && npx playwright test e2e/*.test.js"
+      - name: Cleanup Playwright processes
+        if: always()
+        run: |
+          pkill -9 node || true
+          pkill -9 chromium || true

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -67,3 +67,8 @@ jobs:
           PLAYWRIGHT_BROWSERS_PATH: ~/.cache/ms-playwright
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "0"
         run: npx playwright test e2e/smoke.test.js
+      - name: Cleanup Playwright processes
+        if: always()
+        run: |
+          pkill -9 node || true
+          pkill -9 chromium || true


### PR DESCRIPTION
## Summary
- ensure e2e workflows kill stray Node/Chromium processes to prevent hanging jobs

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a73a92c30c832d95cefcf66511b35f