### PR TITLE
ci: add Go caching workflow

### DIFF
--- a/.github/workflows/go-cache.yml
+++ b/.github/workflows/go-cache.yml
@@ -1,0 +1,43 @@
+name: Go CI with cache
+
+on:
+  pull_request:
+    paths:
+      - 'go/**'
+      - '**/*.go'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      GO_VERSION: '1.22'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5.0.0
+
+      - name: Cache Go toolchain
+        uses: actions/cache@v4.2.4
+        with:
+          path: ${{ runner.tool_cache }}/go
+          key: ${{ runner.os }}-go-${{ env.GO_VERSION }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v5.5.0
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Cache Go modules
+        uses: actions/cache@v4.2.4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Build
+        run: go build ./...
+
+      - name: Test
+        run: go test ./...


### PR DESCRIPTION
## Summary
- add workflow caching Go toolchain and module build directories
- run `go build` and `go test` on Go pull requests

## Testing
- `npm run format`
- `npm test tests/health.test.js` *(fails: STRIPE_SECRET_KEY must be a live secret)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script: "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html)*

------
https://chatgpt.com/codex/tasks/task_e_68a763cb5d64832db9ad2f58254e3236