### PR TITLE
test: add CI plumbing verification tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,9 @@
     "test:frontend:regression": "node scripts/run-jest.js --config tests/jest.config.js --selectProjects frontend",
     "test:ci:regression": "node scripts/run-jest.js --config tests/jest.config.js --selectProjects ci",
     "test:e2e:regression": "playwright test --config tests/playwright.config.ts",
-    "test:regression": "npm run test:backend:regression && npm run test:frontend:regression && npm run test:ci:regression && npm run test:e2e:regression"
+    "test:regression": "npm run test:backend:regression && npm run test:frontend:regression && npm run test:ci:regression && npm run test:e2e:regression",
+    "ci:probe": "bash -O globstar -c 'env -u npm_config_prefix node --test tests/ci/**/*.test.js'",
+    "ci:summary": "node scripts/ci/print-suite-summary.js"
   },
   "babel": {
     "presets": [

--- a/scripts/ci/detect-package-manager.js
+++ b/scripts/ci/detect-package-manager.js
@@ -1,0 +1,32 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const cp = require("node:child_process");
+
+function detect() {
+  const pkgPath = path.join(__dirname, "..", "..", "package.json");
+  let pm = "npm";
+  let hasPnpm = false;
+
+  try {
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+    if (
+      typeof pkg.packageManager === "string" &&
+      pkg.packageManager.startsWith("pnpm@")
+    ) {
+      pm = "pnpm";
+    }
+  } catch {
+    // ignore
+  }
+
+  try {
+    const res = cp.spawnSync("pnpm", ["--version"], { stdio: "ignore" });
+    hasPnpm = res.status === 0;
+  } catch {
+    hasPnpm = false;
+  }
+
+  return { pm, hasPnpm };
+}
+
+module.exports = detect;

--- a/scripts/ci/print-suite-summary.js
+++ b/scripts/ci/print-suite-summary.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+console.log(
+  `CI plumbing verification suite\n\nChecks for:\n- pnpm availability\n- frontend prerequisites (vite)\n- wrangler.toml Pages config\n- Git LFS pointer integrity\n- pnpm lockfile parity\n- composite action shell fields\n- CodeQL tools config\n- artifact producer/consumer contracts\n- dist output paths\n- ESLint config sanity\n- browser global usage in SSR contexts\n\nRun locally with:\n  node --test tests/ci/**/*.test.js\n`,
+);

--- a/tests/ci/README.md
+++ b/tests/ci/README.md
@@ -1,0 +1,10 @@
+# CI plumbing tests
+
+These tests validate continuous integration plumbing instead of application logic.
+Run them locally with:
+
+```
+node --test tests/ci/**/*.test.js
+```
+
+They are lightweight and require no build step.

--- a/tests/ci/action-manifest-sanity.test.js
+++ b/tests/ci/action-manifest-sanity.test.js
@@ -1,0 +1,37 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+function walk(dir, files = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) walk(path.join(dir, entry.name), files);
+    else files.push(path.join(dir, entry.name));
+  }
+  return files;
+}
+
+test("composite actions declare shell", () => {
+  const base = path.join(process.cwd(), ".github", "actions");
+  if (!fs.existsSync(base)) return test.skip("no local actions");
+  const files = walk(base).filter(
+    (f) => f.endsWith("action.yml") || f.endsWith("action.yaml"),
+  );
+  const yaml = require("yaml");
+  const missing = [];
+  for (const file of files) {
+    const doc = yaml.parse(fs.readFileSync(file, "utf8"));
+    if (doc?.runs?.using !== "composite" || !Array.isArray(doc.runs.steps))
+      continue;
+    doc.runs.steps.forEach((step, idx) => {
+      if (step.run && !step.shell) {
+        missing.push(`${file} step ${idx + 1}`);
+      }
+    });
+  }
+  if (missing.length) {
+    assert.fail(
+      `Composite action steps missing shell: ${missing.join(", ")}. Each run step must declare a shell: bash`,
+    );
+  }
+});

