### PR TITLE
docs: add sparse checkout recipes

### DIFF
--- a/docs/codex/sparse-recipes.md
+++ b/docs/codex/sparse-recipes.md
@@ -1,0 +1,40 @@
+# Sparse checkout recipes
+
+Git's sparse checkout can limit the working tree to just the folders you need.
+Start with a minimal clone:
+
+```bash
+git clone https://github.com/OWNER/REPO.git --filter=blob:none --sparse
+cd REPO
+git sparse-checkout init --cone
+```
+
+## Work on app sources only
+
+```bash
+git sparse-checkout set apps
+```
+
+## Work on shared packages
+
+```bash
+git sparse-checkout set packages
+```
+
+## Work on documentation
+
+```bash
+git sparse-checkout set docs
+```
+
+## Combine multiple areas
+
+```bash
+git sparse-checkout set apps packages docs
+```
+
+Return to a full checkout when finished:
+
+```bash
+git sparse-checkout disable
+```


### PR DESCRIPTION
## Summary
- add sparse checkout recipes for apps, packages, and docs directories

## Testing
- `npm run format`
- `npm test tests/api.test.js` *(fails: Running coverage on untested files... interrupted)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: npm error Did you mean this?)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html)*

------
https://chatgpt.com/codex/tasks/task_e_68a764053b94832da9c736455d922a4e