### PR TITLE
ci: add secret scanning workflow

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,36 @@
+name: Secret Scan
+
+env:
+  HUSKY: 0
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
+      - uses: actions/checkout@v5.0.0
+        with:
+          fetch-depth: 0
+      - name: Run gitleaks
+        id: gitleaks
+        uses: gitleaks/gitleaks-action@v2.3.9
+        with:
+          args: '--log-opts "${{ github.event.pull_request.base.sha }}..${{ github.sha }}" --report-format sarif --report-path gitleaks-report.sarif --redact'
+      - name: Upload report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4.3.4
+        with:
+          name: gitleaks-report
+          path: gitleaks-report.sarif


### PR DESCRIPTION
## Summary
- add gitleaks secret scan on pull requests

## Testing
- `npm run format --prefix backend`
- `CI=1 npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: npm run lint --prefix frontend)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a766633570832d87e568d4be5da747