### PR TITLE
ci: add pnpm safe install action

### DIFF
--- a/.github/actions/pnpm-safe-install/action.yml
+++ b/.github/actions/pnpm-safe-install/action.yml
@@ -1,0 +1,20 @@
+name: pnpm safe install
+runs:
+  using: composite
+  steps:
+    - run: corepack enable
+      shell: bash
+    - run: corepack prepare pnpm@latest --activate
+      shell: bash
+    - run: |
+        echo "PNPM_HOME=$HOME/.local/share/pnpm" >> $GITHUB_ENV
+        echo "$HOME/.local/share/pnpm" >> $GITHUB_PATH
+      shell: bash
+    - name: Install dependencies
+      shell: bash
+      run: |
+        if [ -f pnpm-lock.yaml ]; then
+          pnpm install --no-frozen-lockfile
+        else
+          echo "pnpm-lock.yaml not found, skipping pnpm install"
+        fi


### PR DESCRIPTION
## Summary
- add pnpm-safe-install composite action that sets up pnpm and installs deps when lockfile exists

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: ESLint diagnostic log missing)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Prettier YAML parsing errors)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: frontend build artifact missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a79ac0b6ec832d9535bb5465655ca7