### PR TITLE
ci: add docs auto-merge workflow

### DIFF
--- a/.github/workflows/docs-automerge.yml
+++ b/.github/workflows/docs-automerge.yml
@@ -1,0 +1,43 @@
+name: Docs automerge
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'docs/**'
+      - '**/*.md'
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v5.0.0
+      - uses: dorny/paths-filter@v3.0.2
+        id: changes
+        with:
+          filters: |
+            docs:
+              - 'docs/**'
+              - '**/*.md'
+            other:
+              - '**'
+              - '!docs/**'
+              - '!**/*.md'
+      - if: ${{ steps.changes.outputs.other == 'false' }}
+        uses: actions/github-script@v7.0.1
+        with:
+          script: |
+            github.rest.pulls.createReview({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+              event: 'APPROVE'
+            })
+      - if: ${{ steps.changes.outputs.other == 'false' }}
+        uses: peter-evans/enable-pull-request-automerge@v3.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          merge-method: squash


### PR DESCRIPTION
## Summary
- auto-approve and merge docs-only pull requests

## Testing
- `npm run format`
- `npm test`
- `npm run ci` *(fails: Missing script "lint")*
- `npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html)*

------
https://chatgpt.com/codex/tasks/task_e_68a76688194c832d9977f350e2c95732