### PR TITLE
docs: add repo size audit guide

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+.PHONY: size-audit
+
+size-audit:
+	@echo "git count-objects -vH"
+	@echo "git-sizer -v"
+	@echo "git reflog expire --expire=now --all && git gc --prune=now --aggressive"

--- a/docs/codex/repo-size-audit.md
+++ b/docs/codex/repo-size-audit.md
@@ -1,0 +1,23 @@
+# Repository Size Audit
+
+To inspect Git repository size locally, run:
+
+```sh
+git count-objects -vH
+```
+
+For a deeper analysis install [git-sizer](https://github.com/github/git-sizer) and run:
+
+```sh
+git-sizer -v
+```
+
+If the report shows unusually large objects or many unreachable objects, prune your local repository:
+
+```sh
+git reflog expire --expire=now --all
+
+git gc --prune=now --aggressive
+```
+
+This removes discarded objects and repacks the repository to reduce disk usage.


### PR DESCRIPTION
## Summary
- document repository size auditing and object pruning
- add `size-audit` Makefile target to print audit commands

## Testing
- `npm run format` (backend)
- `npm test` (backend)
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script: "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*


------
https://chatgpt.com/codex/tasks/task_e_68a7630c4648832dab464faa80a86d6d