### PR TITLE
ci: add conventional commit check

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,0 +1,17 @@
+name: Conventional Commits
+
+on:
+  pull_request:
+
+jobs:
+  commitlint:
+    name: Commitlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Validate commit messages
+        uses: wagoid/commitlint-github-action@v6.2.1
+        with:
+          configFile: commitlint.config.js


### PR DESCRIPTION
## Summary
- validate PR commit messages against Conventional Commits using commitlint

## Testing
- `npm run format`
- `CI=1 npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html)*

------
https://chatgpt.com/codex/tasks/task_e_68a7666d3e60832dae30391383fdab6f