### PR TITLE
Add wrangler/pages config self‑check and asset link validator

### DIFF
--- a/.github/workflows/pages-preflight.yml
+++ b/.github/workflows/pages-preflight.yml
@@ -1,0 +1,30 @@
+name: Pages Preflight
+
+env:
+  HUSKY: 0
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  preflight:
+    name: Pages Preflight
+    timeout-minutes: 5
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: node scripts/check-wrangler-pages.js
+      - run: node scripts/check-asset-links.js

--- a/scripts/check-asset-links.js
+++ b/scripts/check-asset-links.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+const fs = require("fs");
+const path = require("path");
+
+const distDir = path.join(__dirname, "..", "frontend", "dist");
+if (!fs.existsSync(distDir)) {
+  console.log("frontend/dist missing; skipping asset link check");
+  process.exit(0);
+}
+
+const htmlFiles = [];
+const walk = (dir) => {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(p);
+    else if (entry.isFile() && p.endsWith(".html")) htmlFiles.push(p);
+  }
+};
+walk(distDir);
+
+const errors = [];
+for (const file of htmlFiles) {
+  const content = fs.readFileSync(file, "utf8");
+  const dir = path.dirname(file);
+  const regex = /(?:href|src)="([^"#?]+)"/g;
+  let m;
+  while ((m = regex.exec(content)) !== null) {
+    const link = m[1];
+    if (/^(?:https?:|data:|mailto:|#|\/\/)/.test(link)) continue;
+    const target = path.resolve(dir, link);
+    if (!fs.existsSync(target)) {
+      errors.push(`${path.relative(distDir, file)} -> ${link}`);
+      continue;
+    }
+    const stat = fs.lstatSync(target);
+    if (stat.isSymbolicLink()) {
+      errors.push(`${path.relative(distDir, file)} -> ${link} (symlink)`);
+    }
+  }
+}
+
+if (errors.length) {
+  console.error("Cloudflare Pages: unreachable assets detected:");
+  for (const e of errors) console.error(` - ${e}`);
+  process.exit(1);
+}
+
+console.log("asset links OK");

--- a/scripts/check-wrangler-pages.js
+++ b/scripts/check-wrangler-pages.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+const fs = require("fs");
+const path = require("path");
+
+const file = path.join(__dirname, "..", "wrangler.toml");
+
+if (!fs.existsSync(file)) {
+  console.log("wrangler.toml not found; skipping");
+  process.exit(0);
+}
+
+const content = fs.readFileSync(file, "utf8");
+
+const forbidden = ["build", "site", "main", "workers_dev"];
+const found = forbidden.filter(
+  (key) =>
+    new RegExp(`^${key}\\s*=`, "m").test(content) ||
+    new RegExp(`^\\[${key}\\]`, "m").test(content),
+);
+
+if (found.length) {
+  console.error(
+    `Cloudflare Pages: remove unsupported ${found.join(
+      ", ",
+    )} keys; Pages reads pages_build_output_dir only.`,
+  );
+  process.exit(1);
+}
+
+if (!/^\s*pages_build_output_dir\s*=\s*.+/m.test(content)) {
+  console.error("Cloudflare Pages: pages_build_output_dir is required.");
+  process.exit(1);
+}
+
+console.log("wrangler.toml OK");


### PR DESCRIPTION
## Summary
- add Cloudflare Pages config guard to prevent unsupported keys
- verify built frontend assets link to real files
- run both checks in new "Pages Preflight" workflow

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: YAML parser errors in existing workflow files)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68a7789e5818832d89910f6d31bf8312