### PR TITLE
ci: add self-hosted router workflow

### DIFF
--- a/.github/workflows/ci-router.yml
+++ b/.github/workflows/ci-router.yml
@@ -1,0 +1,33 @@
+name: CI Router
+
+on:
+  workflow_call:
+    inputs:
+      port:
+        required: false
+        type: string
+        default: '3000'
+      ci_require_external:
+        required: false
+        type: string
+        default: '0'
+
+env:
+  PORT: ${{ inputs.port }}
+  CI_REQUIRE_EXTERNAL: ${{ inputs.ci_require_external }}
+
+jobs:
+  selfhosted:
+    runs-on: [self-hosted, linux, aws, mvp-runner]
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/frontend-build
+
+  ubuntu:
+    needs: selfhosted
+    if: needs.selfhosted.result == 'failure' || needs.selfhosted.outcome == 'cancelled'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: ./.github/actions/frontend-build


### PR DESCRIPTION
## Summary
- add optional router workflow that tries self-hosted runner first with ubuntu fallback

## Testing
- `npm run format` (backend)
- `npm test` (backend)
- `SKIP_PW_DEPS=1 npm run ci` *(fails: yaml parse errors in existing workflows)*
- `npm run build`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68a776191268832d8f5ff36a89c69a06