### PR TITLE
ci: guard backend-dist artifact download

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,10 +27,19 @@ jobs:
       - uses: actions/setup-node@v4.4.0
         with:
           node-version: 20
-      - uses: actions/download-artifact@v4
+      - name: Try download backend-dist
+        id: dl
+        uses: actions/download-artifact@v4.3.0
         with:
           name: backend-dist
           path: backend/dist
+        continue-on-error: true
+      - name: Check artifact presence
+        if: steps.dl.outcome == 'failure'
+        run: |
+          echo "::error::Artifact 'backend-dist' not found. Ensure the backend build job uploads it."
+          exit 1
+        shell: bash
       - uses: actions/download-artifact@v4
         with:
           name: frontend-dist


### PR DESCRIPTION
## Summary
- ensure coverage workflow fails gracefully when backend-dist artifact is missing

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format`
```
> backend@1.0.0 preformat
> node ../scripts/ensure-root-deps.js

> backend@1.0.0 format
> sh -c 'cd .. && node scripts/ensure-root-deps.js && prettier --log-level warn --write "**/*.{js,jsx,json,md}" --ignore-path .prettierignore'
```
- `npm test` *(fails: eslint diagnostics, Stripe secret)*
```
FAIL tests/linting-diagnostics-9b3adf.test.js
  ● root eslint exits 0
    Expected: 0
    Received: 1

FAIL tests/health.test.js
  STRIPE_SECRET_KEY must be a live secret
```
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script "lint")*
```
npm error Missing script: "lint"
```
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: missing frontend build artifact)*
```
Missing frontend build artifact: frontend/dist/index.html. Run 'npm run build' and retry
```


------
https://chatgpt.com/codex/tasks/task_e_68a767a1db2c832dab7b7849805e1a3d