### PR TITLE
ci: add concurrency and timeouts to workflows

### DIFF
--- a/.github/workflows/_setup.yml
+++ b/.github/workflows/_setup.yml
@@ -22,6 +22,7 @@ jobs:
     uses: ./.github/workflows/labels.yml
     with:
       use_self_hosted: ${{ inputs.use_self_hosted }}
+    timeout-minutes: 15
 
   run:
     needs: labels
@@ -43,3 +44,4 @@ jobs:
       - run: npm ci --prefix frontend
       - run: npm ci --prefix backend
       - run: ${{ inputs.run }}
+    timeout-minutes: 15

--- a/.github/workflows/auto_rebase_merge_queue.yml
+++ b/.github/workflows/auto_rebase_merge_queue.yml
@@ -3,10 +3,9 @@ name: Auto Rebase and Merge Queue
 env:
   HUSKY: 0
 
-
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [ opened, synchronize, reopened ]
 
 permissions:
   contents: write
@@ -47,6 +46,7 @@ jobs:
               issue_number: context.issue.number,
               labels: ['rebase-needed']
             })
+    timeout-minutes: 15
   merge-queue:
     needs: rebase
     if: ${{ needs.rebase.result == 'success' || needs.rebase.result == 'skipped' }}
@@ -59,3 +59,4 @@ jobs:
         uses: autifyhq/merge-queue-action@v0.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    timeout-minutes: 15

--- a/.github/workflows/backend-only-ci.yml
+++ b/.github/workflows/backend-only-ci.yml
@@ -5,10 +5,11 @@ env:
 
 on:
   workflow_run:
-    workflows: ["Preflight"]
+    workflows: [ "Preflight" ]
     types:
       - completed
   workflow_dispatch:
+
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -19,18 +20,21 @@ permissions:
 
 jobs:
   preflight:
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success' }}
     uses: ./.github/workflows/preflight.yml
+    timeout-minutes: 15
 
   backend-tests:
     needs: preflight
-    if: github.event_name == 'workflow_dispatch' || needs.preflight.outputs.run_backend == 'true'
+    if: github.event_name == 'workflow_dispatch' ||
+      needs.preflight.outputs.run_backend == 'true'
     runs-on: ubuntu-latest
     continue-on-error: true
     strategy:
       fail-fast: true
       matrix:
-        shard: [aa, ab, ac]
+        shard: [ aa, ab, ac ]
     steps:
       - name: Heartbeat
         run: |
@@ -70,3 +74,4 @@ jobs:
           node scripts/run-jest.js backend --listTests | split -n l/3 - test-files-
           TEST_FILES=$(cat test-files-${{ matrix.shard }} | tr '\n' ' ')
           node scripts/run-jest.js --runTestsByPath $TEST_FILES --ci
+    timeout-minutes: 15

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        shard: [aa, ab, ac]
+        shard: [ aa, ab, ac ]
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
@@ -76,3 +76,4 @@ jobs:
           node scripts/run-jest.js backend --listTests | split -n l/3 - test-files-
           TEST_FILES=$(cat test-files-${{ matrix.shard }} | tr '\n' ' ')
           node scripts/run-jest.js --runTestsByPath $TEST_FILES --ci --coverage
+    timeout-minutes: 15

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -3,7 +3,6 @@ name: Build frontend
 env:
   HUSKY: 0
 
-
 on:
   pull_request:
     paths:
@@ -18,7 +17,8 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: ${{ matrix.node != 22 || contains(github.event.pull_request.labels.*.name, 'full-matrix') }}
+    if: ${{ matrix.node != 22 || contains(github.event.pull_request.labels.*.name,
+      'full-matrix') }}
     continue-on-error: ${{ matrix.node == 22 }}
     defaults:
       run:
@@ -26,8 +26,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        node: [20, 22]
-        shard: [1, 2, 3]
+        node: [ 20, 22 ]
+        shard: [ 1, 2, 3 ]
     steps:
       - name: Heartbeat
         run: |
