### PR TITLE
ci: add dependency review workflow

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,14 @@
+name: Dependency Review
+
+on:
+  pull_request:
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: github/dependency-review-action@v4
+        with:
+          fail-on-severity: high


### PR DESCRIPTION
## Summary
- add dependency review workflow to fail on high-severity packages

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend` (partial, interrupted)
- `SKIP_PW_DEPS=1 npm run ci` (partial, interrupted)
- `SKIP_PW_DEPS=1 npm run smoke` (fails: Missing frontend build artifact)


------
https://chatgpt.com/codex/tasks/task_e_68a766664874832db2ea6c942b6c2a5e