### PR TITLE
docs: add secrets example

### DIFF
--- a/.github/secrets.example.md
+++ b/.github/secrets.example.md
@@ -1,0 +1,9 @@
+# Secrets Example
+
+List these secrets in repository settings or environment:
+
+- `AWS_ACCESS_KEY_ID`
+- `AWS_SECRET_ACCESS_KEY`
+- `AWS_REGION` _(if not using OIDC)_
+- `GITHUB_TOKEN_FOR_RUNNER_ADMIN` – to mint runner tokens automatically
+- `RUNNER_EXTRA_LABELS` _(optional)_


### PR DESCRIPTION
## Summary
- add secrets example for GitHub Actions and self-hosted runner setup

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` (fails: Missing script "lint")
- `npm run build`
- `SKIP_PW_DEPS=1 npm run smoke`

<details><summary>npm run format</summary>

```
> mvp-website@1.0.0 preformat
> cross-env SKIP_NET_CHECKS=1 SKIP_PW_DEPS=1 node scripts/assert-setup.js

Skipping network check due to SKIP_NET_CHECKS
Playwright host dependencies already satisfied.
Playwright host dependencies already satisfied.

> mvp-website@1.0.0 format
> prettier --log-level warn --write "**/*.{js,jsx,json,md,html}"
```

</details>

<details><summary>npm test</summary>

```
PASS tests/queue/printWorker.test.js
PASS tests/saleCredits.test.js
PASS tests/apiModels.test.js
```

</details>


------
https://chatgpt.com/codex/tasks/task_e_68a757e690cc832db23fd400e5271023