### PR TITLE
feat: add frontend lint override and color token fixer

### DIFF
--- a/docs/lint/no-hardcoded-colors.md
+++ b/docs/lint/no-hardcoded-colors.md
@@ -1,0 +1,23 @@
+# no-hardcoded-colors
+
+Enforces usage of design tokens instead of hardcoded color literals.
+
+## Allowed tokens
+
+- `var(--color-black)`
+- `var(--color-white)`
+- `var(--color-red)`
+- `var(--color-blue)`
+- `var(--color-green)`
+
+## Auto-fix mappings
+
+| Literal(s)                 | Token                |
+| -------------------------- | -------------------- |
+| `#000`, `#000000`, `black` | `var(--color-black)` |
+| `#fff`, `#ffffff`, `white` | `var(--color-white)` |
+| `#f00`, `#ff0000`, `red`   | `var(--color-red)`   |
+| `#00f`, `#0000ff`, `blue`  | `var(--color-blue)`  |
+| `#0f0`, `#00ff00`, `green` | `var(--color-green)` |
+
+Colors outside these mappings will produce an error. Add a token or extend the whitelist as needed.

--- a/eslint.frontend-87adf32bca1e546.cjs
+++ b/eslint.frontend-87adf32bca1e546.cjs
@@ -7,6 +7,7 @@ const htmlPlugin = require('@html-eslint/eslint-plugin');
 const htmlParser = require('@html-eslint/parser');
 const frontendRules = require('./scripts/eslint-frontend-rules');
 const globals = require('globals');
