### PR TITLE
ci: enforce self-hosted runner fallback

### DIFF
--- a/.github/workflows/_setup.yml
+++ b/.github/workflows/_setup.yml
@@ -26,7 +26,9 @@ jobs:
 
   run:
     needs: labels
-    runs-on: ${{ fromJSON(needs.labels.outputs.runs_on_json) }}
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -15,7 +15,9 @@ concurrency:
 
 jobs:
   actionlint:
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/affected.yml
+++ b/.github/workflows/affected.yml
@@ -12,7 +12,9 @@ concurrency:
 
 jobs:
   affected-builds:
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -12,7 +12,9 @@ concurrency:
 
 jobs:
   build-artifacts:
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/auto_rebase_merge_queue.yml
+++ b/.github/workflows/auto_rebase_merge_queue.yml
@@ -18,7 +18,9 @@ concurrency:
 jobs:
   rebase:
     if: ${{ !startsWith(github.event.pull_request.head.ref, 'codex/') }}
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - name: Heartbeat
         run: |
@@ -50,7 +52,9 @@ jobs:
   merge-queue:
     needs: rebase
     if: ${{ needs.rebase.result == 'success' || needs.rebase.result == 'skipped' }}
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/backend-only-ci.yml
+++ b/.github/workflows/backend-only-ci.yml
@@ -29,7 +29,9 @@ jobs:
     needs: preflight
     if: github.event_name == 'workflow_dispatch' ||
       needs.preflight.outputs.run_backend == 'true'
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     continue-on-error: true
     strategy:
       fail-fast: true

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -16,7 +16,9 @@ concurrency:
 jobs:
   changed-tests:
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v5
@@ -35,7 +37,9 @@ jobs:
 
   full-suite:
     if: github.ref_name == '00000production'
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -16,7 +16,9 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     if: ${{ matrix.node != 22 || contains(github.event.pull_request.labels.*.name,
       'full-matrix') }}
     continue-on-error: ${{ matrix.node == 22 }}

--- a/.github/workflows/cache-primer.yml
+++ b/.github/workflows/cache-primer.yml
@@ -13,7 +13,9 @@ concurrency:
 
 jobs:
   root-cache:
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - name: Heartbeat
         run: |
@@ -28,7 +30,9 @@ jobs:
     timeout-minutes: 15
 
   backend-cache:
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - name: Heartbeat
         run: |
@@ -43,7 +47,9 @@ jobs:
     timeout-minutes: 15
 
   frontend-cache:
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4

--- a/.github/workflows/cache-validator.yml
+++ b/.github/workflows/cache-validator.yml
@@ -17,7 +17,9 @@ concurrency:
 jobs:
   validate:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/cf-pages-preview.yml
+++ b/.github/workflows/cf-pages-preview.yml
@@ -19,7 +19,9 @@ concurrency:
 jobs:
   preview:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/check-watchdog.yml
+++ b/.github/workflows/check-watchdog.yml
@@ -12,7 +12,9 @@ concurrency:
 
 jobs:
   watch:
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     continue-on-error: true
     timeout-minutes: 8
     permissions:

--- a/.github/workflows/ci-env.yml
+++ b/.github/workflows/ci-env.yml
@@ -13,7 +13,9 @@ concurrency:
 jobs:
   versions:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/ci-queue-monitor.yml
+++ b/.github/workflows/ci-queue-monitor.yml
@@ -16,7 +16,9 @@ concurrency:
 jobs:
   monitor:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     permissions:
       actions: write
       pull-requests: write

--- a/.github/workflows/ci-rerun-slow.yml
+++ b/.github/workflows/ci-rerun-slow.yml
@@ -14,7 +14,9 @@ concurrency:
 jobs:
   coverage:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     outputs:
       duration: ${{ steps.duration.outputs.value }}
     steps:
@@ -43,7 +45,9 @@ jobs:
 
   e2e:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     env:
       PORT: 3000
       DB_URL: postgres://user:pass@localhost:5432/testdb
