### PR TITLE
feat: add terraform runner module

### DIFF
--- a/infra/gh-runner-aws/Makefile
+++ b/infra/gh-runner-aws/Makefile
@@ -1,0 +1,13 @@
+.PHONY: plan apply destroy
+
+plan:
+	terraform init
+	terraform plan
+
+apply:
+	terraform init
+	terraform apply
+
+destroy:
+	terraform init
+	terraform destroy

--- a/infra/gh-runner-aws/README.md
+++ b/infra/gh-runner-aws/README.md
@@ -1,0 +1,32 @@
+# GitHub Actions Runner on AWS
+
+This module provisions an ephemeral self-hosted GitHub Actions runner on a single EC2 instance. It can create its own VPC or attach to an existing one and registers itself using tokens stored in SSM Parameter Store.
+
+## Setup
+
+1. **Create SSM parameters**
+   ```bash
+   aws ssm put-parameter --name /github/runner/url --type String --value https://github.com/print3git/MVP-website
+   aws ssm put-parameter --name /github/runner/registration-token --type String --value <TOKEN> --overwrite
+   ```
+   Retrieve a registration token from the repository's **Settings → Actions → Runners** page.
+2. **Deploy with Terraform**
+   ```bash
+   cd infra/gh-runner-aws
+   terraform init && terraform apply
+   # or
+   make apply
+   ```
+3. **Verify the runner** – it should appear under your repository's self-hosted runners with the labels configured in `runner_labels`.
+4. **Use the labels in workflows**
+   ```yaml
+   runs-on: [self-hosted, linux, aws, mvp-runner]
+   ```
+5. **Costs & teardown** – the default `t3.small` incurs hourly charges. Enable `use_spot` or `off_hours` to reduce cost. Destroy the runner when finished:
+   ```bash
+   make destroy
+   ```
+
+## Variables
+
+See [`variables.tf`](variables.tf) for customization options including VPC creation, instance type, labels and scheduling.

--- a/infra/gh-runner-aws/main.tf
+++ b/infra/gh-runner-aws/main.tf
@@ -1,0 +1,241 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+locals {
+  tags = {
+    Project    = var.project
+    Repository = "${var.owner}/${var.repo}"
+  }
+  labels    = join(",", var.runner_labels)
+  user_data = <<-EOT
+    #!/bin/bash
+    set -euo pipefail
+    mkdir -p /var/log/github-runner
+    exec > >(tee /var/log/github-runner/runner.log) 2>&1
+
+    apt-get update
+    apt-get install -y curl jq git unzip awscli
+    curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
+    apt-get install -y nodejs
+    corepack enable
+
+    useradd -m actions-runner
+    cd /home/actions-runner
+    latest=$$(curl -s https://api.github.com/repos/actions/runner/releases/latest | jq -r '.tag_name')
+    curl -L -o actions-runner.tar.gz https://github.com/actions/runner/releases/download/$${latest}/actions-runner-linux-x64-$${latest#v}.tar.gz
+    tar xzf actions-runner.tar.gz
+    rm actions-runner.tar.gz
+    chown -R actions-runner:actions-runner /home/actions-runner
+
+    token=$$(aws ssm get-parameter --name /github/runner/registration-token --with-decryption --query 'Parameter.Value' --output text)
+    url=$$(aws ssm get-parameter --name /github/runner/url --query 'Parameter.Value' --output text)
+    su - actions-runner -c "./config.sh --url $$url --token $$token --labels ${local.labels} --ephemeral --unattended"
+    su - actions-runner -c "sudo ./svc.sh install"
+    su - actions-runner -c "sudo ./svc.sh start"
+    unset token url
+  EOT
+}
+
+resource "aws_vpc" "this" {
+  count                = var.create_vpc ? 1 : 0
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_hostnames = true
+  tags                 = merge(local.tags, { Name = "${var.project}-runner-vpc" })
+}
+
+resource "aws_subnet" "public" {
+  count                   = var.create_vpc ? 2 : 0
+  vpc_id                  = aws_vpc.this[0].id
+  cidr_block              = cidrsubnet(aws_vpc.this[0].cidr_block, 8, count.index)
+  availability_zone       = data.aws_availability_zones.available.names[count.index]
+  map_public_ip_on_launch = true
+  tags                    = merge(local.tags, { Name = "${var.project}-runner-subnet-${count.index}" })
+}
+
+resource "aws_internet_gateway" "this" {
+  count  = var.create_vpc ? 1 : 0
+  vpc_id = aws_vpc.this[0].id
+  tags   = merge(local.tags, { Name = "${var.project}-runner-igw" })
+}
+
+resource "aws_route_table" "public" {
+  count  = var.create_vpc ? 1 : 0
+  vpc_id = aws_vpc.this[0].id
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.this[0].id
+  }
+  tags = merge(local.tags, { Name = "${var.project}-runner-rt" })
+}
+
+resource "aws_route_table_association" "public" {
+  count          = var.create_vpc ? 2 : 0
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public[0].id
+}
+
+locals {
+  vpc_id     = var.create_vpc ? aws_vpc.this[0].id : var.existing_vpc_id
+  subnet_ids = var.create_vpc ? aws_subnet.public[*].id : var.subnet_ids
+}
+
+resource "aws_security_group" "runner" {
+  name        = "${var.project}-runner-sg"
+  description = "Egress-only security group for GitHub runner"
+  vpc_id      = local.vpc_id
+  tags        = merge(local.tags, { Name = "${var.project}-runner-sg" })
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+resource "aws_iam_role" "runner" {
+  name = "${var.project}-runner-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Action    = "sts:AssumeRole"
+      Principal = { Service = "ec2.amazonaws.com" }
+    }]
+  })
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy" "runner" {
+  name = "${var.project}-runner-policy"
+  role = aws_iam_role.runner.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = ["ssm:GetParameter"]
+        Resource = [
+          "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/github/runner/registration-token",
+          "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/github/runner/url"
+        ]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Resource = "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:/github/runner/*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_instance_profile" "runner" {
+  name = "${var.project}-runner-profile"
+  role = aws_iam_role.runner.name
+}
+
+resource "aws_cloudwatch_log_group" "runner" {
+  name              = "/github/runner/${var.project}"
+  retention_in_days = 14
+  tags              = local.tags
+}
+
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  owners      = ["099720109477"]
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
+  }
+}
+
+resource "aws_launch_template" "runner" {
+  name_prefix            = "${var.project}-runner-"
+  image_id               = data.aws_ami.ubuntu.id
+  instance_type          = var.instance_type
+  vpc_security_group_ids = [aws_security_group.runner.id]
+  iam_instance_profile { name = aws_iam_instance_profile.runner.name }
+
+  block_device_mappings {
+    device_name = "/dev/xvda"
+    ebs {
+      volume_size           = 30
+      volume_type           = "gp3"
+      delete_on_termination = true
+    }
+  }
+
+  dynamic "instance_market_options" {
+    for_each = var.use_spot ? [1] : []
+    content {
+      market_type = "spot"
+      spot_options {
+        instance_interruption_behavior = "terminate"
+      }
+    }
+  }
+
+  user_data = base64encode(local.user_data)
+  tag_specifications {
+    resource_type = "instance"
+    tags          = merge(local.tags, { Name = "${var.project}-runner" })
+  }
+}
+
+resource "aws_autoscaling_group" "runner" {
+  name                = "${var.project}-runner-asg"
+  desired_capacity    = 1
+  max_size            = 1
+  min_size            = 0
+  vpc_zone_identifier = local.subnet_ids
+  launch_template {
+    id      = aws_launch_template.runner.id
+    version = "$Latest"
+  }
+  tag {
+    key                 = "Name"
+    value               = "${var.project}-runner"
+    propagate_at_launch = true
+  }
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_autoscaling_schedule" "scale_down" {
+  count                  = var.off_hours ? 1 : 0
+  scheduled_action_name  = "${var.project}-runner-off"
+  min_size               = 0
+  max_size               = 0
+  desired_capacity       = 0
+  recurrence             = "0 22 * * *"
+  autoscaling_group_name = aws_autoscaling_group.runner.name
+}
+
+resource "aws_autoscaling_schedule" "scale_up" {
+  count                  = var.off_hours ? 1 : 0
+  scheduled_action_name  = "${var.project}-runner-on"
+  min_size               = 0
+  max_size               = 1
+  desired_capacity       = 1
+  recurrence             = "0 6 * * *"
+  autoscaling_group_name = aws_autoscaling_group.runner.name
+}

