### PR TITLE
ci: add artifact dedupe action

### DIFF
--- a/.github/actions/artifact-dedupe/action.yml
+++ b/.github/actions/artifact-dedupe/action.yml
@@ -1,0 +1,32 @@
+name: Artifact Dedupe
+description: Upload artifact if path exists and is non-empty
+inputs:
+  name:
+    description: Artifact name
+    required: true
+  path:
+    description: File or directory to upload
+    required: true
+runs:
+  using: composite
+  steps:
+    - id: check
+      shell: bash
+      run: |
+        path="${{ inputs.path }}"
+        if [ ! -e "$path" ]; then
+          echo "upload=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        size=$(du -sb "$path" | cut -f1)
+        if [ "$size" -eq 0 ]; then
+          echo "upload=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        echo "upload=true" >> "$GITHUB_OUTPUT"
+    - uses: actions/upload-artifact@v4
+      if: steps.check.outputs.upload == 'true'
+      with:
+        name: ${{ inputs.name }}
+        path: ${{ inputs.path }}
+        if-no-files-found: ignore

--- a/docs/codex/artifacts.md
+++ b/docs/codex/artifacts.md
@@ -1,0 +1,14 @@
+# Artifacts
+
+This repository includes a composite action that prevents empty artifact uploads. The action checks whether the provided path exists and contains data before uploading. If the path is missing or empty, the step is a no-op.
+
+## Usage
+
+```yaml
+- uses: ./.github/actions/artifact-dedupe
+  with:
+    name: coverage
+    path: coverage
+```
+
+When the `coverage` directory is absent or empty, no artifact is uploaded.


### PR DESCRIPTION
## Summary
- add composite action to skip empty artifact uploads
- document artifact upload helper

## Testing
- `npm run format` (backend)
- `npm test` *(fails: STRIPE_SECRET_KEY must be a live secret)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script: "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html)*

------
https://chatgpt.com/codex/tasks/task_e_68a7640a9f94832dba16b03fe725d4c8