### PR TITLE
ci: add job summary step

### DIFF
--- a/.github/actions/workflow-summary/action.yml
+++ b/.github/actions/workflow-summary/action.yml
@@ -1,0 +1,18 @@
+name: Workflow summary
+inputs:
+  needs-json:
+    description: JSON string of job results
+    required: true
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        NEEDS_JSON: ${{ inputs.needs-json }}
+      run: |
+        echo '## Workflow results' >> "$GITHUB_STEP_SUMMARY"
+        echo "$NEEDS_JSON" | jq -r '
+          to_entries | map("| \(.key) | \(.value.result) |") |
+          ["| Job | Result |", "| --- | --- |"] + . |
+          .[]
+        ' >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,3 +372,16 @@ jobs:
           first_failed=$(echo '${{ toJSON(steps) }}' | jq -r 'to_entries|map(select(.value.outcome=="failure"))|first|.value.name')
           echo '## Job outcome: 🔴 Failure' >> "$GITHUB_STEP_SUMMARY"
           echo "First failing step: ${first_failed}" >> "$GITHUB_STEP_SUMMARY"
+  summary:
+    if: always()
+    needs:
+      - build
+      - test-backend
+      - test-frontend
+      - test-integration
+      - coverage-merge
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/workflow-summary
+        with:
+          needs-json: ${{ toJSON(needs) }}

--- a/.github/workflows/selfhosted-probe.yml
+++ b/.github/workflows/selfhosted-probe.yml
@@ -41,3 +41,14 @@ jobs:
     steps:
       - name: No runner available
         run: echo "Self-hosted runner not available. Run 'terraform apply' to provision." >> "$GITHUB_STEP_SUMMARY"
+
+  summary:
+    if: always()
+    needs:
+      - probe-selfhosted
+      - timeout-notice
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/workflow-summary
+        with:
+          needs-json: ${{ toJSON(needs) }}


### PR DESCRIPTION
## Summary
- add composite action to generate job summaries
- report job results for CI and self-hosted probe workflows

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: root eslint exits 0)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: prettier could not parse multiple workflow files)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a78759f710832db2143341ed9a46fc