### PR TITLE
ci: prefer self-hosted aws runner

### DIFF
--- a/.github/workflows/_reusable-node.yml
+++ b/.github/workflows/_reusable-node.yml
@@ -20,7 +20,9 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws]
+      - ubuntu-latest
     steps:
       - name: Checkout
         if: ${{ inputs.sparse-checkout == '' }}

--- a/.github/workflows/_setup.yml
+++ b/.github/workflows/_setup.yml
@@ -27,7 +27,7 @@ jobs:
   run:
     needs: labels
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   actionlint:
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/affected.yml
+++ b/.github/workflows/affected.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   affected-builds:
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   build-artifacts:
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/auto_rebase_merge_queue.yml
+++ b/.github/workflows/auto_rebase_merge_queue.yml
@@ -19,7 +19,7 @@ jobs:
   rebase:
     if: ${{ !startsWith(github.event.pull_request.head.ref, 'codex/') }}
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - name: Heartbeat
@@ -53,7 +53,7 @@ jobs:
     needs: rebase
     if: ${{ needs.rebase.result == 'success' || needs.rebase.result == 'skipped' }}
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/backend-only-ci.yml
+++ b/.github/workflows/backend-only-ci.yml
@@ -30,7 +30,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch' ||
       needs.preflight.outputs.run_backend == 'true'
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     continue-on-error: true
     strategy:

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -17,7 +17,7 @@ jobs:
   changed-tests:
     if: github.event_name == 'pull_request'
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -40,7 +40,7 @@ jobs:
   full-suite:
     if: github.ref_name == '00000production'
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     strategy:
       fail-fast: true

--- a/.github/workflows/binary-scan.yml
+++ b/.github/workflows/binary-scan.yml
@@ -10,7 +10,9 @@ permissions:
 
 jobs:
   scan:
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws]
+      - ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   build:
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     if: ${{ matrix.node != 22 || contains(github.event.pull_request.labels.*.name,
       'full-matrix') }}

--- a/.github/workflows/cache-primer.yml
+++ b/.github/workflows/cache-primer.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   root-cache:
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - name: Heartbeat
@@ -31,7 +31,7 @@ jobs:
 
   backend-cache:
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - name: Heartbeat
@@ -48,7 +48,7 @@ jobs:
 
   frontend-cache:
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/cache-validator.yml
+++ b/.github/workflows/cache-validator.yml
@@ -18,7 +18,7 @@ jobs:
   validate:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     strategy:
       fail-fast: true

--- a/.github/workflows/cf-pages-preview.yml
+++ b/.github/workflows/cf-pages-preview.yml
@@ -20,7 +20,7 @@ jobs:
   preview:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/check-watchdog.yml
+++ b/.github/workflows/check-watchdog.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   watch:
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     continue-on-error: true
     timeout-minutes: 8

--- a/.github/workflows/ci-env.yml
+++ b/.github/workflows/ci-env.yml
@@ -14,7 +14,7 @@ jobs:
   versions:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/ci-queue-monitor.yml
+++ b/.github/workflows/ci-queue-monitor.yml
@@ -17,7 +17,7 @@ jobs:
   monitor:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     permissions:
       actions: write

--- a/.github/workflows/ci-rerun-slow.yml
+++ b/.github/workflows/ci-rerun-slow.yml
@@ -15,7 +15,7 @@ jobs:
   coverage:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     outputs:
       duration: ${{ steps.duration.outputs.value }}
@@ -46,7 +46,7 @@ jobs:
   e2e:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     env:
       PORT: 3000
@@ -100,7 +100,7 @@ jobs:
   timings:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     needs: [coverage, e2e]
     steps:

--- a/.github/workflows/ci-sparse-checkout.yml
+++ b/.github/workflows/ci-sparse-checkout.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   build:
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/ci-watchdog.yml
+++ b/.github/workflows/ci-watchdog.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 15
     if: ${{ github.repository_owner == 'print3git' }}
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
   build:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     defaults:
       run:
@@ -89,7 +89,7 @@ jobs:
   test-backend:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     strategy:
       fail-fast: true
