### PR TITLE
ci: add workflow trigger auditor

### DIFF
--- a/.github/workflows/ci-trigger-auditor.yml
+++ b/.github/workflows/ci-trigger-auditor.yml
@@ -1,0 +1,20 @@
+name: CI Trigger Auditor
+
+on:
+  push:
+    branches: [dev, 00000production]
+  pull_request:
+    branches: [dev, 00000production]
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.7
+      - uses: actions/setup-node@v4.0.3
+        with:
+          node-version: 20
+      - name: Install deps
+        run: npm install --no-save --no-package-lock yaml@2
+      - name: Audit workflows
+        run: node scripts/ci-trigger-auditor.mjs

--- a/scripts/ci-trigger-auditor.mjs
+++ b/scripts/ci-trigger-auditor.mjs
@@ -1,0 +1,91 @@
+import fs from "node:fs";
+import path from "node:path";
+import yaml from "yaml";
+
+const requiredBranches = ["dev", "00000production"];
+const workflowsDir = path.join(process.cwd(), ".github", "workflows");
+
+function hasRequiredBranches(trigger) {
+  if (!trigger) return false;
+  let branches = trigger.branches;
+  if (!branches) return false;
+  if (typeof branches === "string") branches = [branches];
+  if (!Array.isArray(branches)) return false;
+  return requiredBranches.every((b) => branches.includes(b));
+}
+
+function checkPaths(obj) {
+  return (
+    obj &&
+    (Object.prototype.hasOwnProperty.call(obj, "paths") ||
+      Object.prototype.hasOwnProperty.call(obj, "paths-ignore"))
+  );
+}
+
+const files = fs
+  .readdirSync(workflowsDir)
+  .filter(
+    (f) =>
+      (f.endsWith(".yml") || f.endsWith(".yaml")) &&
+      !f.startsWith("_") &&
+      f !== "ci-trigger-auditor.yml",
+  );
+let failures = [];
+
+for (const file of files) {
+  const fullPath = path.join(workflowsDir, file);
+  const content = fs.readFileSync(fullPath, "utf8");
+  let doc;
+  try {
+    doc = yaml.parse(content);
+  } catch (err) {
+    failures.push(
+      `--- a/.github/workflows/${file}\n+++ b/.github/workflows/${file}\n@@ Parse error\n- ${err.message}`,
+    );
+    continue;
+  }
+  const fileDiffs = [];
+  const triggers = doc.on || {};
+  const push = triggers.push;
+  const pr = triggers.pull_request;
+  if (!hasRequiredBranches(push)) {
+    fileDiffs.push(
+      "@@ Missing push trigger\n- push trigger with dev and 00000production not found\n+ push:\n+   branches:\n+     - dev\n+     - 00000production",
+    );
+  }
+  if (!hasRequiredBranches(pr)) {
+    fileDiffs.push(
+      "@@ Missing pull_request trigger\n- pull_request trigger with dev and 00000production not found\n+ pull_request:\n+   branches:\n+     - dev\n+     - 00000production",
+    );
+  }
+  if (checkPaths(triggers)) {
+    fileDiffs.push(
+      "@@ Risky top-level path filters\n- paths or paths-ignore at top level\n+ remove top-level paths filters",
+    );
+  }
+  for (const [eventName, config] of Object.entries(triggers)) {
+    if (checkPaths(config)) {
+      fileDiffs.push(
+        `@@ Risky path filters for on.${eventName}\n- contains paths or paths-ignore\n+ remove path filters to avoid skipping builds`,
+      );
+    }
+  }
+  const jobs = doc.jobs || {};
+  for (const [jobName, job] of Object.entries(jobs)) {
+    if (Object.prototype.hasOwnProperty.call(job, "if")) {
+      fileDiffs.push(
+        `@@ Job-level conditional in ${jobName}\n- if: ${job.if}\n+ remove job-level if to ensure registration`,
+      );
+    }
+  }
+  if (fileDiffs.length) {
+    failures.push(
+      `--- a/.github/workflows/${file}\n+++ b/.github/workflows/${file}\n${fileDiffs.join("\n")}\n`,
+    );
+  }
+}
+
+if (failures.length) {
+  console.error(failures.join("\n"));
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add CI trigger auditor workflow that scans workflow files for missing dev/00000production triggers, risky path filters, and job-level conditionals

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Error occurred when checking code style in 11 files)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a7af075c84832d94e16b92feab1d8a