### PR TITLE
ci: add CodeQL analysis workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,33 @@
+name: CodeQL analysis
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 0 * * 0'
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'javascript-typescript', 'python' ]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5.0.0
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3.29.11
+        with:
+          languages: ${{ matrix.language }}
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3.29.11
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3.29.11
+        with:
+          category: '/language:${{matrix.language}}'


### PR DESCRIPTION
## Summary
- add GitHub's recommended CodeQL analysis workflow for JavaScript/TypeScript and Python

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: npm error Did you mean this? npm link # Symlink a package folder)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html. Run 'npm run build' and retry)*
- `npm run diagnose` *(fails: mise installer test and multiple missing environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68a7664d37c8832d8aff01dbdd314bae