### PR TITLE
ci: switch frontend build action to pnpm

### DIFF
--- a/.github/actions/frontend-build/action.yml
+++ b/.github/actions/frontend-build/action.yml
@@ -5,15 +5,18 @@ runs:
     - uses: actions/setup-node@v4
       with:
         node-version: '20'
-        cache: npm
-        cache-dependency-path: frontend/package-lock.json
+        cache: pnpm
+        cache-dependency-path: frontend/pnpm-lock.yaml
+    - name: Enable corepack
+      shell: bash
+      run: corepack enable
     - name: Install deps
       shell: bash
-      run: npm ci
+      run: pnpm install --no-frozen-lockfile
       working-directory: frontend
     - name: Build
       shell: bash
-      run: npm run build
+      run: pnpm run build
       working-directory: frontend
     - uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
## Summary
- build: enable corepack and switch frontend build composite action to pnpm

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` (backend)
- `npm test` (backend)
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script: "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html)*

------
https://chatgpt.com/codex/tasks/task_e_68a7676e3da8832da515ce83042dc052