### PR TITLE
feat: add autoscaling GitHub runner module

### DIFF
--- a/infra/github-actions-runner/main.tf
+++ b/infra/github-actions-runner/main.tf
@@ -1,0 +1,156 @@
+data "aws_ami" "al2023" {
+  owners      = ["amazon"]
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-*-x86_64"]
+  }
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}
+
+resource "aws_security_group" "runner" {
+  name_prefix = "gha-runner-"
+  description = "Security group for GitHub Actions runners"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description = "SSH access"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = [var.ssh_ingress_cidr]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+data "aws_iam_policy_document" "assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "runner" {
+  name_prefix        = "gha-runner-"
+  assume_role_policy = data.aws_iam_policy_document.assume.json
+}
+
+data "aws_iam_policy_document" "runner" {
+  statement {
+    actions   = ["ssm:GetParameter"]
+    resources = ["arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter${var.ssm_token_parameter}"]
+  }
+}
+
+resource "aws_iam_policy" "runner" {
+  name_prefix = "gha-runner-"
+  policy      = data.aws_iam_policy_document.runner.json
+}
+
+resource "aws_iam_role_policy_attachment" "ssm" {
+  role       = aws_iam_role.runner.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_role_policy_attachment" "custom" {
+  role       = aws_iam_role.runner.name
+  policy_arn = aws_iam_policy.runner.arn
+}
+
+resource "aws_iam_instance_profile" "runner" {
+  name_prefix = "gha-runner-"
+  role        = aws_iam_role.runner.name
+}
+
+resource "aws_launch_template" "runner" {
+  name_prefix   = "gha-runner-"
+  image_id      = data.aws_ami.al2023.id
+  instance_type = var.instance_type
+
+  iam_instance_profile {
+    name = aws_iam_instance_profile.runner.name
+  }
+
+  instance_market_options {
+    market_type = "spot"
+    spot_options {
+      instance_interruption_behavior = "terminate"
+    }
+  }
+
+  user_data = base64encode(
+    templatefile("${path.module}/userdata.sh", {
+      repo_owner          = var.repo_owner,
+      repo_name           = var.repo_name,
+      labels              = join(",", var.runner_labels),
+      ssm_token_parameter = var.ssm_token_parameter
+    })
+  )
+}
+
+resource "aws_autoscaling_group" "runner" {
+  name_prefix          = "gha-runner-"
+  max_size             = 3
+  min_size             = 0
+  desired_capacity     = 0
+  vpc_zone_identifier  = var.subnet_ids
+  health_check_type    = "EC2"
+  force_delete         = true
+  launch_template {
+    id      = aws_launch_template.runner.id
+    version = "$Latest"
+  }
+}
+
+resource "aws_autoscaling_policy" "scale_up" {
+  name                   = "${aws_autoscaling_group.runner.name}-scale-up"
+  autoscaling_group_name = aws_autoscaling_group.runner.name
+  adjustment_type        = "ChangeInCapacity"
+  scaling_adjustment     = 1
+  cooldown               = 60
+}
+
+resource "aws_autoscaling_policy" "scale_down" {
+  name                   = "${aws_autoscaling_group.runner.name}-scale-down"
+  autoscaling_group_name = aws_autoscaling_group.runner.name
+  adjustment_type        = "ChangeInCapacity"
+  scaling_adjustment     = -1
+  cooldown               = 300
+}
+
+resource "aws_cloudwatch_metric_alarm" "queue_high" {
+  alarm_name          = "${aws_autoscaling_group.runner.name}-queue-high"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  metric_name         = var.queue_length_metric_name
+  namespace           = var.metric_namespace
+  period              = 60
+  statistic           = "Average"
+  threshold           = 1
+  alarm_actions       = [aws_autoscaling_policy.scale_up.arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "queue_low" {
+  alarm_name          = "${aws_autoscaling_group.runner.name}-queue-low"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = var.queue_length_metric_name
+  namespace           = var.metric_namespace
+  period              = 300
+  statistic           = "Average"
+  threshold           = 1
+  alarm_actions       = [aws_autoscaling_policy.scale_down.arn]
+}

--- a/infra/github-actions-runner/outputs.tf
+++ b/infra/github-actions-runner/outputs.tf
@@ -1,0 +1,11 @@
+output "autoscaling_group_name" {
+  value = aws_autoscaling_group.runner.name
+}
+
+output "iam_role_name" {
+  value = aws_iam_role.runner.name
+}
+
+output "security_group_id" {
+  value = aws_security_group.runner.id
+}

--- a/infra/github-actions-runner/userdata.sh
+++ b/infra/github-actions-runner/userdata.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euxo pipefail
+
+dnf update -y
+dnf install -y curl tar jq
+
+useradd -m runner
+cd /home/runner
+RUNNER_VERSION="2.317.0"
+curl -L -o actions-runner.tar.gz https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz
+tar xzf actions-runner.tar.gz
+
+REGION="$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/document | jq -r .region)"
+TOKEN=$(aws ssm get-parameter --name "${ssm_token_parameter}" --with-decryption --region "$REGION" --query Parameter.Value --output text)
+
+chown -R runner:runner /home/runner
+runuser -l runner -c "./bin/installdependencies.sh"
+runuser -l runner -c "./config.sh --url https://github.com/${repo_owner}/${repo_name} --token $TOKEN --labels ${labels} --unattended --ephemeral"
+runuser -l runner -c "./run.sh &"

--- a/infra/github-actions-runner/variables.tf
+++ b/infra/github-actions-runner/variables.tf
@@ -1,0 +1,45 @@
+variable "repo_owner" {
+  type = string
+}
+
+variable "repo_name" {
+  type = string
+}
+
+variable "runner_labels" {
+  type    = list(string)
+  default = []
+}
+
+variable "ssm_token_parameter" {
+  type        = string
+  description = "Name of SSM parameter storing GitHub runner registration token"
+}
+
+variable "subnet_ids" {
+  type = list(string)
+}
+
+variable "vpc_id" {
+  type = string
+}
+
+variable "instance_type" {
+  type    = string
+  default = "t3.micro"
+}
+
+variable "ssh_ingress_cidr" {
+  type    = string
+  default = "0.0.0.0/0"
+}
+
+variable "metric_namespace" {
+  type    = string
+  default = "GitHubRunners"
+}
+
+variable "queue_length_metric_name" {
+  type    = string
+  default = "QueuedJobs"
+}

--- a/infra/github-actions-runner/versions.tf
+++ b/infra/github-actions-runner/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.4"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Terraform module provisioning spot auto-scaling GitHub Actions runners

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci`
- `npm run build`
- `SKIP_PW_DEPS=1 npm run smoke` *(fails to load Playwright config)*

------
https://chatgpt.com/codex/tasks/task_e_68a774596a78832db583cd7c0e2678e6