### PR TITLE
ci: broaden ci workflow branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,27 +2,27 @@ name: CI
 
 on:
   push:
-    branches: [main]
-    paths:
-      - frontend/**
-      - backend/**
-      - package.json
-      - package-lock.json
-      - frontend/package-lock.json
-      - backend/package-lock.json
-      - pnpm-lock.yaml
-      - .github/workflows/**
+    branches: [main, dev, 00000production]
+    # paths: # temporarily broadened to restore coverage
+    #   - frontend/**
+    #   - backend/**
+    #   - package.json
+    #   - package-lock.json
+    #   - frontend/package-lock.json
+    #   - backend/package-lock.json
+    #   - pnpm-lock.yaml
+    #   - .github/workflows/**
   pull_request:
-    branches: [main]
-    paths:
-      - frontend/**
-      - backend/**
-      - package.json
-      - package-lock.json
-      - frontend/package-lock.json
-      - backend/package-lock.json
-      - pnpm-lock.yaml
-      - .github/workflows/**
+    branches: [main, dev, 00000production]
+    # paths: # temporarily broadened to restore coverage
+    #   - frontend/**
+    #   - backend/**
+    #   - package.json
+    #   - package-lock.json
+    #   - frontend/package-lock.json
+    #   - backend/package-lock.json
+    #   - pnpm-lock.yaml
+    #   - .github/workflows/**
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary
- run CI workflow on dev and 00000production branches for push and pull_request
- temporarily broaden workflow paths to restore coverage

## Testing
- `npm run format` (backend)
- `npm test` (backend)
- `SKIP_PW_DEPS=1 npm run ci` (failed: SyntaxError in existing workflow YAML)
- `SKIP_PW_DEPS=1 npm run smoke` (failed: missing frontend build artifact)


------
https://chatgpt.com/codex/tasks/task_e_68a78af587f4832da82a2a4a1a52793b