### PR TITLE
ci: add reusable node workflow

### DIFF
--- a/.github/workflows/_reusable-node.yml
+++ b/.github/workflows/_reusable-node.yml
@@ -1,0 +1,51 @@
+name: Node build
+
+on:
+  workflow_call:
+    inputs:
+      node-version:
+        description: Node.js version to use
+        required: true
+        type: string
+      workspace:
+        description: Path to run the build
+        required: true
+        type: string
+      sparse-checkout:
+        description: |
+          Optional newline-separated list of patterns for sparse checkout
+        required: false
+        default: ""
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        if: ${{ inputs.sparse-checkout == '' }}
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: Checkout with sparse
+        if: ${{ inputs.sparse-checkout != '' }}
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+          sparse-checkout: ${{ inputs.sparse-checkout }}
+          sparse-checkout-cone-mode: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs['node-version'] }}
+          cache: pnpm
+          cache-dependency-path: ${{ inputs.workspace }}/pnpm-lock.yaml
+
+      - name: Enable corepack
+        run: corepack enable
+
+      - name: Build
+        run: pnpm -w run build
+        working-directory: ${{ inputs.workspace }}


### PR DESCRIPTION
## Summary
- add reusable Node workflow for build jobs

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script: "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a763ea2194832d8796a11c05833825