### PR TITLE
ci/node-cache-keys

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,6 +37,9 @@ jobs:
         with:
           node-version: 20
           cache: 'npm'
+          cache-dependency-path: |
+            package-lock.json
+            backend/package-lock.json
       - name: Verify code scanning enabled
         run: node scripts/check-code-scanning.js
       - name: Initialize CodeQL

--- a/.github/workflows/ensure_server_boots_185ecc2b50.yml
+++ b/.github/workflows/ensure_server_boots_185ecc2b50.yml
@@ -50,6 +50,9 @@ jobs:
         with:
           node-version: 20
           cache: 'npm'
+          cache-dependency-path: |
+            package-lock.json
+            backend/package-lock.json
 
       - name: Install dependencies
         run: npm run setup

--- a/.github/workflows/glb-ci-alerts-938dhf.yml
+++ b/.github/workflows/glb-ci-alerts-938dhf.yml
@@ -30,6 +30,9 @@ jobs:
         with:
           node-version: 20
           cache: 'npm'
+          cache-dependency-path: |
+            package-lock.json
+            backend/package-lock.json
       - name: Install dependencies
         run: |
           npm ci

--- a/.github/workflows/healthz-contract.yml
+++ b/.github/workflows/healthz-contract.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           node-version: 20
           cache: 'npm'
+          cache-dependency-path: package-lock.json
       - run: npm ci
       - run: node scripts/run-jest.js tests/diagnostics/healthz_contract.test.js
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           node-version: 20
           cache: 'npm'
+          cache-dependency-path: package-lock.json
       - run: npm install --no-audit --no-fund
       - name: Run Lighthouse CI
         env:

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           node-version: 20
           cache: 'npm'
+          cache-dependency-path: package-lock.json
       - run: npm install --no-audit --no-fund
       - run: npm run load -- -o artillery-report.json
       - name: Upload Artillery report

--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -43,6 +43,9 @@ jobs:
         with:
           node-version: 20
           cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            backend/package-lock.json
       - run: npm run setup
       - name: Start backend
         run: |


### PR DESCRIPTION
## Summary
- include lockfile paths in Node.js setup caching across remaining workflows

## Testing
- `npm run format`
- `npm test`
- `npm run ci` *(fails: Missing script: "lint")*
- `npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html)*


------
https://chatgpt.com/codex/tasks/task_e_68a762fbd41c832d8e470856a06b6b6a