### PR TITLE
feat: add test skeleton generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "netlify:deploy": "scripts/netlify-preflight.sh && netlify deploy",
     "diagnose": "bash scripts/diagnose.sh",
     "codeql": "node scripts/check-code-scanning.js",
+    "gen:test:changed": "git diff --name-only --diff-filter=AM origin/main...HEAD | xargs -r node scripts/gen-test-skeleton.mjs",
     "test:generate": "node scripts/test-generate.js",
     "test:webhook": "node scripts/test-webhook.js",
     "check:code-scanning": "node scripts/check-code-scanning.js",

--- a/scripts/gen-test-skeleton.mjs
+++ b/scripts/gen-test-skeleton.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+const files = process.argv.slice(2);
+const exts = new Set(['.js', '.jsx', '.ts', '.tsx']);
+
+for (const file of files) {
+  const ext = path.extname(file);
+  if (!exts.has(ext)) continue;
+  const dir = path.dirname(file);
+  const base = path.basename(file, ext);
+  const safeBase = base.replace(/[^A-Za-z0-9_$]/g, '_');
+  const candidates = [`${base}.spec${ext}`, `${base}_test${ext}`];
+  if (candidates.some((c) => fs.existsSync(path.join(dir, c)))) continue;
+  const testFile = path.join(dir, candidates[0]);
+  const importPath = `./${base}`;
+  const importLine = ['.ts', '.tsx'].includes(ext)
+    ? `import ${safeBase} from '${importPath}';\n\n`
+    : `const ${safeBase} = require('${importPath}');\n\n`;
+  const content = `${importLine}describe('${base}', () => {
+  it('TODO: write tests for ${base}', () => {
+    // TODO: implement tests
+  });
+});\n`;
+  fs.writeFileSync(testFile, content, { flag: 'wx' });
+  console.log(`Created ${testFile}`);
+}


### PR DESCRIPTION
## Summary
- add script to generate Jest test skeletons for changed sources
- expose `gen:test:changed` npm script for PR automation

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script: "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a76768c6fc832d9d2b0c63ab845318