### PR TITLE
ci: add repository size monitor

### DIFF
--- a/.github/workflows/size-monitor.yml
+++ b/.github/workflows/size-monitor.yml
@@ -1,0 +1,25 @@
+name: Repository size monitor
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+jobs:
+  size:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Record repository size
+        run: |
+          git count-objects -vH > size.txt
+          if command -v git-sizer >/dev/null 2>&1; then
+            git-sizer -v >> size.txt
+          else
+            echo 'git-sizer not installed' >> size.txt
+          fi
+          cat size.txt
+      - uses: actions/upload-artifact@v4.3.4
+        with:
+          name: repo-size
+          path: size.txt


### PR DESCRIPTION
## Summary
- add weekly size-monitor workflow to track repo size and git-sizer output

## Testing
- `npm run format` (`backend/`)
- `npm test` (`backend/`)
- `npm run ci` (fails: Missing script: "lint")
- `npm run smoke` (fails: Missing frontend build artifact: frontend/dist/index.html)

------
https://chatgpt.com/codex/tasks/task_e_68a763b91408832d8c589ec4a6dc9216