### PR TITLE
ci: add sparse checkout workflow

### DIFF
--- a/.github/workflows/ci-sparse-checkout.yml
+++ b/.github/workflows/ci-sparse-checkout.yml
@@ -1,0 +1,35 @@
+name: ci-sparse
+
+env:
+  HUSKY: 0
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          filter: blob:none
+          sparse-checkout: |
+            apps/**
+            packages/**
+          sparse-checkout-cone-mode: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: corepack enable
+      - run: pnpm i --frozen-lockfile
+      - run: pnpm -w run build


### PR DESCRIPTION
## Summary
- add workflow that uses sparse checkout to build apps and packages only

## Testing
- `npm run setup`
- `npm run format` (backend)
- `cd backend && SKIP_PW_DEPS=1 npm test` *(fails: attempts to download Playwright Chromium)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Playwright browsers not installed)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a762e6ce84832daff168066d5b3dc6