### PR TITLE
ci: add bootstrap script

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "typecheck": "tsc --noEmit",
     "typecheck:watchdog": "tsc -p scripts/tsconfig.json",
     "i18n:lint": "node scripts/i18n-lint.js",
+    "ci:bootstrap": "node -e \"console.log('manager:', process.env.CI_PM || 'pnpm')\" && (if [ \"$CI_PM\" = \"npm\" ]; then npm ci; else corepack enable && corepack prepare pnpm@9.0.0 --activate && pnpm install --no-frozen-lockfile; fi)",
     "ci": "node scripts/ci-env-preflight.js && node scripts/assert-setup.js && npm run format:check && npm run lint && npm run typecheck && npm run typecheck:watchdog && npm run i18n:lint && npm run test:ci && npm run test:a11y && npm run test:ui",
     "test:ci": "cross-env JEST_CI=true npm run test-ci --prefix backend && node scripts/run-jest.js --runTestsByPath tests/ci/build-artifact-check-a1b2c3d4e5f6g7h.ts tests/ci",
     "test:update-threshold": "node scripts/update-coverage-threshold.js",


### PR DESCRIPTION
## Summary
- add `ci:bootstrap` script to install dependencies with npm or pnpm

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html. Run 'npm run build' and retry)*

------
https://chatgpt.com/codex/tasks/task_e_68a767aa6194832d9a21d6d50d0fef4c