### PR TITLE
docs: add editor setup recommendations

### DIFF
--- a/docs/codex/editor-setup.md
+++ b/docs/codex/editor-setup.md
@@ -1,0 +1,19 @@
+# Editor Setup
+
+To streamline development, install the following extensions in your editor of choice.
+
+## Visual Studio Code
+
+- **ESLint** – highlights linting issues in JavaScript/TypeScript.
+- **Prettier** – formats code according to project style.
+- **Docker** – integrates Dockerfile and compose editing.
+- **GitLens** – enhances Git blame and history viewing.
+- **EditorConfig** – applies `.editorconfig` settings automatically.
+
+## IntelliJ IDEA / WebStorm
+
+- **ESLint** – run linting and show problems inline.
+- **Prettier** – keep formatting consistent with the project.
+- **Docker** – manage Docker containers and compose files.
+- **Git ToolBox** or built‑in Git integration for rich Git features.
+- **EditorConfig** – respect repository-wide coding styles.


### PR DESCRIPTION
## Summary
- add editor setup doc with suggested VS Code / IntelliJ extensions

## Testing
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` (fails: Missing script "lint")
- `SKIP_PW_DEPS=1 npm run smoke` (fails: Missing frontend build artifact)
- `npm run diagnose` (fails: expected 0 toBe 127)


------
https://chatgpt.com/codex/tasks/task_e_68a7666a18cc832da7f347c5662642c8