### PR TITLE
ci: add pnpm sentinel workflow

### DIFF
--- a/.github/workflows/pnpm-sentinel.yml
+++ b/.github/workflows/pnpm-sentinel.yml
@@ -1,0 +1,20 @@
+name: pnpm sentinel
+
+on:
+  push:
+    branches:
+      - dev
+      - 00000production
+  pull_request:
+    branches:
+      - dev
+      - 00000production
+
+jobs:
+  sentinel:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: Ensure pnpm
+        uses: ./.github/actions/ensure-pnpm


### PR DESCRIPTION
## Summary
- add pnpm sentinel workflow to expose pnpm issues without failing CI

## Testing
- `npm run format` *(fails: `.github/workflows/_setup.yml: SyntaxError: A collection cannot be both a mapping and a sequence (37:9)`)*
- `npm test` *(backend tests pass)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: `.github/workflows/_setup.yml: SyntaxError: A collection cannot be both a mapping and a sequence (37:9)`)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: `Missing frontend build artifact: frontend/dist/index.html. Run 'npm run build' and retry`)*

------
https://chatgpt.com/codex/tasks/task_e_68a79ac407ec832db734582705987464