### PR TITLE
ci: add skip-heavy workflow

### DIFF
--- a/.github/workflows/skip-heavy.yml
+++ b/.github/workflows/skip-heavy.yml
@@ -1,0 +1,16 @@
+name: Skip heavy
+
+# Runs on pull requests to short-circuit CI when the `skip-heavy` label is present.
+# Heavy jobs should use `if: "! contains(github.event.pull_request.labels.*.name, 'skip-heavy')"` to honor the label.
+
+on:
+  pull_request:
+
+jobs:
+  skip-heavy:
+    if: contains(github.event.pull_request.labels.*.name, 'skip-heavy')
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          echo "skip-heavy label present, skipping heavy workflows"
+          exit 0


### PR DESCRIPTION
## Summary
- add workflow that exits quickly when PRs are labeled `skip-heavy`

## Testing
- `npm run validate-env`
- `curl -I https://registry.npmjs.org`
- `curl -I https://cdn.playwright.dev`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` (backend)
- `npm test` (backend)
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact frontend/dist/index.html)*

------
https://chatgpt.com/codex/tasks/task_e_68a763dedd98832dbad2af46624b2dcb