### PR TITLE
feat: add terraform for self-hosted runner

### DIFF
--- a/infra/selfhosted-runner/terraform/main.tf
+++ b/infra/selfhosted-runner/terraform/main.tf
@@ -1,0 +1,115 @@
+data "aws_default_vpc" "default" {}
+
+data "aws_availability_zones" "available" {}
+
+data "aws_subnet" "default" {
+  default_for_az    = true
+  availability_zone = data.aws_availability_zones.available.names[0]
+}
+
+data "http" "my_ip" {
+  url = "https://checkip.amazonaws.com/"
+}
+
+resource "aws_security_group" "runner" {
+  name_prefix = "gha-runner-"
+  description = "Security group for GitHub Actions runner"
+  vpc_id      = data.aws_default_vpc.default.id
+
+  ingress {
+    description = "SSH from current IP"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["${chomp(data.http.my_ip.response_body)}/32"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+data "aws_ami" "al2023" {
+  owners      = ["amazon"]
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-*-x86_64"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+}
+
+data "aws_iam_policy_document" "assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "runner" {
+  name_prefix        = "gha-runner-"
+  assume_role_policy = data.aws_iam_policy_document.assume.json
+}
+
+resource "aws_iam_role_policy_attachment" "ssm" {
+  role       = aws_iam_role.runner.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_role_policy_attachment" "cw" {
+  role       = aws_iam_role.runner.name
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
+}
+
+resource "aws_iam_instance_profile" "runner" {
+  name_prefix = "gha-runner-"
+  role        = aws_iam_role.runner.name
+}
+
+resource "aws_instance" "runner" {
+  ami                         = data.aws_ami.al2023.id
+  instance_type               = var.instance_type
+  subnet_id                   = data.aws_subnet.default.id
+  vpc_security_group_ids      = [aws_security_group.runner.id]
+  iam_instance_profile        = aws_iam_instance_profile.runner.name
+  associate_public_ip_address = true
+
+  root_block_device {
+    volume_size = 20
+    volume_type = "gp3"
+  }
+
+  tags = {
+    Name = "gha-selfhosted-runner"
+  }
+}
+
+resource "aws_ssm_association" "runner_setup" {
+  name = "AWS-RunShellScript"
+
+  targets {
+    key    = "InstanceIds"
+    values = [aws_instance.runner.id]
+  }
+
+  parameters = {
+    commands = [templatefile("${path.module}/userdata.sh", {
+      repo_owner = var.repo_owner
+      repo_name  = var.repo_name
+      labels     = var.labels
+    })]
+  }
+
+  depends_on = [aws_instance.runner]
+}

--- a/infra/selfhosted-runner/terraform/outputs.tf
+++ b/infra/selfhosted-runner/terraform/outputs.tf
@@ -1,0 +1,9 @@
+output "instance_id" {
+  description = "ID of the runner instance"
+  value       = aws_instance.runner.id
+}
+
+output "public_ip" {
+  description = "Public IP address of the runner"
+  value       = aws_instance.runner.public_ip
+}

--- a/infra/selfhosted-runner/terraform/userdata.sh
+++ b/infra/selfhosted-runner/terraform/userdata.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+
+dnf update -y
+dnf install -y git curl tar
+
+curl -fsSL https://rpm.nodesource.com/setup_20.x | bash -
+dnf install -y nodejs
+
+RUNNER_VERSION=$(curl -fsSL https://api.github.com/repos/actions/runner/releases/latest | grep tag_name | cut -d '"' -f4)
+ARCH="linux-x64"
+curl -fsSL -o actions-runner.tar.gz https://github.com/actions/runner/releases/download/${RUNNER_VERSION}/actions-runner-${ARCH}-${RUNNER_VERSION#v}.tar.gz
+tar xzf actions-runner.tar.gz
+./bin/installdependencies.sh
+
+./config.sh --url https://github.com/${repo_owner}/${repo_name} --token ${GH_RUNNER_REG_TOKEN} --labels ${labels} --unattended
+
+./svc.sh install
+./svc.sh start

--- a/infra/selfhosted-runner/terraform/variables.tf
+++ b/infra/selfhosted-runner/terraform/variables.tf
@@ -1,0 +1,21 @@
+variable "instance_type" {
+  description = "EC2 instance type for the runner"
+  type        = string
+  default     = "t3.small"
+}
+
+variable "labels" {
+  description = "Comma-separated list of labels for the GitHub Actions runner"
+  type        = string
+  default     = "self-hosted,aws,node20,x64"
+}
+
+variable "repo_owner" {
+  description = "Owner of the GitHub repository"
+  type        = string
+}
+
+variable "repo_name" {
+  description = "Name of the GitHub repository"
+  type        = string
+}

--- a/infra/selfhosted-runner/terraform/versions.tf
+++ b/infra/selfhosted-runner/terraform/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.6.0, < 2.0.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Terraform configuration for EC2-based GitHub Actions runner using default VPC and subnet
- bootstrap runner via SSM association to install Node 20 and register with the repository

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `cd backend && npm run format`
- `cd backend && npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*


------
https://chatgpt.com/codex/tasks/task_e_68a757a3df2c832d980c5afba66917ee