### PR TITLE
chore: add pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.1.0
+    hooks:
+      - id: prettier
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: v9.33.0
+    hooks:
+      - id: eslint

--- a/docs/codex/pre-commit.md
+++ b/docs/codex/pre-commit.md
@@ -1,0 +1,18 @@
+# Pre-commit Hooks
+
+This repository uses [pre-commit](https://pre-commit.com/) to manage Git hooks and enforce consistent formatting and linting.
+
+## Setup
+
+1. Install pre-commit:
+   ```bash
+   pip install pre-commit
+   ```
+2. Install the hooks:
+   ```bash
+   pre-commit install
+   ```
+3. Run all hooks against the codebase:
+   ```bash
+   pre-commit run --all-files
+   ```


### PR DESCRIPTION
## Summary
- add .pre-commit-config.yaml configuring trailing whitespace, EOF fixer, Prettier, and ESLint hooks
- document pre-commit setup in docs/codex/pre-commit.md

## Testing
- `pre-commit run --files .pre-commit-config.yaml docs/codex/pre-commit.md`
- `npm run format` (backend)
- `node ../scripts/run-jest.js --runInBand` (backend)
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a7667afaf8832db0a71742d34df823