### PR TITLE
ci: add pnpm lockfile sync workflow

### DIFF
--- a/.github/workflows/pnpm-lock-sync.yml
+++ b/.github/workflows/pnpm-lock-sync.yml
@@ -1,0 +1,34 @@
+name: Sync pnpm lockfile
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [labeled, synchronize]
+
+jobs:
+  sync:
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && (
+        (github.event.action == 'labeled' && github.event.label.name == 'sync-lock') ||
+        (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'sync-lock'))
+      ))
+    runs-on: ubuntu-latest
+    env:
+      HUSKY: 0
+    steps:
+      - uses: actions/checkout@v5.0.0
+      - run: corepack enable
+      - uses: pnpm/action-setup@v4.1.0
+        with:
+          run_install: false
+      - run: pnpm install
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6.1.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: sync pnpm-lock.yaml"
+          title: "chore: sync pnpm-lock.yaml"
+          body: Update pnpm-lock.yaml
+          branch: chore/sync-pnpm-lock
+          add-paths: pnpm-lock.yaml


### PR DESCRIPTION
## Summary
- add workflow to sync pnpm-lock.yaml via peter-evans/create-pull-request

## Testing
- `npm run format` *(fails: SyntaxError in existing workflow YAML)*
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: SyntaxError in existing workflow YAML)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a77b1b59e0832daac494a9b590f8ff