@@ -95,7 +99,9 @@ jobs:
 
   timings:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     needs: [coverage, e2e]
     steps:
       - name: Heartbeat

--- a/.github/workflows/ci-sparse-checkout.yml
+++ b/.github/workflows/ci-sparse-checkout.yml
@@ -15,7 +15,9 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-watchdog.yml
+++ b/.github/workflows/ci-watchdog.yml
@@ -23,7 +23,9 @@ jobs:
   scan:
     timeout-minutes: 15
     if: ${{ github.repository_owner == 'print3git' }}
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
   build:
     timeout-minutes: 15
     runs-on:
-      - self-hosted
+      - [self-hosted, linux, aws, small]
       - ubuntu-latest
     defaults:
       run:
@@ -88,7 +88,9 @@ jobs:
 
   test-backend:
     timeout-minutes: 15
-    runs-on: ubuntu-latest-XXL
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     strategy:
       fail-fast: true
       max-parallel: 2
@@ -161,7 +163,7 @@ jobs:
   test-frontend:
     timeout-minutes: 15
     runs-on:
-      - self-hosted
+      - [self-hosted, linux, aws, small]
       - ubuntu-latest
     strategy:
       fail-fast: true
@@ -239,7 +241,7 @@ jobs:
     timeout-minutes: 15
     if: github.event_name == 'push'
     runs-on:
-      - self-hosted
+      - [self-hosted, linux, aws, small]
       - ubuntu-latest
     steps:
       - name: Heartbeat
@@ -296,7 +298,7 @@ jobs:
     timeout-minutes: 15
     if: github.event_name == 'push'
     runs-on:
-      - self-hosted
+      - [self-hosted, linux, aws, small]
       - ubuntu-latest
     needs:
       - test-backend

--- a/.github/workflows/cloudflare-preview.yml
+++ b/.github/workflows/cloudflare-preview.yml
@@ -16,7 +16,9 @@ concurrency:
 jobs:
   preview:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,9 @@ jobs:
     timeout-minutes: 15
     if: github.event_name != 'pull_request' || startsWith(github.head_ref, 'security/')
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/collect-artifacts.yml
+++ b/.github/workflows/collect-artifacts.yml
@@ -23,7 +23,9 @@ jobs:
   collect-logs:
     timeout-minutes: 15
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,7 +13,9 @@ concurrency:
 jobs:
   coverage:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/coveralls-upload.yml
+++ b/.github/workflows/coveralls-upload.yml
@@ -18,7 +18,9 @@ jobs:
   upload:
     timeout-minutes: 15
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -16,7 +16,9 @@ concurrency:
 jobs:
   backup:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/debug-queue.yml
+++ b/.github/workflows/debug-queue.yml
@@ -16,6 +16,8 @@ permissions: {}
 jobs:
   debug:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - run: echo "I ran on ${{ runner.os }} with job id ${{ github.run_id }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,9 @@ jobs:
   deploy:
     timeout-minutes: 15
     if: vars.ENABLE_PAGES == '1' && github.event.workflow_run.conclusion == 'success'
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     env:
       WRANGLER_VERSION: 3.72.0
 
@@ -143,7 +145,9 @@ jobs:
   pages-disabled:
     timeout-minutes: 15
     if: vars.ENABLE_PAGES != '1' && github.event.workflow_run.conclusion == 'success'
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/destroy-selfhosted-runner.yml
+++ b/.github/workflows/destroy-selfhosted-runner.yml
@@ -17,7 +17,9 @@ concurrency:
 jobs:
   destroy:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/diagnostics-dist-check.yml
+++ b/.github/workflows/diagnostics-dist-check.yml
@@ -14,7 +14,9 @@ concurrency:
 jobs:
   build:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     continue-on-error: true
     steps:
       - name: Heartbeat

