### PR TITLE
ci: add sccache composite action

### DIFF
--- a/.github/actions/sccache/action.yml
+++ b/.github/actions/sccache/action.yml
@@ -1,0 +1,23 @@
+name: Setup sccache
+runs:
+  using: composite
+  steps:
+    - name: Download sccache
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        set -euo pipefail
+        version=0.7.7
+        url="https://github.com/mozilla/sccache/releases/download/v${version}/sccache-v${version}-x86_64-unknown-linux-musl.tar.gz"
+        mkdir -p "$HOME/.local/bin"
+        curl -sSL "$url" | tar xz --strip-components=1 -C "$HOME/.local/bin" "sccache-v${version}-x86_64-unknown-linux-musl/sccache"
+        chmod +x "$HOME/.local/bin/sccache"
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+    - name: Export env
+      shell: bash
+      run: |
+        echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+        echo "SCCACHE_DIR=$HOME/.cache/sccache" >> "$GITHUB_ENV"
+    - name: Show sccache stats
+      shell: bash
+      run: sccache --show-stats || true

--- a/docs/codex/sccache.md
+++ b/docs/codex/sccache.md
@@ -1,0 +1,19 @@
+# sccache
+
+This repository provides a composite action at `.github/actions/sccache` that installs and configures [sccache](https://github.com/mozilla/sccache) for Rust builds.
+
+## Usage
+
+Add the action to a workflow before running `cargo` commands:
+
+```yaml
+- uses: actions/cache@v4.0.2
+  with:
+    path: ~/.cache/sccache
+    key: ${{ runner.os }}-sccache-${{ hashFiles('**/Cargo.lock') }}
+    restore-keys: ${{ runner.os }}-sccache-
+- uses: ./.github/actions/sccache
+- run: cargo build --locked
+```
+
+The action downloads a static `sccache` binary on Linux, adds it to the `PATH`, and exports `RUSTC_WRAPPER` and `SCCACHE_DIR` environment variables. It also prints cache statistics so cache effectiveness is visible in the workflow logs.


### PR DESCRIPTION
## Summary
- add composite action to install and configure sccache for Rust builds
- document sccache usage and caching setup

## Testing
- `npm run format`
```
> backend@1.0.0 preformat
> node ../scripts/ensure-root-deps.js

> backend@1.0.0 format
> sh -c 'cd .. && node scripts/ensure-root-deps.js && prettier --log-level warn --write "**/*.{js,jsx,json,md}" --ignore-path .prettierignore'
```
- `npm test`
```
PASS tests/frontend/modelViewerLoader.test.js
PASS tests/queue/printWorker.test.js
PASS tests/saleCredits.test.js
PASS tests/apiModels.test.js
PASS __tests__/server-endpoints.test.ts
PASS tests/frontend/flashBanner.test.js
PASS tests/frontend/index.test.js
PASS tests/textToImage.test.ts
PASS tests/envValidation.test.js
```
- `npm run ci` *(fails: Missing script "lint")*
```
npm error Missing script: "lint"
```
- `npm run smoke` *(fails: Missing frontend build artifact)*
```
Missing frontend build artifact: frontend/dist/index.html. Run 'npm run build' and retry
```


------
https://chatgpt.com/codex/tasks/task_e_68a763bc8e18832d8217269711c45b7c