### PR TITLE
ci: add concurrency group and timeout to post-mortem reporter

### DIFF
--- a/.github/workflows/post-mortem-report.yml
+++ b/.github/workflows/post-mortem-report.yml
@@ -3,9 +3,14 @@ name: Post-mortem reporter
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   fail-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     steps:
       - name: Intentionally fail
         id: fail_step


### PR DESCRIPTION
## Summary
- add concurrency group and cancel-in-progress to post-mortem reporter workflow
- set job timeout to 40 minutes to avoid zombie runs

## Testing
- `npm run format` (backend)
- `npm test` (backend) *(fails: setup runs and exits without executing tests)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: interrupted during dependency install)*
- `npm run smoke` *(fails: missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a757efae0c832da848e26eac4bfd71