### PR TITLE
ci: add toolchain debug job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,3 +372,16 @@ jobs:
           first_failed=$(echo '${{ toJSON(steps) }}' | jq -r 'to_entries|map(select(.value.outcome=="failure"))|first|.value.name')
           echo '## Job outcome: 🔴 Failure' >> "$GITHUB_STEP_SUMMARY"
           echo "First failing step: ${first_failed}" >> "$GITHUB_STEP_SUMMARY"
+
+  toolchain-debug:
+    runs-on:
+      - [self-hosted, linux, aws]
+      - ubuntu-latest
+    strategy:
+      matrix:
+        tool: [pnpm, vite, eslint, jest, tsc, wrangler, aws, docker]
+    steps:
+      - name: Show tool path and version
+        run: |
+          which ${{ matrix.tool }} || true
+          ${{ matrix.tool }} --version || true


### PR DESCRIPTION
## Summary
- add toolchain-debug matrix job to display versions of key tools

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup` *(fails: process terminated while downloading Playwright dependencies)*
- `cd backend && npm run format`
- `npm test` *(fails: ensure-deps.js terminated)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: npm ci ENOTEMPTY error)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: missing frontend dist artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a7875cf548832d8b8d5c45865abebb