### PR TITLE
ci: add self-hosted runner toggle

### DIFF
--- a/.github/workflows/_setup.yml
+++ b/.github/workflows/_setup.yml
@@ -7,14 +7,25 @@ on:
         description: Command to execute after dependencies install
         required: true
         type: string
+      use_self_hosted:
+        description: Use self-hosted runners
+        required: false
+        type: boolean
+        default: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  labels:
+    uses: ./.github/workflows/labels.yml
+    with:
+      use_self_hosted: ${{ inputs.use_self_hosted }}
+
   run:
-    runs-on: ubuntu-latest
+    needs: labels
+    runs-on: ${{ fromJSON(needs.labels.outputs.runs_on_json) }}
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -6,14 +6,25 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      use_self_hosted:
+        description: Use self-hosted runners
+        type: boolean
+        default: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  labels:
+    uses: ./.github/workflows/labels.yml
+    with:
+      use_self_hosted: ${{ inputs.use_self_hosted }}
+
   lint:
-    runs-on: ubuntu-latest
+    needs: labels
+    runs-on: ${{ fromJSON(needs.labels.outputs.runs_on_json) }}
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,6 +19,12 @@ on:
       - package-lock.json
       - pnpm-lock.yaml
       - .github/workflows/**
+  workflow_dispatch:
+    inputs:
+      use_self_hosted:
+        description: Use self-hosted runners
+        type: boolean
+        default: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -32,3 +38,4 @@ jobs:
         npm run lint:root
         npm run lint --prefix frontend
         npm run lint --prefix backend
+      use_self_hosted: ${{ inputs.use_self_hosted }}

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      use_self_hosted:
+        description: Use self-hosted runners
+        type: boolean
+        default: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -15,3 +21,4 @@ jobs:
     uses: ./.github/workflows/_setup.yml
     with:
       run: npx tsc --noEmit
+      use_self_hosted: ${{ inputs.use_self_hosted }}


### PR DESCRIPTION
## Summary
- allow opting into self-hosted runners via `use_self_hosted` input
- wire eslint, lint, and typecheck workflows to dynamic runner selection

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*


------
https://chatgpt.com/codex/tasks/task_e_68a757c6174c832d8be48bae47fbb11c