@@ -165,7 +165,7 @@ jobs:
   test-frontend:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     strategy:
       fail-fast: true
@@ -245,7 +245,7 @@ jobs:
     timeout-minutes: 15
     if: github.event_name == 'push'
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - name: Heartbeat
@@ -304,7 +304,7 @@ jobs:
     timeout-minutes: 15
     if: github.event_name == 'push'
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     needs:
       - test-backend

--- a/.github/workflows/cloudflare-preview.yml
+++ b/.github/workflows/cloudflare-preview.yml
@@ -17,7 +17,7 @@ jobs:
   preview:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,7 +13,9 @@ permissions:
 
 jobs:
   analyze:
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws]
+      - ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,7 +25,7 @@ jobs:
     if: github.event_name != 'pull_request' || startsWith(github.head_ref, 'security/')
     name: Analyze
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/collect-artifacts.yml
+++ b/.github/workflows/collect-artifacts.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 15
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -6,7 +6,9 @@ on:
 jobs:
   commitlint:
     name: Commitlint
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws]
+      - ubuntu-latest
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,7 +14,7 @@ jobs:
   coverage:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/coveralls-upload.yml
+++ b/.github/workflows/coveralls-upload.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 15
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -17,7 +17,7 @@ jobs:
   backup:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/debug-queue.yml
+++ b/.github/workflows/debug-queue.yml
@@ -17,7 +17,7 @@ jobs:
   debug:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - run: echo "I ran on ${{ runner.os }} with job id ${{ github.run_id }}"

--- a/.github/workflows/dependency-checker.yml
+++ b/.github/workflows/dependency-checker.yml
@@ -6,7 +6,9 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws]
+      - ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -5,7 +5,9 @@ on:
 
 jobs:
   dependency-review:
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws]
+      - ubuntu-latest
     permissions:
       contents: read
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 15
     if: vars.ENABLE_PAGES == '1' && github.event.workflow_run.conclusion == 'success'
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     env:
       WRANGLER_VERSION: 3.72.0
@@ -146,7 +146,7 @@ jobs:
     timeout-minutes: 15
     if: vars.ENABLE_PAGES != '1' && github.event.workflow_run.conclusion == 'success'
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/destroy-selfhosted-runner.yml
+++ b/.github/workflows/destroy-selfhosted-runner.yml
@@ -18,7 +18,7 @@ jobs:
   destroy:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/diagnostics-dist-check.yml
+++ b/.github/workflows/diagnostics-dist-check.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     continue-on-error: true
     steps:

--- a/.github/workflows/diagnostics.yml
+++ b/.github/workflows/diagnostics.yml
@@ -21,7 +21,7 @@ jobs:
   lint:
     if: github.event_name != 'pull_request'
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     timeout-minutes: 5
     continue-on-error: true
@@ -44,7 +44,7 @@ jobs:
   audit:
     if: github.event_name != 'pull_request'
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     timeout-minutes: 5
     continue-on-error: true
@@ -69,7 +69,7 @@ jobs:
   stripe_cloudflare:
     if: github.event_name != 'pull_request'
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     timeout-minutes: 5
     continue-on-error: true

--- a/.github/workflows/diff-summary.yml
+++ b/.github/workflows/diff-summary.yml
@@ -9,7 +9,9 @@ concurrency:
 
 jobs:
   diff:
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws]
+      - ubuntu-latest
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -18,7 +18,7 @@ jobs:
   docker:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     env:
       SKIP_TESTS: 0

--- a/.github/workflows/docker-prune.yml
+++ b/.github/workflows/docker-prune.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   prune:
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - name: Prune Docker on self-hosted runners

--- a/.github/workflows/docs-automerge.yml
+++ b/.github/workflows/docs-automerge.yml
@@ -9,7 +9,9 @@ on:
 
 jobs:
   automerge:
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws]
+      - ubuntu-latest
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/endpoint-health.yml
+++ b/.github/workflows/endpoint-health.yml
@@ -16,7 +16,7 @@ jobs:
   probe:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/ensure_server_boots_185ecc2b50.yml
