### PR TITLE
ci: add secret validation script

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "deps:dedupe": "npm dedupe",
     "deps:dedupe-check": "npm dedupe --dry-run",
     "check-cycles": "node scripts/check-cycles.js",
+    "check-secrets": "node scripts/check-secrets.js",
     "bundle:size": "size-limit",
     "dev": "node backend/server.js",
     "validate-env": "bash scripts/validate-env.sh",

--- a/scripts/check-secrets.js
+++ b/scripts/check-secrets.js
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+
+const required = [
+  "AWS_ACCESS_KEY_ID",
+  "AWS_SECRET_ACCESS_KEY",
+  "AWS_REGION",
+  "STRIPE_SECRET_KEY",
+  "STRIPE_PUBLISHABLE_KEY",
+  "S3_BUCKET",
+  "DB_URL",
+];
+
+const missing = [];
+for (const name of required) {
+  const value = process.env[name];
+  if (!value || String(value).trim() === "") {
+    missing.push(name);
+  }
+}
+
+// Handle alternate S3 bucket variable
+if (missing.includes("S3_BUCKET")) {
+  if (
+    process.env.S3_BUCKET_NAME &&
+    String(process.env.S3_BUCKET_NAME).trim() !== ""
+  ) {
+    missing.splice(missing.indexOf("S3_BUCKET"), 1);
+  } else {
+    missing[missing.indexOf("S3_BUCKET")] = "S3_BUCKET or S3_BUCKET_NAME";
+  }
+}
+
+if (missing.length) {
+  console.error("Missing required secrets:");
+  for (const name of missing) {
+    console.error(`- ${name}`);
+  }
+  process.exit(1);
+}
+
+console.log("All required secrets are set.");


### PR DESCRIPTION
## Summary
- add script to verify critical secrets exist in CI
- expose `npm run check-secrets` to run the validator

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run check-secrets`
- `npm run format` *(fails: SyntaxError in `.github/workflows/_setup.yml`)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: SyntaxError in `.github/workflows/_setup.yml` and others)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a774630418832dac6119e538b65af1