### PR TITLE
docs: add CI badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # MVP Website
 
+[![Build](https://github.com/OWNER/REPO/actions/workflows/build-frontend.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/build-frontend.yml)
+[![Lint](https://github.com/OWNER/REPO/actions/workflows/lint.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/lint.yml)
+[![Tests](https://github.com/OWNER/REPO/actions/workflows/backend-tests.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/backend-tests.yml)
 [![CI](https://github.com/OWNER/REPO/actions/workflows/ci.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/ci.yml)
 [![npm version](https://img.shields.io/npm/v/mvp-website.svg)](https://www.npmjs.com/package/mvp-website)
 [![Coverage Status](https://coveralls.io/repos/github/OWNER/REPO/badge.svg?branch=main)](https://coveralls.io/github/OWNER/REPO?branch=main)


### PR DESCRIPTION
## Summary
- add build, lint, and tests workflow badges to README

## Testing
- `npm run format`
- `npm test` *(fails: manual interruption after extended runtime)*
- `npm run ci` *(fails: Missing script "lint")*
- `npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a7667ec894832db0b97268109d03f2