### PR TITLE
ci: add markdown link checker

### DIFF
--- a/.github/workflows/md-link-check.yml
+++ b/.github/workflows/md-link-check.yml
@@ -1,0 +1,16 @@
+name: Markdown link check
+
+on:
+  pull_request:
+    paths:
+      - '**/*.md'
+
+jobs:
+  md-link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5.0.0
+      - name: Check markdown links
+        uses: lycheeverse/lychee-action@v2.5.0
+        with:
+          args: --no-progress './**/*.md'


### PR DESCRIPTION
## Summary
- add GitHub Action to verify Markdown links with lychee

## Testing
- `npm run format` (backend)
- `npm test` (backend)
- `npm run ci` *(fails: Missing script "lint")*
- `npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a76653bc58832da0945b4024cad2a6