### PR TITLE
ci: reuse frontend dist artifact

### DIFF
--- a/.github/workflows/sync-space.yml
+++ b/.github/workflows/sync-space.yml
@@ -63,8 +63,13 @@ jobs:
       - name: Run backend tests
         run: npm run coverage --prefix backend
 
+      - uses: actions/download-artifact@v4
+        with:
+          name: frontend-dist
+          path: frontend/dist
+        continue-on-error: true
       - name: Ensure frontend build output exists
-        run: test -f frontend/dist/index.html
+        run: node -e "require('fs').accessSync('frontend/dist/index.html')"
 
       - name: Run smoke tests
         run: npm run smoke


### PR DESCRIPTION
## Summary
- reuse existing `frontend-dist` artifact in sync-space workflow before verifying dist output

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script: "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a767a7010c832d9d35bfadc396e178