### PR TITLE
ci: enforce image LFS pointers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -23,7 +23,7 @@
 *.otf binary
 *.woff binary
 *.woff2 binary
-img/* binary
+img/* filter=lfs diff=lfs merge=lfs -text
 sounds/* binary
 models/* binary
 uploads/* binary

--- a/.github/workflows/lfs-guard.yml
+++ b/.github/workflows/lfs-guard.yml
@@ -1,0 +1,21 @@
+name: LFS guard
+on:
+  pull_request:
+
+jobs:
+  lfs-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.6
+        with:
+          fetch-depth: 0
+      - name: Verify LFS pointers
+        run: |
+          set -e
+          git lfs install
+          patterns=("img/*" "*.png" "*.jpg" "*.jpeg")
+          for pattern in "${patterns[@]}"; do
+            git ls-files "$pattern" | while read -r file; do
+              git lfs ls-files --error-unmatch "$file" >/dev/null 2>&1 || { echo "$file is not an LFS pointer" >&2; exit 1; }
+            done
+          done

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This repository contains the early MVP code for print2's website and backend.
 
 - The backend communicates with the Sparc3D API service.
 - The `img/` folder is now reserved strictly for image assets.
+- Image files are tracked with Git LFS. Existing history won't be rewritten; re-add any affected images through LFS in new commits.
 - HTML files in the `uploads/` directory should use the `.links` extension to avoid being served as plain text.
 
 ## Quick Start


### PR DESCRIPTION
## Summary
- track `img/` assets with Git LFS
- add workflow failing PRs when images aren't LFS pointers
- document Git LFS policy in README

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` (backend)
- `npm test` (backend)
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Error occurred when checking code style in 9 files)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html)*

------
https://chatgpt.com/codex/tasks/task_e_68a77b320e54832da94d385fd5f318f0