### PR TITLE
feat: add AWS GitHub runner Terraform module

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,13 @@
+name: build
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    uses: ./.github/workflows/_router.yml
+    with:
+      job_name: "build-frontend"
+      steps_yaml: |
+        - uses: actions/checkout@v4
+        - run: node -v

--- a/infra/gh-runner-aws/README.md
+++ b/infra/gh-runner-aws/README.md
@@ -1,0 +1,34 @@
+# GitHub Actions Runner on AWS
+
+This Terraform module provisions a single Amazon Linux 2023 EC2 instance
+preconfigured as a GitHub Actions runner. The instance installs Docker and the
+GitHub Actions runner software, then registers itself using parameters stored in
+AWS Systems Manager Parameter Store.
+
+The runner is created with the labels:
+`self-hosted,linux,aws,mvp-runner`.
+
+## Prerequisites
+
+1. Configure AWS credentials and choose your region.
+2. Store the following parameters in SSM Parameter Store:
+
+```bash
+aws ssm put-parameter --name /github/runner/url --type String \
+  --value "https://github.com/OWNER/REPO"
+aws ssm put-parameter --name /github/runner/registration-token \
+  --type SecureString --value "TOKEN"
+```
+
+The `registration-token` value is obtained from the repository or organization
+settings when adding a new self-hosted runner.
+
+## Usage
+
+```bash
+cd infra/gh-runner-aws
+terraform init
+terraform apply
+```
+
+The module uses local state; no backend is configured.

--- a/infra/gh-runner-aws/main.tf
+++ b/infra/gh-runner-aws/main.tf
@@ -1,0 +1,106 @@
+provider "aws" {
+  region = var.region
+}
+
+data "aws_vpc" "default" {
+  default = true
+}
+
+data "aws_subnet_ids" "default" {
+  vpc_id = data.aws_vpc.default.id
+}
+
+resource "aws_security_group" "runner" {
+  name        = "${var.name}-sg"
+  description = "Security group for GitHub Actions runner allowing egress only"
+  vpc_id      = data.aws_vpc.default.id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.name}-sg"
+  }
+}
+
+resource "aws_iam_role" "runner" {
+  name = "${var.name}-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = { Service = "ec2.amazonaws.com" }
+        Action    = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ssm" {
+  role       = aws_iam_role.runner.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_role_policy_attachment" "cloudwatch" {
+  role       = aws_iam_role.runner.name
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
+}
+
+resource "aws_iam_instance_profile" "runner" {
+  name = "${var.name}-profile"
+  role = aws_iam_role.runner.name
+}
+
+data "aws_ami" "al2023" {
+  owners      = ["amazon"]
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-*-x86_64"]
+  }
+}
+
+resource "aws_instance" "runner" {
+  ami                    = data.aws_ami.al2023.id
+  instance_type          = var.instance_type
+  iam_instance_profile   = aws_iam_instance_profile.runner.name
+  subnet_id              = data.aws_subnet_ids.default.ids[0]
+  vpc_security_group_ids = [aws_security_group.runner.id]
+
+  user_data = <<-EOF
+              #!/bin/bash
+              set -e
+              yum update -y
+
+              # Install Docker
+              yum install -y docker
+              systemctl enable docker
+              systemctl start docker
+
+              # Install GitHub Actions runner
+              RUNNER_VERSION="2.317.0"
+              cd /opt
+              mkdir actions-runner && cd actions-runner
+              curl -O -L https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz
+              tar xzf actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz
+              ./bin/installdependencies.sh
+
+              RUNNER_URL=$(aws ssm get-parameter --name /github/runner/url --query Parameter.Value --output text)
+              TOKEN=$(aws ssm get-parameter --name /github/runner/registration-token --with-decryption --query Parameter.Value --output text)
+
+              ./config.sh --url ${RUNNER_URL} --token ${TOKEN} --labels self-hosted,linux,aws,mvp-runner --unattended
+              ./svc.sh install
+              ./svc.sh start
+              EOF
+
+  tags = {
+    Name = var.name
+  }
+}

--- a/infra/gh-runner-aws/outputs.tf
+++ b/infra/gh-runner-aws/outputs.tf
@@ -1,0 +1,9 @@
+output "instance_id" {
+  description = "ID of the runner EC2 instance"
+  value       = aws_instance.runner.id
+}
+
+output "iam_role_name" {
+  description = "Name of IAM role attached to the runner"
+  value       = aws_iam_role.runner.name
+}

--- a/infra/gh-runner-aws/variables.tf
+++ b/infra/gh-runner-aws/variables.tf
@@ -1,0 +1,17 @@
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "instance_type" {
+  description = "EC2 instance type for the runner"
+  type        = string
+  default     = "t3.small"
+}
+
+variable "name" {
+  description = "Name prefix for runner resources"
+  type        = string
+  default     = "mvp-runner"
+}

--- a/infra/gh-runner-aws/versions.tf
+++ b/infra/gh-runner-aws/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Terraform module to provision AWS-hosted self-hosted runner
- document parameter store setup and Terraform apply
- add basic router workflow

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `cd backend && npm run format`
- `cd backend && npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: SyntaxError in existing workflow YAML files)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a77b0f5d04832dab3bfe5193036752