### PR TITLE
ci: add shallow submodule checkout workflow

### DIFF
--- a/.github/workflows/submodules-shallow.yml
+++ b/.github/workflows/submodules-shallow.yml
@@ -1,0 +1,19 @@
+name: submodules-shallow
+
+on:
+  pull_request:
+    paths:
+      - '.gitmodules'
+      # Add submodule paths here when present
+
+jobs:
+  verify-submodules:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 1
+      - name: Verify submodule status
+        run: git submodule status


### PR DESCRIPTION
## Summary
- add workflow to verify submodules with shallow checkout

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` (backend)
- `npm test` (backend)
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a763d42708832da836eb451adfcd7b