--- a/infra/gh-runner-aws/outputs.tf
+++ b/infra/gh-runner-aws/outputs.tf
@@ -1,0 +1,19 @@
+output "instance_id" {
+  description = "Instance ID of the GitHub runner"
+  value       = try(aws_autoscaling_group.runner.instances[0], null)
+}
+
+output "asg_name" {
+  description = "Name of the Auto Scaling group"
+  value       = aws_autoscaling_group.runner.name
+}
+
+output "log_group_name" {
+  description = "CloudWatch log group for runner logs"
+  value       = aws_cloudwatch_log_group.runner.name
+}
+
+output "runner_labels" {
+  description = "Labels applied to the runner"
+  value       = var.runner_labels
+}

--- a/infra/gh-runner-aws/variables.tf
+++ b/infra/gh-runner-aws/variables.tf
@@ -1,0 +1,56 @@
+variable "project" {
+  type        = string
+  description = "Project name used for resource naming"
+}
+
+variable "owner" {
+  type        = string
+  description = "GitHub organization or user owning the repository"
+}
+
+variable "repo" {
+  type        = string
+  description = "Repository name"
+}
+
+variable "runner_labels" {
+  type        = list(string)
+  default     = ["self-hosted", "linux", "aws", "mvp-runner"]
+  description = "Labels to apply to the GitHub runner"
+}
+
+variable "instance_type" {
+  type        = string
+  default     = "t3.small"
+  description = "EC2 instance type for the runner"
+}
+
+variable "use_spot" {
+  type        = bool
+  default     = true
+  description = "Launch the runner as a spot instance"
+}
+
+variable "create_vpc" {
+  type        = bool
+  default     = true
+  description = "When true, create a new VPC and public subnets"
+}
+
+variable "existing_vpc_id" {
+  type        = string
+  default     = null
+  description = "ID of an existing VPC to use when create_vpc is false"
+}
+
+variable "subnet_ids" {
+  type        = list(string)
+  default     = []
+  description = "Subnet IDs when using an existing VPC"
+}
+
+variable "off_hours" {
+  type        = bool
+  default     = false
+  description = "Scale the ASG to zero overnight"
+}


### PR DESCRIPTION
## Summary
- add standalone Terraform to launch ephemeral GitHub Actions runner on AWS
- document setup and provide Makefile helpers

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` (backend)
- `npm test` *(fails: Setup flag missing)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: process terminated)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: log file missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a775f7df38832db69be8381238f327