### PR TITLE
ci: guard against LFS in frontend

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -28,3 +28,6 @@ sounds/* binary
 models/* binary
 uploads/* binary
 upload/* binary
+
+frontend/** -filter=lfs -diff=lfs -merge=lfs
+frontend/public/** -filter=lfs -diff=lfs -merge=lfs

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,6 +81,14 @@ jobs:
       - name: Verify dist output
         run: node scripts/assert-frontend-dist.js
 
+      - name: Ensure dist contains no LFS pointers
+        run: |
+          git lfs install
+          if grep -RIl "https://git-lfs.github.com/spec/v1" frontend/dist; then
+            echo "Git LFS pointers found in build output. Commit real assets or host them externally."
+            exit 1
+          fi
+
       - name: Copy dist without symlinks
         run: cp -aL frontend/dist/. pages_dist/
 

--- a/.github/workflows/lfs-guard.yml
+++ b/.github/workflows/lfs-guard.yml
@@ -1,6 +1,7 @@
 name: LFS guard
 on:
   pull_request:
+  push:
 
 jobs:
   lfs-guard:
@@ -9,13 +10,16 @@ jobs:
       - uses: actions/checkout@v4.1.6
         with:
           fetch-depth: 0
-      - name: Verify LFS pointers
+      - name: Fail on LFS pointers in frontend paths
         run: |
           set -e
           git lfs install
-          patterns=("img/*" "*.png" "*.jpg" "*.jpeg")
-          for pattern in "${patterns[@]}"; do
-            git ls-files "$pattern" | while read -r file; do
-              git lfs ls-files --error-unmatch "$file" >/dev/null 2>&1 || { echo "$file is not an LFS pointer" >&2; exit 1; }
-            done
-          done
+          pointer_files=$(git ls-files frontend public assets 2>/dev/null | xargs -r grep -l 'version https://git-lfs.github.com/spec/v1' || true)
+          if [ -n "$pointer_files" ]; then
+            echo "Git LFS pointers detected in frontend build paths:"
+            echo "$pointer_files"
+            echo
+            echo "Please commit real assets or host them in S3/CDN instead of using Git LFS for the frontend."
+            exit 1
+          fi
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,7 @@ Thank you for helping improve this project! Please follow these steps to keep ou
 2. Format code in `backend/` with `npm run format` and ensure linting passes via `npm run ci`.
 3. Execute `npm test` and, if possible, `npm run smoke` before opening the PR.
 4. Open a PR against the `dev` branch and request review.
+5. Do not use Git LFS for files under `frontend/`. Commit real assets or host large files externally (e.g., S3/CDN).
 
 ## Tests
 


### PR DESCRIPTION
## Summary
- enforce no Git LFS pointers in frontend build paths
- document that frontend assets must not use LFS
- ensure deploy fails if LFS pointers reach build output

## Testing
- `npm run format`
- `npm test`
- `npm run ci` *(fails: SyntaxError in multiple workflow YAML files)*
- `npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html)*

------
https://chatgpt.com/codex/tasks/task_e_68a79875999c832d954293413ed527f1