+++ b/.github/workflows/ensure_server_boots_185ecc2b50.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       max-parallel: 2
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     env:
       STRIPE_TEST_KEY: ${{ secrets.STRIPE_TEST_KEY }}

--- a/.github/workflows/env-parity.yml
+++ b/.github/workflows/env-parity.yml
@@ -15,7 +15,7 @@ jobs:
   env-parity:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/eslint-diagnostics.yml
+++ b/.github/workflows/eslint-diagnostics.yml
@@ -19,7 +19,7 @@ jobs:
   eslint:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     continue-on-error: true
     steps:

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -27,7 +27,7 @@ jobs:
     timeout-minutes: 15
     needs: labels
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/frontend-dry-build.yml
+++ b/.github/workflows/frontend-dry-build.yml
@@ -19,7 +19,7 @@ jobs:
   dry-build:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/frontend-local-build.yml
+++ b/.github/workflows/frontend-local-build.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/glb-ci-alerts-938dhf.yml
+++ b/.github/workflows/glb-ci-alerts-938dhf.yml
@@ -19,7 +19,7 @@ jobs:
   notify:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     env:
       PORT: 3000

--- a/.github/workflows/glb-tests.yml
+++ b/.github/workflows/glb-tests.yml
@@ -28,7 +28,7 @@ jobs:
   unit-tests:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - name: Heartbeat
@@ -54,7 +54,7 @@ jobs:
     timeout-minutes: 15
     needs: unit-tests
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     env:
       PORT: 3000

--- a/.github/workflows/go-cache.yml
+++ b/.github/workflows/go-cache.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     env:
       GO_VERSION: '1.22'

--- a/.github/workflows/guardrails.yml
+++ b/.github/workflows/guardrails.yml
@@ -5,7 +5,9 @@ on:
 
 jobs:
   guardrails:
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws]
+      - ubuntu-latest
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/healthz-contract.yml
+++ b/.github/workflows/healthz-contract.yml
@@ -19,7 +19,7 @@ jobs:
   snapshot:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/jest-open-handles.yml
+++ b/.github/workflows/jest-open-handles.yml
@@ -19,7 +19,7 @@ jobs:
   jest-open-handles:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     continue-on-error: true
     steps:

--- a/.github/workflows/json-validate.yml
+++ b/.github/workflows/json-validate.yml
@@ -7,7 +7,9 @@ on:
 
 jobs:
   json-validate:
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws]
+      - ubuntu-latest
     steps:
       - uses: actions/checkout@v5.0.0
       - uses: actions/setup-node@v4.0.2

--- a/.github/workflows/junit-artifacts.yml
+++ b/.github/workflows/junit-artifacts.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   upload:
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -9,7 +9,9 @@ permissions:
 
 jobs:
   label:
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws]
+      - ubuntu-latest
     steps:
       - uses: actions/labeler@v5
         with:

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -20,7 +20,7 @@ jobs:
   select:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     outputs:
       runs_on: ${{ steps.choose.outputs.runs_on }}

--- a/.github/workflows/large-file-guard.yml
+++ b/.github/workflows/large-file-guard.yml
@@ -5,7 +5,9 @@ on:
 
 jobs:
   large-file-guard:
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws]
+      - ubuntu-latest
     steps:
       - uses: actions/checkout@v5.0.0
         with:

--- a/.github/workflows/license-scan.yml
+++ b/.github/workflows/license-scan.yml
@@ -8,7 +8,9 @@ on:
 
 jobs:
   scan:
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws]
+      - ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - name: Install licensee

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 15
     if: ${{ github.event.deployment_status.environment == 'preview' }}
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -16,7 +16,7 @@ jobs:
   load:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/md-link-check.yml
+++ b/.github/workflows/md-link-check.yml
@@ -7,7 +7,9 @@ on:
 
 jobs:
   md-link-check:
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws]
+      - ubuntu-latest
     steps:
       - uses: actions/checkout@v5.0.0
       - name: Check markdown links

