### PR TITLE
ci: add catalog validation

### DIFF
--- a/.github/workflows/priority.yml
+++ b/.github/workflows/priority.yml
@@ -62,6 +62,12 @@ jobs:
     needs: [lint-fast, smoke-api]
     if: ${{ always() }}
     steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Validate CI suites
+        run: node scripts/validate-ci.js
       - name: Evaluate gate
         run: |
           if [ "${{ needs.lint-fast.result }}" != "success" ] || [ "${{ needs.smoke-api.result }}" != "success" ]; then

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -7,7 +7,7 @@ on:
       runner:
         description: "Run on specific runner (e.g., self-hosted)"
         required: false
-        default: ''
+        default: ""
 
 env:
   HUSKY: 0
@@ -167,3 +167,8 @@ jobs:
             echo -e "$failed" >> "$GITHUB_STEP_SUMMARY"
             exit 1
           fi
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Validate CI suites
+        run: node scripts/validate-ci.js

--- a/ci/catalog.json
+++ b/ci/catalog.json
@@ -1,0 +1,25 @@
+{
+  "suites": [
+    {
+      "id": "frontend:lint",
+      "type": "lint",
+      "paths": ["frontend/**"],
+      "junit": "frontend/reports/junit.xml"
+    },
+    {
+      "id": "frontend:test",
+      "type": "unit",
+      "paths": ["frontend/**"],
+      "junit": "frontend/reports/junit.xml"
+    },
+    {
+      "id": "backend:test",
+      "type": "unit",
+      "paths": ["backend/**"],
+      "junit": "backend/junit.xml"
+    },
+    { "id": "types:check", "type": "types" },
+    { "id": "e2e:smoke", "type": "e2e", "reportDir": "playwright-report" },
+    { "id": "codeql:analyze", "type": "sast" }
+  ]
+}

--- a/scripts/validate-ci.js
+++ b/scripts/validate-ci.js
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+const fs = require("fs");
+const path = require("path");
+
+const repoRoot = path.resolve(__dirname, "..");
+const catalogPath = path.join(repoRoot, "ci", "catalog.json");
+const catalog = JSON.parse(fs.readFileSync(catalogPath, "utf8"));
+
+function parseList(value) {
+  if (!value) return [];
+  try {
+    const arr = JSON.parse(value);
+    return Array.isArray(arr) ? arr : [];
+  } catch {
+    return value
+      .split(/\r?\n|,/)
+      .map((s) => s.trim())
+      .filter(Boolean);
+  }
+}
+
+function match(pathname, pattern) {
+  const esc = pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(
+    "^" + esc.replace(/\*\*/g, ".*").replace(/\*/g, "[^/]*") + "$",
+  );
+  return re.test(pathname);
+}
+
+const changedFiles = parseList(process.env.CHANGED_FILES);
+const suitesRan = new Set(parseList(process.env.CI_SUITES));
+const artifacts = new Set(parseList(process.env.CI_ARTIFACTS));
+
+let ok = true;
+for (const file of changedFiles) {
+  const relevant = catalog.suites.filter((s) =>
+    (s.paths || []).some((p) => match(file, p)),
+  );
+  if (relevant.length && !relevant.some((s) => suitesRan.has(s.id))) {
+    console.error(`No suite ran for changed file ${file}`);
+    ok = false;
+  }
+}
+
+for (const suite of catalog.suites) {
+  if (!suitesRan.has(suite.id)) continue;
+  if (suite.junit && !artifacts.has(suite.junit)) {
+    console.error(`Suite ${suite.id} missing junit artifact ${suite.junit}`);
+    ok = false;
+  }
+  if (suite.reportDir && !artifacts.has(suite.reportDir)) {
+    console.error(
+      `Suite ${suite.id} missing reportDir artifact ${suite.reportDir}`,
+    );
+    ok = false;
+  }
+}
+
+if (!ok) {
+  console.error("CI validation failed");
+  process.exit(1);
+}
+console.log("CI validation passed");


### PR DESCRIPTION
## Summary
- define test suites in `ci/catalog.json`
- add `scripts/validate-ci.js` to check suites and artifacts
- run validation in regression summary and gate jobs

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Error occurred when checking code style in 9 files)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html. Run 'npm run build' and retry)*

------
https://chatgpt.com/codex/tasks/task_e_68a79cdaf924832daf1b3aa1c8df6591