### PR TITLE
ci: add script to install GitHub Actions runner

### DIFF
--- a/scripts/runners/install-gh-runner.sh
+++ b/scripts/runners/install-gh-runner.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Placeholder configuration. Update before running.
+GITHUB_URL="https://github.com/my-org/my-repo"
+GITHUB_TOKEN="" # TODO: Paste the GitHub token from the GitHub UI.
+RUNNER_NAME="$(hostname)-$(openssl rand -hex 4)"
+RUNNER_LABELS="aws,ec2,self-hosted"
+
+RUNNER_DIR="/opt/actions-runner"
+
+# Install required packages
+sudo apt-get update
+sudo apt-get install -y curl jq
+
+# Download latest runner release
+mkdir -p "$RUNNER_DIR"
+cd "$RUNNER_DIR"
+LATEST_URL="$(curl -s https://api.github.com/repos/actions/runner/releases/latest | jq -r '.assets[] | select(.name | test("linux-x64")) | .browser_download_url')"
+curl -L "$LATEST_URL" -o actions-runner.tar.gz
+tar xzf actions-runner.tar.gz
+rm actions-runner.tar.gz
+
+# Configure the runner
+./config.sh --url "$GITHUB_URL" --token "$GITHUB_TOKEN" --name "$RUNNER_NAME" --labels "$RUNNER_LABELS" --unattended
+
+# Install and start the service
+sudo ./svc.sh install
+sudo ./svc.sh start


### PR DESCRIPTION
## Summary
- add installer for GitHub Actions self-hosted runner

## Testing
- `npm run format`
```
> backend@1.0.0 preformat
> node ../scripts/ensure-root-deps.js

> backend@1.0.0 format
> sh -c 'cd .. && node scripts/ensure-root-deps.js && prettier --log-level warn --write "**/*.{js,jsx,json,md}" --ignore-path .prettierignore'
```
- `npm test`
```
PASS tests/frontend/flashBanner.test.js
  flash banner
    ✓ hides after countdown ends (341 ms)
    ✓ does not restart after expiration (140 ms)
    ✓ countdown shows 4:59 after one second (125 ms)
    ✓ banner hidden when chance disabled (111 ms)

PASS tests/frontend/index.test.js
  index validatePrompt
    ✓ rejects short prompt (95 ms)
    ✓ accepts valid prompt (56 ms)
    ✓ rejects empty prompt without images (58 ms)
    ✓ rejects prompts with line breaks (56 ms)
    ✓ rejects prompts with angle brackets (58 ms)
    ✓ rejects overly long prompts (47 ms)

PASS tests/textToImage.test.ts
  textToImage
    ✓ uploads generated image and returns url (37 ms)
    ✓ works without AWS credentials when uploadFile is mocked (14 ms)
    ✓ returns unique url with real uploadFile (57 ms)
```
- `npm run ci` *(fails: SyntaxError in workflow YAML files)*
```
[error] .github/workflows/_setup.yml: SyntaxError: A collection cannot be both a mapping and a sequence (37:9)
...
[error] .github/workflows/cache-validator.yml: SyntaxError: Nested mappings are not allowed in compact mappings (49:14)
```
- `npm run smoke` *(fails: Missing frontend build artifact)*
```
Checking STRIPE_SECRET_KEY: sk_test_dummy
Missing frontend build artifact: frontend/dist/index.html. Run 'npm run build' and retry
```


------
https://chatgpt.com/codex/tasks/task_e_68a7744cdd48832da98375c5920a6deb