### PR TITLE
ci: cache npm dependencies on self-hosted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,14 +59,9 @@ jobs:
         id: setup-node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
-      - name: Cache npm
-        id: cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.npm
-          key: npm-fe-${{ hashFiles('frontend/package-lock.json') }}
-          restore-keys: npm-fe-
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
       - name: Install, lint, build
         id: build
         run: npm ci && npm run lint && npm run build
@@ -198,14 +193,9 @@ jobs:
         id: setup-node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
-      - name: Cache npm
-        id: cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.npm
-          key: npm-fe-${{ hashFiles('frontend/package-lock.json') }}
-          restore-keys: npm-fe-
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
       - name: Install frontend dependencies
         id: npm-ci-frontend
         run: npm ci --prefix frontend


### PR DESCRIPTION
## Summary
- cache npm dependencies directly via setup-node in self-hosted CI jobs

## Testing
- `npm run format --prefix backend`
- `SKIP_PW_DEPS=1 npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: aborted after format check)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html. Run 'npm run build' and retry)*

------
https://chatgpt.com/codex/tasks/task_e_68a757f7daa0832d821d13e41abc7db2