--- a/tests/ci/artifact-contracts.test.js
+++ b/tests/ci/artifact-contracts.test.js
@@ -1,0 +1,42 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const yaml = require("yaml");
+
+function workflowFiles(dir) {
+  return fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith(".yml") || f.endsWith(".yaml"))
+    .map((f) => path.join(dir, f));
+}
+
+test("artifact producer/consumer contracts", () => {
+  const wfDir = path.join(process.cwd(), ".github", "workflows");
+  if (!fs.existsSync(wfDir)) return test.skip("no workflows");
+  const produced = new Set();
+  const consumed = new Set();
+
+  for (const file of workflowFiles(wfDir)) {
+    const doc = yaml.parse(fs.readFileSync(file, "utf8"));
+    const jobs = doc.jobs || {};
+    for (const job of Object.values(jobs)) {
+      const steps = job.steps || [];
+      steps.forEach((step) => {
+        if (step.uses && /actions\/upload-artifact/.test(step.uses)) {
+          if (step.with && step.with.name) produced.add(String(step.with.name));
+        }
+        if (step.uses && /actions\/download-artifact/.test(step.uses)) {
+          if (step.with && step.with.name) consumed.add(String(step.with.name));
+        }
+      });
+    }
+  }
+
+  const missing = [...consumed].filter((n) => !produced.has(n));
+  if (missing.length) {
+    assert.fail(
+      `Artifact consumed but never produced: ${missing.join(", ")}. Ensure corresponding upload-artifact steps exist.`,
+    );
+  }
+});

--- a/tests/ci/browser-globals-ssr-sanity.test.js
+++ b/tests/ci/browser-globals-ssr-sanity.test.js
@@ -1,0 +1,35 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+function walk(dir, files = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) walk(path.join(dir, entry.name), files);
+    else files.push(path.join(dir, entry.name));
+  }
+  return files;
+}
+
+test("browser globals guarded for SSR", () => {
+  const base = path.join(process.cwd(), "frontend");
+  if (!fs.existsSync(base)) return test.skip("no frontend");
+  const files = walk(base).filter((f) => /\.(js|ts|tsx)$/.test(f));
+  const offenders = [];
+  files.forEach((file) => {
+    const lines = fs.readFileSync(file, "utf8").split(/\n/);
+    lines.forEach((line, idx) => {
+      if (
+        /\b(window|document|localStorage)\b/.test(line) &&
+        !/typeof\s+(window|document|localStorage)/.test(line)
+      ) {
+        offenders.push(`${file}:${idx + 1} ${line.trim()}`);
+      }
+    });
+  });
+  if (offenders.length) {
+    assert.fail(`UnGuarded browser globals:
+${offenders.join("\n")}
+Fix: wrap in typeof window !== 'undefined' guards or move to effect hooks.`);
+  }
+});

--- a/tests/ci/codeql-tools-config.test.js
+++ b/tests/ci/codeql-tools-config.test.js
@@ -1,0 +1,38 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+function walk(dir) {
+  return fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith(".yml") || f.endsWith(".yaml"))
+    .map((f) => path.join(dir, f));
+}
+
+test("CodeQL tools config", () => {
+  const wfDir = path.join(process.cwd(), ".github", "workflows");
+  if (!fs.existsSync(wfDir)) return test.skip("no workflows");
+  const yaml = require("yaml");
+  const bad = [];
+  for (const file of walk(wfDir)) {
+    const doc = yaml.parse(fs.readFileSync(file, "utf8"));
+    const jobs = doc.jobs || {};
+    for (const job of Object.values(jobs)) {
+      const steps = job.steps || [];
+      steps.forEach((step) => {
+        if (step.uses && /github\/codeql-action\/init/.test(step.uses)) {
+          const tools = step.with && step.with.tools;
+          if (tools && !/\.(tar\.gz|tar\.zst)$/.test(tools)) {
+            bad.push(`${file} -> ${tools}`);
+          }
+        }
+      });
+    }
+  }
+  if (bad.length) {
+    assert.fail(
+      `CodeQL tools misconfig: ${bad.join(", ")}. Fix: remove tools: or use an official bundle URL; do not set tools: 2.22.4.`,
+    );
+  }
+});

--- a/tests/ci/dist-outputs-contract.test.js
+++ b/tests/ci/dist-outputs-contract.test.js
@@ -1,0 +1,50 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const wfDir = path.join(process.cwd(), ".github", "workflows");
+
+test("dist output path matches workflow expectations", () => {
+  if (!fs.existsSync(wfDir)) return test.skip("no workflows");
+  let expectsDist = false;
+  for (const file of fs.readdirSync(wfDir)) {
+    if (!file.endsWith(".yml") && !file.endsWith(".yaml")) continue;
+    const content = fs.readFileSync(path.join(wfDir, file), "utf8");
+    if (
+      content.includes("frontend/dist/index.html") ||
+      content.includes("'dist/index.html")
+    ) {
+      expectsDist = true;
+      break;
+    }
+  }
+  if (!expectsDist) return test.skip("workflows do not check dist outputs");
+
+  const frontendDir = path.join(process.cwd(), "frontend");
+  if (!fs.existsSync(frontendDir)) {
+    return assert.fail(
+      "Workflows expect frontend/dist/index.html but frontend/ directory is missing. Fix: update workflows or add frontend project.",
+    );
+  }
+  const configFiles = fs
+    .readdirSync(frontendDir)
+    .filter((f) => f.startsWith("vite.config"));
+  let outDir = "dist";
+  if (configFiles.length) {
+    const cfg = fs.readFileSync(path.join(frontendDir, configFiles[0]), "utf8");
+    const m = cfg.match(/outDir\s*:\s*['"]([^'"\n]+)['"]/);
+    if (m) outDir = m[1];
+  }
+  if (outDir !== "dist") {
+    assert.fail(
+      `Workflow expects frontend/dist/index.html but vite config outputs to ${outDir}. Fix: align outDir or workflow.`,
+    );
+  }
+  const viteBin = path.join(frontendDir, "node_modules", ".bin", "vite");
+  if (!fs.existsSync(viteBin)) {
+    assert.fail(
+      "Workflow expects frontend/dist/index.html but vite not installed. Fix: add vite to frontend devDependencies or adjust workflow.",
+    );
+  }
+});

