### PR TITLE
ci: warn on missing expected jobs

### DIFF
--- a/.github/workflows/ci-full-suite-compat.yml
+++ b/.github/workflows/ci-full-suite-compat.yml
@@ -1,0 +1,45 @@
+name: ci-full-suite-compat
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  summarize:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: gather
+        id: gather
+        run: |
+          expected=$(jq -r '.expected[]' ci/expected-jobs.json)
+          echo "expected<<EOF" >> $GITHUB_OUTPUT
+          echo "$expected" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+          curl -s -H "Authorization: Bearer ${{ github.token }}" "${{ github.event.workflow_run.jobs_url }}?per_page=100" \
+            | jq -r '.jobs[].name' > ran.txt
+          echo "ran<<EOF" >> $GITHUB_OUTPUT
+          cat ran.txt >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+      - name: summarize
+        run: |
+          echo '| Job | Status |' >> $GITHUB_STEP_SUMMARY
+          echo '| --- | --- |' >> $GITHUB_STEP_SUMMARY
+          missing=()
+          while read job; do
+            if grep -Fxq "$job" <<<"${{ steps.gather.outputs.ran }}"; then
+              echo "| $job | present |" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "| $job | missing |" >> $GITHUB_STEP_SUMMARY
+              missing+=("$job")
+            fi
+          done <<< "${{ steps.gather.outputs.expected }}"
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::warning::Missing jobs: ${missing[*]}"
+          fi

--- a/ci/expected-jobs.json
+++ b/ci/expected-jobs.json
@@ -1,0 +1,11 @@
+{
+  "expected": [
+    "frontend:lint",
+    "frontend:build",
+    "frontend:test",
+    "backend:test",
+    "types:check",
+    "e2e:smoke",
+    "codeql:analyze"
+  ]
+}


### PR DESCRIPTION
## Summary
- list expected CI jobs in ci/expected-jobs.json
- summarize upstream run and warn on missing expected jobs

## Testing
- `npm run format`
- `npm test`
- `npm run ci` *(fails: SyntaxError: Nested mappings are not allowed in compact mappings (85:14))*
- `npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html. Run 'npm run build' and retry)*

------
https://chatgpt.com/codex/tasks/task_e_68a79aa45740832d9a7c2ee68983cd71