### PR TITLE
ci: add rust sccache workflow

### DIFF
--- a/.github/workflows/rust-sccache.yml
+++ b/.github/workflows/rust-sccache.yml
@@ -1,0 +1,26 @@
+name: Rust sccache
+
+on:
+  pull_request:
+    paths:
+      - 'crates/**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/sccache
+      - name: Build
+        run: cargo build
+      - name: Test
+        run: cargo test
+      - name: Gather sccache stats
+        if: always()
+        run: sccache --show-stats > sccache-stats.txt
+      - name: Upload sccache stats
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sccache-stats
+          path: sccache-stats.txt


### PR DESCRIPTION
### Summary
- add rust-sccache workflow to build/test crates using local sccache action and upload stats

### Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` (backend)
- `npm test` (backend) *(fails: STRIPE_SECRET_KEY must be a live secret; linting failures)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: npm error)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

```shell
$ npm run format
> backend@1.0.0 preformat
> node ../scripts/ensure-root-deps.js

> backend@1.0.0 format
> sh -c 'cd .. && node scripts/ensure-root-deps.js && prettier --log-level warn --write "**/*.{js,jsx,json,md}" --ignore-path .prettierignore'
```

```shell
$ npm test
FAIL tests/health.test.js
  ● Test suite failed to run
    STRIPE_SECRET_KEY must be a live secret
```


------
https://chatgpt.com/codex/tasks/task_e_68a763c00c24832d8adea79e3a4f70a0