--- a/tests/ci/eslint-config-sanity.test.js
+++ b/tests/ci/eslint-config-sanity.test.js
@@ -1,0 +1,26 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const cp = require("node:child_process");
+
+test("eslint ignore migration", () => {
+  const hasIgnore = fs.existsSync(path.join(process.cwd(), ".eslintignore"));
+  const hasConfig = fs.existsSync(path.join(process.cwd(), "eslint.config.js"));
+  if (hasIgnore && hasConfig) {
+    assert.fail(
+      "Migrate ignores into eslint.config.js – .eslintignore no longer supported.",
+    );
+  }
+  const eslintBin = path.join(process.cwd(), "node_modules", ".bin", "eslint");
+  if (fs.existsSync(eslintBin)) {
+    const res = cp.spawnSync(eslintBin, ["--print-config", "package.json"], {
+      stdio: "ignore",
+    });
+    if (res.status !== 0) {
+      console.warn(
+        "eslint --print-config failed; verify eslint setup locally.",
+      );
+    }
+  }
+});

--- a/tests/ci/frontend-prereqs.test.js
+++ b/tests/ci/frontend-prereqs.test.js
@@ -1,0 +1,54 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+function rootScripts() {
+  try {
+    const pkg = JSON.parse(
+      fs.readFileSync(path.join(process.cwd(), "package.json"), "utf8"),
+    );
+    return pkg.scripts || {};
+  } catch {
+    return {};
+  }
+}
+
+const scripts = rootScripts();
+const buildScript = scripts.build || "";
+const referencesFrontend = /--prefix\s+frontend/.test(buildScript);
+
+const frontendDir = path.join(process.cwd(), "frontend");
+
+if (!fs.existsSync(frontendDir)) {
+  test("frontend directory referenced", () => {
+    if (referencesFrontend) {
+      assert.fail(
+        "root build script references frontend but frontend/ directory is missing. Fix: add frontend/ or update build step.",
+      );
+    }
+  });
+  test.skip("no frontend directory");
+} else {
+  test("frontend prerequisites", () => {
+    const pkgPath = path.join(frontendDir, "package.json");
+    if (!fs.existsSync(pkgPath)) {
+      return assert.fail(
+        "frontend/package.json missing. Fix: add frontend package manifest.",
+      );
+    }
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+    const deps = Object.assign({}, pkg.dependencies, pkg.devDependencies);
+    const hasVite = !!deps.vite;
+    if (referencesFrontend && !hasVite) {
+      assert.fail("Add vite to frontend devDependencies or update build step.");
+    }
+    const viteBin = path.join(frontendDir, "node_modules", ".bin", "vite");
+    if (referencesFrontend) {
+      assert.ok(
+        fs.existsSync(viteBin),
+        "frontend build referenced but vite binary not found. Run pnpm install in frontend/",
+      );
+    }
+  });
+}

--- a/tests/ci/git-lfs-pointers.test.js
+++ b/tests/ci/git-lfs-pointers.test.js
@@ -1,0 +1,42 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+function walk(dir, files = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      walk(path.join(dir, entry.name), files);
+    } else {
+      files.push(path.join(dir, entry.name));
+    }
+  }
+  return files;
+}
+
+test("git-lfs pointer integrity", () => {
+  const attrPath = path.join(process.cwd(), ".gitattributes");
+  const hasAttr =
+    fs.existsSync(attrPath) &&
+    /\.(png|jpe?g|gif|webp)/i.test(fs.readFileSync(attrPath, "utf8"));
+  const imgDir = path.join(process.cwd(), "img");
+  if (!hasAttr && !fs.existsSync(imgDir)) {
+    return test.skip("no images or LFS attributes to check");
+  }
+  const patterns = [".png", ".jpg", ".jpeg", ".gif", ".webp"];
+  const files = fs.existsSync(imgDir)
+    ? walk(imgDir).filter((f) =>
+        patterns.some((p) => f.toLowerCase().endsWith(p)),
+      )
+    : [];
+  const offenders = files.filter((f) => {
+    const buf = fs.readFileSync(f, { encoding: "utf8", flag: "r" });
+    return !buf.startsWith("version https://git-lfs.github.com/spec/v1");
+  });
+  if (offenders.length) {
+    const list = offenders.join(", ");
+    assert.fail(
+      `Non-LFS images detected: ${list}. Fix: git lfs migrate import --include="${offenders.join(",")}"`,
+    );
+  }
+});