--- a/.github/workflows/diagnostics.yml
+++ b/.github/workflows/diagnostics.yml
@@ -20,7 +20,9 @@ concurrency:
 jobs:
   lint:
     if: github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     timeout-minutes: 5
     continue-on-error: true
     steps:
@@ -41,7 +43,9 @@ jobs:
 
   audit:
     if: github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     timeout-minutes: 5
     continue-on-error: true
     steps:
@@ -64,7 +68,9 @@ jobs:
 
   stripe_cloudflare:
     if: github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     timeout-minutes: 5
     continue-on-error: true
     env:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -17,7 +17,9 @@ concurrency:
 jobs:
   docker:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     env:
       SKIP_TESTS: 0
     steps:

--- a/.github/workflows/docker-prune.yml
+++ b/.github/workflows/docker-prune.yml
@@ -7,7 +7,9 @@ on:
 
 jobs:
   prune:
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - name: Prune Docker on self-hosted runners
         if: ${{ startsWith(runner.name, 'self-hosted') || contains(runner.labels, 'self-hosted') }}

--- a/.github/workflows/endpoint-health.yml
+++ b/.github/workflows/endpoint-health.yml
@@ -15,7 +15,9 @@ concurrency:
 jobs:
   probe:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/ensure_server_boots_185ecc2b50.yml
+++ b/.github/workflows/ensure_server_boots_185ecc2b50.yml
@@ -17,7 +17,9 @@ jobs:
     timeout-minutes: 15
     strategy:
       max-parallel: 2
-    runs-on: ubuntu-latest-XXL
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     env:
       STRIPE_TEST_KEY: ${{ secrets.STRIPE_TEST_KEY }}
       # Fallback DB connection so check-env.sh passes

--- a/.github/workflows/env-parity.yml
+++ b/.github/workflows/env-parity.yml
@@ -14,7 +14,9 @@ concurrency:
 jobs:
   env-parity:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/eslint-diagnostics.yml
+++ b/.github/workflows/eslint-diagnostics.yml
@@ -18,7 +18,9 @@ concurrency:
 jobs:
   eslint:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     continue-on-error: true
     steps:
       - name: Heartbeat

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -26,7 +26,9 @@ jobs:
   lint:
     timeout-minutes: 15
     needs: labels
-    runs-on: ${{ fromJSON(needs.labels.outputs.runs_on_json) }}
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/frontend-dry-build.yml
+++ b/.github/workflows/frontend-dry-build.yml
@@ -18,7 +18,9 @@ concurrency:
 jobs:
   dry-build:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/frontend-local-build.yml
+++ b/.github/workflows/frontend-local-build.yml
@@ -14,7 +14,9 @@ concurrency:
 jobs:
   build:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/glb-ci-alerts-938dhf.yml
+++ b/.github/workflows/glb-ci-alerts-938dhf.yml
@@ -18,7 +18,9 @@ concurrency:
 jobs:
   notify:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     env:
       PORT: 3000
       DB_URL: postgres://user:pass@localhost:5432/testdb

--- a/.github/workflows/glb-tests.yml
+++ b/.github/workflows/glb-tests.yml
@@ -27,7 +27,9 @@ concurrency:
 jobs:
   unit-tests:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - name: Heartbeat
         run: |
@@ -51,7 +53,9 @@ jobs:
   e2e-tests:
     timeout-minutes: 15
     needs: unit-tests
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     env:
       PORT: 3000
       DB_URL: postgres://user:pass@localhost:5432/testdb

--- a/.github/workflows/go-cache.yml
+++ b/.github/workflows/go-cache.yml
@@ -8,7 +8,9 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     env:
       GO_VERSION: '1.22'
     steps:

--- a/.github/workflows/healthz-contract.yml
+++ b/.github/workflows/healthz-contract.yml
@@ -18,7 +18,9 @@ concurrency:
 jobs:
   snapshot:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/jest-open-handles.yml
