### PR TITLE
ci: broaden workflow triggers

### DIFF
--- a/.github/workflows/auto_rebase_merge_queue.yml
+++ b/.github/workflows/auto_rebase_merge_queue.yml
@@ -4,7 +4,14 @@ env:
   HUSKY: 0
 
 on:
+  push:
+    branches:
+      - dev
+      - 00000production
   pull_request:
+    branches:
+      - dev
+      - 00000production
     types: [ opened, synchronize, reopened ]
 
 permissions:

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -4,11 +4,14 @@ env:
   HUSKY: 0
 
 on:
+  push:
+    branches:
+      - dev
+      - 00000production
   pull_request:
-    paths:
-      - 'frontend/**'
-      - '!docs/**'
-      - 'package.json'
+    branches:
+      - dev
+      - 00000production
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -19,8 +22,6 @@ jobs:
     runs-on:
       - [self-hosted, linux, aws]
       - ubuntu-latest
-    if: ${{ matrix.node != 22 || contains(github.event.pull_request.labels.*.name,
-      'full-matrix') }}
     continue-on-error: ${{ matrix.node == 22 }}
     defaults:
       run:
@@ -32,21 +33,29 @@ jobs:
         shard: [ 1, 2, 3 ]
     steps:
       - name: Heartbeat
+        if: ${{ matrix.node != 22 || contains(github.event.pull_request.labels.*.name, 'full-matrix') }}
         run: |
           while true; do date; sleep 120; done &
       - uses: actions/checkout@v4
+        if: ${{ matrix.node != 22 || contains(github.event.pull_request.labels.*.name, 'full-matrix') }}
       - uses: actions/setup-node@v4
+        if: ${{ matrix.node != 22 || contains(github.event.pull_request.labels.*.name, 'full-matrix') }}
         with:
           node-version: ${{ matrix.node }}
           cache: npm
           cache-dependency-path: frontend/package-lock.json
       - run: npm ci
+        if: ${{ matrix.node != 22 || contains(github.event.pull_request.labels.*.name, 'full-matrix') }}
       - run: npm run lint
-        if: ${{ matrix.shard == 1 }}
+        if: ${{ (matrix.node != 22 || contains(github.event.pull_request.labels.*.name, 'full-matrix')) && matrix.shard == 1 }}
       - run: npm run build -- --ssr.split=${{ matrix.shard }}/3
+        if: ${{ matrix.node != 22 || contains(github.event.pull_request.labels.*.name, 'full-matrix') }}
       - run: test -d dist
+        if: ${{ matrix.node != 22 || contains(github.event.pull_request.labels.*.name, 'full-matrix') }}
       - run: node ../scripts/assert-frontend-dist.js
+        if: ${{ matrix.node != 22 || contains(github.event.pull_request.labels.*.name, 'full-matrix') }}
       - uses: actions/upload-artifact@v4
+        if: ${{ matrix.node != 22 || contains(github.event.pull_request.labels.*.name, 'full-matrix') }}
         with:
           name: frontend-dist-${{ matrix.node }}-${{ matrix.shard }}
           path: frontend/dist

--- a/.github/workflows/pnpm-guard.yml
+++ b/.github/workflows/pnpm-guard.yml
@@ -1,14 +1,19 @@
 name: pnpm guard
 
 on:
+  push:
+    branches:
+      - dev
+      - 00000production
+  pull_request:
+    branches:
+      - dev
+      - 00000production
   workflow_call:
 
 jobs:
   install:
     runs-on: ubuntu-latest
     steps:
-      - run: corepack enable
-      - uses: pnpm/action-setup@v4.0.0
-        with:
-          version: 8.15.8
+      - run: corepack enable && pnpm -v
       - run: pnpm install --no-frozen-lockfile

--- a/.github/workflows/skip-heavy.yml
+++ b/.github/workflows/skip-heavy.yml
@@ -4,15 +4,22 @@ name: Skip heavy
 # Heavy jobs should use `if: "! contains(github.event.pull_request.labels.*.name, 'skip-heavy')"` to honor the label.
 
 on:
+  push:
+    branches:
+      - dev
+      - 00000production
   pull_request:
+    branches:
+      - dev
+      - 00000production
 
 jobs:
   skip-heavy:
-    if: contains(github.event.pull_request.labels.*.name, 'skip-heavy')
     runs-on:
       - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
-      - run: |
+      - if: contains(github.event.pull_request.labels.*.name, 'skip-heavy')
+        run: |
           echo "skip-heavy label present, skipping heavy workflows"
           exit 0


### PR DESCRIPTION
## Summary
- ensure workflows run on pushes to dev and 00000production and on pull requests
- move label gating to steps and drop path filters
- setup pnpm with corepack before install

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup` *(fails: long Playwright browser downloads)*
- `npm run format` *(backend)*
- `npm test` *(fails: setup interrupted)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: setup interrupted)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a7ac7564d0832dae3ec4adf0d7b729