### PR TITLE
ci: add Python pip cache workflow

### DIFF
--- a/.github/workflows/python-pip.yml
+++ b/.github/workflows/python-pip.yml
@@ -1,0 +1,33 @@
+name: Python pip cache
+
+on:
+  pull_request:
+    paths:
+      - "python/**"
+      - "**/*.py"
+
+jobs:
+  install:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11"]
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Install dependencies
+        run: |
+          if [ -f requirements.txt ]; then
+            pip install -r requirements.txt
+          else
+            echo "No requirements.txt found"
+            exit 0
+          fi


### PR DESCRIPTION
## Summary
- add workflow to install and cache Python dependencies on PRs touching Python files

## Testing
- `npx prettier --write .github/workflows/python-pip.yml`
- `npm test` *(fails: runs setup and terminates early)*
- `npm run ci` *(fails: missing dependencies, setup not complete)*
- `npm run smoke` *(fails: missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a763cfba70832dbb780d1369cd1791