### PR TITLE
docs: add changelog generator configuration

### DIFF
--- a/.github/changelog.yml
+++ b/.github/changelog.yml
@@ -1,0 +1,20 @@
+# Configuration for github-changelog-generator
+# https://github.com/github-changelog-generator/github-changelog-generator
+
+# labels to exclude from changelog
+exclude_labels:
+  - duplicate
+  - question
+  - invalid
+  - wontfix
+  - dependencies
+
+# label mappings
+enhancement_labels:
+  - enhancement
+  - feat
+bug_labels:
+  - bug
+  - fix
+breaking_labels:
+  - breaking

--- a/docs/codex/changelog.md
+++ b/docs/codex/changelog.md
@@ -1,0 +1,23 @@
+# Changelog Generation
+
+This project uses [github-changelog-generator](https://github.com/github-changelog-generator/github-changelog-generator) to build `CHANGELOG.md` from merged pull requests.
+
+## Generate a changelog
+
+1. Install the gem if it is not already available:
+
+   ```bash
+   gem install github_changelog_generator
+   ```
+
+2. Ensure a GitHub token with access to the repository is available in the `GITHUB_TOKEN` environment variable.
+
+3. Run the generator from the repository root:
+
+   ```bash
+   github_changelog_generator --user <OWNER> --project <REPO> --config-file .github/changelog.yml
+   ```
+
+   Replace `<OWNER>` and `<REPO>` with the GitHub organisation and repository name.
+
+The command will update `CHANGELOG.md` based on pull requests and tags. Commit the updated file to publish the new changelog.


### PR DESCRIPTION
## Summary
- configure github-changelog-generator labels
- document how to run the changelog generator

## Testing
- `npm run format` (backend)
- `npx prettier .github/changelog.yml docs/codex/changelog.md --write`
- `npm test` (backend)
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script "lint" in frontend)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a76670b590832dbd921255c3d4068f