### PR TITLE
ci: add queue watchdog workflow

### DIFF
--- a/.github/workflows/queue-watchdog.yml
+++ b/.github/workflows/queue-watchdog.yml
@@ -1,28 +1,13 @@
 name: Queue Watchdog
 
 on:
-  workflow_dispatch:
+  workflow_run:
+    workflows: ["CI Full Suite (compat)", "CI Auditor", "Full CI Aggregate / safety", "CI Sanity Guard / sanity"]
+    types: [requested]
 
 jobs:
-  queue-watchdog:
+  watchdog:
     runs-on: ubuntu-latest
-    permissions:
-      actions: read
-    env:
-      GH_TOKEN: ${{ github.token }}
+    continue-on-error: true
     steps:
-      - name: Runner availability
-        run: |
-          echo "Self-hosted runner availability:"
-          gh api repos/${{ github.repository }}/actions/runners --jq '.runners[] | "\(.name): \(.status)"' || echo "No self-hosted runners or gh api failed"
-      - name: Workflow queue length
-        run: |
-          queued=$(gh api repos/${{ github.repository }}/actions/runs --paginate -q '.workflow_runs[] | select(.status=="queued") | .id' | wc -l)
-          echo "Queued workflow runs: $queued"
-      - name: Jobs stuck over 10 minutes
-        run: |
-          cutoff=$(date -u -d '10 minutes ago' +%FT%TZ)
-          echo "Jobs started before $cutoff and still running:"
-          gh api repos/${{ github.repository }}/actions/runs?status=in_progress --paginate --jq '.workflow_runs[].id' | while read run_id; do
-            gh api repos/${{ github.repository }}/actions/runs/$run_id/jobs --jq ".jobs[] | select(.status==\"in_progress\" and .started_at < \"$cutoff\") | \"- Run $run_id job \(.name) started at \(.started_at)\""
-          done || true
+      - uses: print3d/queue-watchdog@v0


### PR DESCRIPTION
## Summary
- add queue watchdog workflow triggered by key CI runs

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: SyntaxError in existing workflow YAML)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a79ab553a8832dbabf343ba3a5c9b5