### PR TITLE
ci: deploy frontend to Cloudflare Pages

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,52 @@
+name: Deploy Pages
+
+on:
+  push:
+    branches:
+      - 00000production
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    name: Deploy Pages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.7
+        with:
+          lfs: true
+      - name: Git LFS fetch
+        run: |
+          git lfs install
+          git lfs fetch --all
+          git lfs checkout
+      - name: Setup Node.js
+        uses: actions/setup-node@v4.0.3
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            frontend/package-lock.json
+      - name: Install dependencies and build
+        run: |
+          npm ci
+          npm run build --prefix frontend
+      - name: Verify build output
+        run: |
+          if [ ! -d frontend/dist ]; then
+            echo "Error: frontend/dist directory not found" >&2
+            exit 1
+          fi
+          if [ ! -f frontend/dist/index.html ]; then
+            echo "Error: frontend/dist/index.html not found" >&2
+            exit 1
+          fi
+      - name: Install Wrangler
+        run: npm i -g wrangler
+      - name: Deploy to Cloudflare Pages
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: wrangler pages deploy frontend/dist --project-name "<YOUR_PAGES_PROJECT_NAME>"
+      - name: Summarize deployment
+        run: echo "Deployed commit $GITHUB_SHA" >> "$GITHUB_STEP_SUMMARY"

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,6 +1,1 @@
-name = "mvp-website"
 pages_build_output_dir = "frontend/dist"
-compatibility_date = "2024-12-01"
-
-[vars]
-NODE_ENV = "production"


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and deploy frontend to Cloudflare Pages
- slim wrangler.toml to only declare Pages build output

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: SyntaxError in existing workflow YAML)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: frontend/dist/index.html missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a7986b4498832dbeddacec901f165f