### PR TITLE
infra: AWS self-hosted GitHub runners (spot, ephemeral)

### DIFF
--- a/.github/workflows/selfhosted-prefer.yml
+++ b/.github/workflows/selfhosted-prefer.yml
@@ -1,0 +1,14 @@
+name: Self-hosted preference
+on:
+  workflow_call:
+    inputs:
+      label: { required: false, type: string, default: "aws-spot-x64" }
+      fallback: { required: false, type: string, default: "ubuntu-latest" }
+jobs:
+  choose:
+    runs-on: ${{ inputs.fallback }}
+    steps:
+      - id: decide
+        run: echo "label=${{ inputs.label }}" >> $GITHUB_OUTPUT
+    outputs:
+      label: ${{ steps.decide.outputs.label }}

--- a/infra/aws/github-runners/terraform/README.md
+++ b/infra/aws/github-runners/terraform/README.md
@@ -1,0 +1,24 @@
+# AWS GitHub Runners
+
+Terraform configuration for on‑demand ephemeral runners using [philips-labs/terraform-aws-github-runner](https://registry.terraform.io/modules/philips-labs/github-runner/aws/latest).
+
+## Usage
+
+```sh
+terraform init
+terraform apply \
+  -var "github_app_id=0000" \
+  -var "github_app_private_key=$(base64 < path/to/private-key.pem)" \
+  -var "github_owner=your-org" \
+  -var "github_repo=your-repo"
+```
+
+## Required GitHub App secrets
+
+Create a GitHub App with access to the repository. Record:
+
+- **App ID**
+- **Private key** (base64 encoded)
+- **Owner** and **repository** names
+
+Pass these values via `terraform apply` as shown above or via a `terraform.tfvars` file.

--- a/infra/aws/github-runners/terraform/main.tf
+++ b/infra/aws/github-runners/terraform/main.tf
@@ -1,0 +1,48 @@
+terraform {
+  required_version = ">= 1.3"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  owners      = ["099720109477"]
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
+  }
+}
+
+module "github_runners" {
+  source  = "philips-labs/github-runner/aws"
+  version = "6.1.0"
+
+  aws_region = var.aws_region
+
+  github_app = {
+    id         = var.github_app_id
+    key_base64 = var.github_app_private_key
+  }
+
+  repository_white_list = ["${var.github_owner}/${var.github_repo}"]
+
+  runner_extra_labels = [var.runner_label]
+  runners_maximum_count = var.max_runners
+  instance_types        = [var.instance_type]
+  instance_target_capacity_type = var.spot ? "spot" : "on-demand"
+
+  ami_filter = {
+    name  = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
+    state = ["available"]
+  }
+  ami_owners = ["099720109477"]
+}

--- a/infra/aws/github-runners/terraform/outputs.tf
+++ b/infra/aws/github-runners/terraform/outputs.tf
@@ -1,0 +1,9 @@
+output "runners" {
+  description = "Details about the created runners"
+  value       = module.github_runners.runners
+}
+
+output "webhook" {
+  description = "Webhook configuration for GitHub App"
+  value       = module.github_runners.webhook
+}

--- a/infra/aws/github-runners/terraform/variables.tf
+++ b/infra/aws/github-runners/terraform/variables.tf
@@ -1,0 +1,62 @@
+variable "aws_region" {
+  description = "AWS region to deploy runners in"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "github_app_id" {
+  description = "GitHub App ID"
+  type        = string
+}
+
+variable "github_app_private_key" {
+  description = "Base64-encoded GitHub App private key"
+  type        = string
+  sensitive   = true
+}
+
+variable "github_owner" {
+  description = "GitHub organization or user name"
+  type        = string
+}
+
+variable "github_repo" {
+  description = "GitHub repository name"
+  type        = string
+}
+
+variable "runner_label" {
+  description = "Label used to target these runners"
+  type        = string
+  default     = "aws-spot-x64"
+}
+
+variable "min_runners" {
+  description = "Minimum number of runners to keep idle"
+  type        = number
+  default     = 0
+}
+
+variable "max_runners" {
+  description = "Maximum number of runners"
+  type        = number
+  default     = 5
+}
+
+variable "instance_type" {
+  description = "EC2 instance type for runners"
+  type        = string
+  default     = "t3.large"
+}
+
+variable "spot" {
+  description = "Use spot instances"
+  type        = bool
+  default     = true
+}
+
+variable "ami" {
+  description = "Runner AMI selection"
+  type        = string
+  default     = "ubuntu-22.04"
+}


### PR DESCRIPTION
## Summary
- add Terraform config for spot-based GitHub runners
- add reusable workflow to prefer self-hosted runners

## Testing
- `npm run format`
- `npm test`
- `npm run ci` *(fails: YAML SyntaxError in existing workflow files)*
- `npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a634cba4832db34b753c3ed4ac61