@@ -48,3 +48,4 @@ jobs:
         with:
           name: frontend-dist-${{ matrix.node }}-${{ matrix.shard }}
           path: frontend/dist
+    timeout-minutes: 15

--- a/.github/workflows/cache-primer.yml
+++ b/.github/workflows/cache-primer.yml
@@ -3,9 +3,9 @@ name: Cache primer
 env:
   HUSKY: 0
 
-
 on:
   pull_request:
+
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -25,6 +25,7 @@ jobs:
           cache: npm
           cache-dependency-path: package-lock.json
       - run: npm ci
+    timeout-minutes: 15
 
   backend-cache:
     runs-on: ubuntu-latest
@@ -39,6 +40,7 @@ jobs:
           cache: npm
           cache-dependency-path: backend/package-lock.json
       - run: npm ci --prefix backend
+    timeout-minutes: 15
 
   frontend-cache:
     runs-on: ubuntu-latest
@@ -50,3 +52,4 @@ jobs:
           cache: npm
           cache-dependency-path: frontend/package-lock.json
       - run: npm ci --prefix frontend
+    timeout-minutes: 15

--- a/.github/workflows/cache-validator.yml
+++ b/.github/workflows/cache-validator.yml
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   validate:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true

--- a/.github/workflows/cf-pages-preview.yml
+++ b/.github/workflows/cf-pages-preview.yml
@@ -18,6 +18,7 @@ concurrency:
 
 jobs:
   preview:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/ci-env.yml
+++ b/.github/workflows/ci-env.yml
@@ -12,6 +12,7 @@ concurrency:
 
 jobs:
   versions:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/ci-queue-monitor.yml
+++ b/.github/workflows/ci-queue-monitor.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   monitor:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     permissions:
       actions: write

--- a/.github/workflows/ci-rerun-slow.yml
+++ b/.github/workflows/ci-rerun-slow.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   coverage:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     outputs:
       duration: ${{ steps.duration.outputs.value }}
@@ -41,6 +42,7 @@ jobs:
         run: echo "value=$(( ${{ steps.end.outputs.end }} - ${{ steps.start.outputs.start }} ))" >> "$GITHUB_OUTPUT"
 
   e2e:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     env:
       PORT: 3000
@@ -92,6 +94,7 @@ jobs:
         run: echo "value=$(( ${{ steps.end.outputs.end }} - ${{ steps.start.outputs.start }} ))" >> "$GITHUB_OUTPUT"
 
   timings:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     needs: [coverage, e2e]
     steps:

--- a/.github/workflows/ci-watchdog.yml
+++ b/.github/workflows/ci-watchdog.yml
@@ -21,6 +21,7 @@ concurrency:
 
 jobs:
   scan:
