### PR TITLE
ci: add self-hosted runner probe workflow

### DIFF
--- a/.github/workflows/selfhosted-probe.yml
+++ b/.github/workflows/selfhosted-probe.yml
@@ -1,0 +1,43 @@
+name: Self-hosted runner probe
+
+on:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "*/15 * * * *"
+
+jobs:
+  probe-selfhosted:
+    name: Probe self-hosted runner
+    runs-on: [self-hosted, linux, aws, mvp-runner]
+    timeout-minutes: 5
+    outputs:
+      queue_latency: ${{ steps.latency.outputs.queue_latency }}
+    steps:
+      - name: Runner context
+        run: echo '${{ toJSON(runner) }}'
+      - name: Node version
+        run: node -v
+      - name: npm version
+        run: npm -v
+      - name: Measure queue latency
+        id: latency
+        run: |
+          now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          created_at="${{ github.event.created_at }}"
+          queue_latency=$(( $(date -u -d "$now" +"%s") - $(date -u -d "$created_at" +"%s") ))
+          echo "queue_latency=$queue_latency" | tee latency.txt
+          echo "queue_latency=$queue_latency" >> "$GITHUB_OUTPUT"
+      - name: Upload probe artifact
+        uses: actions/upload-artifact@v4.3.1
+        with:
+          name: probe-${{ github.run_id }}
+          path: latency.txt
+
+  timeout-notice:
+    if: ${{ needs.probe-selfhosted.result != 'success' }}
+    needs: probe-selfhosted
+    runs-on: ubuntu-latest
+    steps:
+      - name: No runner available
+        run: echo "Self-hosted runner not available. Run 'terraform apply' to provision." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- add self-hosted runner probe workflow to check self-hosted runner availability and queue latency

## Testing
- `npm run format` *(fails: SyntaxError: A collection cannot be both a mapping and a sequence)*
- `(cd backend && npm test)`
- `npm run ci` *(fails: SyntaxError: A collection cannot be both a mapping and a sequence)*
- `npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html. Run 'npm run build' and retry)*

------
https://chatgpt.com/codex/tasks/task_e_68a775fdad90832d83c0d97a52348c16