--- a/.github/workflows/nightly-warmup.yml
+++ b/.github/workflows/nightly-warmup.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   nightly-cache-warmup:
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/nock-report.yml
+++ b/.github/workflows/nock-report.yml
@@ -19,7 +19,7 @@ jobs:
   nock-report:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -31,7 +31,7 @@ concurrency:
 jobs:
   build:
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     env:
       PORT: 3000

--- a/.github/workflows/nx-optional.yml
+++ b/.github/workflows/nx-optional.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   nx:
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/openapi-lint.yml
+++ b/.github/workflows/openapi-lint.yml
@@ -18,7 +18,7 @@ jobs:
   lint:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/ops-report.yml
+++ b/.github/workflows/ops-report.yml
@@ -17,7 +17,7 @@ jobs:
   report:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/package-helm.yml
+++ b/.github/workflows/package-helm.yml
@@ -17,7 +17,7 @@ jobs:
   package:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 15
     name: Pages config validate
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -43,7 +43,7 @@ jobs:
     timeout-minutes: 15
     needs: validate
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/pages-url-comment.yml
+++ b/.github/workflows/pages-url-comment.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 15
     if: ${{ github.event.workflow_run.conclusion != 'cancelled' }}
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/pipeline-deadlock-check.yml
+++ b/.github/workflows/pipeline-deadlock-check.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   deadlock:
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     timeout-minutes: 1
     steps:

--- a/.github/workflows/pipeline-smoke.yml
+++ b/.github/workflows/pipeline-smoke.yml
@@ -18,7 +18,7 @@ jobs:
   smoke_test:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     env:
       STRIPE_TEST_KEY: ${{ secrets.STRIPE_TEST_KEY }}

--- a/.github/workflows/playwright-browsers-cache.yml
+++ b/.github/workflows/playwright-browsers-cache.yml
@@ -15,7 +15,7 @@ jobs:
   cache-browsers:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/post-mortem-report.yml
+++ b/.github/workflows/post-mortem-report.yml
@@ -10,7 +10,7 @@ concurrency:
 jobs:
   fail-test:
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     timeout-minutes: 40
     steps:

--- a/.github/workflows/pr-path-filters.yml
+++ b/.github/workflows/pr-path-filters.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   lint-typecheck:
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - uses: actions/checkout@v5.0.0

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -33,7 +33,7 @@ jobs:
   changed:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     outputs:
       backend: ${{ steps.filter.outputs.backend }}

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -17,7 +17,7 @@ jobs:
   deploy:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     env:
       PORT: 3000

--- a/.github/workflows/printclub-reminders.yml
+++ b/.github/workflows/printclub-reminders.yml
@@ -17,7 +17,7 @@ jobs:
   remind:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/priority.yml
+++ b/.github/workflows/priority.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   lint-fast:
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -37,7 +37,7 @@ jobs:
 
   smoke-api:
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -57,7 +57,7 @@ jobs:
     timeout-minutes: 15
     name: Gate
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     needs: [lint-fast, smoke-api]
     if: ${{ always() }}

--- a/.github/workflows/prod-env-guard.yml
+++ b/.github/workflows/prod-env-guard.yml
@@ -5,7 +5,9 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws]
+      - ubuntu-latest
     environment:
       name: production
       reviewers:

--- a/.github/workflows/provision-selfhosted-runner.yml
+++ b/.github/workflows/provision-selfhosted-runner.yml
@@ -28,7 +28,7 @@ jobs:
   provision:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/python-pip.yml
+++ b/.github/workflows/python-pip.yml
@@ -8,7 +8,9 @@ on:
 
 jobs:
   install:
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws]
+      - ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.10", "3.11"]

--- a/.github/workflows/queue-probe.yml
+++ b/.github/workflows/queue-probe.yml
@@ -17,7 +17,7 @@ permissions: {}
 jobs:
   probe:
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     continue-on-error: true
     timeout-minutes: 5

