### PR TITLE
ci: add JSON validation workflow

### DIFF
--- a/.github/workflows/json-validate.yml
+++ b/.github/workflows/json-validate.yml
@@ -1,0 +1,31 @@
+name: JSON validate
+
+on:
+  pull_request:
+    paths:
+      - "**/*.json"
+
+jobs:
+  json-validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5.0.0
+      - uses: actions/setup-node@v4.0.2
+        with:
+          node-version: 20
+      - name: Validate JSON syntax
+        run: |
+          set -e
+          for file in $(git ls-files '*.json'); do
+            jq . "$file" >/dev/null
+          done
+      - name: Validate against schemas
+        if: ${{ hashFiles('schemas/**') != '' }}
+        run: |
+          set -e
+          for file in $(git ls-files '*.json'); do
+            schema="schemas/$(basename "$file")"
+            if [ -f "$schema" ]; then
+              npx ajv-cli@5.0.0 validate -s "$schema" -d "$file"
+            fi
+          done


### PR DESCRIPTION
## Summary
- add workflow to validate JSON files using jq and ajv

## Testing
- `npm run setup`
- `npm run format` (backend)
- `npm test` (backend)
- `npm run ci` *(fails: Missing script: lint)*
- `npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html)*

------
https://chatgpt.com/codex/tasks/task_e_68a7665f7b20832da0cc85357b52f13b