### PR TITLE
runners/warm-cache-bootstrap

### DIFF
--- a/docs/codex/runner-cache-layout.md
+++ b/docs/codex/runner-cache-layout.md
@@ -1,0 +1,10 @@
+# Runner cache layout
+
+The CI runner initializes several cache directories to speed up dependency installation:
+
+- `~/.cache/pip` – Python packages
+- `~/.cache/go-build` – Go build cache
+- `~/.cargo` – Rust crate cache
+- `.turbo` – Turbo build artifacts
+
+Use `scripts/runners/warm-cache.sh` to create these directories on a fresh runner and display their disk usage.

--- a/scripts/runners/warm-cache.sh
+++ b/scripts/runners/warm-cache.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Create expected cache directories for CI runners
+mkdir -p "$HOME/.cache/pip"
+mkdir -p "$HOME/.cache/go-build"
+mkdir -p "$HOME/.cargo"
+mkdir -p .turbo
+
+# Show disk usage of the caches
+du -sh "$HOME/.cache/pip" "$HOME/.cache/go-build" "$HOME/.cargo" .turbo


### PR DESCRIPTION
## Summary
- add script to create standard cache directories and show their usage
- document expected cache layout for runners

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` (fails: Missing script: "lint")
- `SKIP_PW_DEPS=1 npm run smoke` (exited 0 but logged Playwright config error)


------
https://chatgpt.com/codex/tasks/task_e_68a7661968dc832db06b8a8017130720