### PR TITLE
ci: add nightly cache warmup workflow

### DIFF
--- a/.github/workflows/nightly-warmup.yml
+++ b/.github/workflows/nightly-warmup.yml
@@ -1,0 +1,34 @@
+name: nightly-cache-warmup
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+
+jobs:
+  nightly-cache-warmup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Restore turbo cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: turbo-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}-${{ github.run_id }}
+          restore-keys: |
+            turbo-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}-
+            turbo-${{ runner.os }}-
+            turbo-
+
+      - name: Warm cache
+        run: npx turbo run build --cache-dir=.turbo
+
+      - name: Save turbo cache
+        if: always()
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: turbo-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}-${{ github.run_id }}


### PR DESCRIPTION
## Summary
- add nightly cache warmup workflow

## Testing
- `npm run format`
- `npm test` *(fails: process hung and was terminated)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: terminated early due to time)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html)*

------
https://chatgpt.com/codex/tasks/task_e_68a763b0b634832da4d1962eea82f699