+++ b/.github/workflows/jest-open-handles.yml
@@ -18,7 +18,9 @@ concurrency:
 jobs:
   jest-open-handles:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     continue-on-error: true
     steps:
       - name: Heartbeat

--- a/.github/workflows/junit-artifacts.yml
+++ b/.github/workflows/junit-artifacts.yml
@@ -5,7 +5,9 @@ on:
 
 jobs:
   upload:
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -19,7 +19,9 @@ concurrency:
 jobs:
   select:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     outputs:
       runs_on: ${{ steps.choose.outputs.runs_on }}
     steps:

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -16,7 +16,9 @@ jobs:
   lighthouse:
     timeout-minutes: 15
     if: ${{ github.event.deployment_status.environment == 'preview' }}
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -15,7 +15,9 @@ concurrency:
 jobs:
   load:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/nightly-warmup.yml
+++ b/.github/workflows/nightly-warmup.yml
@@ -6,7 +6,9 @@ on:
 
 jobs:
   nightly-cache-warmup:
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/nock-report.yml
+++ b/.github/workflows/nock-report.yml
@@ -18,7 +18,9 @@ concurrency:
 jobs:
   nock-report:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -30,7 +30,9 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     env:
       PORT: 3000
       CI_REQUIRE_EXTERNAL: '0'

--- a/.github/workflows/nx-optional.yml
+++ b/.github/workflows/nx-optional.yml
@@ -8,7 +8,9 @@ on:
 
 jobs:
   nx:
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/openapi-lint.yml
+++ b/.github/workflows/openapi-lint.yml
@@ -17,7 +17,9 @@ concurrency:
 jobs:
   lint:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/ops-report.yml
+++ b/.github/workflows/ops-report.yml
@@ -16,7 +16,9 @@ concurrency:
 jobs:
   report:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/package-helm.yml
+++ b/.github/workflows/package-helm.yml
@@ -16,7 +16,9 @@ concurrency:
 jobs:
   package:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -16,7 +16,9 @@ jobs:
   validate:
     timeout-minutes: 15
     name: Pages config validate
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
@@ -40,7 +42,9 @@ jobs:
   deploy:
     timeout-minutes: 15
     needs: validate
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/pages-url-comment.yml
+++ b/.github/workflows/pages-url-comment.yml
@@ -13,7 +13,9 @@ jobs:
   comment:
     timeout-minutes: 15
     if: ${{ github.event.workflow_run.conclusion != 'cancelled' }}
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/pipeline-deadlock-check.yml
+++ b/.github/workflows/pipeline-deadlock-check.yml
@@ -14,7 +14,9 @@ concurrency:
   cancel-in-progress: true
 jobs:
   deadlock:
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     timeout-minutes: 1
     steps:
       - name: Heartbeat

--- a/.github/workflows/pipeline-smoke.yml
+++ b/.github/workflows/pipeline-smoke.yml
@@ -17,7 +17,9 @@ concurrency:
 jobs:
   smoke_test:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     env:
       STRIPE_TEST_KEY: ${{ secrets.STRIPE_TEST_KEY }}
       DB_URL: ${{ secrets.DB_URL }}

--- a/.github/workflows/playwright-browsers-cache.yml
+++ b/.github/workflows/playwright-browsers-cache.yml
@@ -14,7 +14,9 @@ concurrency:
 jobs:
   cache-browsers:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/post-mortem-report.yml
+++ b/.github/workflows/post-mortem-report.yml
@@ -9,7 +9,9 @@ concurrency:
 
 jobs:
   fail-test:
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     timeout-minutes: 40
     steps:
       - name: Intentionally fail

--- a/.github/workflows/pr-path-filters.yml
+++ b/.github/workflows/pr-path-filters.yml
@@ -8,7 +8,9 @@ on:
 
 jobs:
   lint-typecheck:
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - uses: actions/checkout@v5.0.0
       - uses: pnpm/action-setup@v4.1.0

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -32,7 +32,9 @@ concurrency:
 jobs:
   changed:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
     steps:

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -16,7 +16,9 @@ concurrency:
 jobs:
   deploy:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     env:
       PORT: 3000
     steps:

