### PR TITLE
ci: add binary scan workflow

### DIFF
--- a/.github/workflows/binary-scan.yml
+++ b/.github/workflows/binary-scan.yml
@@ -1,0 +1,19 @@
+name: binary scan
+
+on:
+  pull_request:
+    paths-ignore:
+      - allowed-binaries.txt
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Scan for new binary files
+        run: scripts/guard/binary-scan.sh origin/${{ github.event.pull_request.base.ref }}

--- a/scripts/guard/binary-scan.sh
+++ b/scripts/guard/binary-scan.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE=${1:-origin/main}
+
+git fetch --depth=1 origin "${BASE#origin/}" >/dev/null 2>&1 || true
+
+mapfile -t changed < <(git diff --name-only --diff-filter=AM "$BASE"...HEAD)
+mapfile -t allowed < <(grep -v '^#' allowed-binaries.txt 2>/dev/null || true)
+
+bad_files=()
+
+for file in "${changed[@]}"; do
+  [[ -f "$file" ]] || continue
+  if printf '%s\n' "${allowed[@]}" | grep -Fxq "$file"; then
+    continue
+  fi
+  magic=$(head -c 4 "$file" | od -An -t x1 | tr -d ' \n')
+  case "$magic" in
+    7f454c46*) bad_files+=("$file (ELF)");;
+    feedface*|cefaedfe*|feedfacf*|cffaedfe*|cafebabe*|cafebabf*) bad_files+=("$file (Mach-O)");;
+    4d5a*) bad_files+=("$file (PE)");;
+    504b0304*|504b0506*|504b0708*)
+      if [[ "$file" == *.jar ]]; then
+        bad_files+=("$file (JAR)")
+      else
+        bad_files+=("$file (ZIP)")
+      fi
+      ;;
+  esac
+done
+
+if [ ${#bad_files[@]} -ne 0 ]; then
+  echo "Binary files detected in diff:" >&2
+  printf ' - %s\n' "${bad_files[@]}" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- scan for common binary file types in diffs
- add CI workflow to run binary scan on pull requests
- track approved binaries in allowed-binaries.txt

## Testing
- `npm run format`
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*


------
https://chatgpt.com/codex/tasks/task_e_68a76401be40832d888da4ef000977b9