### PR TITLE
ci/web-matrix

### DIFF
--- a/.github/workflows/web-matrix.yml
+++ b/.github/workflows/web-matrix.yml
@@ -1,0 +1,44 @@
+name: web-matrix
+
+env:
+  HUSKY: 0
+
+on:
+  pull_request:
+    paths:
+      - "apps/site/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [18, 20]
+    steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
+      - uses: actions/checkout@v5.0.0
+        with:
+          fetch-depth: 1
+          sparse-checkout: |
+            apps/site
+            package.json
+            pnpm-lock.yaml
+          sparse-checkout-cone: true
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+      - name: Install dependencies
+        run: |
+          corepack enable
+          pnpm install --frozen-lockfile --ignore-scripts
+      - name: Build
+        run: pnpm -w run build


### PR DESCRIPTION
## Summary
- add web-matrix workflow to build apps/site with Node 18 & 20 using pnpm cache and sparse checkout

## Testing
- `npm run format` (backend)
```
> backend@1.0.0 preformat
> node ../scripts/ensure-root-deps.js

> backend@1.0.0 format
> sh -c 'cd .. && node scripts/ensure-root-deps.js && prettier --log-level warn --write "**/*.{js,jsx,json,md}" --ignore-path .prettierignore'
```
- `npm test` (backend)
```
PASS tests/api.test.js (5.247 s)
...
```
- `npm run ci` (fails: Missing script "lint")
- `npm run smoke` (fails: Missing frontend build artifact)


------
https://chatgpt.com/codex/tasks/task_e_68a7633495b8832db841a6baf82c770a