### PR TITLE
ci: add install-deps composite action

### DIFF
--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -1,0 +1,28 @@
+name: Install deps
+runs:
+  using: composite
+  steps:
+    - name: Ensure pnpm
+      shell: bash
+      run: |
+        if ! command -v pnpm >/dev/null 2>&1; then
+          npm install -g pnpm
+        fi
+    - name: Ensure vite
+      shell: bash
+      run: |
+        if ! command -v vite >/dev/null 2>&1; then
+          npm install -g vite
+        fi
+    - name: Ensure husky
+      shell: bash
+      run: |
+        if ! command -v husky >/dev/null 2>&1; then
+          npm install -g husky
+        fi
+    - name: Ensure wrangler
+      shell: bash
+      run: |
+        if ! command -v wrangler >/dev/null 2>&1; then
+          npm install -g wrangler
+        fi

--- a/.github/workflows/cf-pages-preview.yml
+++ b/.github/workflows/cf-pages-preview.yml
@@ -34,6 +34,7 @@ jobs:
           cache-dependency-path: |
             package-lock.json
             frontend/package-lock.json
+      - uses: ./.github/actions/install-deps
       - run: npm ci && npm run build --prefix frontend
       - name: Start preview
         id: preview

--- a/.github/workflows/ci-env.yml
+++ b/.github/workflows/ci-env.yml
@@ -26,6 +26,7 @@ jobs:
           node-version: 20
           cache: npm
           cache-dependency-path: package-lock.json
+      - uses: ./.github/actions/install-deps
       - run: npm ci
       - run: npm ci --prefix frontend
       - name: Record tool versions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,10 +198,7 @@ jobs:
           run: npm ci
         - name: Build scripts
           run: npm run ci:build-scripts
-      - name: Ensure pnpm
-        uses: ./.github/actions/ensure-pnpm
-        with:
-          cache-dependency-path: pnpm-lock.yaml
+      - uses: ./.github/actions/install-deps
       - name: Install frontend dependencies
         run: pnpm -C frontend install --no-frozen-lockfile
       - name: Run frontend tests

--- a/.github/workflows/cloudflare-preview.yml
+++ b/.github/workflows/cloudflare-preview.yml
@@ -31,6 +31,7 @@ jobs:
           cache-dependency-path: |
             package-lock.json
             frontend/package-lock.json
+      - uses: ./.github/actions/install-deps
       - run: npm ci && npm ci --prefix frontend && npm run build --prefix frontend
       - name: Run wrangler pages dev
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,6 +64,7 @@ jobs:
           node-version: 20
           cache: npm
           cache-dependency-path: package-lock.json
+      - uses: ./.github/actions/install-deps
 
       - name: Mask secrets
         env:

--- a/.github/workflows/env-parity.yml
+++ b/.github/workflows/env-parity.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+      - uses: ./.github/actions/install-deps
       - name: Record environment
         run: |
           {

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+      - uses: ./.github/actions/install-deps
       - run: npm ci && npm run build --prefix frontend
       - name: ban dist symlinks
         run: |
@@ -57,6 +58,7 @@ jobs:
           cache-dependency-path: |
             package-lock.json
             frontend/package-lock.json
+      - uses: ./.github/actions/install-deps
       - run: npm ci && npm run build --prefix frontend
       - name: ban dist symlinks
         run: |

--- a/.github/workflows/pages-preflight.yml
+++ b/.github/workflows/pages-preflight.yml
@@ -26,5 +26,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+      - uses: ./.github/actions/install-deps
       - run: node scripts/check-wrangler-pages.js
       - run: node scripts/check-asset-links.js

--- a/.github/workflows/pr-path-filters.yml
+++ b/.github/workflows/pr-path-filters.yml
@@ -13,7 +13,12 @@ jobs:
       - ubuntu-latest
     steps:
       - uses: actions/checkout@v5.0.0
-      - uses: ./.github/actions/ensure-pnpm
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+      - uses: ./.github/actions/install-deps
       - run: pnpm install --no-frozen-lockfile
       - run: pnpm lint
       - run: pnpm typecheck

--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -14,7 +14,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/ensure-pnpm
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+      - uses: ./.github/actions/install-deps
       - name: Get pnpm store directory
         id: pnpm-cache
         shell: bash

--- a/.github/workflows/test-rerun.yml
+++ b/.github/workflows/test-rerun.yml
@@ -11,7 +11,12 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5
-      - uses: ./.github/actions/ensure-pnpm
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+      - uses: ./.github/actions/install-deps
       - name: Install dependencies
         run: |
           pnpm install --no-frozen-lockfile --ignore-scripts

--- a/.github/workflows/web-matrix.yml
+++ b/.github/workflows/web-matrix.yml
@@ -31,9 +31,12 @@ jobs:
             package.json
             pnpm-lock.yaml
           sparse-checkout-cone: true
-      - uses: ./.github/actions/ensure-pnpm
+      - uses: actions/setup-node@v4
         with:
+          node-version: 20
+          cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
+      - uses: ./.github/actions/install-deps
       - name: Install dependencies
         run: |
           pnpm install --no-frozen-lockfile --ignore-scripts


### PR DESCRIPTION
## Summary
- add composite install-deps action ensuring pnpm, vite, husky, and wrangler are installed only if missing
- call install-deps at start of workflows using pnpm, Vite, or Wrangler tooling

## Testing
- `npm run format`【168a69†L1-L9】
- `npm test`【108038†L1-L10】
- `SKIP_PW_DEPS=1 npm run ci`【f906a7†L1-L9】
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html)*【1210d4†L1-L6】

------
https://chatgpt.com/codex/tasks/task_e_68a787605a98832da7f04693855d3a5f