### PR TITLE
ci: update CodeQL tools to latest

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,8 +26,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        codeql-version: ["2.22.4"]
     steps:
       - name: Heartbeat
         run: |
@@ -43,7 +41,7 @@ jobs:
         uses: github/codeql-action/init@v3.29.9
         with:
           languages: javascript-typescript
-          tools: ${{ matrix.codeql-version }}
+          tools: latest
       - name: Build
         run: |
           npm ci


### PR DESCRIPTION
## Summary
- simplify CodeQL workflow by removing version matrix and using latest CodeQL tools

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` (backend)
- `npm test` (backend) *(fails: setup flag missing, runs setup)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: only installs dependencies)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a7679b96a8832d9a785cd25f27adc7