### PR TITLE
ci: add runner watchdog workflow

### DIFF
--- a/.github/workflows/runner-watchdog.yml
+++ b/.github/workflows/runner-watchdog.yml
@@ -1,0 +1,63 @@
+name: Runner watchdog
+
+on:
+  schedule:
+    - cron: '*/10 * * * *'
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  pull-requests: write
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  watchdog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check self-hosted AWS runner
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: { runners } } = await github.request('GET /repos/{owner}/{repo}/actions/runners', {
+              owner, repo, per_page: 100
+            });
+            const online = runners.some(r => r.status === 'online' &&
+              r.labels.some(l => l.name === 'self-hosted') &&
+              r.labels.some(l => l.name === 'aws'));
+            core.setOutput('online', online);
+
+      - name: Configure AWS credentials
+        if: steps.check.outputs.online != 'true' && secrets.AWS_ACCESS_KEY_ID != ''
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION || 'us-east-1' }}
+
+      - name: Restart runner via SSM
+        if: steps.check.outputs.online != 'true' && secrets.AWS_ACCESS_KEY_ID != ''
+        run: |
+          aws ssm send-command \
+            --document-name AWS-RunShellScript \
+            --targets Key=tag:Name,Values=github-runner \
+            --parameters 'commands=["sudo systemctl restart actions.runner*"]'
+
+      - name: Comment on latest PR and fail
+        if: steps.check.outputs.online != 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: prs } = await github.request('GET /repos/{owner}/{repo}/pulls', {
+              owner, repo, state: 'open', sort: 'updated', direction: 'desc', per_page: 1
+            });
+            if (prs.length > 0) {
+              await github.request('POST /repos/{owner}/{repo}/issues/{issue_number}/comments', {
+                owner, repo, issue_number: prs[0].number,
+                body: '⚠️ No self-hosted AWS runners are online. Watchdog failing.'
+              });
+            }
+            core.setFailed('No self-hosted AWS runners are online.');


### PR DESCRIPTION
## Summary
- monitor self-hosted AWS runner availability every 10 minutes
- optionally restart offline runner via AWS SSM and notify latest PR

## Testing
- `npm run format`
- `npm test`
- `npm run ci` *(fails: Missing script "lint")*
- `npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a757cbc63c832d9ad567d3ee23d0de