### PR TITLE
ci: add CI aggregate workflow

### DIFF
--- a/.github/workflows/ci-aggregate.yml
+++ b/.github/workflows/ci-aggregate.yml
@@ -1,0 +1,30 @@
+name: Full CI Aggregate
+on:
+  push:
+    branches: [dev, 00000production]
+  pull_request:
+    branches: [dev, 00000production]
+
+concurrency:
+  group: ci-${{ github.ref }}-aggregate
+  cancel-in-progress: true
+
+jobs:
+  safety:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Ensure core workflows present
+        run: |
+          missing=0
+          # List is non-blocking; only fails if truly missing. Adjust freely; this doesn’t run tests.
+          for f in codeql.yml cloudflare.yml lfs-guard.yml tests.yml backend.yml frontend.yml aws-runner-probe.yml; do
+            test -f ".github/workflows/$f" || { echo "Missing .github/workflows/$f"; missing=1; }
+          done
+          [ $missing -eq 0 ] || { echo "❌ Missing required workflows"; exit 1; }
+  manifest:
+    runs-on: ubuntu-latest
+    needs: safety
+    steps:
+      - name: Print trigger context
+        run: echo "event=${{ github.event_name }} ref=${{ github.ref }} sha=${{ github.sha }}"


### PR DESCRIPTION
## Summary
- add `ci-aggregate` workflow to provide parent CI check and core workflow verification

## Testing
- `npm run validate-env`
- `npm run format` *(fails: ENOENT rename / EEXIST)*
- `npm test` *(fails: ENOENT rename / EEXIST)*
- `npm run ci` *(fails: ENOTEMPTY during dependency installation)*
- `npm run smoke` *(fails: missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a78afe422c832d95f51801ecb63255