### PR TITLE
chore: cache eslint results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ infra/awscliv2.zip
 test-results/
 
 .artifacts/
+.eslintcache

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "preformat:check": "cross-env SKIP_NET_CHECKS=1 SKIP_PW_DEPS=1 node scripts/assert-setup.js",
     "format": "prettier --log-level warn --write \"**/*.{js,jsx,json,md,html}\"",
     "format:check": "prettier --log-level warn --check \"**/*.{js,jsx,json,md,html}\"",
-    "lint:root": "eslint . --ext .ts,.tsx,.js --max-warnings=0",
+    "lint:root": "eslint . --ext .ts,.tsx,.js --max-warnings=0 --cache --cache-location .eslintcache",
     "lint:backend": "eslint . --ext .ts,.tsx,.js --max-warnings=0 --no-eslintrc -c backend/.eslintrc.cjs --ignore-path backend/.eslintignore",
     "lint": "npm run lint --prefix frontend && npm run lint --prefix backend",
     "lint:fix": "eslint . --fix",


### PR DESCRIPTION
## Summary
- ignore top-level `.eslintcache`
- cache root ESLint runs

## Testing
- `npm run format` (backend)
- `npm test` *(fails: lint errors and STRIPE_SECRET_KEY must be a live secret)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script: "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a762f4020c832d8004d2a7c168373f