### PR TITLE
ci: add labeler workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,4 @@
+area:web:
+  - frontend/**
+area:api:
+  - backend/**

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,16 @@
+name: PR Labeler
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## Summary
- auto apply area labels based on path
- trigger labeler workflow on pull requests

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `cd backend && npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact `frontend/dist/index.html`)*


------
https://chatgpt.com/codex/tasks/task_e_68a763db6960832da5ad827f74ae89eb