### PR TITLE
ci: add docker prune workflow

### DIFF
--- a/.github/workflows/docker-prune.yml
+++ b/.github/workflows/docker-prune.yml
@@ -1,0 +1,20 @@
+name: Docker prune
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+jobs:
+  prune:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prune Docker on self-hosted runners
+        if: ${{ startsWith(runner.name, 'self-hosted') || contains(runner.labels, 'self-hosted') }}
+        run: |
+          docker builder prune -f
+          docker image prune -af
+      - name: Skip on GitHub-hosted runners
+        if: ${{ !(startsWith(runner.name, 'self-hosted') || contains(runner.labels, 'self-hosted')) }}
+        run: |
+          echo "GitHub-hosted runner detected; skipping docker prune" && exit 0


### PR DESCRIPTION
## Summary
- add a scheduled workflow to prune Docker artifacts weekly on self-hosted runners

## Testing
- `npm run format` (backend)
- `npm test` (backend) *(terminated: took too long)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a763f4a600832db4e263a255b080ec