### PR TITLE
ci: add latency metric script and self-hosted runner docs

### DIFF
--- a/docs/ci/self-hosted-aws.md
+++ b/docs/ci/self-hosted-aws.md
@@ -1,0 +1,11 @@
+# Self-hosted runners on AWS
+
+Short playbook:
+
+1. Put repo URL and runner registration token into SSM:
+   - `/github/runner/url`
+   - `/github/runner/registration-token`
+2. `cd infra/gh-runner-aws && terraform init && terraform apply`.
+3. Check **Settings → Actions → Runners** for `mvp-runner`.
+4. (Optional) toggle `off_hours` to save costs.
+5. Use `.github/actions/js-stack-setup` in jobs that need `pnpm`/`vite`.

--- a/scripts/runner/latency-metric.sh
+++ b/scripts/runner/latency-metric.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Measure how long a run spent in the GitHub Actions queue.
+# Prints the delta between queued_at and run_started_at in milliseconds.
+# Never fails the job.
+main() {
+  if ! command -v gh >/dev/null 2>&1; then
+    echo 0
+    return
+  fi
+  run_json=$(gh api "/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" 2>/dev/null) || {
+    echo 0
+    return
+  }
+  queued=$(echo "$run_json" | jq -r '.queued_at')
+  started=$(echo "$run_json" | jq -r '.run_started_at')
+  if [[ -z "$queued" || -z "$started" || "$queued" == "null" || "$started" == "null" ]]; then
+    echo 0
+    return
+  fi
+  q_ms=$(date -d "$queued" +%s%3N)
+  s_ms=$(date -d "$started" +%s%3N)
+  echo $((s_ms - q_ms))
+}
+
+main "$@" || true


### PR DESCRIPTION
## Summary
- add runner latency-metric script for queue start delta
- document AWS self-hosted runner setup

## Testing
- `npx prettier -w docs/ci/self-hosted-aws.md`
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: SyntaxError in workflow YAML)*
- `npm run build`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68a7761c5ce8832d9b42ae0f11506d63