### PR TITLE
ci: ensure backend artifacts are retained and validated

### DIFF
--- a/.github/actions/frontend-build/action.yml
+++ b/.github/actions/frontend-build/action.yml
@@ -17,5 +17,6 @@ runs:
       working-directory: frontend
     - uses: actions/upload-artifact@v4
       with:
-        name: frontend-dist
+        name: frontend-dist-${{ github.run_id }}
         path: frontend/dist
+        retention-days: 3

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,7 +3,6 @@ name: Coverage
 env:
   HUSKY: 0
 
-
 on: [push, pull_request]
 
 concurrency:
@@ -11,7 +10,34 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  build-frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/frontend-build
+
+  build-backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            backend/package-lock.json
+      - run: npm ci
+      - run: npm ci --prefix backend
+      - run: npx tsc -p backend/tsconfig.build.json --outDir backend/dist
+      - uses: actions/upload-artifact@v4.6.2
+        with:
+          name: backend-dist-${{ github.run_id }}
+          path: backend/dist
+          retention-days: 3
+
   coverage:
+    needs: [build-frontend, build-backend]
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
@@ -19,7 +45,6 @@ jobs:
         run: |
           while true; do date; sleep 120; done &
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/frontend-build
       - name: Load Stripe env
         run: node scripts/ci-env-preflight.js
         env:
@@ -28,13 +53,19 @@ jobs:
       - uses: actions/setup-node@v4.4.0
         with:
           node-version: 20
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            backend/package-lock.json
+      - run: npm ci
+      - run: npm ci --prefix backend
       - uses: actions/download-artifact@v4
         with:
-          name: backend-dist
+          name: backend-dist-${{ github.run_id }}
           path: backend/dist
       - uses: actions/download-artifact@v4
         with:
-          name: frontend-dist
+          name: frontend-dist-${{ github.run_id }}
           path: frontend/dist
       - run: SKIP_PW_DEPS=1 npm run coverage
       - name: Coverage summary
@@ -65,3 +96,4 @@ jobs:
         with:
           name: lcov
           path: coverage/lcov.info
+          retention-days: 3

--- a/tests/ci/workflow-artifact-usage-8f7d2c1e.test.ts
+++ b/tests/ci/workflow-artifact-usage-8f7d2c1e.test.ts
@@ -1,0 +1,51 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import YAML from 'yaml';
+
+const repoRoot = path.resolve(__dirname, '../..');
+
+test('coverage workflow artifacts are uploaded and downloaded with retention', async () => {
+  const coveragePath = path.join(repoRoot, '.github', 'workflows', 'coverage.yml');
+  const coverage = YAML.parse(await fs.readFile(coveragePath, 'utf8'));
+  const frontendActionPath = path.join(repoRoot, '.github', 'actions', 'frontend-build', 'action.yml');
+  const frontendAction = YAML.parse(await fs.readFile(frontendActionPath, 'utf8'));
+
+  const uploads = new Map<string, number>();
+  const downloads = new Set<string>();
+
+  for (const step of coverage.jobs['build-backend'].steps || []) {
+    if (typeof step.uses === 'string' && step.uses.startsWith('actions/upload-artifact')) {
+      uploads.set(step.with.name, step.with['retention-days']);
+    }
+  }
+
+  for (const step of frontendAction.runs.steps || []) {
+    if (typeof step.uses === 'string' && step.uses.startsWith('actions/upload-artifact')) {
+      uploads.set(step.with.name, step.with['retention-days']);
+    }
+  }
+
+  for (const step of coverage.jobs.coverage.steps || []) {
+    if (typeof step.uses === 'string' && step.uses.startsWith('actions/download-artifact')) {
+      downloads.add(step.with.name);
+    }
+  }
+
+  const expected = [
+    'backend-dist-${{ github.run_id }}',
+    'frontend-dist-${{ github.run_id }}',
+  ];
+
+  for (const name of expected) {
+    if (!uploads.has(name)) {
+      throw new Error(`Missing upload for ${name}`);
+    }
+    const retention = uploads.get(name);
+    if (typeof retention !== 'number' || retention < 3) {
+      throw new Error(`Retention for ${name} is less than 3 days`);
+    }
+    if (!downloads.has(name)) {
+      throw new Error(`Missing download for ${name}`);
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- build backend and frontend artifacts with unique run IDs and 3-day retention
- ensure coverage workflow downloads matching artifacts
- add test checking artifact upload/download pairs and retention

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `node scripts/run-jest.js tests/ci/workflow-artifact-usage-8f7d2c1e.test.ts`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing script "lint")*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a76bfb74b0832d86710f4a8f0e3332