### PR TITLE
ci: add teardown workflow for self-hosted runner

### DIFF
--- a/.github/workflows/destroy-selfhosted-runner.yml
+++ b/.github/workflows/destroy-selfhosted-runner.yml
@@ -1,0 +1,35 @@
+name: Destroy self-hosted runner
+
+env:
+  HUSKY: 0
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: "type YES to destroy"
+        required: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  destroy:
+    runs-on: ubuntu-latest
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    steps:
+      - name: Require confirmation
+        if: ${{ github.event.inputs.confirm != 'YES' }}
+        run: |
+          echo "Confirmation required: type YES to destroy." >&2
+          exit 1
+      - name: Checkout code
+        uses: actions/checkout@v5
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+      - name: Terraform destroy
+        working-directory: infra/selfhosted-runner
+        run: terraform destroy -auto-approve


### PR DESCRIPTION
## Summary
- add workflow to destroy self-hosted runner infrastructure after manual confirmation

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: STRIPE_SECRET_KEY must be a live secret)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script: "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a757ad4574832db5638662c578b958