### PR TITLE
ci: diff summary workflow

### DIFF
--- a/.github/workflows/diff-summary.yml
+++ b/.github/workflows/diff-summary.yml
@@ -1,0 +1,52 @@
+name: Diff Summary
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  diff:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v5.0.0
+        with:
+          fetch-depth: 0
+      - name: Generate diff summary
+        run: |
+          bash scripts/guard/diff-summary.sh > diff-summary.md
+      - name: Upload diff summary
+        uses: actions/upload-artifact@v4.3.4
+        with:
+          name: diff-summary
+          path: diff-summary.md
+      - name: Compute diff stats
+        id: diff
+        run: |
+          stats=$(git diff --shortstat origin/${{ github.event.pull_request.base.ref }}...${{ github.sha }})
+          echo "$stats"
+          added=$(echo "$stats" | awk '{print $4}')
+          removed=$(echo "$stats" | awk '{print $6}')
+          echo "added=${added:-0}" >> "$GITHUB_OUTPUT"
+          echo "removed=${removed:-0}" >> "$GITHUB_OUTPUT"
+      - name: Comment on PR
+        uses: actions/github-script@v7.0.1
+        continue-on-error: true
+        env:
+          ADDED: ${{ steps.diff.outputs.added }}
+          REMOVED: ${{ steps.diff.outputs.removed }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const body = `Lines added: ${process.env.ADDED}, removed: ${process.env.REMOVED}`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body
+            });


### PR DESCRIPTION
## Summary
- add GitHub Action to generate diff summary and comment lines added/removed

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(partial, terminated)*
- `SKIP_PW_DEPS=1 npm run smoke` *(missing frontend build artifact)*
- `npm run diagnose` *(terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68a763ee0dd8832db0ea1811df59db1e