### PR TITLE
docs: add ci anchors documentation

### DIFF
--- a/docs/codex/ci-anchors.md
+++ b/docs/codex/ci-anchors.md
@@ -1,0 +1,41 @@
+# CI anchors
+
+This guide shows how to use YAML anchors in GitHub Actions to reuse common steps. The accompanying [`ci-anchors.yml`](ci-anchors.yml) workflow demonstrates anchors for checkout, Node.js setup, and caching.
+
+Define reusable steps:
+
+```yaml
+x-checkout: &checkout
+  uses: actions/checkout@v4
+  with:
+    fetch-depth: 0
+
+x-setup-node: &setup-node
+  uses: actions/setup-node@v4
+  with:
+    node-version: 20
+    cache: npm
+
+x-cache-node-modules: &cache-node-modules
+  uses: actions/cache@v4
+  with:
+    path: ~/.npm
+    key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+    restore-keys: |
+      ${{ runner.os }}-node-
+```
+
+Reference them in jobs:
+
+```yaml
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - *checkout
+      - *setup-node
+      - *cache-node-modules
+      - run: npm test
+```
+
+Using anchors centralizes common configuration and keeps workflows concise. Copy these patterns into your own workflows to avoid duplication. This example does not modify any live workflows.

--- a/docs/codex/ci-anchors.yml
+++ b/docs/codex/ci-anchors.yml
@@ -1,0 +1,32 @@
+name: Example CI anchors
+
+on:
+  workflow_dispatch:
+
+x-checkout: &checkout
+  uses: actions/checkout@v4
+  with:
+    fetch-depth: 0
+
+x-setup-node: &setup-node
+  uses: actions/setup-node@v4
+  with:
+    node-version: 20
+    cache: npm
+
+x-cache-node-modules: &cache-node-modules
+  uses: actions/cache@v4
+  with:
+    path: ~/.npm
+    key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+    restore-keys: |
+      ${{ runner.os }}-node-
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - *checkout
+      - *setup-node
+      - *cache-node-modules
+      - run: npm test


### PR DESCRIPTION
## Summary
- add example workflow showing YAML anchors for checkout, Node.js setup, and caching
- document how to define and reference shared anchors in GitHub Actions

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script: "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a7660cd08c832db17fee09397b5cd2