### PR TITLE
ci: add regression workflow

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -1,0 +1,157 @@
+name: High-Fidelity Regression
+
+on:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      runner:
+        description: "Run on specific runner (e.g., self-hosted)"
+        required: false
+        default: ''
+
+env:
+  HUSKY: 0
+
+jobs:
+  backend-unit:
+    name: Backend Unit (Node ${{ matrix.node }})
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && inputs.runner || 'ubuntu-latest' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [20.x]
+    steps:
+      - uses: actions/checkout@v5.0.0
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+      - uses: actions/cache@v4.2.4
+        with:
+          path: |
+            node_modules
+            backend/node_modules
+          key: ${{ runner.os }}-backend-unit-${{ matrix.node }}-${{ hashFiles('package-lock.json', 'backend/package-lock.json') }}
+          restore-keys: ${{ runner.os }}-backend-unit-${{ matrix.node }}-
+      - run: npm ci
+      - run: npm ci --prefix backend
+      - run: npm test --prefix backend
+
+  backend-integration:
+    name: Backend Integration (Node ${{ matrix.node }})
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && inputs.runner || 'ubuntu-latest' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [20.x]
+    steps:
+      - uses: actions/checkout@v5.0.0
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+      - uses: actions/cache@v4.2.4
+        with:
+          path: |
+            node_modules
+            backend/node_modules
+          key: ${{ runner.os }}-backend-int-${{ matrix.node }}-${{ hashFiles('package-lock.json', 'backend/package-lock.json') }}
+          restore-keys: ${{ runner.os }}-backend-int-${{ matrix.node }}-
+      - run: npm ci
+      - run: npm ci --prefix backend
+      - run: npm run test-ci --prefix backend
+
+  frontend:
+    name: Frontend (Node ${{ matrix.node }})
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && inputs.runner || 'ubuntu-latest' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [20.x]
+    steps:
+      - uses: actions/checkout@v5.0.0
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+      - uses: actions/cache@v4.2.4
+        with:
+          path: |
+            node_modules
+            frontend/node_modules
+          key: ${{ runner.os }}-frontend-${{ matrix.node }}-${{ hashFiles('package-lock.json', 'frontend/package-lock.json') }}
+          restore-keys: ${{ runner.os }}-frontend-${{ matrix.node }}-
+      - run: npm ci
+      - run: npm ci --prefix frontend
+      - run: npm run lint --prefix frontend
+      - run: npm run build --prefix frontend
+
+  e2e:
+    name: E2E (${{ matrix.browser }})
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && inputs.runner || 'ubuntu-latest' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: [chromium, firefox]
+    steps:
+      - uses: actions/checkout@v5.0.0
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version: 20.x
+          cache: npm
+      - uses: actions/cache@v4.2.4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-e2e-${{ hashFiles('package-lock.json') }}
+          restore-keys: ${{ runner.os }}-e2e-
+      - run: npm ci
+      - run: npx playwright install --with-deps
+      - run: npm run e2e -- --project=${{ matrix.browser }}
+
+  cicd-selftest:
+    name: CI/CD Selftest
+    runs-on: ${{ github.event_name == 'workflow_dispatch' && inputs.runner || 'ubuntu-latest' }}
+    steps:
+      - uses: actions/checkout@v5.0.0
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version: 20.x
+          cache: npm
+      - uses: actions/cache@v4.2.4
+        with:
+          path: |
+            node_modules
+            backend/node_modules
+          key: ${{ runner.os }}-cicd-selftest-${{ hashFiles('package-lock.json', 'backend/package-lock.json') }}
+          restore-keys: ${{ runner.os }}-cicd-selftest-
+      - run: npm ci
+      - run: npm ci --prefix backend
+      - run: npm run ci
+
+  summary:
+    name: Summary
+    runs-on: ubuntu-latest
+    needs:
+      - backend-unit
+      - backend-integration
+      - frontend
+      - e2e
+      - cicd-selftest
+    if: always()
+    steps:
+      - name: Generate summary
+        run: |
+          run_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          failed=""
+          [[ "${{ needs.backend-unit.result }}" != "success" ]] && failed="$failed\n- [backend-unit]($run_url)"
+          [[ "${{ needs.backend-integration.result }}" != "success" ]] && failed="$failed\n- [backend-integration]($run_url)"
+          [[ "${{ needs.frontend.result }}" != "success" ]] && failed="$failed\n- [frontend]($run_url)"
+          [[ "${{ needs.e2e.result }}" != "success" ]] && failed="$failed\n- [e2e]($run_url)"
+          [[ "${{ needs.cicd-selftest.result }}" != "success" ]] && failed="$failed\n- [cicd-selftest]($run_url)"
+          if [ -z "$failed" ]; then
+            echo "✅ All tests passed" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "❌ Some groups failed:" >> "$GITHUB_STEP_SUMMARY"
+            echo -e "$failed" >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- add regression workflow splitting backend, frontend, e2e and self-test jobs with final summary

## Testing
- `npm run format --prefix backend`
- `SKIP_PW_DEPS=1 npm test --prefix backend` *(fails: npm ci encountered tar or filesystem errors)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: dependency installation stalled)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a761db4404832d8a37d3cfff721737