### PR TITLE
ci: add inputs and shell to frontend build action

### DIFF
--- a/.github/actions/frontend-build/action.yml
+++ b/.github/actions/frontend-build/action.yml
@@ -1,4 +1,15 @@
 name: Frontend Build
+inputs:
+  frontend-dir:
+    description: Path to the frontend project
+    default: frontend
+  build-script:
+    description: NPM script to build the frontend
+    default: build
+outputs:
+  dist-exists:
+    description: 'true if dist/index.html exists'
+    value: ${{ steps.check-dist.outputs.dist-exists }}
 runs:
   using: composite
   steps:
@@ -6,19 +17,26 @@ runs:
       with:
         node-version: '20'
         cache: pnpm
-        cache-dependency-path: frontend/pnpm-lock.yaml
-    - name: Enable corepack
-      shell: bash
-      run: corepack enable
+        cache-dependency-path: ${{ inputs.frontend-dir }}/pnpm-lock.yaml
+    - uses: ./.github/actions/setup-pnpm
     - name: Install deps
       shell: bash
       run: pnpm install --no-frozen-lockfile
-      working-directory: frontend
+      working-directory: ${{ inputs.frontend-dir }}
     - name: Build
       shell: bash
-      run: pnpm run build
-      working-directory: frontend
+      run: npm run ${{ inputs.build-script }} --prefix ${{ inputs.frontend-dir }}
+    - id: check-dist
+      name: Check dist
+      shell: bash
+      run: |
+        if [ -f "${{ inputs.frontend-dir }}/dist/index.html" ]; then
+          echo "dist-exists=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "dist-exists=false" >> "$GITHUB_OUTPUT"
+        fi
     - uses: actions/upload-artifact@v4
+      if: steps.check-dist.outputs.dist-exists == 'true'
       with:
         name: frontend-dist
-        path: frontend/dist
+        path: ${{ inputs.frontend-dir }}/dist


### PR DESCRIPTION
## Summary
- parameterize frontend-build action with reusable inputs and outputs
- add bash shell and dist existence check for artifact upload

## Testing
- `npm run format` (backend)
- `npm test` (backend, fails: setup flag missing, runs setup)
- `npm run ci` (fails: process terminated)


------
https://chatgpt.com/codex/tasks/task_e_68a7760d41f4832d81e5b455cc761a84