### PR TITLE
ci: remove invalid codeql tools version

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,8 +29,6 @@ jobs:
       - ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        codeql-version: ["2.22.4"]
     steps:
       - name: Heartbeat
         run: |
@@ -49,7 +47,6 @@ jobs:
         uses: github/codeql-action/init@v3.29.9
         with:
           languages: javascript-typescript
-          tools: ${{ matrix.codeql-version }}
       - name: CodeQL CLI version
         run: codeql --version
         shell: bash


### PR DESCRIPTION
## Summary
- remove pinned CodeQL tools version that was interpreted as a path

## Testing
- `npm run format` (backend)
- `npm test` (backend)
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Error occurred when checking code style in 9 files)*
- `npm run build`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68a77b128edc832d955aec2773d26347