### PR TITLE
ci: add script to fetch runner registration token

### DIFF
--- a/scripts/get-runner-token.sh
+++ b/scripts/get-runner-token.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TOKEN="$(node "$SCRIPT_DIR/gh-runner-token.js")"
+if [[ -n "${GITHUB_ENV:-}" ]]; then
+  echo "GH_RUNNER_REG_TOKEN=$TOKEN" >> "$GITHUB_ENV"
+else
+  export GH_RUNNER_REG_TOKEN="$TOKEN"
+fi

--- a/scripts/gh-runner-token.js
+++ b/scripts/gh-runner-token.js
@@ -1,0 +1,57 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const node_child_process_1 = require("node:child_process");
+async function main() {
+  const adminToken = process.env.GITHUB_TOKEN_FOR_RUNNER_ADMIN;
+  if (!adminToken) {
+    console.error("GITHUB_TOKEN_FOR_RUNNER_ADMIN is required");
+    process.exit(1);
+  }
+  let owner = process.argv[2];
+  let repo = process.argv[3];
+  if (!owner || !repo) {
+    const origin = (0, node_child_process_1.execSync)(
+      "git config --get remote.origin.url",
+      {
+        encoding: "utf8",
+      },
+    ).trim();
+    const match = origin.match(
+      /github.com[:/](?<owner>[^/]+)\/(?<repo>[^/]+?)(?:\.git)?$/,
+    );
+    if (match && match.groups) {
+      owner ||= match.groups.owner;
+      repo ||= match.groups.repo;
+    }
+  }
+  if (!owner || !repo) {
+    console.error("Could not determine repository owner and name");
+    process.exit(1);
+  }
+  const res = await fetch(
+    `https://api.github.com/repos/${owner}/${repo}/actions/runners/registration-token`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${adminToken}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    },
+  );
+  if (!res.ok) {
+    const text = await res.text();
+    console.error(`GitHub API request failed: ${res.status} ${text}`);
+    process.exit(1);
+  }
+  const json = await res.json();
+  if (!json.token) {
+    console.error("No token in response");
+    process.exit(1);
+  }
+  console.log(json.token);
+}
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/gh-runner-token.ts
+++ b/scripts/gh-runner-token.ts
@@ -1,0 +1,60 @@
+import { execSync } from "node:child_process";
+
+async function main() {
+  const adminToken = process.env.GITHUB_TOKEN_FOR_RUNNER_ADMIN;
+  if (!adminToken) {
+    console.error("GITHUB_TOKEN_FOR_RUNNER_ADMIN is required");
+    process.exit(1);
+  }
+
+  let owner: string | undefined = process.argv[2];
+  let repo: string | undefined = process.argv[3];
+
+  if (!owner || !repo) {
+    const origin = execSync("git config --get remote.origin.url", {
+      encoding: "utf8",
+    }).trim();
+    const match = origin.match(
+      /github.com[:/](?<owner>[^/]+)\/(?<repo>[^/]+?)(?:\.git)?$/,
+    );
+    if (match && match.groups) {
+      owner ||= match.groups.owner;
+      repo ||= match.groups.repo;
+    }
+  }
+
+  if (!owner || !repo) {
+    console.error("Could not determine repository owner and name");
+    process.exit(1);
+  }
+
+  const res = await fetch(
+    `https://api.github.com/repos/${owner}/${repo}/actions/runners/registration-token`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${adminToken}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    },
+  );
+
+  if (!res.ok) {
+    const text = await res.text();
+    console.error(`GitHub API request failed: ${res.status} ${text}`);
+    process.exit(1);
+  }
+
+  const json = (await res.json()) as { token?: string };
+  if (!json.token) {
+    console.error("No token in response");
+    process.exit(1);
+  }
+  console.log(json.token);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -11,5 +11,5 @@
     "noEmitOnError": false,
     "moduleResolution": "node"
   },
-  "files": ["ci_watchdog.ts"]
+  "files": ["ci_watchdog.ts", "gh-runner-token.ts"]
 }


### PR DESCRIPTION
## Summary
- add TypeScript script to request GitHub Actions runner registration token via REST API
- add shell wrapper exporting GH_RUNNER_REG_TOKEN for GitHub Actions jobs

## Testing
- `npm run format --prefix backend`
- `npm run format`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script: "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html)*

------
https://chatgpt.com/codex/tasks/task_e_68a757b2ea64832da6edb639e0f70be5