+const ssrFriendly = require('eslint-plugin-ssr-friendly');
 
 module.exports = [
   {
@@ -33,15 +34,87 @@ module.exports = [
     rules: {
       'no-console': 'error',
       'no-inline-styles/no-inline-styles': 'error',
-      'frontendRules/no-hardcoded-colors': 'error',
+      'frontendRules/no-hardcoded-colors': [
+        'error',
+        {
+          tokens: [
+            'var(--color-black)',
+            'var(--color-white)',
+            'var(--color-red)',
+            'var(--color-blue)',
+            'var(--color-green)',
+          ],
+        },
+      ],
       'frontendRules/button-requires-aria': 'error',
       'frontendRules/controlled-input': 'error',
       'frontendRules/no-deprecated-html-tags': 'error',
     },
   },
   {
-    files: ['*.html'],
-    languageOptions: { parser: htmlParser, globals: { ...globals.browser } },
+    files: ['frontend/**/*.{js,jsx,ts,tsx}'],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        ecmaVersion: 2023,
+        sourceType: 'module',
+        ecmaFeatures: { jsx: true },
+        project: ['./tsconfig.base.json'],
+        tsconfigRootDir: __dirname,
+      },
+      globals: {
+        ...globals.browser,
+        ...globals.es2023,
+        window: 'readonly',
+        document: 'readonly',
+        localStorage: 'readonly',
+      },
+    },
+    plugins: {
+      react,
+      jsxA11y,
+      'no-inline-styles': noInlineStyles,
+      frontendRules,
+      '@typescript-eslint': ts,
+      'ssr-friendly': ssrFriendly,
+    },
+    rules: {
+      'no-console': ['error', { allow: ['warn', 'error'] }],
+      'no-undef': 'error',
+      'no-inline-styles/no-inline-styles': 'error',
+      'frontendRules/no-hardcoded-colors': [
+        'error',
+        {
+          tokens: [
+            'var(--color-black)',
+            'var(--color-white)',
+            'var(--color-red)',
+            'var(--color-blue)',
+            'var(--color-green)',
+          ],
+        },
+      ],
+      'frontendRules/button-requires-aria': 'error',
+      'frontendRules/controlled-input': 'error',
+      'frontendRules/no-deprecated-html-tags': 'error',
+      'ssr-friendly/no-dom-globals-in-module-scope': 'error',
+      'ssr-friendly/no-dom-globals-in-constructor': 'error',
+      'ssr-friendly/no-dom-globals-in-react-cc-render': 'error',
+      'ssr-friendly/no-dom-globals-in-react-fc': 'error',
+    },
+  },
+  {
+    files: ['*.html', 'frontend/**/*.html'],
+    languageOptions: {
+      parser: htmlParser,
+      globals: {
+        ...globals.browser,
+        ...globals.es2023,
+        window: 'readonly',
+        document: 'readonly',
+        localStorage: 'readonly',
+      },
+    },
     plugins: {
       html: htmlPlugin,
       'no-inline-styles': noInlineStyles,
@@ -49,7 +122,18 @@ module.exports = [
     },
     rules: {
       'no-inline-styles/no-inline-styles': 'error',
-      'frontendRules/no-hardcoded-colors': 'error',
+      'frontendRules/no-hardcoded-colors': [
+        'error',
+        {
+          tokens: [
+            'var(--color-black)',
+            'var(--color-white)',
+            'var(--color-red)',
+            'var(--color-blue)',
+            'var(--color-green)',
+          ],
+        },
+      ],
       'frontendRules/button-requires-aria': 'error',
       'frontendRules/controlled-input': 'error',
       'frontendRules/no-deprecated-html-tags': 'error',

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "eslint-plugin-node": "11.1.0",
         "eslint-plugin-promise": "7.2.1",
         "eslint-plugin-react": "7.37.5",
+        "eslint-plugin-ssr-friendly": "^1.3.0",
         "execa": "^9.6.0",
         "express": "^4.21.2",
         "gltf-validator": "^2.0.0-dev.3.10",
@@ -10457,6 +10458,48 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/eslint-plugin-ssr-friendly": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-ssr-friendly/-/eslint-plugin-ssr-friendly-1.3.0.tgz",
+      "integrity": "sha512-VOYl9OgK9mSVWxwl3pSTzNmBUMhPYjDGmxgyjSM9Agdve4GHjn0gAcCG/seg1taaW/aBWTkb7Aw4GIBsxVhL9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "globals": "^13.8.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=0.8.0"
+      }
+    },
+    "node_modules/eslint-plugin-ssr-friendly/node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-plugin-ssr-friendly/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint-plugin-unicorn": {

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-promise": "7.2.1",
     "eslint-plugin-react": "7.37.5",
+    "eslint-plugin-ssr-friendly": "^1.3.0",
     "execa": "^9.6.0",
     "express": "^4.21.2",
     "gltf-validator": "^2.0.0-dev.3.10",

--- a/scripts/eslint-frontend-rules.js
+++ b/scripts/eslint-frontend-rules.js
@@ -1,12 +1,65 @@
 module.exports = {
   rules: {
     "no-hardcoded-colors": {
+      meta: {
+        type: "suggestion",
+        fixable: "code",
+        docs: {
+          description:
+            "Disallow hardcoded color values in favor of design tokens",
+        },
+        schema: [
+          {
+            type: "object",
+            properties: {
+              tokens: {
+                type: "array",
+                items: { type: "string" },
+              },
+            },
+            additionalProperties: false,
+          },
+        ],
+      },
       create(context) {
+        const options = context.options[0] || {};
+        const tokenSet = new Set(options.tokens || []);
+        const literalToToken = {
+          "#000": "var(--color-black)",
+          "#000000": "var(--color-black)",
+          black: "var(--color-black)",
+          "#fff": "var(--color-white)",
+          "#ffffff": "var(--color-white)",
+          white: "var(--color-white)",
+          red: "var(--color-red)",
+          "#f00": "var(--color-red)",
+          "#ff0000": "var(--color-red)",
+          blue: "var(--color-blue)",
+          "#00f": "var(--color-blue)",
+          "#0000ff": "var(--color-blue)",
+          green: "var(--color-green)",
+          "#0f0": "var(--color-green)",
+          "#00ff00": "var(--color-green)",
+        };
         const colorRegex =
           /#[0-9A-Fa-f]{3,8}\b|\brgba?\(|\bhsl[a]?\(|\b(?:red|blue|green|orange|yellow|purple|black|white|gray|grey|pink|brown)\b/i;
         return {
           Literal(node) {
-            if (typeof node.value === "string" && colorRegex.test(node.value)) {
+            if (typeof node.value !== "string") return;
+            const value = node.value.toLowerCase();
+            if (tokenSet.has(value) || value.startsWith("var(--")) {
+              return;
+            }
+            const token = literalToToken[value];
+            if (token) {
+              context.report({
+                node,
+                message: `Hardcoded color '${node.value}' detected. Use ${token} instead`,
+                fix: (fixer) => fixer.replaceText(node, `'${token}'`),
+              });
+              return;
+            }
+            if (colorRegex.test(value)) {
               context.report({ node, message: "Hardcoded color detected" });
             }
           },


### PR DESCRIPTION
## Summary
- extend frontend eslint setup with browser/SSR override and DOM guard rules
- enhance `no-hardcoded-colors` with design tokens whitelist and auto-fixer
- document color token usage for lint rule

## Testing
- `npm run format`
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails to exit, manually terminated after passes)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: npm run lint missing script frontend)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*


------
https://chatgpt.com/codex/tasks/task_e_68a7676fe424832d9ae737e01e5dde3f