### PR TITLE
ci: add affected builds workflow

### DIFF
--- a/.github/workflows/affected.yml
+++ b/.github/workflows/affected.yml
@@ -1,0 +1,40 @@
+name: affected-builds
+
+env:
+  HUSKY: 0
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  affected-builds:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: Check for turbo.json
+        id: turbo
+        run: |
+          if [ ! -f turbo.json ]; then
+            echo "missing=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Restore turbo cache
+        if: steps.turbo.outputs.missing != 'true'
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: pr-${{ github.event.pull_request.number }}-turbo-${{ github.sha }}
+          restore-keys: |
+            pr-${{ github.event.pull_request.number }}-turbo-
+            pr-3-turbo-
+      - name: Run affected build
+        if: steps.turbo.outputs.missing != 'true'
+        run: npx turbo run build --filter=...[HEAD^1]
+      - name: No turbo config
+        if: steps.turbo.outputs.missing == 'true'
+        run: echo 'turbo.json not found, skipping'


### PR DESCRIPTION
## Summary
- add workflow to build only packages affected by a pull request, reusing the turbo cache from PR #3 when available

## Testing
- `npm run format` (backend)

```text
> backend@1.0.0 preformat
> node ../scripts/ensure-root-deps.js

> backend@1.0.0 format
> sh -c 'cd .. && node scripts/ensure-root-deps.js && prettier --log-level warn --write "**/*.{js,jsx,json,md}" --ignore-path .prettierignore'
```

- `npm test` (backend)

```text
PASS tests/api.test.js (7.476 s)
PASS tests/api.test.ts
PASS tests/additionalApi.test.js
PASS tests/analytics.test.js
```

- `npm run ci` (fails: Missing script "lint")
- `npm run smoke` (fails: Missing frontend build artifact)


------
https://chatgpt.com/codex/tasks/task_e_68a7631113e4832d9abed44a9aae5eec