### PR TITLE
docs: add branch protection guidelines

### DIFF
--- a/docs/codex/branch-protection.md
+++ b/docs/codex/branch-protection.md
@@ -1,0 +1,18 @@
+# Branch protection settings
+
+To keep the repository stable and predictable, configure branch protection with these recommendations:
+
+## Required status checks
+- Enable "Require status checks to pass before merging".
+- Include continuous integration, formatting, and test checks in the required list.
+
+## Linear history
+- Enable "Require linear history" so merges do not introduce merge commits.
+- This ensures a clean, straight commit history and simplifies reverts.
+
+## Review requirements
+- Enable "Require a pull request before merging".
+- Require at least one approving review from someone other than the author.
+- Dismiss stale approvals when new commits are pushed.
+
+Following these settings encourages high quality contributions and keeps main branches reliable.


### PR DESCRIPTION
## Summary
- add documentation describing recommended branch protection settings

## Testing
- `npm run format` in backend
- `npm test` in backend
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a766780090832dab2ed5fa039dd321