### PR TITLE
ci: add pnpm frontend build action

### DIFF
--- a/.github/actions/frontend-build/action.yml
+++ b/.github/actions/frontend-build/action.yml
@@ -2,20 +2,18 @@ name: Frontend Build
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v4
-      with:
-        node-version: '20'
-        cache: npm
-        cache-dependency-path: frontend/package-lock.json
-    - name: Install deps
+    - name: Setup pnpm
+      uses: ./.github/actions/setup-pnpm
+    - name: Install frontend deps
+      run: pnpm install --no-frozen-lockfile
       shell: bash
-      run: npm ci
       working-directory: frontend
     - name: Build
+      run: pnpm run build
       shell: bash
-      run: npm run build
       working-directory: frontend
-    - uses: actions/upload-artifact@v4
+    - name: Upload dist
+      uses: actions/upload-artifact@v4
       with:
         name: frontend-dist
         path: frontend/dist


### PR DESCRIPTION
## Summary
- switch frontend-build composite action to pnpm and upload dist artifact

## Testing
- `npm run format`
- `CI=1 npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a76798fac4832da93515eca9a35adb