### PR TITLE
refactor: improve ci watchdog types and tests

### DIFF
--- a/scripts/ci_watchdog.js
+++ b/scripts/ci_watchdog.js
@@ -3,6 +3,8 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
+exports.patchFiles = patchFiles;
+exports.globWalk = globWalk;
 const action_1 = require("@octokit/action");
 const node_child_process_1 = require("node:child_process");
 const promises_1 = __importDefault(require("node:fs/promises"));
@@ -13,48 +15,28 @@ const WINDOW_HOURS = 4;
 const MIN_HITS = 5;
 const MAX_RUNS = 25;
 const sinceIso = new Date(Date.now() - WINDOW_HOURS * 3600_000).toISOString();
-function isWorkflowRun(val) {
-    return (typeof val === "object" &&
-        val !== null &&
-        typeof val.id === "number");
-}
-function isIssue(val) {
-    return (typeof val === "object" &&
-        val !== null &&
-        typeof val.number === "number");
-}
 async function main() {
-    const runsRaw = (await octo.paginate(octo.rest.actions.listWorkflowRunsForRepo, {
+    const apiRuns = await octo.paginate("GET /repos/{owner}/{repo}/actions/runs", {
         owner,
         repo,
         per_page: 100,
         status: "failure",
         event: "pull_request",
         created: `>${sinceIso}`,
+    });
+    const runs = apiRuns.map((r) => ({
+        id: r.id,
+        pull_requests: r.pull_requests?.map((pr) => ({ number: pr.number })),
     }));
-    const runs = Array.isArray(runsRaw)
-        ? runsRaw.filter(isWorkflowRun)
-        : [];
     const clusters = {};
     for (const r of runs.slice(0, MAX_RUNS)) {
-        const log = await octo.rest.actions.downloadWorkflowRunLogs({
+        const log = (await octo.request("GET /repos/{owner}/{repo}/actions/runs/{run_id}/logs", {
             owner,
             repo,
             run_id: r.id,
-            request: { raw: true },
-        });
-        const raw = log.data;
-        const buf = raw instanceof ArrayBuffer
-            ? Buffer.from(raw)
-            : Buffer.isBuffer(raw)
-                ? raw
-                : typeof raw === "string"
-                    ? Buffer.from(raw)
-                    : ArrayBuffer.isView(raw)
-                        ? Buffer.from(raw.buffer)
-                        : null;
-        if (!buf)
-            throw new Error("unexpected log data type");
+            request: { responseType: "arraybuffer" },
+        }));
+        const buf = Buffer.from(log.data);
         const firstLine = buf.toString("utf8").split("\n").find(Boolean) ?? "unknown error";
         const key = firstLine.trim().slice(0, 120);
         clusters[key] ??= { msg: key, runs: [], prs: [] };
@@ -149,8 +131,10 @@ async function upsertIssue(title, cluster) {
         state: "open",
         labels: "ci-watchdog",
     });
-    const data = issuesResp.data;
-    const issues = Array.isArray(data) ? data.filter(isIssue) : [];
+    const issues = issuesResp.data.map((i) => ({
+        title: i.title,
+        number: i.number,
+    }));
     const existing = issues.find((i) => i.title === title);
     const body = `Detected **${cluster.prs.length} PRs** failing with:\n\n\`\`\`\n${cluster.msg}\n\`\`\``;
     if (existing) {
@@ -183,7 +167,9 @@ async function commentOnPRs(cluster) {
         });
     }
 }
-main().catch((e) => {
-    console.error(e);
-    process.exit(1);
-});
+if (require.main === module) {
+    main().catch((e) => {
+        console.error(e);
+        process.exit(1);
+    });
+}

--- a/scripts/ci_watchdog.ts
+++ b/scripts/ci_watchdog.ts
@@ -1,4 +1,5 @@
 import { Octokit } from "@octokit/action";
+import type { Endpoints } from "@octokit/types";
 import { execSync } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -14,32 +15,19 @@ const sinceIso = new Date(Date.now() - WINDOW_HOURS * 3600_000).toISOString();
 
 type Cluster = { msg: string; runs: number[]; prs: number[] };
 
-type WorkflowRun = {
-  id: number;
-  pull_requests?: { number: number }[] | null;
-};
+type ApiWorkflowRun =
+  Endpoints["GET /repos/{owner}/{repo}/actions/runs"]["response"]["data"]["workflow_runs"][number];
 
-type Issue = { title?: string; number: number };
+type WorkflowRun = { id: number; pull_requests?: { number: number }[] };
 
-function isWorkflowRun(val: unknown): val is WorkflowRun {
-  return (
-    typeof val === "object" &&
-    val !== null &&
-    typeof (val as { id?: unknown }).id === "number"
-  );
-}
-
-function isIssue(val: unknown): val is Issue {
-  return (
-    typeof val === "object" &&
-    val !== null &&
-    typeof (val as { number?: unknown }).number === "number"
-  );
-}
+type Issue = Pick<
+  Endpoints["GET /repos/{owner}/{repo}/issues"]["response"]["data"][number],
+  "title" | "number"
+>;
 
 async function main() {
-  const runsRaw = (await octo.paginate(
-    octo.rest.actions.listWorkflowRunsForRepo,
+  const apiRuns = await octo.paginate<ApiWorkflowRun>(
+    "GET /repos/{owner}/{repo}/actions/runs",
     {
       owner,
       repo,
@@ -48,33 +36,25 @@ async function main() {
       event: "pull_request",
       created: `>${sinceIso}`,
     },
-  )) as unknown;
-  const runs = Array.isArray(runsRaw)
-    ? runsRaw.filter(isWorkflowRun)
-    : [];
+  );
+  const runs: WorkflowRun[] = apiRuns.map((r) => ({
+    id: r.id,
+    pull_requests: r.pull_requests?.map((pr) => ({ number: pr.number })),
+  }));
 
   const clusters: Record<string, Cluster> = {};
 
   for (const r of runs.slice(0, MAX_RUNS)) {
-    const log: { data: unknown } =
-      await octo.rest.actions.downloadWorkflowRunLogs({
+    const log = (await octo.request(
+      "GET /repos/{owner}/{repo}/actions/runs/{run_id}/logs",
+      {
         owner,
         repo,
         run_id: r.id,
-        request: { raw: true },
-      });
-    const raw = log.data;
-    const buf =
-      raw instanceof ArrayBuffer
-        ? Buffer.from(raw)
-        : Buffer.isBuffer(raw)
-        ? raw
-        : typeof raw === "string"
-        ? Buffer.from(raw)
-        : ArrayBuffer.isView(raw)
-        ? Buffer.from(raw.buffer)
-        : null;
-    if (!buf) throw new Error("unexpected log data type");
+        request: { responseType: "arraybuffer" },
+      },
+    )) as { data: ArrayBuffer };
+    const buf = Buffer.from(log.data);
     const firstLine =
       buf.toString("utf8").split("\n").find(Boolean) ?? "unknown error";
     const key = firstLine.trim().slice(0, 120);
@@ -156,7 +136,7 @@ fi`,
   });
 }
 
-async function patchFiles(pattern: RegExp, replacement: string) {
+export async function patchFiles(pattern: RegExp, replacement: string) {
   const files = [
     "Dockerfile",
     ...(await globWalk(".github/workflows", ".yml")),
@@ -172,7 +152,11 @@ async function patchFiles(pattern: RegExp, replacement: string) {
   return altered;
 }
 
-async function globWalk(dir: string, ext: string, out: string[] = []) {
+export async function globWalk(
+  dir: string,
+  ext: string,
+  out: string[] = [],
+): Promise<string[]> {
   for (const e of await fs.readdir(dir, { withFileTypes: true })) {
     const p = path.join(dir, e.name);
     if (e.isDirectory()) {
@@ -191,8 +175,10 @@ async function upsertIssue(title: string, cluster: Cluster) {
     state: "open",
     labels: "ci-watchdog",
   });
-  const data = issuesResp.data as unknown;
-  const issues = Array.isArray(data) ? data.filter(isIssue) : [];
+  const issues: Issue[] = issuesResp.data.map((i) => ({
+    title: i.title,
+    number: i.number,
+  }));
   const existing = issues.find((i) => i.title === title);
   const body = `Detected **${cluster.prs.length} PRs** failing with:\n\n\`\`\`\n${cluster.msg}\n\`\`\``;
 
@@ -226,7 +212,9 @@ async function commentOnPRs(cluster: Cluster) {
   }
 }
 
-main().catch((e) => {
-  console.error(e);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });
+}

--- a/tests/ci/watchdog-utils.test.ts
+++ b/tests/ci/watchdog-utils.test.ts
@@ -1,0 +1,50 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+describe("ci_watchdog helpers", () => {
+  test("globWalk finds files recursively", async () => {
+    process.env.GITHUB_ACTION = "1";
+    process.env.GITHUB_TOKEN = "test";
+    process.env.GITHUB_REPOSITORY = "owner/repo";
+    const { globWalk } = await import("../../scripts/ci_watchdog");
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "watchdog-"));
+    const nested = path.join(tmp, "a/b");
+    await fs.mkdir(nested, { recursive: true });
+    const file1 = path.join(tmp, "one.yml");
+    const file2 = path.join(nested, "two.yml");
+    await fs.writeFile(file1, "");
+    await fs.writeFile(file2, "");
+    await fs.writeFile(path.join(tmp, "ignore.txt"), "");
+
+    const result = await globWalk(tmp, ".yml");
+    expect(result.sort()).toEqual([file1, file2].sort());
+
+    await fs.rm(tmp, { recursive: true, force: true });
+  });
+
+  test("patchFiles replaces matches", async () => {
+    process.env.GITHUB_ACTION = "1";
+    process.env.GITHUB_TOKEN = "test";
+    process.env.GITHUB_REPOSITORY = "owner/repo";
+    const { patchFiles } = await import("../../scripts/ci_watchdog");
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "watchdog-"));
+    await fs.mkdir(path.join(tmp, ".github/workflows"), { recursive: true });
+    const dockerfile = path.join(tmp, "Dockerfile");
+    await fs.writeFile(dockerfile, "npm ci --no-audit --no-fund");
+    const cwd = process.cwd();
+    process.chdir(tmp);
+    try {
+      const changed = await patchFiles(
+        /npm ci --no-audit --no-fund/g,
+        "npm install --no-audit --no-fund",
+      );
+      const content = await fs.readFile(dockerfile, "utf8");
+      expect(changed).toBe(true);
+      expect(content).toBe("npm install --no-audit --no-fund");
+    } finally {
+      process.chdir(cwd);
+      await fs.rm(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/utils/testEnv.ts
+++ b/tests/utils/testEnv.ts
@@ -1,5 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const reaper = require('./reaper');
+const { afterEach, beforeEach, expect } = require("@jest/globals");
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const reaper = require("./reaper");
 
 const STALL_MS = 10_000;
 let stallTimer: NodeJS.Timeout | null = null;


### PR DESCRIPTION
## Summary
- type CI watchdog responses with `@octokit/types`
- download workflow logs as array buffers
- add unit tests for watchdog helpers

## Testing
- `npm run format`
- `npm run typecheck`
- `npm run typecheck:watchdog`
- `npm test --prefix backend`
- `node scripts/run-jest.js tests/ci/watchdog-utils.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a76779b4a8832d9b2b10347cb68fa0