### PR TITLE
test: add full stack test suite

### DIFF
--- a/tests/full-stack/backend.integration.test.js
+++ b/tests/full-stack/backend.integration.test.js
@@ -1,0 +1,49 @@
+jest.mock("../../backend/db.js", () => ({
+  query: jest.fn(),
+}));
+
+const db = require("../../backend/db.js");
+const {
+  healthHandler,
+  readyHandler,
+} = require("../../backend/routes/healthz.js");
+const pkg = require("../../backend/package.json");
+
+function createRes() {
+  const res = {};
+  res.statusCode = 200;
+  res.status = (code) => {
+    res.statusCode = code;
+    return res;
+  };
+  res.json = (body) => {
+    res.body = body;
+    return res;
+  };
+  return res;
+}
+
+describe("health routes", () => {
+  test("healthHandler", () => {
+    const res = createRes();
+    healthHandler({}, res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ ok: true, version: pkg.version });
+  });
+
+  test("readyHandler success", async () => {
+    db.query.mockResolvedValueOnce({ rows: [] });
+    const res = createRes();
+    await readyHandler({}, res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  test("readyHandler failure", async () => {
+    db.query.mockRejectedValueOnce(new Error("fail"));
+    const res = createRes();
+    await readyHandler({}, res);
+    expect(res.statusCode).toBe(500);
+    expect(res.body.ok).toBe(false);
+  });
+});

--- a/tests/full-stack/backend.unit.test.js
+++ b/tests/full-stack/backend.unit.test.js
@@ -1,0 +1,22 @@
+const { getEnv } = require("../../backend/utils/getEnv.js");
+
+describe("getEnv", () => {
+  afterEach(() => {
+    delete process.env.TEST_VAR;
+  });
+
+  test("returns existing value", () => {
+    process.env.TEST_VAR = "abc";
+    expect(getEnv("TEST_VAR")).toBe("abc");
+  });
+
+  test("returns default when missing", () => {
+    expect(getEnv("TEST_VAR", { default: "def" })).toBe("def");
+  });
+
+  test("throws when required missing", () => {
+    expect(() => getEnv("TEST_VAR", { required: true })).toThrow(
+      /Environment variable TEST_VAR is required/,
+    );
+  });
+});

--- a/tests/full-stack/cicd.workflow.test.js
+++ b/tests/full-stack/cicd.workflow.test.js
@@ -1,0 +1,25 @@
+const { spawn } = require("child_process");
+
+jest.setTimeout(1000 * 60 * 10);
+
+function run(cmd, args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, { stdio: "inherit" });
+    child.on("exit", (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`${cmd} ${args.join(" ")} exited with ${code}`));
+    });
+  });
+}
+
+describe("ci workflow", () => {
+  test("lint, typecheck, build pass", async () => {
+    await run("npx", ["eslint", "tests/full-stack"]);
+    await run("npx", [
+      "tsc",
+      "--noEmit",
+      "tests/full-stack/e2e-signup.spec.ts",
+    ]);
+    await run("npm", ["run", "build:frontend"]);
+  });
+});

--- a/tests/full-stack/e2e-signup.spec.ts
+++ b/tests/full-stack/e2e-signup.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from "@playwright/test";
+
+test("homepage loads", async ({ page }) => {
+  await page.goto("/");
+  await expect(page).toHaveTitle(/print2/i);
+});

--- a/tests/full-stack/frontend.signup.test.js
+++ b/tests/full-stack/frontend.signup.test.js
@@ -1,0 +1,60 @@
+/* eslint-env browser */
+/* eslint-disable jsdoc/check-tag-names */
+/* global document, localStorage */
+/**
+ * @jest-environment jsdom
+ */
+
+function loadScript() {
+  jest.resetModules();
+  require("../../js/signup.js");
+}
+
+describe("signup form", () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <form id="signupForm">
+        <input id="su-name" />
+        <input id="su-email" />
+        <input id="su-pass" />
+        <div id="error"></div>
+      </form>`;
+    localStorage.clear();
+  });
+
+  test("shows error when fields missing", () => {
+    loadScript();
+    const form = document.getElementById("signupForm");
+    form.dispatchEvent(
+      new Event("submit", { bubbles: true, cancelable: true }),
+    );
+    expect(document.getElementById("error").textContent).toBe(
+      "Fields required",
+    );
+  });
+
+  test("successful signup stores token", async () => {
+    loadScript();
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({ json: () => Promise.resolve({ token: "t123" }) })
+      .mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+
+    document.getElementById("su-name").value = "user";
+    document.getElementById("su-email").value = "a@b.com";
+    document.getElementById("su-pass").value = "pw";
+
+    const form = document.getElementById("signupForm");
+    try {
+      form.dispatchEvent(
+        new Event("submit", { bubbles: true, cancelable: true }),
+      );
+    } catch (_e) {
+      // ignore navigation not implemented errors
+    }
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(localStorage.getItem("token")).toBe("t123");
+  });
+});

--- a/tests/full-stack/playwright.config.js
+++ b/tests/full-stack/playwright.config.js
@@ -1,0 +1,14 @@
+const { defineConfig } = require("@playwright/test");
+const path = require("path");
+
+module.exports = defineConfig({
+  testDir: ".",
+  timeout: 120 * 1000,
+  use: { headless: true },
+  webServer: {
+    command: `node ${path.join(__dirname, "../../scripts/dev-server.js")}`,
+    port: 3000,
+    timeout: 120 * 1000,
+    reuseExistingServer: true,
+  },
+});


### PR DESCRIPTION
## Summary
- cover environment helper logic with unit tests
- exercise health endpoints and signup flow
- check lint, typecheck, and frontend build via CI workflow

## Testing
- `node scripts/run-jest.js tests/full-stack/backend.unit.test.js tests/full-stack/backend.integration.test.js tests/full-stack/frontend.signup.test.js`
- `node scripts/run-jest.js tests/full-stack/cicd.workflow.test.js`
- `npx playwright test tests/full-stack/e2e-signup.spec.ts --config=tests/full-stack/playwright.config.js`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(partial, see logs)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68a761d97cf8832da68088edfe2acb25