+    timeout-minutes: 15
     if: ${{ github.repository_owner == 'print3git' }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ env:
 
 jobs:
   build:
+    timeout-minutes: 15
     runs-on:
       - self-hosted
       - ubuntu-latest
@@ -86,6 +87,7 @@ jobs:
           echo "First failing step: ${first_failed}" >> "$GITHUB_STEP_SUMMARY"
 
   test-backend:
+    timeout-minutes: 15
     runs-on: ubuntu-latest-XXL
     strategy:
       fail-fast: true
@@ -157,6 +159,7 @@ jobs:
           echo "First failing step: ${first_failed}" >> "$GITHUB_STEP_SUMMARY"
 
   test-frontend:
+    timeout-minutes: 15
     runs-on:
       - self-hosted
       - ubuntu-latest
@@ -233,6 +236,7 @@ jobs:
           echo "First failing step: ${first_failed}" >> "$GITHUB_STEP_SUMMARY"
 
   test-integration:
+    timeout-minutes: 15
     if: github.event_name == 'push'
     runs-on:
       - self-hosted
@@ -289,6 +293,7 @@ jobs:
           echo "First failing step: ${first_failed}" >> "$GITHUB_STEP_SUMMARY"
 
   coverage-merge:
+    timeout-minutes: 15
     if: github.event_name == 'push'
     runs-on:
       - self-hosted

--- a/.github/workflows/cloudflare-preview.yml
+++ b/.github/workflows/cloudflare-preview.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   preview:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,6 +21,7 @@ concurrency:
 
 jobs:
   analyze:
+    timeout-minutes: 15
     if: github.event_name != 'pull_request' || startsWith(github.head_ref, 'security/')
     name: Analyze
     runs-on: ubuntu-latest

--- a/.github/workflows/collect-artifacts.yml
+++ b/.github/workflows/collect-artifacts.yml
@@ -21,6 +21,7 @@ concurrency:
 
 jobs:
   collect-logs:
+    timeout-minutes: 15
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,6 +12,7 @@ concurrency:
 
 jobs:
   coverage:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/coveralls-upload.yml
+++ b/.github/workflows/coveralls-upload.yml
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   upload:
+    timeout-minutes: 15
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   backup:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/debug-queue.yml
+++ b/.github/workflows/debug-queue.yml
@@ -15,6 +15,7 @@ permissions: {}
 
 jobs:
   debug:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - run: echo "I ran on ${{ runner.os }} with job id ${{ github.run_id }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,7 @@ concurrency:
 
 jobs:
   deploy:
+    timeout-minutes: 15
     if: vars.ENABLE_PAGES == '1' && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     env:
@@ -140,6 +141,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CF_PAGES_API_TOKEN }}
 
   pages-disabled:
+    timeout-minutes: 15
     if: vars.ENABLE_PAGES != '1' && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/destroy-selfhosted-runner.yml
+++ b/.github/workflows/destroy-selfhosted-runner.yml
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   destroy:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/diagnostics-dist-check.yml
+++ b/.github/workflows/diagnostics-dist-check.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   build:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   docker:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     env:
       SKIP_TESTS: 0

--- a/.github/workflows/endpoint-health.yml
+++ b/.github/workflows/endpoint-health.yml
@@ -14,6 +14,7 @@ concurrency:
 
 jobs:
   probe:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/ensure_server_boots_185ecc2b50.yml
+++ b/.github/workflows/ensure_server_boots_185ecc2b50.yml
@@ -14,6 +14,7 @@ concurrency:
 
 jobs:
   boot_check:
+    timeout-minutes: 15
     strategy:
       max-parallel: 2
     runs-on: ubuntu-latest-XXL

--- a/.github/workflows/env-parity.yml
+++ b/.github/workflows/env-parity.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   env-parity:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/eslint-diagnostics.yml
+++ b/.github/workflows/eslint-diagnostics.yml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   eslint:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -18,11 +18,13 @@ concurrency:
 
 jobs:
   labels:
+    timeout-minutes: 15
     uses: ./.github/workflows/labels.yml
     with:
       use_self_hosted: ${{ inputs.use_self_hosted }}
 
   lint:
+    timeout-minutes: 15
     needs: labels
     runs-on: ${{ fromJSON(needs.labels.outputs.runs_on_json) }}
     steps:

--- a/.github/workflows/frontend-dry-build.yml
+++ b/.github/workflows/frontend-dry-build.yml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   dry-build:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/frontend-local-build.yml
+++ b/.github/workflows/frontend-local-build.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   build:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/glb-ci-alerts-938dhf.yml
+++ b/.github/workflows/glb-ci-alerts-938dhf.yml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   notify:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     env:
       PORT: 3000

--- a/.github/workflows/glb-tests.yml
+++ b/.github/workflows/glb-tests.yml
@@ -26,6 +26,7 @@ concurrency:
 
 jobs:
   unit-tests:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - name: Heartbeat
