### PR TITLE
ci: add runner selection workflow

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,27 +1,36 @@
-name: Sync Labels
-
-env:
-  HUSKY: 0
+name: Determine Runner
 
 on:
-  push:
-    paths:
-      - '.github/labels.yml'
-      - '.github/workflows/labels.yml'
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  workflow_call:
+    inputs:
+      use_self_hosted:
+        description: 'Use self-hosted runner when available'
+        type: boolean
+        default: false
+    outputs:
+      runs_on:
+        description: 'Runner specification'
+        value: ${{ jobs.select.outputs.runs_on }}
 
 jobs:
-  sync:
+  select:
     runs-on: ubuntu-latest
+    outputs:
+      runs_on: ${{ steps.choose.outputs.runs_on }}
     steps:
-      - name: Heartbeat
-        run: |
-          while true; do date; sleep 120; done &
-      - uses: actions/checkout@v5
-      - uses: EndBug/label-sync@v2
+      - id: choose
+        uses: actions/github-script@v7.0.1
         with:
-          config-file: .github/labels.yml
-          delete-other-labels: false
+          script: |
+            const useSelf = Boolean(inputs.use_self_hosted);
+            if (!useSelf) {
+              core.setOutput('runs_on', 'ubuntu-latest');
+              return;
+            }
+            const runners = await github.paginate(github.rest.actions.listSelfHostedRunnersForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+            const hasAws = runners.some(r => r.status === 'online' && r.labels.some(l => l.name === 'aws'));
+            core.setOutput('runs_on', hasAws ? '["self-hosted","aws"]' : 'ubuntu-latest');
+

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,27 @@
+name: Sync Labels
+
+env:
+  HUSKY: 0
+
+on:
+  push:
+    paths:
+      - '.github/labels.yml'
+      - '.github/workflows/sync-labels.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
+      - uses: actions/checkout@v5
+      - uses: EndBug/label-sync@v2
+        with:
+          config-file: .github/labels.yml
+          delete-other-labels: false


### PR DESCRIPTION
## Summary
- add reusable workflow to choose between self-hosted aws runner or ubuntu-latest
- rename label sync workflow to sync-labels.yml

## Testing
- `npm run format`
- `npm test` *(fails: linting-diagnostics and health tests)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: missing script "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a757bbaf20832d8edb41ef6c177594