### PR TITLE
chore: enable browser env for frontend lint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -14,6 +14,12 @@ const globals = require("globals");
 const jsdoc = require("eslint-plugin-jsdoc");
 const tsParser = require("@typescript-eslint/parser");
 const frontend = require("./eslint.frontend-87adf32bca1e546.cjs");
+let ssrFriendly;
+try {
+  ssrFriendly = require("eslint-plugin-ssr-friendly");
+} catch {
+  ssrFriendly = null;
+}
 const isCI = Boolean(process.env.CI);
 
 module.exports = [
@@ -125,6 +131,14 @@ module.exports = [
   {
     files: ["tests/**/*"],
     rules: { "jsdoc/require-jsdoc": "off" },
+  },
+  {
+    files: ["frontend/src/**/*.{ts,tsx,js,jsx}"],
+    env: { browser: true },
+    languageOptions: {
+      globals: { ...globals.browser },
+    },
+    ...(ssrFriendly ? { plugins: { "ssr-friendly": ssrFriendly } } : {}),
   },
   ...frontend,
 ];


### PR DESCRIPTION
## Summary
- add conditional ssr-friendly plugin import in eslint config
- ensure frontend/src linting uses browser globals

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a77b3a094c832d876bd495ea81242b