### PR TITLE
ci: add workflow check probe

### DIFF
--- a/.github/workflows/ci-probe.yml
+++ b/.github/workflows/ci-probe.yml
@@ -1,0 +1,47 @@
+name: CI Probe
+on:
+  workflow_run:
+    workflows: [ "Full CI Aggregate" ]
+    types: [ completed ]
+
+jobs:
+  verify-checks:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: read
+      statuses: read
+      actions: read
+      contents: read
+    steps:
+      - name: Determine SHA
+        id: sha
+        run: echo "sha=${{ github.event.workflow_run.head_sha }}" >> $GITHUB_OUTPUT
+
+      - name: Verify expected checks present
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHA: ${{ steps.sha.outputs.sha }}
+        run: |
+          set -euo pipefail
+          owner_repo="${GITHUB_REPOSITORY}"
+          expected=(
+            "Full CI Aggregate"
+            "CI Sanity Guard"
+            "Backend"         # e.g. jest/backend tests job name prefix
+            "Frontend"        # frontend build/tests job name prefix
+            "Cloudflare Pages"
+            "CodeQL"
+            "LFS guard"
+          )
+          # Fetch checks for this SHA
+          names=$(gh api repos/$owner_repo/commits/$SHA/check-runs --jq '.check_runs[].name' | sort -u || true)
+          echo "Found checks:"; echo "$names"
+          missing=0
+          for need in "${expected[@]}"; do
+            if ! grep -qiE "^$need" <<<"$names"; then
+              echo "MISSING: $need"
+              missing=1
+            fi
+          done
+          test $missing -eq 0 || { echo "❌ Missing expected checks"; exit 1; }
+          echo "✅ Expected checks present"


### PR DESCRIPTION
## Summary
- add CI Probe workflow to verify expected checks on completed runs

## Testing
- `npm run format` (backend)
- `npm test` (backend)
- `npm run ci` *(fails: numerous YAML syntax errors)*
- `npm run smoke` *(fails: Missing frontend build artifact)*


------
https://chatgpt.com/codex/tasks/task_e_68a78b15bbcc832da9b474090039a620