### PR TITLE
ci: add release drafter configuration

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,18 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+change-template: '- $TITLE (#$NUMBER)'
+categories:
+  - title: 'Features'
+    labels:
+      - 'feat'
+      - 'feature'
+  - title: 'Fixes'
+    labels:
+      - 'fix'
+      - 'bug'
+  - title: 'Chores'
+    labels:
+      - 'chore'
+      - 'ci'
+      - 'docs'
+

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,15 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
## Summary
- add Release Drafter workflow to generate release notes
- configure release drafter categories for features, fixes, and chores

## Testing
- `npm run format` (backend)
- `npm test` (backend) *(tests ran but process did not complete; see logs)*
- `SKIP_PW_DEPS=1 npm run ci` *(missing script: lint)*
- `SKIP_PW_DEPS=1 npm run smoke` *(missing frontend build artifact)*

```text
$ npm run format
> backend@1.0.0 preformat
> node ../scripts/ensure-root-deps.js
> backend@1.0.0 format
> sh -c 'cd .. && node scripts/ensure-root-deps.js && prettier --log-level warn --write "**/*.{js,jsx,json,md}" --ignore-path .prettierignore'
```

```text
$ npm test
PASS  tests/api.test.ts
PASS  tests/rewards.test.js
PASS  tests/subscriptions.test.js
PASS  tests/stripe-route-types.test.ts
PASS  tests/frontend/modelViewerLoader.test.js
...
```


------
https://chatgpt.com/codex/tasks/task_e_68a76674990c832da486598b48ab6331