--- a/.github/workflows/printclub-reminders.yml
+++ b/.github/workflows/printclub-reminders.yml
@@ -16,7 +16,9 @@ concurrency:
 jobs:
   remind:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/priority.yml
+++ b/.github/workflows/priority.yml
@@ -16,7 +16,9 @@ concurrency:
 
 jobs:
   lint-fast:
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v5
@@ -34,7 +36,9 @@ jobs:
       - run: npm run lint:fast
 
   smoke-api:
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v5
@@ -52,7 +56,9 @@ jobs:
   gate:
     timeout-minutes: 15
     name: Gate
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     needs: [lint-fast, smoke-api]
     if: ${{ always() }}
     steps:

--- a/.github/workflows/provision-selfhosted-runner.yml
+++ b/.github/workflows/provision-selfhosted-runner.yml
@@ -27,7 +27,9 @@ concurrency:
 jobs:
   provision:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/queue-probe.yml
+++ b/.github/workflows/queue-probe.yml
@@ -16,7 +16,9 @@ permissions: {}
 
 jobs:
   probe:
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     continue-on-error: true
     timeout-minutes: 5
     steps:

--- a/.github/workflows/regression-guard.yml
+++ b/.github/workflows/regression-guard.yml
@@ -17,7 +17,9 @@ concurrency:
 jobs:
   guard:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/reset-credits.yml
+++ b/.github/workflows/reset-credits.yml
@@ -16,7 +16,9 @@ concurrency:
 jobs:
   reset:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/runner-scheduler.yml
+++ b/.github/workflows/runner-scheduler.yml
@@ -16,7 +16,9 @@ jobs:
   stop:
     timeout-minutes: 15
     if: ${{ false }}
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - name: Stop runner service
         run: |
@@ -30,7 +32,9 @@ jobs:
   start:
     timeout-minutes: 15
     if: ${{ false }}
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - name: Start instance
         run: aws ec2 start-instances --instance-ids "$RUNNER_INSTANCE_ID"

--- a/.github/workflows/runner-watchdog.yml
+++ b/.github/workflows/runner-watchdog.yml
@@ -20,7 +20,9 @@ defaults:
 jobs:
   watchdog:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - name: Check self-hosted AWS runner
         id: check

--- a/.github/workflows/schedule-check.yml
+++ b/.github/workflows/schedule-check.yml
@@ -15,7 +15,9 @@ concurrency:
 jobs:
   check:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/size-monitor.yml
+++ b/.github/workflows/size-monitor.yml
@@ -7,7 +7,9 @@ on:
 
 jobs:
   size:
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - name: Record repository size

--- a/.github/workflows/skip-heavy.yml
+++ b/.github/workflows/skip-heavy.yml
@@ -9,7 +9,9 @@ on:
 jobs:
   skip-heavy:
     if: contains(github.event.pull_request.labels.*.name, 'skip-heavy')
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - run: |
           echo "skip-heavy label present, skipping heavy workflows"

--- a/.github/workflows/smoke-backend.yml
+++ b/.github/workflows/smoke-backend.yml
@@ -25,7 +25,9 @@ jobs:
   db-seed:
     timeout-minutes: 15
     needs: preflight
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     services:
       postgres:
         image: postgres:15
@@ -67,7 +69,9 @@ jobs:
   backend-smoke:
     needs: [preflight, db-seed]
     if: needs.preflight.outputs.run_backend == 'true'
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     timeout-minutes: 5
     services:
       postgres:

--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -14,7 +14,9 @@ concurrency:
 jobs:
   changes:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     outputs:
       frontend: ${{ steps.filter.outputs.frontend }}
     steps:
@@ -31,7 +33,9 @@ jobs:
   backend-smoke:
     timeout-minutes: 15
     needs: changes
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     env:
       PORT: 3000
       DB_URL: postgres://user:pass@localhost:5432/testdb
