### PR TITLE
ci: add pnpm setup composite action

### DIFF
--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -1,0 +1,12 @@
+name: Setup pnpm
+runs:
+  using: composite
+  steps:
+    - run: corepack enable
+      shell: bash
+    - run: corepack prepare pnpm@9.0.0 --activate
+      shell: bash
+    - run: echo "PNPM_HOME=$HOME/.local/share/pnpm" >> $GITHUB_ENV
+      shell: bash
+    - run: echo "$HOME/.local/share/pnpm" >> $GITHUB_PATH
+      shell: bash


### PR DESCRIPTION
## Summary
- add composite action to set up pnpm with corepack and environment variables

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `cd backend && npm run format`
- `cd backend && npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*


------
https://chatgpt.com/codex/tasks/task_e_68a767925000832da7b769ea504fb3b6