--- a/.github/workflows/regression-guard.yml
+++ b/.github/workflows/regression-guard.yml
@@ -18,7 +18,7 @@ jobs:
   guard:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -15,7 +15,9 @@ env:
 jobs:
   backend-unit:
     name: Backend Unit (Node ${{ matrix.node }})
-    runs-on: ${{ github.event_name == 'workflow_dispatch' && inputs.runner || 'ubuntu-latest' }}
+    runs-on:
+      - [self-hosted, linux, aws]
+      - ${{ github.event_name == 'workflow_dispatch' && inputs.runner || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
@@ -39,7 +41,9 @@ jobs:
 
   backend-integration:
     name: Backend Integration (Node ${{ matrix.node }})
-    runs-on: ${{ github.event_name == 'workflow_dispatch' && inputs.runner || 'ubuntu-latest' }}
+    runs-on:
+      - [self-hosted, linux, aws]
+      - ${{ github.event_name == 'workflow_dispatch' && inputs.runner || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
@@ -63,7 +67,9 @@ jobs:
 
   frontend:
     name: Frontend (Node ${{ matrix.node }})
-    runs-on: ${{ github.event_name == 'workflow_dispatch' && inputs.runner || 'ubuntu-latest' }}
+    runs-on:
+      - [self-hosted, linux, aws]
+      - ${{ github.event_name == 'workflow_dispatch' && inputs.runner || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
@@ -88,7 +94,9 @@ jobs:
 
   e2e:
     name: E2E (${{ matrix.browser }})
-    runs-on: ${{ github.event_name == 'workflow_dispatch' && inputs.runner || 'ubuntu-latest' }}
+    runs-on:
+      - [self-hosted, linux, aws]
+      - ${{ github.event_name == 'workflow_dispatch' && inputs.runner || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:
@@ -110,7 +118,9 @@ jobs:
 
   cicd-selftest:
     name: CI/CD Selftest
-    runs-on: ${{ github.event_name == 'workflow_dispatch' && inputs.runner || 'ubuntu-latest' }}
+    runs-on:
+      - [self-hosted, linux, aws]
+      - ${{ github.event_name == 'workflow_dispatch' && inputs.runner || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v5.0.0
       - uses: actions/setup-node@v4.4.0
@@ -130,7 +140,9 @@ jobs:
 
   summary:
     name: Summary
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws]
+      - ubuntu-latest
     needs:
       - backend-unit
       - backend-integration

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,7 +7,9 @@ on:
 
 jobs:
   update_release_draft:
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws]
+      - ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@v5
         env:

--- a/.github/workflows/reset-credits.yml
+++ b/.github/workflows/reset-credits.yml
@@ -17,7 +17,7 @@ jobs:
   reset:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/runner-scheduler.yml
+++ b/.github/workflows/runner-scheduler.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 15
     if: ${{ false }}
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - name: Stop runner service
@@ -33,7 +33,7 @@ jobs:
     timeout-minutes: 15
     if: ${{ false }}
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - name: Start instance

--- a/.github/workflows/runner-watchdog.yml
+++ b/.github/workflows/runner-watchdog.yml
@@ -21,7 +21,7 @@ jobs:
   watchdog:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - name: Check self-hosted AWS runner

--- a/.github/workflows/rust-sccache.yml
+++ b/.github/workflows/rust-sccache.yml
@@ -7,7 +7,9 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws]
+      - ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/sccache

--- a/.github/workflows/schedule-check.yml
+++ b/.github/workflows/schedule-check.yml
@@ -16,7 +16,7 @@ jobs:
   check:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -15,7 +15,9 @@ permissions:
 
 jobs:
   scan:
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws]
+      - ubuntu-latest
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/size-monitor.yml
+++ b/.github/workflows/size-monitor.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   size:
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/skip-heavy.yml
+++ b/.github/workflows/skip-heavy.yml
@@ -10,7 +10,7 @@ jobs:
   skip-heavy:
     if: contains(github.event.pull_request.labels.*.name, 'skip-heavy')
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - run: |

--- a/.github/workflows/smoke-backend.yml
+++ b/.github/workflows/smoke-backend.yml
@@ -26,7 +26,7 @@ jobs:
     timeout-minutes: 15
     needs: preflight
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     services:
       postgres:
@@ -70,7 +70,7 @@ jobs:
     needs: [preflight, db-seed]
     if: needs.preflight.outputs.run_backend == 'true'
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     timeout-minutes: 5
     services:

--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -15,7 +15,7 @@ jobs:
   changes:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     outputs:
       frontend: ${{ steps.filter.outputs.frontend }}
@@ -34,7 +34,7 @@ jobs:
     timeout-minutes: 15
     needs: changes
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     env:
       PORT: 3000
@@ -76,7 +76,7 @@ jobs:
     needs: [changes, backend-smoke]
     if: needs.changes.outputs.frontend == 'true'
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -8,7 +8,9 @@ on:
 
 jobs:
   codespell:
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws]
+      - ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - uses: codespell-project/actions-codespell@v2.1

--- a/.github/workflows/submodules-shallow.yml
+++ b/.github/workflows/submodules-shallow.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   verify-submodules:
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -17,7 +17,7 @@ jobs:
   sync:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/sync-space.yml
+++ b/.github/workflows/sync-space.yml
@@ -16,7 +16,7 @@ jobs:
   sync:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     env:
       STRIPE_TEST_KEY: ${{ secrets.STRIPE_TEST_KEY }}

--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -5,7 +5,9 @@ on:
 
 jobs:
   test:
-    runs-on: ${{ matrix.os }}
+    runs-on:
+      - [self-hosted, linux, aws]
+      - ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]

--- a/.github/workflows/test-rerun.yml
+++ b/.github/workflows/test-rerun.yml
@@ -5,7 +5,9 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws]
+      - ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/test-timeout.yml
+++ b/.github/workflows/test-timeout.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/turbo-cache.yml
+++ b/.github/workflows/turbo-cache.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   turbo:
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/update_locks.yml
+++ b/.github/workflows/update_locks.yml
@@ -18,7 +18,7 @@ jobs:
   update:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/verify-lockfile.yml
+++ b/.github/workflows/verify-lockfile.yml
@@ -17,7 +17,7 @@ jobs:
   verify:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - name: Heartbeat
@@ -59,7 +59,9 @@ jobs:
   lockfile-diff:
     needs: verify
     if: ${{ needs.verify.result == 'failure' }}
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws]
+      - ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - run: corepack enable

--- a/.github/workflows/vuln-scan.yml
+++ b/.github/workflows/vuln-scan.yml
@@ -9,7 +9,9 @@ concurrency:
 
 jobs:
   scan:
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws]
+      - ubuntu-latest
     steps:
       - uses: actions/checkout@v5.0.0
       - uses: actions/setup-node@v4.4.0

--- a/.github/workflows/warm-cache.yml
+++ b/.github/workflows/warm-cache.yml
@@ -15,7 +15,7 @@ jobs:
   root-cache:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - name: Heartbeat
@@ -32,7 +32,7 @@ jobs:
   backend-cache:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - name: Heartbeat
@@ -49,7 +49,7 @@ jobs:
   frontend-cache:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
       - name: Heartbeat

--- a/.github/workflows/web-matrix.yml
+++ b/.github/workflows/web-matrix.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   build:
     runs-on:
-      - [self-hosted, linux, aws, small]
+      - [self-hosted, linux, aws]
       - ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -9,7 +9,9 @@ on:
 
 jobs:
   yamllint:
-    runs-on: ubuntu-latest
+    runs-on:
+      - [self-hosted, linux, aws]
+      - ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Install yamllint


### PR DESCRIPTION
## Summary
- prioritize self-hosted AWS runner across workflows with ubuntu-latest fallback

## Testing
- `npm run format`
- `npm test` *(fails: npm ci encountered tar or filesystem errors)*
- `npm run ci` *(fails: npm tarball data corrupted errors)*
- `npm run smoke` *(fails: npm tarball data corrupted errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a7745488b0832db7c9bfd3266128d1