### PR TITLE
ci: add secret sentinel

### DIFF
--- a/.github/actions/secret-sentinel/action.yml
+++ b/.github/actions/secret-sentinel/action.yml
@@ -1,0 +1,29 @@
+name: Secret Sentinel
+description: Check presence of CI secrets
+inputs:
+  vars:
+    description: Space-separated list of environment variable names
+    required: true
+outputs:
+  missing:
+    description: JSON array of missing variables
+    value: ${{ steps.check.outputs.missing }}
+runs:
+  using: composite
+  steps:
+    - id: check
+      shell: bash
+      run: |
+        python - <<'PY'
+import os, json
+vars = "${{ inputs.vars }}".split()
+missing = []
+for v in vars:
+    if os.getenv(v):
+        print(f"✅ {v}")
+    else:
+        print(f"❌ {v}")
+        missing.append(v)
+with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
+    fh.write(f"missing={json.dumps(missing)}\n")
+PY

--- a/.github/workflows/ci-secrets-sentinel.yml
+++ b/.github/workflows/ci-secrets-sentinel.yml
@@ -1,0 +1,51 @@
+name: CI Secrets Sentinel
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check required secrets
+        id: scan
+        uses: ./.github/actions/secret-sentinel
+        with:
+          vars: |
+            AWS_ACCESS_KEY_ID
+            AWS_SECRET_ACCESS_KEY
+            AWS_REGION
+            CLOUDFLARE_API_TOKEN
+            CLOUDFLARE_ACCOUNT_ID
+            CF_ACCOUNT_ID
+            CF_PAGES_API_TOKEN
+            CF_PAGES_PROJECT
+            CLOUDFRONT_MODEL_DOMAIN
+            DB_URL
+            DISCORD_WEBHOOK_URL
+            HF_API_KEY
+            HF_TOKEN
+            HF_WRITE_TOKEN
+            NETLIFY_AUTH_TOKEN
+            NETLIFY_SITE_ID
+            S3_BUCKET
+            SLACK_WEBHOOK
+            SLACK_WEBHOOK_URL
+            SPARC3D_ENDPOINT
+            SPARC3D_TOKEN
+            STABILITY_KEY
+            STRIPE_SECRET_KEY
+            STRIPE_TEST_KEY
+            STRIPE_WEBHOOK_SECRET
+            COVERALLS_REPO_TOKEN
+            SNYK_TOKEN
+      - name: Summary
+        run: |
+          echo "Missing secrets: ${{ steps.scan.outputs.missing }}" >> "$GITHUB_STEP_SUMMARY"
+          if [ "${{ steps.scan.outputs.missing }}" != "[]" ]; then
+            echo "::warning::Some suites are gated on these secrets. Re-run with write permissions or trigger workflow_dispatch on a branch."
+          else
+            echo "All secrets present." >> "$GITHUB_STEP_SUMMARY"
+          fi


### PR DESCRIPTION
## Summary
- add `secret-sentinel` composite action to check CI secrets
- run secret sentinel workflow on push and pull requests

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a79ce099e8832dba95d7accdf59ecc