### PR TITLE
ci: add frontend dist presence check workflow

### DIFF
--- a/.github/workflows/frontend-dist-check.yml
+++ b/.github/workflows/frontend-dist-check.yml
@@ -1,0 +1,39 @@
+name: frontend-dist-check
+
+env:
+  HUSKY: 0
+
+on:
+  workflow_run:
+    workflows: ["Build frontend"]
+    types: [completed]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
+    steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
+      - uses: actions/checkout@v4
+      - name: Verify dist index
+        run: |
+          if [ ! -f frontend/dist/index.html ]; then
+            echo "::error::frontend/dist/index.html is missing."
+            echo "To build it locally run:"
+            echo "  pnpm enable"
+            echo "  pnpm install"
+            echo "  pnpm run build"
+            echo ""
+            echo "Ensure Vite is installed and available."
+            exit 1
+          fi
+


### PR DESCRIPTION
## Summary
- add workflow to ensure `frontend/dist/index.html` exists after frontend build or on PR
- print steps to rebuild and reminder about Vite when missing

## Testing
- `npm run format --prefix backend`【ed24e2†L1-L9】
- `npm test --prefix backend`【b98d48†L1-L20】
- `SKIP_PW_DEPS=1 npm run ci` (YAML syntax errors)【16ab50†L1-L120】
- `SKIP_PW_DEPS=1 npm run smoke` (missing dist artifact)【958287†L1-L6】

------
https://chatgpt.com/codex/tasks/task_e_68a77b3655a0832db81481cd84406578