### PR TITLE
ci: add regression workflow

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -1,0 +1,259 @@
+name: Regression
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  backend-unit:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20, 18]
+    outputs:
+      coverage-url: ${{ steps.upload-coverage.outputs.artifact-url }}
+      junit-url: ${{ steps.upload-junit.outputs.artifact-url }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix['node-version'] }}
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            backend/package-lock.json
+      - name: Enable Corepack
+        run: corepack enable
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-pw-${{ matrix['node-version'] }}-${{ hashFiles('package-lock.json', 'backend/package-lock.json') }}
+      - run: npm ci
+      - run: npm ci --prefix backend
+      - name: Run unit tests
+        run: npm test --prefix backend -- --ci --reporters=default --reporters=jest-junit --coverage --coverageDirectory=backend/coverage
+        env:
+          JEST_JUNIT_OUTPUT: backend/junit-unit.xml
+      - name: Upload coverage
+        if: always()
+        id: upload-coverage
+        uses: actions/upload-artifact@v4.3.4
+        with:
+          name: coverage-backend-unit-${{ matrix['node-version'] }}
+          path: backend/coverage
+          if-no-files-found: ignore
+      - name: Upload junit
+        if: always()
+        id: upload-junit
+        uses: actions/upload-artifact@v4.3.4
+        with:
+          name: junit-backend-unit-${{ matrix['node-version'] }}
+          path: backend/junit-unit.xml
+          if-no-files-found: ignore
+
+  backend-integration:
+    runs-on: ubuntu-latest
+    outputs:
+      coverage-url: ${{ steps.upload-coverage.outputs.artifact-url }}
+      junit-url: ${{ steps.upload-junit.outputs.artifact-url }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            backend/package-lock.json
+      - name: Enable Corepack
+        run: corepack enable
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-pw-20-${{ hashFiles('package-lock.json', 'backend/package-lock.json') }}
+      - run: npm ci
+      - run: npm ci --prefix backend
+      - name: Run integration tests
+        run: node scripts/run-jest.js tests/integration --ci --coverage --coverageDirectory=backend/coverage-integration --reporters=default --reporters=jest-junit
+        env:
+          JEST_JUNIT_OUTPUT: backend/junit-integration.xml
+      - name: Upload coverage
+        if: always()
+        id: upload-coverage
+        uses: actions/upload-artifact@v4.3.4
+        with:
+          name: coverage-backend-integration
+          path: backend/coverage-integration
+          if-no-files-found: ignore
+      - name: Upload junit
+        if: always()
+        id: upload-junit
+        uses: actions/upload-artifact@v4.3.4
+        with:
+          name: junit-backend-integration
+          path: backend/junit-integration.xml
+          if-no-files-found: ignore
+
+  frontend:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20, 18]
+    outputs:
+      coverage-url: ${{ steps.upload-coverage.outputs.artifact-url }}
+      junit-url: ${{ steps.upload-junit.outputs.artifact-url }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix['node-version'] }}
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            frontend/package-lock.json
+      - name: Enable Corepack
+        run: corepack enable
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-pw-${{ matrix['node-version'] }}-${{ hashFiles('package-lock.json', 'frontend/package-lock.json') }}
+      - run: npm ci
+      - run: npm ci --prefix frontend
+      - name: Run frontend tests
+        run: npm test --prefix frontend -- --ci --reporters=default --reporters=jest-junit --coverage --coverageDirectory=frontend/coverage
+        env:
+          JEST_JUNIT_OUTPUT: frontend/junit-frontend.xml
+      - name: Upload coverage
+        if: always()
+        id: upload-coverage
+        uses: actions/upload-artifact@v4.3.4
+        with:
+          name: coverage-frontend-${{ matrix['node-version'] }}
+          path: frontend/coverage
+          if-no-files-found: ignore
+      - name: Upload junit
+        if: always()
+        id: upload-junit
+        uses: actions/upload-artifact@v4.3.4
+        with:
+          name: junit-frontend-${{ matrix['node-version'] }}
+          path: frontend/junit-frontend.xml
+          if-no-files-found: ignore
+
+  e2e:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
+    outputs:
+      junit-url: ${{ steps.upload-junit.outputs.artifact-url }}
+      trace-url: ${{ steps.upload-trace.outputs.artifact-url }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - name: Enable Corepack
+        run: corepack enable
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-pw-20-${{ hashFiles('package-lock.json') }}
+      - run: npm ci
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+      - name: Run e2e tests
+        run: npx playwright test --shard=${{ matrix.shard }}/2 --reporter=junit --trace=on --output=playwright-report
+        env:
+          PLAYWRIGHT_JUNIT_OUTPUT_NAME: junit-e2e-${{ matrix.shard }}.xml
+      - name: Upload junit
+        if: always()
+        id: upload-junit
+        uses: actions/upload-artifact@v4.3.4
+        with:
+          name: junit-e2e-${{ matrix.shard }}
+          path: playwright-report/junit-e2e-${{ matrix.shard }}.xml
+          if-no-files-found: ignore
+      - name: Upload traces
+        if: always()
+        id: upload-trace
+        uses: actions/upload-artifact@v4.3.4
+        with:
+          name: traces-e2e-${{ matrix.shard }}
+          path: playwright-report/**/trace.zip
+          if-no-files-found: ignore
+
+  cicd-selftest:
+    runs-on: ubuntu-latest
+    outputs:
+      junit-url: ${{ steps.upload-junit.outputs.artifact-url }}
+      coverage-url: ${{ steps.upload-coverage.outputs.artifact-url }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - name: Enable Corepack
+        run: corepack enable
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-pw-20-${{ hashFiles('package-lock.json') }}
+      - run: npm ci
+      - name: Run CI self test
+        run: npm run test:ci --if-present -- --reporters=default --reporters=jest-junit --coverage
+        env:
+          JEST_JUNIT_OUTPUT: junit-cicd-selftest.xml
+      - name: Upload coverage
+        if: always()
+        id: upload-coverage
+        uses: actions/upload-artifact@v4.3.4
+        with:
+          name: coverage-cicd-selftest
+          path: coverage
+          if-no-files-found: ignore
+      - name: Upload junit
+        if: always()
+        id: upload-junit
+        uses: actions/upload-artifact@v4.3.4
+        with:
+          name: junit-cicd-selftest
+          path: junit-cicd-selftest.xml
+          if-no-files-found: ignore
+
+  all-green:
+    needs:
+      - backend-unit
+      - backend-integration
+      - frontend
+      - e2e
+      - cicd-selftest
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Summary
+        run: |
+          echo '| Job | Result | Coverage | Junit | Traces |' >> "$GITHUB_STEP_SUMMARY"
+          echo '| --- | ------ | -------- | ----- | ------ |' >> "$GITHUB_STEP_SUMMARY"
+          echo "| backend-unit | ${{ needs.backend-unit.result }} | [coverage](${{ needs.backend-unit.outputs.coverage-url }}) | [junit](${{ needs.backend-unit.outputs.junit-url }}) | |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| backend-integration | ${{ needs.backend-integration.result }} | [coverage](${{ needs.backend-integration.outputs.coverage-url }}) | [junit](${{ needs.backend-integration.outputs.junit-url }}) | |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| frontend | ${{ needs.frontend.result }} | [coverage](${{ needs.frontend.outputs.coverage-url }}) | [junit](${{ needs.frontend.outputs.junit-url }}) | |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| e2e | ${{ needs.e2e.result }} | | [junit](${{ needs.e2e.outputs.junit-url }}) | [traces](${{ needs.e2e.outputs.trace-url }}) |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| cicd-selftest | ${{ needs.cicd-selftest.result }} | [coverage](${{ needs.cicd-selftest.outputs.coverage-url }}) | [junit](${{ needs.cicd-selftest.outputs.junit-url }}) | |" >> "$GITHUB_STEP_SUMMARY"
+      - name: Verify all jobs passed
+        run: |
+          if [ "${{ needs.backend-unit.result }}" != 'success' ] || [ "${{ needs.backend-integration.result }}" != 'success' ] || [ "${{ needs.frontend.result }}" != 'success' ] || [ "${{ needs.e2e.result }}" != 'success' ] || [ "${{ needs.cicd-selftest.result }}" != 'success' ]; then
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- add regression workflow with backend, frontend, e2e and self-test jobs and final all-green gate

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a767648cb4832dae41ccbb7f0ccba1