### PR TITLE
ci: add Cloudflare Pages deploy script

### DIFF
--- a/scripts/deploy-cf-pages.sh
+++ b/scripts/deploy-cf-pages.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+if [ ! -f frontend/dist/index.html ]; then
+  echo "No frontend/dist/index.html; skipping Cloudflare Pages deployment."
+  exit 0
+fi
+
+if [ -z "$CF_PAGES_API_TOKEN" ] || [ -z "$CF_ACCOUNT_ID" ] || [ -z "$CF_PAGES_PROJECT" ]; then
+  echo "CF_PAGES_API_TOKEN, CF_ACCOUNT_ID, and CF_PAGES_PROJECT must be set" >&2
+  exit 1
+fi
+
+npx wrangler pages deploy frontend/dist --project-name "$CF_PAGES_PROJECT"
+


### PR DESCRIPTION
## Summary
- add script to deploy `frontend/dist` to Cloudflare Pages when build exists and credentials provided

## Testing
- `npm run format` (backend)
- `npm test` (backend)
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Error occurred when checking code style in 9 files)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68a79ab96eb4832d83c78adcad053147