### PR TITLE
chore: ignore build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,11 @@ infra/awscliv2.zip
 test-results/
 
 .artifacts/
+
+# build artifacts
+dist/
+.out/
+.turbo/
+.cache/
+.eslintcache
+.prettiercache


### PR DESCRIPTION
## Summary
- ignore common build artifact directories in root .gitignore

## Testing
- `npm run format`
- `CI=1 npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a7632ba9d0832d9707344a325fd614