@@ -71,7 +75,9 @@ jobs:
     timeout-minutes: 15
     needs: [changes, backend-smoke]
     if: needs.changes.outputs.frontend == 'true'
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/submodules-shallow.yml
+++ b/.github/workflows/submodules-shallow.yml
@@ -8,7 +8,9 @@ on:
 
 jobs:
   verify-submodules:
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -16,7 +16,9 @@ concurrency:
 jobs:
   sync:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/sync-space.yml
+++ b/.github/workflows/sync-space.yml
@@ -15,7 +15,9 @@ concurrency:
 jobs:
   sync:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     env:
       STRIPE_TEST_KEY: ${{ secrets.STRIPE_TEST_KEY }}
       PORT: 3000

--- a/.github/workflows/test-timeout.yml
+++ b/.github/workflows/test-timeout.yml
@@ -8,7 +8,9 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/turbo-cache.yml
+++ b/.github/workflows/turbo-cache.yml
@@ -6,7 +6,9 @@ on:
 
 jobs:
   turbo:
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/update_locks.yml
+++ b/.github/workflows/update_locks.yml
@@ -17,7 +17,9 @@ concurrency:
 jobs:
   update:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/verify-lockfile.yml
+++ b/.github/workflows/verify-lockfile.yml
@@ -17,7 +17,9 @@ concurrency:
 jobs:
   verify:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/warm-cache.yml
+++ b/.github/workflows/warm-cache.yml
@@ -14,7 +14,9 @@ concurrency:
 jobs:
   root-cache:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - name: Heartbeat
         run: |
@@ -29,7 +31,9 @@ jobs:
 
   backend-cache:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - name: Heartbeat
         run: |
@@ -44,7 +48,9 @@ jobs:
 
   frontend-cache:
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/web-matrix.yml
+++ b/.github/workflows/web-matrix.yml
@@ -14,7 +14,9 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/tests/ci/self-hosted-fallback.test.js
+++ b/tests/ci/self-hosted-fallback.test.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const path = require('path');
+const { test } = require('node:test');
+
+const workflowsDir = path.join(__dirname, '..', '..', '.github', 'workflows');
+const baseline = require('./workflow-baseline.json');
+const runsOnPattern = /runs-on:\n\s+- \[self-hosted, linux, aws, small\]\n\s+- ubuntu-latest/g;
+
+test('workflows use self-hosted with ubuntu fallback and retain env and cache', () => {
+  const files = Object.keys(baseline);
+  const errors = [];
+  for (const file of files) {
+    const content = fs.readFileSync(path.join(workflowsDir, file), 'utf8');
+    const runOnMatches = content.match(runsOnPattern) || [];
+    const runOnCount = (content.match(/runs-on:/g) || []).length;
+    if (runOnMatches.length !== runOnCount) {
+      errors.push(`${file}: some jobs missing self-hosted runner fallback`);
+    }
+    if (baseline[file].env && !/env:/i.test(content)) {
+      errors.push(`${file}: missing env configuration`);
+    }
+    if (baseline[file].cache && !/cache/i.test(content)) {
+      errors.push(`${file}: missing cache configuration`);
+    }
+  }
+  if (errors.length) {
+    throw new Error(errors.join('\n'));
+  }
+});

