### PR TITLE
docs: add large files policy

### DIFF
--- a/docs/codex/large-files-policy.md
+++ b/docs/codex/large-files-policy.md
@@ -1,0 +1,5 @@
+# Large Files Policy
+
+- Keep binary files out of Git repositories.
+- Use GitHub Releases or external object storage for distributing large assets.
+- If binary assets must be committed, prefer Git LFS to manage them.


### PR DESCRIPTION
## Summary
- document policy for handling large binary assets

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup` *(fails: stuck during dependency install)*
- `npm run format` *(fails: npm cache errors)*
- `npm test` *(fails: setup script hang)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: ENOTEMPTY during npm ci)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a7632ffce8832d94516c9a5bc7f748