### PR TITLE
ci: verify frontend dist output

### DIFF
--- a/.github/workflows/frontend-dry-build.yml
+++ b/.github/workflows/frontend-dry-build.yml
@@ -31,7 +31,11 @@ jobs:
           cache-dependency-path: package-lock.json
       - run: npm ci
       - run: npm run build
-      - run: node -e "require('fs').accessSync('dist/index.html')"
+      - run: |
+          node -e "require('fs').accessSync('frontend/dist/index.html')" || {
+            echo "::error::frontend/dist/index.html missing — build didn’t run or produced no output.";
+            exit 1;
+          }
       - uses: actions/upload-artifact@v4
         with:
           name: frontend-dist


### PR DESCRIPTION
## Summary
- ensure frontend dry-build workflow checks for frontend/dist/index.html and emits a clear error if missing

## Testing
- `npm run format`
- `npm test` *(failed: process hung and was interrupted)*
- `SKIP_PW_DEPS=1 npm run ci` *(failed: Missing script: "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(failed: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a767a38aa8832d830fd55dfa94126d