### PR TITLE
ci: add production environment guard workflow

### DIFF
--- a/.github/workflows/prod-env-guard.yml
+++ b/.github/workflows/prod-env-guard.yml
@@ -1,0 +1,18 @@
+name: Production environment guard
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    name: Deploy to production
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4.1.1
+      - name: Placeholder deploy
+        run: |
+          echo "Simulating deployment to production environment"
+          echo "No real deploy commands run"


### PR DESCRIPTION
## Summary
- add workflow demonstrating production environment protection with placeholder deploy job

## Testing
- `npm run format`
- `npm test`
- `npm run ci` *(fails: Missing script: "lint")*
- `npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html)*

------
https://chatgpt.com/codex/tasks/task_e_68a766113e84832d998e3eccf03a29ee