### PR TITLE
docs: add IAM policies for self-hosted runner

### DIFF
--- a/infra/selfhosted-runner/iam/github-actions-oidc-readme.md
+++ b/infra/selfhosted-runner/iam/github-actions-oidc-readme.md
@@ -1,0 +1,37 @@
+# GitHub Actions OIDC setup
+
+This directory contains IAM configuration for a self-hosted GitHub Actions runner that uses AWS role assumption via OpenID Connect (OIDC).
+
+## Steps
+
+1. **Create the OIDC identity provider** (only once per AWS account):
+
+   ```sh
+   aws iam create-open-id-connect-provider \
+     --url https://token.actions.githubusercontent.com \
+     --client-id-list sts.amazonaws.com \
+     --thumbprint-list <thumbprint>
+   ```
+
+   Replace `<thumbprint>` with the current SHA1 thumbprint for `token.actions.githubusercontent.com`.
+
+2. **Create an IAM role** that the runner will assume:
+
+   ```sh
+   aws iam create-role \
+     --role-name <ROLE_NAME> \
+     --assume-role-policy-document file://oidc-trust-policy.json
+   ```
+
+3. **Attach the instance policy** granting SSM and CloudWatch Logs permissions:
+
+   ```sh
+   aws iam put-role-policy \
+     --role-name <ROLE_NAME> \
+     --policy-name runner-instance \
+     --policy-document file://runner-instance-role-policy.json
+   ```
+
+4. **Enable OIDC** in the runner configuration by setting `use_oidc: true`.
+
+After these steps the self-hosted runner can exchange GitHub's OIDC token for temporary AWS credentials without storing long-lived secrets.

--- a/infra/selfhosted-runner/iam/oidc-trust-policy.json
+++ b/infra/selfhosted-runner/iam/oidc-trust-policy.json
@@ -1,0 +1,18 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::<AWS_ACCOUNT_ID>:oidc-provider/token.actions.githubusercontent.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
+          "token.actions.githubusercontent.com:sub": "repo:ORG_NAME/REPO_NAME:ref:refs/heads/BRANCH_NAME"
+        }
+      }
+    }
+  ]
+}

--- a/infra/selfhosted-runner/iam/runner-instance-role-policy.json
+++ b/infra/selfhosted-runner/iam/runner-instance-role-policy.json
@@ -1,0 +1,32 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "SSM",
+      "Effect": "Allow",
+      "Action": [
+        "ssmmessages:CreateControlChannel",
+        "ssmmessages:CreateDataChannel",
+        "ssmmessages:OpenControlChannel",
+        "ssmmessages:OpenDataChannel",
+        "ec2messages:AcknowledgeMessage",
+        "ec2messages:DeleteMessage",
+        "ec2messages:GetEndpoint",
+        "ec2messages:GetMessages",
+        "ec2messages:SendReply",
+        "ssm:UpdateInstanceInformation"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "CloudWatchLogs",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "*"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add IAM policy for self-hosted runner instance role
- document OIDC role setup for GitHub Actions self-hosted runner

## Testing
- `npm run format`
```
> backend@1.0.0 preformat
> node ../scripts/ensure-root-deps.js

> backend@1.0.0 format
> sh -c 'cd .. && node scripts/ensure-root-deps.js && prettier --log-level warn --write "**/*.{js,jsx,json,md}" --ignore-path .prettierignore'
```
- `SKIP_PW_DEPS=1 npm test` *(failed: setup completed but tests did not run)*
```
> backend@1.0.0 pretest
> node scripts/ensure-deps.js
✅ network OK
Setup flag missing. Running 'npm run setup'...
> mvp-website@1.0.0 setup
> bash scripts/setup.sh
✅ environment OK
added 1646 packages in 30s
```
- `SKIP_PW_DEPS=1 npm run ci` *(failed: aborted after environment check)*
```
Using dummy STRIPE_TEST_KEY
Checking AWS_ACCESS_KEY_ID: your-aws-access-key-id
Checking AWS_SECRET_ACCESS_KEY: your-aws-secret-access-key
Checking DB_URL: postgres://user:password@localhost:5432/your_database
Checking STRIPE_SECRET_KEY: sk_test_1755798509_mock
```
- `SKIP_PW_DEPS=1 npm run smoke` *(failed: missing frontend build artifact)*
```
Checking AWS_ACCESS_KEY_ID: your-aws-access-key-id
Checking AWS_SECRET_ACCESS_KEY: your-aws-secret-access-key
Checking DB_URL: postgres://user:password@localhost:5432/your_database
Checking STRIPE_SECRET_KEY: sk_test_dummy
Missing frontend build artifact: frontend/dist/index.html. Run 'npm run build' and retry
```


------
https://chatgpt.com/codex/tasks/task_e_68a757e3f4ac832db521105df5664cb8