### PR TITLE
ci: automate self-hosted runner token

### DIFF
--- a/.github/workflows/provision-selfhosted-runner.yml
+++ b/.github/workflows/provision-selfhosted-runner.yml
@@ -1,0 +1,45 @@
+name: provision-selfhosted-runner
+
+on:
+  workflow_dispatch:
+    inputs:
+      runner_token:
+        description: 'Registration token for the GitHub runner'
+        required: false
+
+jobs:
+  provision:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate runner token
+        id: token
+        if: secrets.GITHUB_TOKEN_FOR_RUNNER_ADMIN != ''
+        run: echo "token=$(node scripts/gh-runner-token.js)" >> "$GITHUB_OUTPUT"
+        env:
+          GITHUB_TOKEN_FOR_RUNNER_ADMIN: ${{ secrets.GITHUB_TOKEN_FOR_RUNNER_ADMIN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+
+      - name: Set runner token
+        run: echo "GH_RUNNER_REG_TOKEN=${{ steps.token.outputs.token || inputs.runner_token }}" >> "$GITHUB_ENV"
+
+      - name: Require runner token
+        run: |
+          if [ -z "$GH_RUNNER_REG_TOKEN" ]; then
+            echo 'Runner registration token is required.'
+            exit 1
+          fi
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Terraform init
+        working-directory: infra
+        run: terraform init
+
+      - name: Terraform apply
+        working-directory: infra
+        env:
+          GH_RUNNER_REG_TOKEN: ${{ env.GH_RUNNER_REG_TOKEN }}
+        run: terraform apply -auto-approve

--- a/scripts/gh-runner-token.js
+++ b/scripts/gh-runner-token.js
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+const process = require("node:process");
+
+async function main() {
+  const adminToken = process.env.GITHUB_TOKEN_FOR_RUNNER_ADMIN;
+  const repo = process.env.GITHUB_REPOSITORY;
+  if (!adminToken) {
+    console.error("GITHUB_TOKEN_FOR_RUNNER_ADMIN is not set");
+    process.exit(1);
+  }
+  if (!repo) {
+    console.error("GITHUB_REPOSITORY is not set");
+    process.exit(1);
+  }
+  const url = `https://api.github.com/repos/${repo}/actions/runners/registration-token`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${adminToken}`,
+      Accept: "application/vnd.github+json",
+    },
+  });
+  if (!response.ok) {
+    console.error(
+      `Failed to get runner token: ${response.status} ${response.statusText}`,
+    );
+    process.exit(1);
+  }
+  const data = await response.json();
+  process.stdout.write(data.token);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add script to request GitHub runner registration tokens
- provision workflow auto-generates token when admin secret exists and passes token to Terraform

## Testing
- `npm run format`
- `npm test` (backend)
- `npm run ci` *(fails: Missing script: "lint")*
- `npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html. Run 'npm run build' and retry)*

------
https://chatgpt.com/codex/tasks/task_e_68a757b71954832d821ddb1c9c5edd4a