### PR TITLE
ci: add OS test matrix workflow

### DIFF
--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -1,0 +1,33 @@
+name: Test matrix
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 10
+          run_install: false
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: echo "dir=$(pnpm store path)" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.dir }}
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
+      - run: pnpm install
+      - run: pnpm test


### PR DESCRIPTION
## Summary
- run pnpm tests on pull requests across ubuntu, macos, and windows
- cache pnpm store per operating system

## Testing
- `npm run validate-env`
- `npm run format` (backend)
- `npm test` *(fails: Setup flag missing. Running 'npm run setup'...)*
- `npm run ci` *(timeout; Playwright browsers not installed. Running 'bash scripts/setup.sh' to install them)*
- `npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a766810e54832d8c59a5c398849997