### PR TITLE
ci: add AWS runner health check workflow

### DIFF
--- a/.github/workflows/aws-runner-health.yml
+++ b/.github/workflows/aws-runner-health.yml
@@ -1,0 +1,28 @@
+name: AWS runner health check
+
+on:
+  workflow_dispatch:
+
+jobs:
+  health:
+    name: AWS runner health
+    runs-on: [self-hosted, linux, aws, mvp-runner]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5.0.0
+      - name: Set up Node.js
+        uses: actions/setup-node@v4.0.3
+        with:
+          node-version: 20
+          cache: "npm"
+      - name: Print environment info
+        run: |
+          cat /etc/os-release
+          node -v
+          corepack enable
+          pnpm -v
+      - name: Install dependencies and build
+        run: |
+          unset npm_config_http_proxy npm_config_https_proxy
+          npm ci
+          npm run build


### PR DESCRIPTION
## Summary
- add workflow to manually verify self-hosted AWS runner

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: SyntaxError in .github/workflows/_setup.yml)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html)*

------
https://chatgpt.com/codex/tasks/task_e_68a78763fff0832da1e922e07311aeee