### PR TITLE
ci: add frontend codemod lint workflow

### DIFF
--- a/.github/workflows/codemod-lint-frontend.yml
+++ b/.github/workflows/codemod-lint-frontend.yml
@@ -1,0 +1,56 @@
+name: Codemod Lint Frontend
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - frontend/**
+      - scripts/codemods/**
+      - package.json
+      - package-lock.json
+      - .github/workflows/**
+  pull_request:
+    branches: [main]
+    paths:
+      - frontend/**
+      - scripts/codemods/**
+      - package.json
+      - package-lock.json
+      - .github/workflows/**
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  codemod:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    env:
+      HUSKY: 0
+    steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            frontend/package-lock.json
+      - run: npm ci
+      - run: npm ci --prefix frontend
+      - name: Run codemod and lint
+        run: npm run codemod:lint:frontend
+      - name: Diff summary
+        run: |
+          git status --short > codemod-diff.txt
+          git diff --stat >> codemod-diff.txt || true
+      - name: Upload diff summary
+        uses: actions/upload-artifact@v4
+        with:
+          name: codemod-lint-frontend
+          path: codemod-diff.txt

--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
     "test:webhook": "node scripts/test-webhook.js",
     "check:code-scanning": "node scripts/check-code-scanning.js",
     "commitlint": "commitlint --from=HEAD~1",
-    "lint:md": "markdownlint-cli2 \"**/*.md\""
+    "lint:md": "markdownlint-cli2 \"**/*.md\"",
+    "codemod:lint:frontend": "npx -y ts-node --transpile-only scripts/codemods/fix-browser-globals.ts && npm run lint --prefix frontend"
   },
   "babel": {
     "presets": [

--- a/scripts/codemods/fix-browser-globals.ts
+++ b/scripts/codemods/fix-browser-globals.ts
@@ -1,0 +1,82 @@
+import fs from "fs";
+import path from "path";
+
+const ROOT = path.join(process.cwd(), "frontend");
+
+const COLOR_MAP: Record<string, string> = {
+  "#000": "var(--color-black)",
+  "#000000": "var(--color-black)",
+  "#fff": "var(--color-white)",
+  "#ffffff": "var(--color-white)",
+  "#f00": "var(--color-red)",
+  "#ff0000": "var(--color-red)",
+  "#0f0": "var(--color-green)",
+  "#00ff00": "var(--color-green)",
+  "#00f": "var(--color-blue)",
+  "#0000ff": "var(--color-blue)",
+};
+
+const GLOBALS = ["window", "document", "localStorage"];
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of fs.readdirSync(dir)) {
+    if (entry === "node_modules") continue;
+    const full = path.join(dir, entry);
+    const stat = fs.statSync(full);
+    if (stat.isDirectory()) {
+      walk(full, out);
+    } else if (/\.(tsx?|jsx?|css)$/i.test(entry)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function guardGlobals(code: string): string {
+  for (const name of GLOBALS) {
+    const regex = new RegExp(`(?<![.\w$]|typeof\s)${name}\b`, "g");
+    code = code.replace(
+      regex,
+      `(typeof ${name} !== 'undefined' ? ${name} : undefined)`,
+    );
+  }
+  return code;
+}
+
+function replaceConsole(code: string): string {
+  code = code.replace(/console\.(log|debug)\([^\n]*\);?\n?/g, "");
+  code = code.replace(/console\.warn/g, "logger.warn");
+  code = code.replace(/console\.error/g, "logger.error");
+  code = code.replace(/console\.info/g, "logger.info");
+  code = code.replace(/console\.trace/g, "logger.trace");
+  return code;
+}
+
+function replaceColors(code: string): string {
+  for (const [hex, token] of Object.entries(COLOR_MAP)) {
+    const regex = new RegExp(hex.replace(/[#]/g, "\\$&"), "gi");
+    code = code.replace(regex, token);
+  }
+  return code;
+}
+
+function processFile(file: string) {
+  const original = fs.readFileSync(file, "utf8");
+  let code = original;
+  code = guardGlobals(code);
+  code = replaceConsole(code);
+  code = replaceColors(code);
+  if (code !== original) {
+    fs.writeFileSync(file, code);
+  }
+}
+
+function main() {
+  if (!fs.existsSync(ROOT)) return;
+  const files = walk(ROOT);
+  for (const file of files) {
+    processFile(file);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- add codemod to guard browser globals, swap console calls and color literals
- add npm script `codemod:lint:frontend`
- run codemod lint in non-blocking workflow that uploads diff summary

## Testing
- `npm run format --prefix backend`
- `SKIP_PW_DEPS=1 npm test --prefix backend` *(fails: setup reruns and tests did not execute)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: setup reruns and CI did not complete)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a76772b0bc832d89c87f2d1fc63f94