@@ -48,6 +49,7 @@ jobs:
         run: npm run test:unit --prefix backend
 
   e2e-tests:
+    timeout-minutes: 15
     needs: unit-tests
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/healthz-contract.yml
+++ b/.github/workflows/healthz-contract.yml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   snapshot:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/jest-early-warning.yml
+++ b/.github/workflows/jest-early-warning.yml
@@ -12,4 +12,5 @@ concurrency:
 
 jobs:
   backend-tests:
+    timeout-minutes: 15
     uses: ./.github/workflows/backend-tests.yml

--- a/.github/workflows/jest-open-handles.yml
+++ b/.github/workflows/jest-open-handles.yml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   jest-open-handles:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -12,8 +12,13 @@ on:
         description: 'Runner specification'
         value: ${{ jobs.select.outputs.runs_on }}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   select:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     outputs:
       runs_on: ${{ steps.choose.outputs.runs_on }}

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -14,6 +14,7 @@ concurrency:
 
 jobs:
   lighthouse:
+    timeout-minutes: 15
     if: ${{ github.event.deployment_status.environment == 'preview' }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,6 +32,7 @@ concurrency:
 
 jobs:
   lint:
+    timeout-minutes: 15
     uses: ./.github/workflows/_setup.yml
     with:
       run: |

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -9,11 +9,12 @@ on:
 
 concurrency:
   # Limit load tests to a single runner across all refs to avoid saturating runner capacity
-  group: load-test
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   load:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,4 +14,5 @@ concurrency:
 
 jobs:
   build:
+    timeout-minutes: 15
     uses: ./.github/workflows/node.yml

--- a/.github/workflows/nock-report.yml
+++ b/.github/workflows/nock-report.yml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   nock-report:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/openapi-lint.yml
+++ b/.github/workflows/openapi-lint.yml
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   lint:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/ops-report.yml
+++ b/.github/workflows/ops-report.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   report:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/package-helm.yml
+++ b/.github/workflows/package-helm.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   package:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -9,11 +9,12 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: pages-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   validate:
+    timeout-minutes: 15
     name: Pages config validate
     runs-on: ubuntu-latest
     steps:
@@ -37,6 +38,7 @@ jobs:
         run: npx -y wrangler pages config validate --project-name "${{ secrets.CF_PAGES_PROJECT }}"
 
   deploy:
+    timeout-minutes: 15
     needs: validate
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pages-url-comment.yml
+++ b/.github/workflows/pages-url-comment.yml
@@ -11,6 +11,7 @@ concurrency:
 
 jobs:
   comment:
+    timeout-minutes: 15
     if: ${{ github.event.workflow_run.conclusion != 'cancelled' }}
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/pipeline-smoke.yml
+++ b/.github/workflows/pipeline-smoke.yml
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   smoke_test:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     env:
       STRIPE_TEST_KEY: ${{ secrets.STRIPE_TEST_KEY }}

--- a/.github/workflows/playwright-browsers-cache.yml
+++ b/.github/workflows/playwright-browsers-cache.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   cache-browsers:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -31,6 +31,7 @@ concurrency:
 
 jobs:
   changed:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     outputs:
       backend: ${{ steps.filter.outputs.backend }}

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   deploy:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     env:
       PORT: 3000

--- a/.github/workflows/printclub-reminders.yml
+++ b/.github/workflows/printclub-reminders.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   remind:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/priority.yml
+++ b/.github/workflows/priority.yml
@@ -50,6 +50,7 @@ jobs:
       - run: npm run smoke:api
 
   gate:
+    timeout-minutes: 15
     name: Gate
     runs-on: ubuntu-latest
     needs: [lint-fast, smoke-api]

--- a/.github/workflows/provision-selfhosted-runner.yml
+++ b/.github/workflows/provision-selfhosted-runner.yml
@@ -20,8 +20,13 @@ on:
         required: false
         default: ''
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   provision:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/regression-guard.yml
+++ b/.github/workflows/regression-guard.yml
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   guard:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/reset-credits.yml
+++ b/.github/workflows/reset-credits.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   reset:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/runner-scheduler.yml
+++ b/.github/workflows/runner-scheduler.yml
@@ -8,8 +8,13 @@ env:
 on:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   stop:
+    timeout-minutes: 15
     if: ${{ false }}
     runs-on: ubuntu-latest
     steps:
@@ -23,6 +28,7 @@ jobs:
       - name: Stop instance
         run: aws ec2 stop-instances --instance-ids "$RUNNER_INSTANCE_ID"
   start:
+    timeout-minutes: 15
     if: ${{ false }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/runner-watchdog.yml
+++ b/.github/workflows/runner-watchdog.yml
@@ -5,6 +5,10 @@ on:
     - cron: '*/10 * * * *'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   actions: read
   pull-requests: write
@@ -15,6 +19,7 @@ defaults:
 
 jobs:
   watchdog:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - name: Check self-hosted AWS runner

--- a/.github/workflows/schedule-check.yml
+++ b/.github/workflows/schedule-check.yml
@@ -14,6 +14,7 @@ concurrency:
 
 jobs:
   check:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/smoke-backend.yml
+++ b/.github/workflows/smoke-backend.yml
@@ -18,10 +18,12 @@ permissions:
 
 jobs:
   preflight:
+    timeout-minutes: 15
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     uses: ./.github/workflows/preflight.yml
 
   db-seed:
+    timeout-minutes: 15
     needs: preflight
     runs-on: ubuntu-latest
     services:

--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   changes:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     outputs:
       frontend: ${{ steps.filter.outputs.frontend }}
@@ -28,6 +29,7 @@ jobs:
               - 'frontend/**'
 
   backend-smoke:
+    timeout-minutes: 15
     needs: changes
     runs-on: ubuntu-latest
     env:
@@ -63,6 +65,7 @@ jobs:
         shell: bash
 
   frontend-artifact-check:
+    timeout-minutes: 15
     needs: [changes, backend-smoke]
     if: needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   sync:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/sync-space.yml
+++ b/.github/workflows/sync-space.yml
@@ -14,6 +14,7 @@ concurrency:
 
 jobs:
   sync:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     env:
       STRIPE_TEST_KEY: ${{ secrets.STRIPE_TEST_KEY }}

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -18,6 +18,7 @@ concurrency:
 
 jobs:
   typecheck:
+    timeout-minutes: 15
     uses: ./.github/workflows/_setup.yml
     with:
       run: npx tsc --noEmit

--- a/.github/workflows/update_locks.yml
+++ b/.github/workflows/update_locks.yml
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   update:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/verify-lockfile.yml
+++ b/.github/workflows/verify-lockfile.yml
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   verify:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/warm-cache.yml
+++ b/.github/workflows/warm-cache.yml
@@ -13,6 +13,7 @@ concurrency:
 
 jobs:
   root-cache:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - name: Heartbeat
@@ -27,6 +28,7 @@ jobs:
       - run: npm ci
 
   backend-cache:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - name: Heartbeat
@@ -41,6 +43,7 @@ jobs:
       - run: npm ci --prefix backend
 
   frontend-cache:
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - name: Heartbeat


### PR DESCRIPTION
## Summary
- ensure all workflows use concurrency group `${{ github.workflow }}-${{ github.ref }}` with cancel-in-progress
- default any missing job timeouts to 15 minutes

## Testing
- `npm run format` (pass)
- `npm test` (fails: `STRIPE_SECRET_KEY must be a live secret` and other missing envs)
- `npm run ci` (fails: missing script)
- `npm run smoke` (fails: frontend build artifact missing)


------
https://chatgpt.com/codex/tasks/task_e_68a763041c18832d924ef9620343d2bc