### PR TITLE
ci: use policy-aware install step

### DIFF
--- a/.github/workflows/_setup.yml
+++ b/.github/workflows/_setup.yml
@@ -39,7 +39,15 @@ jobs:
             package-lock.json
             backend/package-lock.json
             frontend/package-lock.json
-      - run: npm ci
-      - run: npm ci --prefix frontend
-      - run: npm ci --prefix backend
+      - name: Install deps (policy-aware)
+        run: CI_PM=pnpm npm run ci:bootstrap
+        shell: bash
+      - name: Install deps (policy-aware)
+        run: CI_PM=pnpm npm run ci:bootstrap
+        shell: bash
+        working-directory: frontend
+      - name: Install deps (policy-aware)
+        run: CI_PM=pnpm npm run ci:bootstrap
+        shell: bash
+        working-directory: backend
       - run: ${{ inputs.run }}

--- a/.github/workflows/cache-validator.yml
+++ b/.github/workflows/cache-validator.yml
@@ -41,6 +41,8 @@ jobs:
           node-version: 20
           cache: npm
           cache-dependency-path: ${{ matrix.lockfile }}
-      - run: npm ci --prefer-offline
+      - name: Install deps (policy-aware)
+        run: CI_PM=pnpm npm run ci:bootstrap
+        shell: bash
         working-directory: ${{ matrix.working-directory }}
       - run: echo "cache hit: ${{ steps.setup.outputs.cache-hit }}"

--- a/.github/workflows/ci-env.yml
+++ b/.github/workflows/ci-env.yml
@@ -23,8 +23,13 @@ jobs:
           node-version: 20
           cache: npm
           cache-dependency-path: package-lock.json
-      - run: npm ci
-      - run: npm ci --prefix frontend
+      - name: Install deps (policy-aware)
+        run: CI_PM=pnpm npm run ci:bootstrap
+        shell: bash
+      - name: Install deps (policy-aware)
+        run: CI_PM=pnpm npm run ci:bootstrap
+        shell: bash
+        working-directory: frontend
       - name: Record tool versions
         run: |
           echo "node: $(node -v)" >> versions.txt

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -61,7 +61,9 @@ jobs:
           cache: 'npm'
           cache-dependency-path: 'backend/package-lock.json'
 
-      - run: npm install --no-audit --no-fund
+      - name: Install deps (policy-aware)
+        run: CI_PM=pnpm npm run ci:bootstrap
+        shell: bash
         working-directory: backend
 
 

--- a/.github/workflows/reset-credits.yml
+++ b/.github/workflows/reset-credits.yml
@@ -26,7 +26,9 @@ jobs:
           node-version: 20
           cache: 'npm'
           cache-dependency-path: 'backend/package-lock.json'
-      - run: npm install --no-audit --no-fund
+      - name: Install deps (policy-aware)
+        run: CI_PM=pnpm npm run ci:bootstrap
+        shell: bash
         working-directory: backend
       - run: npm run reset-credits
         working-directory: backend


### PR DESCRIPTION
## Summary
- use `CI_PM=pnpm npm run ci:bootstrap` for dependency installs in select workflows

## Testing
- `npm run format` (backend)
- `npm test` (backend) *(passes; interrupted after completion)*
- `npm run smoke` *(fails: Missing frontend build artifact)*
- `npm run ci` *(incomplete: interrupted during run)*

------
https://chatgpt.com/codex/tasks/task_e_68a767aceda4832d93929ab07bc752ac