### PR TITLE
ci: add backend-dist artifact guard

### DIFF
--- a/.github/workflows/artifact-guard.yml
+++ b/.github/workflows/artifact-guard.yml
@@ -1,0 +1,25 @@
+name: backend-dist artifact guard
+
+on:
+  workflow_call:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    outputs:
+      run-id: ${{ steps.lookup.outputs.run-id }}
+    steps:
+      - name: Lookup backend-dist artifact
+        id: lookup
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          run_id=$(curl -sSf -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/artifacts?name=backend-dist" | jq -r '.artifacts[0].workflow_run.id // empty')
+          if [ -z "$run_id" ]; then
+            echo "::error::Artifact 'backend-dist' not found. Ensure the 'Upload backend dist' step in 'Node CI' ran successfully."
+            exit 1
+          fi
+          echo "run-id=$run_id" >> "$GITHUB_OUTPUT"
+


### PR DESCRIPTION
## Summary
- add reusable workflow to verify backend-dist artifact before download

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` (backend)
- `npm test` (backend)
- `SKIP_PW_DEPS=1 npm run ci` *(fails: A collection cannot be both a mapping and a sequence)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a77b3ddbd8832d99f8688a4eded808