### PR TITLE
chore: expand editorconfig rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,8 +5,17 @@ charset = utf-8
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[*.{js,ts,tsx,rs,py,md,yml}]
 indent_style = space
 indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.go]
+indent_style = tab
+indent_size = 4
 
 [Makefile]
 indent_style = tab


### PR DESCRIPTION
## Summary
- add .editorconfig to enforce LF/UTF-8 and per-language indentation

## Testing
- `npm run format`
- `npm test` *(terminated after partial run)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a763e60d44832da63c62bfc7728dbe