### PR TITLE
ci: add actionlint workflow

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,30 @@
+name: Actionlint
+
+env:
+  HUSKY: 0
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
+      - uses: actions/checkout@v5
+      - name: Install actionlint
+        run: |
+          if ! command -v actionlint >/dev/null 2>&1; then
+            curl -sSfL https://github.com/rhysd/actionlint/releases/latest/download/actionlint_Linux_x86_64.tar.gz \
+              | sudo tar -xz -C /usr/local/bin actionlint
+          fi
+      - run: actionlint


### PR DESCRIPTION
## Summary
- add workflow to run actionlint on GitHub Actions files

## Testing
- `npm run format`
- `npm test` *(partial, process did not exit)*
- `npm run ci` *(failed: terminated after format check)*
- `npm run smoke` *(failed: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a763e23274832d9b5b1d58ea7a87fe