### PR TITLE
ci: build frontend artifact before pages deploy

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -36,21 +36,15 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         run: npx -y wrangler pages config validate --project-name "${{ secrets.CF_PAGES_PROJECT }}"
 
-  deploy:
-    needs: validate
+  build:
+    name: Build frontend
     runs-on: ubuntu-latest
+    needs: validate
     steps:
-      - name: Heartbeat
-        run: |
-          while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: npm
-          cache-dependency-path: |
-            package-lock.json
-            frontend/package-lock.json
       - run: npm ci && npm run build --prefix frontend
       - name: ban dist symlinks
         run: |
@@ -60,17 +54,29 @@ jobs:
               tgt="$(readlink -f "$l")"; rm "$l"; cp -R "$tgt" "$l";
             done < <(find frontend/dist -type l -print0)
           fi
-      - name: verify build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: frontend-dist
+          path: frontend/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Heartbeat
         run: |
-          if [ ! -f frontend/dist/index.html ]; then
-            echo "frontend/dist/index.html is missing"
-            if command -v tree >/dev/null; then
-              tree frontend/dist
-            else
-              find frontend/dist -maxdepth 2 -print
-            fi
-            exit 1
-          fi
+          while true; do date; sleep 120; done &
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - uses: actions/download-artifact@v4
+        with:
+          name: frontend-dist
+          path: frontend/dist
+      - name: verify dist
+        run: |
+          test -f frontend/dist/index.html || (echo "vite build did not run or produced no output." && exit 1)
       - name: copy dist
         run: cp -a frontend/dist/. pages_dist/
       - name: Deploy to Cloudflare Pages


### PR DESCRIPTION
## Summary
- build frontend in a dedicated job and upload dist artifact
- deploy job downloads build artifact and checks for vite output before publishing

## Testing
- `npm run format` (backend)
- `npm test` (backend)
- `npm run ci` *(fails: Missing script: "lint")*
- `npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html)*

------
https://chatgpt.com/codex/tasks/task_e_68a767778180832d84313f051fe27103