### PR TITLE
ci: add queue watchdog workflow

### DIFF
--- a/.github/workflows/queue-watchdog.yml
+++ b/.github/workflows/queue-watchdog.yml
@@ -1,0 +1,28 @@
+name: Queue Watchdog
+
+on:
+  workflow_dispatch:
+
+jobs:
+  queue-watchdog:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Runner availability
+        run: |
+          echo "Self-hosted runner availability:"
+          gh api repos/${{ github.repository }}/actions/runners --jq '.runners[] | "\(.name): \(.status)"' || echo "No self-hosted runners or gh api failed"
+      - name: Workflow queue length
+        run: |
+          queued=$(gh api repos/${{ github.repository }}/actions/runs --paginate -q '.workflow_runs[] | select(.status=="queued") | .id' | wc -l)
+          echo "Queued workflow runs: $queued"
+      - name: Jobs stuck over 10 minutes
+        run: |
+          cutoff=$(date -u -d '10 minutes ago' +%FT%TZ)
+          echo "Jobs started before $cutoff and still running:"
+          gh api repos/${{ github.repository }}/actions/runs?status=in_progress --paginate --jq '.workflow_runs[].id' | while read run_id; do
+            gh api repos/${{ github.repository }}/actions/runs/$run_id/jobs --jq ".jobs[] | select(.status==\"in_progress\" and .started_at < \"$cutoff\") | \"- Run $run_id job \(.name) started at \(.started_at)\""
+          done || true


### PR DESCRIPTION
## Summary
- add diagnostic queue watchdog workflow to inspect runner availability, queue length, and stuck jobs

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: SyntaxError in existing workflow YAML)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a77b4302d8832d972754ab6a7bdc5a