### PR TITLE
ci: add pnpm setup step to backend tests

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -24,6 +24,8 @@ jobs:
         with:
           node-version: 20
           cache: pnpm
+      - name: Setup pnpm
+        uses: ./.github/actions/setup-pnpm
       - name: Run changed tests
         run: |
           corepack enable


### PR DESCRIPTION
## Summary
- add pnpm setup action to backend tests workflow

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format --prefix backend` *(fails: Dependencies missing. Installing root dependencies...)*
- `npm test --prefix backend` *(fails: process terminated)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Playwright browsers not installed)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a76794064c832d9acff851ebb70954