### PR TITLE
ci: add dependency checker workflow

### DIFF
--- a/.github/workflows/dependency-checker.yml
+++ b/.github/workflows/dependency-checker.yml
@@ -1,0 +1,32 @@
+name: dependency-checker
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check Node dependencies
+        run: |
+          (npm outdated || pnpm outdated) > node-outdated.txt 2>&1 || true
+        continue-on-error: true
+
+      - name: Check Python dependencies
+        if: ${{ hashFiles('**/requirements.txt') != '' }}
+        run: |
+          pip list --outdated > python-outdated.txt 2>&1 || true
+        continue-on-error: true
+
+      - name: Upload dependency report
+        uses: actions/upload-artifact@v4
+        with:
+          name: dependency-report
+          path: |
+            node-outdated.txt
+            python-outdated.txt
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary
- add scheduled dependency checker workflow

## Testing
- `npm run format`
```
> backend@1.0.0 preformat
> node ../scripts/ensure-root-deps.js

> backend@1.0.0 format
> sh -c 'cd .. && node scripts/ensure-root-deps.js && prettier --log-level warn --write "**/*.{js,jsx,json,md}" --ignore-path .prettierignore'
```
- `npm test` *(fails: setup script errors and process terminated)*
```
Setup flag missing. Running 'npm run setup'...
apt-utils package is missing. Set SKIP_PW_DEPS=1 to skip Playwright dependencies.
APT repositories unreachable. Falling back to SKIP_PW_DEPS=1
npm warn deprecated source-map-resolve@0.6.0: See https://github.com/lydell/source-map-resolve#deprecated
npm error process terminated
npm error signal SIGINT
```
- `SKIP_PW_DEPS=1 npm run ci` *(fails: ENOTEMPTY during npm ci)*
```
npm error ENOTEMPTY: directory not empty, rmdir '/workspace/MVP-website/node_modules/lodash-es'
Failed to install dependencies: Command failed: npm ci --no-audit --no-fund --ignore-scripts
```
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: missing frontend build artifact)*
```
Missing frontend build artifact: frontend/dist/index.html. Run 'npm run build' and retry
```


------
https://chatgpt.com/codex/tasks/task_e_68a766494a64832dbba0ffaab114adc4