### PR TITLE
chore: add CODEOWNERS and PR template

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,17 +1,17 @@
-* @print3git
+# Default owner for all files
+* @example/owners
 
 # Frontend HTML files
-/*.html @web-team
+/*.html @example/frontend
 
 # Backend code
-/backend/* @your-org/backend-team
+/backend/* @example/backend
 
 # Frontend source code
-/frontend/* @your-org/frontend-team
-
+/frontend/* @example/frontend
 
 # GitHub workflows
-/.github/workflows/** @devops-team
+/.github/workflows/** @example/devops
 
 # CI scripts
-/scripts/ci/** @devops-team
+/scripts/ci/** @example/devops

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,11 @@
-- [ ] npm run format
-- [ ] npm run lint
-- [ ] npm run test-ci
-- [ ] npx playwright test e2e/smoke.test.js
+## Summary
+- Touched paths:
+  - <!-- list modified paths -->
+- [ ] Docs-only changes
+
+## Checklist
+- [ ] `npm run format`
+- [ ] `npm run lint`
+- [ ] `npm run test-ci`
+- [ ] `npx playwright test e2e/smoke.test.js`
 - [ ] No unintended files modified


### PR DESCRIPTION
## Summary
- add path-based CODEOWNERS placeholders
- request touched paths and docs-only flag in PR template

## Testing
- `npm run validate-env`
- `curl -I https://registry.npmjs.org`
- `curl -I https://cdn.playwright.dev`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` (backend)
- `npm test` (backend) *(fails: `STRIPE_SECRET_KEY must be a live secret`, lint diagnostics)*
- `SKIP_PW_DEPS=1 npm run ci` *(aborted after format check)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a763d83a04832d9a400bc779c3d766