### PR TITLE
ci/path-filters

### DIFF
--- a/.github/workflows/pr-path-filters.yml
+++ b/.github/workflows/pr-path-filters.yml
@@ -1,0 +1,23 @@
+name: pr-path-filters
+
+on:
+  pull_request:
+    paths:
+      - 'apps/site/**'
+      - 'packages/ui/**'
+
+jobs:
+  lint-typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5.0.0
+      - uses: pnpm/action-setup@v4.1.0
+        with:
+          run_install: false
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm lint
+      - run: pnpm typecheck


### PR DESCRIPTION
## Summary
- add `pr-path-filters` workflow that runs lint and typecheck when PRs touch `apps/site/**` or `packages/ui/**`

## Testing
- `npm run format --prefix backend`
```
> backend@1.0.0 preformat
> node ../scripts/ensure-root-deps.js

> backend@1.0.0 format
> sh -c 'cd .. && node scripts/ensure-root-deps.js && prettier --log-level warn --write "**/*.{js,jsx,json,md}" --ignore-path .prettierignore'
```
- `npm test --prefix backend`
```
PASS tests/frontend/index.test.js
PASS tests/textToImage.test.ts
PASS tests/envValidation.test.js
```
- `SKIP_PW_DEPS=1 npm run ci` (fails: Missing script: "lint")
- `SKIP_PW_DEPS=1 npm run smoke` (fails: Missing frontend build artifact: frontend/dist/index.html)


------
https://chatgpt.com/codex/tasks/task_e_68a762ebd074832d82a5f54e541845fd