### PR TITLE
ci: add pnpm setup action

### DIFF
--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -1,0 +1,12 @@
+name: Setup pnpm
+runs:
+  using: composite
+  steps:
+    - run: corepack enable
+      shell: bash
+    - run: corepack prepare pnpm@9.0.0 --activate
+      shell: bash
+    - run: echo "PNPM_HOME=$HOME/.local/share/pnpm" >> $GITHUB_ENV
+      shell: bash
+    - run: echo "$HOME/.local/share/pnpm" >> $GITHUB_PATH
+      shell: bash


### PR DESCRIPTION
## Summary
- add composite action to setup pnpm 9.0.0

## Testing
- `npm run format` (backend)
- `npm test` (backend)
- `npm run ci` (fails: Missing script "lint")
- `npm run smoke` (fails: Missing frontend build artifact)


------
https://chatgpt.com/codex/tasks/task_e_68a767925000832da7b769ea504fb3b6