### PR TITLE
ci: add test timeout guard workflow

### DIFF
--- a/.github/workflows/test-timeout.yml
+++ b/.github/workflows/test-timeout.yml
@@ -1,0 +1,31 @@
+name: Test Timeout Guard
+
+env:
+  HUSKY: 0
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - name: Install dependencies
+        run: |
+          corepack enable
+          pnpm i --frozen-lockfile --ignore-scripts
+      - name: Run tests
+        run: pnpm test -- --maxWorkers=50% --runInBand=false
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: junit.xml
+          path: junit.xml
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary
- add workflow to run tests on pull requests with a 10-minute timeout
- archive junit.xml test results when available

## Testing
- `npm run format`
```
> backend@1.0.0 preformat
> node ../scripts/ensure-root-deps.js

> backend@1.0.0 format
> sh -c 'cd .. && node scripts/ensure-root-deps.js && prettier --log-level warn --write "**/*.{js,jsx,json,md}" --ignore-path .prettierignore'
```
- `npm test -- --runInBand`
```
PASS tests/frontend/flashBanner.test.js
PASS tests/frontend/index.test.js
PASS tests/textToImage.test.ts
```
- `SKIP_PW_DEPS=1 npm run ci` *(missing script: "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(missing frontend build artifact)*


------
https://chatgpt.com/codex/tasks/task_e_68a76339b664832d898b2e7c9f498f65