### PR TITLE
ci: add workflow trigger guard

### DIFF
--- a/.github/workflows/ci-sanity.yml
+++ b/.github/workflows/ci-sanity.yml
@@ -1,0 +1,21 @@
+name: CI Sanity Guard
+on:
+  push:
+    branches: [dev, 00000production]
+  pull_request:
+    branches: [dev, 00000production]
+
+jobs:
+  sanity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.3.0
+      - uses: actions/setup-node@v4.4.0
+        with: { node-version: 20 }
+      - name: Install actionlint
+        run: |
+          curl -sSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash | bash -s -- -b .bin
+      - name: Lint workflow YAMLs
+        run: ./.bin/actionlint -color
+      - name: Verify triggers exist on all workflows
+        run: node scripts/ci/verify-triggers.mjs

--- a/scripts/ci/verify-triggers.mjs
+++ b/scripts/ci/verify-triggers.mjs
@@ -1,0 +1,47 @@
+// Simple trigger verifier: ensure both push & PR include dev and 00000production
+import fs from "fs";
+import path from "path";
+import yaml from "yaml";
+
+const dir = ".github/workflows";
+const files = fs
+  .readdirSync(dir)
+  .filter((f) => f.endsWith(".yml") || f.endsWith(".yaml"));
+
+const wantBranches = ["dev", "00000production"];
+let bad = [];
+
+for (const file of files) {
+  const text = fs.readFileSync(path.join(dir, file), "utf8");
+  let doc;
+  try {
+    doc = yaml.parse(text);
+  } catch {
+    bad.push({ file, push: "(invalid yaml)", pr: "(invalid yaml)" });
+    continue;
+  }
+  const on = doc?.on || {};
+  const pushBranches = (on.push?.branches ?? []).map(String);
+  const prBranches = (on.pull_request?.branches ?? []).map(String);
+
+  const missingPush = wantBranches.some((b) => !pushBranches.includes(b));
+  const missingPR = wantBranches.some((b) => !prBranches.includes(b));
+
+  if (missingPush || missingPR) {
+    bad.push({
+      file,
+      push: pushBranches.length ? pushBranches.join(",") : "(none)",
+      pr: prBranches.length ? prBranches.join(",") : "(none)",
+    });
+  }
+}
+
+if (bad.length) {
+  console.error("❌ Workflows missing required triggers:");
+  for (const row of bad) {
+    console.error(` - ${row.file} | push:[${row.push}] pr:[${row.pr}]`);
+  }
+  process.exit(1);
+} else {
+  console.log("✅ All workflows include push+PR for dev & 00000production");
+}


### PR DESCRIPTION
## Summary
- add CI sanity guard to lint workflows and enforce push/pull_request triggers for dev and 00000production
- add trigger verification script with invalid YAML handling

## Testing
- `npm run format` *(fails: SyntaxError: A collection cannot be both a mapping and a sequence)*
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: root eslint exits 0)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html)*

------
https://chatgpt.com/codex/tasks/task_e_68a78b095628832da525bd35e14ba481