### PR TITLE
chore: configure git-lfs and document usage

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,8 @@
 # Treat common asset types as binary to avoid patching issues
-*.png binary
-*.jpg binary
-*.jpeg binary
+*.png filter=lfs diff=lfs merge=lfs -text
+*.jpg filter=lfs diff=lfs merge=lfs -text
+*.jpeg filter=lfs diff=lfs merge=lfs -text
+*.psd filter=lfs diff=lfs merge=lfs -text
 *.gif binary
 *.webp binary
 *.svg binary
@@ -13,7 +14,7 @@
 *.gltf binary
 *.ico binary
 *.pdf binary
-*.zip binary
+*.zip filter=lfs diff=lfs merge=lfs -text
 *.tar binary
 *.gz binary
 *.bz2 binary

--- a/docs/codex/git-lfs.md
+++ b/docs/codex/git-lfs.md
@@ -1,0 +1,34 @@
+# Git LFS
+
+Large binary files should be stored using [Git Large File Storage](https://git-lfs.com/).
+
+## Install
+
+1. Install the Git LFS package for your platform.
+   - macOS: `brew install git-lfs`
+   - Debian/Ubuntu: `apt-get install git-lfs`
+2. Run `git lfs install` once per machine to enable LFS.
+
+## Tracking files
+
+The repository's `.gitattributes` tracks common formats such as `*.png`, `*.jpg`, `*.jpeg`, `*.psd` and `*.zip`.
+To track a new binary type:
+
+```bash
+git lfs track "*.ext"
+```
+
+This command updates `.gitattributes`; commit the change so others pull it.
+
+## Migrating existing files
+
+If a binary was committed without LFS, remove it and commit the change, then re-add after tracking:
+
+```bash
+git rm --cached path/to/file
+# update .gitattributes or run git lfs track if needed
+git add .gitattributes path/to/file
+git commit -m "migrate file to LFS"
+```
+
+This moves the file to LFS in future commits without rewriting history.


### PR DESCRIPTION
## Summary
- configure Git LFS for common binary types
- document LFS installation and usage for future binaries

## Testing
- `npm run format`
- `npm test`
- `npm run ci` *(fails: Missing script "lint" for frontend)*
- `npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a763086ba4832d9c5d11b11b0863f7