--- a/tests/ci/workflow-baseline.json
+++ b/tests/ci/workflow-baseline.json
@@ -1,0 +1,358 @@
+{
+  "_setup.yml": {
+    "env": false,
+    "cache": true
+  },
+  "actionlint.yml": {
+    "env": true,
+    "cache": false
+  },
+  "affected.yml": {
+    "env": true,
+    "cache": true
+  },
+  "artifacts.yml": {
+    "env": true,
+    "cache": true
+  },
+  "auto_rebase_merge_queue.yml": {
+    "env": true,
+    "cache": false
+  },
+  "backend-only-ci.yml": {
+    "env": true,
+    "cache": true
+  },
+  "backend-tests.yml": {
+    "env": true,
+    "cache": true
+  },
+  "build-frontend.yml": {
+    "env": true,
+    "cache": true
+  },
+  "cache-primer.yml": {
+    "env": true,
+    "cache": true
+  },
+  "cache-validator.yml": {
+    "env": true,
+    "cache": true
+  },
+  "cf-pages-preview.yml": {
+    "env": true,
+    "cache": true
+  },
+  "check-watchdog.yml": {
+    "env": true,
+    "cache": false
+  },
+  "ci-env.yml": {
+    "env": false,
+    "cache": true
+  },
+  "ci-queue-monitor.yml": {
+    "env": true,
+    "cache": false
+  },
+  "ci-rerun-slow.yml": {
+    "env": true,
+    "cache": true
+  },
+  "ci-sparse-checkout.yml": {
+    "env": true,
+    "cache": true
+  },
+  "ci-watchdog.yml": {
+    "env": true,
+    "cache": false
+  },
+  "ci.yml": {
+    "env": true,
+    "cache": true
+  },
+  "cloudflare-preview.yml": {
+    "env": false,
+    "cache": true
+  },
+  "codeql.yml": {
+    "env": true,
+    "cache": true
+  },
+  "collect-artifacts.yml": {
+    "env": true,
+    "cache": false
+  },
+  "coverage.yml": {
+    "env": true,
+    "cache": false
+  },
+  "coveralls-upload.yml": {
+    "env": true,
+    "cache": false
+  },
+  "db-backup.yml": {
+    "env": true,
+    "cache": false
+  },
+  "debug-queue.yml": {
+    "env": true,
+    "cache": false
+  },
+  "deploy.yml": {
+    "env": true,
+    "cache": true
+  },
+  "destroy-selfhosted-runner.yml": {
+    "env": true,
+    "cache": false
+  },
+  "diagnostics-dist-check.yml": {
+    "env": true,
+    "cache": true
+  },
+  "diagnostics.yml": {
+    "env": true,
+    "cache": true
+  },
+  "docker-build.yml": {
+    "env": true,
+    "cache": false
+  },
+  "docker-prune.yml": {
+    "env": false,
+    "cache": false
+  },
+  "endpoint-health.yml": {
+    "env": true,
+    "cache": false
+  },
+  "ensure_server_boots_185ecc2b50.yml": {
+    "env": true,
+    "cache": true
+  },
+  "env-parity.yml": {
+    "env": false,
+    "cache": false
+  },
+  "eslint-diagnostics.yml": {
+    "env": true,
+    "cache": true
+  },
+  "eslint.yml": {
+    "env": false,
+    "cache": true
+  },
+  "frontend-dry-build.yml": {
+    "env": true,
+    "cache": true
+  },
+  "frontend-local-build.yml": {
+    "env": true,
+    "cache": true
+  },
+  "glb-ci-alerts-938dhf.yml": {
+    "env": true,
+    "cache": true
+  },
+  "glb-tests.yml": {
+    "env": true,
+    "cache": true
+  },
+  "go-cache.yml": {
+    "env": true,
+    "cache": true
+  },
+  "healthz-contract.yml": {
+    "env": true,
+    "cache": true
+  },
+  "jest-early-warning.yml": {
+    "env": true,
+    "cache": false
+  },
+  "jest-open-handles.yml": {
+    "env": true,
+    "cache": true
+  },
+  "junit-artifacts.yml": {
+    "env": false,
+    "cache": false
+  },
+  "labels.yml": {
+    "env": false,
+    "cache": false
+  },
+  "lighthouse.yml": {
+    "env": true,
+    "cache": true
+  },
+  "lint.yml": {
+    "env": false,
+    "cache": false
+  },
+  "load-test.yml": {
+    "env": true,
+    "cache": true
+  },
+  "nightly-warmup.yml": {
+    "env": false,
+    "cache": true
+  },
+  "nightly.yml": {
+    "env": true,
+    "cache": false
+  },
+  "nock-report.yml": {
+    "env": true,
+    "cache": true
+  },
+  "node.yml": {
+    "env": true,
+    "cache": true
+  },
+  "nx-optional.yml": {
+    "env": false,
+    "cache": true
+  },
+  "openapi-lint.yml": {
+    "env": true,
+    "cache": false
+  },
+  "ops-report.yml": {
+    "env": true,
+    "cache": true
+  },
+  "package-helm.yml": {
+    "env": true,
+    "cache": false
+  },
+  "pages-deploy.yml": {
+    "env": true,
+    "cache": true
+  },
+  "pages-url-comment.yml": {
+    "env": true,
+    "cache": false
+  },
+  "pipeline-deadlock-check.yml": {
+    "env": true,
+    "cache": false
+  },
+  "pipeline-smoke.yml": {
+    "env": true,
+    "cache": false
+  },
+  "playwright-browsers-cache.yml": {
+    "env": true,
+    "cache": true
+  },
+  "post-mortem-report.yml": {
+    "env": true,
+    "cache": false
+  },
+  "pr-path-filters.yml": {
+    "env": false,
+    "cache": true
+  },
+  "preflight.yml": {
+    "env": true,
+    "cache": false
+  },
+  "preview-deploy.yml": {
+    "env": true,
+    "cache": true
+  },
+  "printclub-reminders.yml": {
+    "env": true,
+    "cache": true
+  },
+  "priority.yml": {
+    "env": true,
+    "cache": true
+  },
+  "provision-selfhosted-runner.yml": {
+    "env": true,
+    "cache": false
+  },
+  "queue-probe.yml": {
+    "env": true,
+    "cache": false
+  },
+  "regression-guard.yml": {
+    "env": true,
+    "cache": true
+  },
+  "reset-credits.yml": {
+    "env": true,
+    "cache": true
+  },
+  "runner-scheduler.yml": {
+    "env": true,
+    "cache": false
+  },
+  "runner-watchdog.yml": {
+    "env": false,
+    "cache": false
+  },
+  "schedule-check.yml": {
+    "env": true,
+    "cache": false
+  },
+  "size-monitor.yml": {
+    "env": false,
+    "cache": false
+  },
+  "skip-heavy.yml": {
+    "env": false,
+    "cache": false
+  },
+  "smoke-backend.yml": {
+    "env": true,
+    "cache": true
+  },
+  "smoke_test.yml": {
+    "env": true,
+    "cache": true
+  },
+  "submodules-shallow.yml": {
+    "env": false,
+    "cache": false
+  },
+  "sync-labels.yml": {
+    "env": true,
+    "cache": false
+  },
+  "sync-space.yml": {
+    "env": true,
+    "cache": false
+  },
+  "test-timeout.yml": {
+    "env": true,
+    "cache": true
+  },
+  "turbo-cache.yml": {
+    "env": false,
+    "cache": true
+  },
+  "typecheck.yml": {
+    "env": false,
+    "cache": false
+  },
+  "update_locks.yml": {
+    "env": true,
+    "cache": false
+  },
+  "verify-lockfile.yml": {
+    "env": true,
+    "cache": true
+  },
+  "warm-cache.yml": {
+    "env": true,
+    "cache": true
+  },
+  "web-matrix.yml": {
+    "env": true,
+    "cache": true
+  }
+}


### PR DESCRIPTION
## Summary
- ensure all workflow jobs use self-hosted linux runners with aws/small labels and ubuntu fallback
- add CI guard verifying runner setup and preserving env and cache settings

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format`
- `npm run format --prefix backend`
- `node tests/ci/self-hosted-fallback.test.js`
- `node scripts/run-jest.js backend/tests/awsCredentials.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a76bf61278832da4c0106e4e08314c