### PR TITLE
fix: remove build step from wrangler config

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,6 +4,3 @@ compatibility_date = "2024-12-01"
 
 [vars]
 NODE_ENV = "production"
-
-[build]
-command = "npm ci --prefix frontend && npm run build --prefix frontend && node scripts/assert-frontend-dist.js"


### PR DESCRIPTION
## Summary
- remove build command from wrangler.toml for Pages compatibility

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: SyntaxError in .github/workflows YAML files)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html)*

------
https://chatgpt.com/codex/tasks/task_e_68a77b28ec5c832daf019feca8136c17