--- a/tests/ci/lockfile-parity.test.js
+++ b/tests/ci/lockfile-parity.test.js
@@ -1,0 +1,32 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const lockPath = path.join(process.cwd(), "pnpm-lock.yaml");
+
+test("pnpm lockfile parity", () => {
+  if (!fs.existsSync(lockPath)) {
+    return test.skip("no pnpm-lock.yaml");
+  }
+  const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+  const deps = Object.keys(
+    Object.assign({}, pkg.dependencies, pkg.devDependencies),
+  );
+  let lock;
+  try {
+    const yaml = require("yaml");
+    lock = yaml.parse(fs.readFileSync(lockPath, "utf8"));
+  } catch (err) {
+    return assert.fail(
+      `pnpm-lock.yaml parse error: ${err.message}. Run pnpm install --no-frozen-lockfile locally and commit the updated lockfile.`,
+    );
+  }
+  const specifiers = lock?.importers?.["."]?.specifiers || {};
+  const missing = deps.filter((d) => !(d in specifiers));
+  if (missing.length) {
+    assert.fail(
+      `pnpm-lock.yaml out of sync; missing specs for: ${missing.join(", ")}. Fix: run pnpm install --no-frozen-lockfile locally and commit the updated lockfile.`,
+    );
+  }
+});

--- a/tests/ci/pnpm-availability.test.js
+++ b/tests/ci/pnpm-availability.test.js
@@ -1,0 +1,21 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const cp = require("node:child_process");
+const detect = require("../../scripts/ci/detect-package-manager");
+
+test("pnpm availability", () => {
+  const { pm, hasPnpm } = detect();
+  if (pm !== "pnpm") return test.skip("project does not require pnpm");
+  let hasCorepack = false;
+  try {
+    hasCorepack =
+      cp.spawnSync("corepack", ["--version"], { stdio: "ignore" }).status === 0;
+  } catch {
+    hasCorepack = false;
+  }
+  if (!hasPnpm && !hasCorepack) {
+    assert.fail(
+      "pnpm unavailable in CI. Fix: add pnpm/action-setup@v3 (or corepack enable) before caching, or pin packageManager in package.json.",
+    );
+  }
+});

--- a/tests/ci/wrangler-pages-config.test.js
+++ b/tests/ci/wrangler-pages-config.test.js
@@ -1,0 +1,39 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+function parseToml(str) {
+  try {
+    const toml = require("toml");
+    return toml.parse(str);
+  } catch {
+    const out = {};
+    str.split(/\n+/).forEach((line) => {
+      const m = line.match(/^\s*([^#=]+)\s*=\s*"?([^"#]+)"?/);
+      if (m) out[m[1].trim()] = m[2].trim();
+    });
+    return out;
+  }
+}
+
+const wranglerPath = path.join(process.cwd(), "wrangler.toml");
+
+test("wrangler.toml pages config", () => {
+  if (!fs.existsSync(wranglerPath)) {
+    test.skip("no wrangler.toml");
+    return;
+  }
+  const config = parseToml(fs.readFileSync(wranglerPath, "utf8"));
+  const errors = [];
+  if ("build" in config)
+    errors.push('remove "build" (Pages uses pages_build_output_dir)');
+  if (!config.name) errors.push("missing name");
+  if (!config.pages_build_output_dir)
+    errors.push("missing pages_build_output_dir");
+  if (errors.length) {
+    assert.fail(
+      `wrangler.toml invalid: ${errors.join(", ")}. See Cloudflare Pages docs for fixes.`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- add helper to detect package manager and CI plumbing test suite summary script
- introduce CI meta tests for pnpm, frontend deps, wrangler, LFS, lockfile, actions, CodeQL, artifacts, dist output, eslint, and browser globals
- expose `ci:probe` and `ci:summary` npm scripts

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci:summary`
- `npm run ci:probe` *(fails: artifact contracts parsing)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: multiple YAML syntax errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a77ee2e27c832d871e2f0eb478b10c