### PR TITLE
ci: add large-file guard

### DIFF
--- a/.github/workflows/large-file-guard.yml
+++ b/.github/workflows/large-file-guard.yml
@@ -1,0 +1,14 @@
+name: Large File Guard
+
+on:
+  pull_request:
+
+jobs:
+  large-file-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5.0.0
+        with:
+          fetch-depth: 0
+      - name: Run guard
+        run: bash scripts/guard/large-file-guard.sh

--- a/scripts/guard/large-file-guard.sh
+++ b/scripts/guard/large-file-guard.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_REF=${GITHUB_BASE_REF:-main}
+THRESHOLD=$((5 * 1024 * 1024))
+
+git fetch origin "$BASE_REF" >/dev/null 2>&1 || true
+
+mapfile -t files < <(git diff --numstat "origin/${BASE_REF}"... | cut -f3-)
+
+offenders=()
+for file in "${files[@]}"; do
+  if [ -f "$file" ]; then
+    size=$(stat -c%s "$file")
+    if [ "$size" -gt "$THRESHOLD" ]; then
+      offenders+=("$file")
+    fi
+  fi
+done
+
+if [ ${#offenders[@]} -gt 0 ]; then
+  echo "Error: the following files exceed 5MB:" >&2
+  printf '%s\n' "${offenders[@]}" >&2
+  exit 1
+fi
+
+echo "No files exceed 5MB." 


### PR DESCRIPTION
## Summary
- fail pull requests that add or modify files over 5 MB
- add script to check file sizes against base branch

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: terminated early)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html. Run 'npm run build' and retry)*

------
https://chatgpt.com/codex/tasks/task_e_68a763b4379c832d87835f23ccd9baaa