### PR TITLE
ci/prod-env-guard

### DIFF
--- a/.github/workflows/prod-env-guard.yml
+++ b/.github/workflows/prod-env-guard.yml
@@ -1,0 +1,14 @@
+name: Prod Env Guard
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      reviewers:
+        - octocat
+    steps:
+      - run: echo "Deploy placeholder"


### PR DESCRIPTION
## Summary
- add prod deployment guard workflow requiring approval

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script: "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a766fc62cc832dbab28e1f67a6c523