### PR TITLE
ci/test-rerun

### DIFF
--- a/.github/workflows/test-rerun.yml
+++ b/.github/workflows/test-rerun.yml
@@ -1,0 +1,57 @@
+name: Test rerun
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - name: Install dependencies
+        run: |
+          corepack enable
+          pnpm install --frozen-lockfile --ignore-scripts
+      - name: Run tests with retries
+        id: test
+        run: |
+          set -o pipefail
+          attempts=1
+          flaky=false
+          rm -f test-summary.txt
+          while [ $attempts -le 3 ]; do
+            echo "Attempt $attempts" >> test-summary.txt
+            if pnpm test 2>&1 | tee -a test-summary.txt; then
+              if [ $attempts -gt 1 ]; then
+                flaky=true
+                echo "Tests passed on attempt $attempts" >> test-summary.txt
+              else
+                echo "Tests passed" >> test-summary.txt
+              fi
+              break
+            elif [ $attempts -eq 3 ]; then
+              echo "Tests failed after $attempts attempts" >> test-summary.txt
+              exit 1
+            fi
+            attempts=$((attempts+1))
+          done
+          echo "flaky=$flaky" >> $GITHUB_OUTPUT
+      - name: Report result
+        run: |
+          if [ "${{ steps.test.outputs.flaky }}" = "true" ]; then
+            echo "Tests passed on a retry. Flaky tests detected." >> test-summary.txt
+            echo "### Flaky tests detected" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "Tests passed on first try." >> test-summary.txt
+            echo "### Tests passed" >> $GITHUB_STEP_SUMMARY
+          fi
+      - name: Upload summary
+        uses: actions/upload-artifact@v4.3.1
+        with:
+          name: test-rerun-summary
+          path: test-summary.txt


### PR DESCRIPTION
## Summary
- add workflow to rerun `pnpm test` up to three times
- report flaky tests and upload summary artifact

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup` *(fails: Playwright download was interrupted)*
- `cd backend && npm run format`
- `npm test` *(fails: setup requires Playwright dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a766845628832d8e7c99ff762ff9b6