### PR TITLE
ci: add nx optional workflow

### DIFF
--- a/.github/workflows/nx-optional.yml
+++ b/.github/workflows/nx-optional.yml
@@ -1,0 +1,40 @@
+name: Nx optional
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  nx:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: nx.json not found
+        if: ${{ hashFiles('nx.json') == '' }}
+        run: echo "nx.json not found, skipping"
+
+      - name: Setup Node
+        if: ${{ hashFiles('nx.json') != '' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Restore node_modules cache
+        if: ${{ hashFiles('nx.json') != '' }}
+        id: node-modules-cache
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
+          restore-keys: ${{ runner.os }}-node-modules-
+
+      - name: Install dependencies
+        if: ${{ hashFiles('nx.json') != '' && steps.node-modules-cache.outputs.cache-hit != 'true' }}
+        run: npm ci
+
+      - name: Run Nx affected targets
+        if: ${{ hashFiles('nx.json') != '' }}
+        run: npx nx affected -t build,test,lint


### PR DESCRIPTION
## Summary
- add optional Nx workflow that restores node_modules cache and runs Nx affected tasks when nx.json exists

## Testing
- `npm run format` (backend)
- `npm test` (backend)
- `SKIP_PW_DEPS=1 npm run ci` *(partial run)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a76316d270832da0ee6fd5ed159121