### PR TITLE
chore: add Vite scaffold guard

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+});

--- a/scripts/guard/vite-scaffold.js
+++ b/scripts/guard/vite-scaffold.js
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+const fs = require("fs");
+const path = require("path");
+
+const dir = path.join(process.cwd(), "frontend");
+if (!fs.existsSync(dir)) {
+  process.exit(0);
+}
+
+const pkgPath = path.join(dir, "package.json");
+if (fs.existsSync(pkgPath)) {
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+  pkg.scripts ||= {};
+  if (!pkg.scripts.build) pkg.scripts.build = "vite build";
+  if (!pkg.scripts.preview) pkg.scripts.preview = "vite preview";
+  pkg.devDependencies ||= {};
+  if (!pkg.devDependencies.vite) pkg.devDependencies.vite = "^5.4.19";
+  if (!pkg.devDependencies["@vitejs/plugin-react"])
+    pkg.devDependencies["@vitejs/plugin-react"] = "^5.0.1";
+  fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
+}
+
+const cfgPath = path.join(dir, "vite.config.ts");
+if (!fs.existsSync(cfgPath)) {
+  fs.writeFileSync(
+    cfgPath,
+    `import { defineConfig } from "vite";\n` +
+      `import react from "@vitejs/plugin-react";\n\n` +
+      `export default defineConfig({\n` +
+      `  plugins: [react()],\n` +
+      `});\n`,
+  );
+}
+
+const htmlPath = path.join(dir, "index.html");
+if (!fs.existsSync(htmlPath)) {
+  fs.writeFileSync(
+    htmlPath,
+    `<!DOCTYPE html>\n` +
+      `<html lang="en">\n` +
+      `  <head>\n` +
+      `    <meta charset="UTF-8" />\n` +
+      `    <meta name="viewport" content="width=device-width, initial-scale=1.0" />\n` +
+      `    <title>Vite App</title>\n` +
+      `  </head>\n` +
+      `  <body>\n` +
+      `    <div id="root"></div>\n` +
+      `    <script type="module" src="/src/main.tsx"></script>\n` +
+      `  </body>\n` +
+      `</html>\n`,
+  );
+}


### PR DESCRIPTION
## Summary
- add script to scaffold Vite files only when missing
- include default Vite config

## Testing
- `npm run validate-env`
- `npm run setup`
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: SyntaxError in GitHub workflow YAML)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: SyntaxError in GitHub workflow YAML)*

------
https://chatgpt.com/codex/tasks/task_e_68a77b25a100832d8a8de1b20c7f863a