### PR TITLE
ci: check terraform drift

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,6 +33,28 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
 
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3.1.2
+
+      - name: Check infrastructure drift
+        id: terraform-plan
+        working-directory: infra
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: |
+          terraform init -input=false
+          terraform plan -no-color > plan.txt
+          if grep -q 'No changes' plan.txt; then
+            echo "No drift detected" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "### Terraform Drift Detected" >> $GITHUB_STEP_SUMMARY
+            echo '```diff' >> $GITHUB_STEP_SUMMARY
+            cat plan.txt >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            echo "[Re-apply](https://github.com/${{ github.repository }}/actions/workflows/deploy.yml)" >> $GITHUB_STEP_SUMMARY
+          fi
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary
- run terraform plan in deploy workflow
- post diff summary and link to re-apply when drift detected

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` (backend)
- `npm test` *(fails: process truncated; unable to capture full summary)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: missing script lint)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a757d1eab8832d923fc3fe13eeb83c