### PR TITLE
ci: print CodeQL CLI version

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,6 +44,9 @@ jobs:
         with:
           languages: javascript-typescript
           tools: ${{ matrix.codeql-version }}
+      - name: CodeQL CLI version
+        run: codeql --version
+        shell: bash
       - name: Build
         run: |
           npm ci


### PR DESCRIPTION
## Summary
- print CodeQL CLI version in CodeQL workflow

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` (fails: Missing script: "lint")
- `SKIP_PW_DEPS=1 npm run smoke` (fails: Missing frontend build artifact)


------
https://chatgpt.com/codex/tasks/task_e_68a7679dde40832db087016241704bcc