### PR TITLE
ci: add junit artifacts workflow

### DIFF
--- a/.github/workflows/junit-artifacts.yml
+++ b/.github/workflows/junit-artifacts.yml
@@ -1,0 +1,27 @@
+name: junit artifacts
+
+on:
+  pull_request:
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install dependencies
+        run: npm ci
+      - name: Run tests
+        run: npm test
+      - name: Upload junit and coverage artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: junit-and-coverage
+          path: |
+            **/junit*.xml
+            coverage/**
+          if-no-files-found: ignore
+          retention-days: 7


### PR DESCRIPTION
## Summary
- upload JUnit XML and coverage artifacts for pull requests

## Testing
- `npm run format`
- `npm test`
- `npm run ci` *(fails: Missing script "lint")*
- `npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a763f14508832dbf5c16049d19f304