### PR TITLE
ci: add CloudWatch monitoring for self-hosted runner

### DIFF
--- a/infra/selfhosted-runner/terraform/main.tf
+++ b/infra/selfhosted-runner/terraform/main.tf
@@ -2,6 +2,8 @@ data "aws_default_vpc" "default" {}
 
 data "aws_availability_zones" "available" {}
 
+data "aws_region" "current" {}
+
 data "aws_subnet" "default" {
   default_for_az    = true
   availability_zone = data.aws_availability_zones.available.names[0]
@@ -67,9 +69,39 @@ resource "aws_iam_role_policy_attachment" "ssm" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }
 
+data "aws_iam_policy_document" "cw_agent" {
+  statement {
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:DescribeLogStreams"
+    ]
+    resources = [
+      aws_cloudwatch_log_group.runner.arn,
+      "${aws_cloudwatch_log_group.runner.arn}:*"
+    ]
+  }
+
+  statement {
+    actions   = ["cloudwatch:PutMetricData"]
+    resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      variable = "cloudwatch:namespace"
+      values   = ["CWAgent"]
+    }
+  }
+}
+
+resource "aws_iam_policy" "cw_agent" {
+  name_prefix = "gha-runner-cw-agent-"
+  policy      = data.aws_iam_policy_document.cw_agent.json
+}
+
 resource "aws_iam_role_policy_attachment" "cw" {
   role       = aws_iam_role.runner.name
-  policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
+  policy_arn = aws_iam_policy.cw_agent.arn
 }
 
 resource "aws_iam_instance_profile" "runner" {
@@ -95,6 +127,59 @@ resource "aws_instance" "runner" {
   }
 }
 
+resource "aws_cloudwatch_log_group" "runner" {
+  name              = "/github-runner/service"
+  retention_in_days = 14
+}
+
+resource "aws_cloudwatch_metric_alarm" "runner_offline" {
+  alarm_name          = "github-runner-offline"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 5
+  metric_name         = "StatusCheckFailed_Instance"
+  namespace           = "AWS/EC2"
+  period              = 60
+  statistic           = "Maximum"
+  threshold           = 1
+  alarm_description   = "Runner EC2 instance failed status checks for 5 minutes"
+  treat_missing_data  = "breaching"
+  dimensions = {
+    InstanceId = aws_instance.runner.id
+  }
+}
+
+resource "aws_cloudwatch_dashboard" "runner" {
+  dashboard_name = "gha-runner"
+  dashboard_body = jsonencode({
+    widgets = [
+      {
+        type   = "metric"
+        width  = 12
+        height = 6
+        properties = {
+          metrics = [["AWS/EC2", "CPUUtilization", "InstanceId", aws_instance.runner.id]]
+          stat    = "Average"
+          period  = 300
+          region  = data.aws_region.current.name
+          title   = "CPU Utilization"
+        }
+      },
+      {
+        type   = "metric"
+        width  = 12
+        height = 6
+        properties = {
+          metrics = [["CWAgent", "mem_used_percent", "InstanceId", aws_instance.runner.id]]
+          stat    = "Average"
+          period  = 300
+          region  = data.aws_region.current.name
+          title   = "Memory Usage"
+        }
+      }
+    ]
+  })
+}
+
 resource "aws_ssm_association" "runner_setup" {
   name = "AWS-RunShellScript"
 
@@ -108,6 +193,7 @@ resource "aws_ssm_association" "runner_setup" {
       repo_owner = var.repo_owner
       repo_name  = var.repo_name
       labels     = var.labels
+      log_group  = aws_cloudwatch_log_group.runner.name
     })]
   }
 

--- a/infra/selfhosted-runner/terraform/userdata.sh
+++ b/infra/selfhosted-runner/terraform/userdata.sh
@@ -2,10 +2,13 @@
 set -euo pipefail
 
 dnf update -y
-dnf install -y git curl tar
+dnf install -y git curl tar amazon-cloudwatch-agent
 
 curl -fsSL https://rpm.nodesource.com/setup_20.x | bash -
 dnf install -y nodejs
+
+mkdir -p /actions-runner
+cd /actions-runner
 
 RUNNER_VERSION=$(curl -fsSL https://api.github.com/repos/actions/runner/releases/latest | grep tag_name | cut -d '"' -f4)
 ARCH="linux-x64"
@@ -17,3 +20,32 @@ tar xzf actions-runner.tar.gz
 
 ./svc.sh install
 ./svc.sh start
+
+cat <<EOF >/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
+{
+  "logs": {
+    "logs_collected": {
+      "files": {
+        "collect_list": [
+          {
+            "file_path": "/actions-runner/_diag/*.log",
+            "log_group_name": "${log_group}",
+            "log_stream_name": "{instance_id}"
+          }
+        ]
+      }
+    }
+  },
+  "metrics": {
+    "metrics_collected": {
+      "mem": {
+        "measurement": [
+          { "name": "mem_used_percent", "unit": "Percent" }
+        ]
+      }
+    }
+  }
+}
+EOF
+
+/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json -s


### PR DESCRIPTION
## Summary
- collect GitHub runner logs and memory metrics via CloudWatch Agent
- alarm when EC2 runner is offline for 5 minutes and dashboard CPU/memory

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html. Run 'npm run build' and retry)*

------
https://chatgpt.com/codex/tasks/task_e_68a7745eecf0832d8ff7c73b7201aea5