### PR TITLE
ci: cache pnpm and vite deps

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -24,6 +24,11 @@ jobs:
         with:
           node-version: 20
           cache: pnpm
+      - name: Cache pnpm store
+        uses: actions/cache@v4.2.4
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
       - name: Run changed tests
         run: |
           corepack enable

--- a/.github/workflows/web-matrix.yml
+++ b/.github/workflows/web-matrix.yml
@@ -36,6 +36,16 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
+      - name: Cache pnpm store
+        uses: actions/cache@v4.2.4
+        with:
+          path: ~/.pnpm-store
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml', 'apps/site/vite.config.ts') }}
+      - name: Cache Vite cache
+        uses: actions/cache@v4.2.4
+        with:
+          path: node_modules/.vite
+          key: ${{ runner.os }}-vite-${{ hashFiles('pnpm-lock.yaml', 'apps/site/vite.config.ts') }}
       - name: Install dependencies
         run: |
           corepack enable

--- a/tests/workflow-cache.test.js
+++ b/tests/workflow-cache.test.js
@@ -1,0 +1,56 @@
+const fs = require("fs");
+const path = require("path");
+const yaml = require("yaml");
+
+const repoRoot = path.join(__dirname, "..");
+
+function loadWorkflow(file) {
+  const content = fs.readFileSync(
+    path.join(repoRoot, ".github", "workflows", file),
+    "utf8",
+  );
+  return yaml.parse(content);
+}
+
+function cacheSteps(workflow) {
+  const jobs = workflow.jobs || {};
+  const caches = [];
+  for (const job of Object.values(jobs)) {
+    for (const step of job.steps || []) {
+      if (step.uses && step.uses.startsWith("actions/cache")) {
+        caches.push(step.with || {});
+      }
+    }
+  }
+  return caches;
+}
+
+describe("workflow caching", () => {
+  test("backend workflows cache pnpm store", () => {
+    const wf = loadWorkflow("backend-tests.yml");
+    const caches = cacheSteps(wf);
+    const pnpmCache = caches.find((c) =>
+      (c.path || "").includes("~/.pnpm-store"),
+    );
+    expect(pnpmCache).toBeTruthy();
+    expect(pnpmCache.key).toMatch(/pnpm-lock\.yaml/);
+  });
+
+  test("frontend workflows cache pnpm store and vite cache", () => {
+    const wf = loadWorkflow("web-matrix.yml");
+    const caches = cacheSteps(wf);
+    const pnpmCache = caches.find((c) =>
+      (c.path || "").includes("~/.pnpm-store"),
+    );
+    expect(pnpmCache).toBeTruthy();
+    expect(pnpmCache.key).toMatch(/pnpm-lock\.yaml/);
+    expect(pnpmCache.key).toMatch(/vite.config.ts/);
+
+    const viteCache = caches.find((c) =>
+      (c.path || "").includes("node_modules/.vite"),
+    );
+    expect(viteCache).toBeTruthy();
+    expect(viteCache.key).toMatch(/pnpm-lock\.yaml/);
+    expect(viteCache.key).toMatch(/vite.config.ts/);
+  });
+});


### PR DESCRIPTION
## Summary
- cache pnpm store in backend tests workflow
- add pnpm and Vite caches to web-matrix workflow
- verify workflows include required caches

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: eslint warnings)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: prettier warnings)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*
- `node scripts/run-jest.js tests/workflow-cache.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a76bf77ec4832daf81f7b9dc5c5ca2