### PR TITLE
ci: upload backend dist artifact

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -109,3 +109,11 @@ jobs:
           echo "⚠️ SNYK_TOKEN missing or invalid; running npm audit instead"
           npm audit --audit-level=high --prefix backend
 
+      - name: Upload backend dist
+        if: ${{ always() && hashFiles('backend/dist/**') != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-dist
+          path: backend/dist
+          if-no-files-found: error
+


### PR DESCRIPTION
## Summary
- upload backend dist artifact in Node CI

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html)*

------
https://chatgpt.com/codex/tasks/task_e_68a7679fb85c832d877e455ee53bb69d