### PR TITLE
ci: add node setup action and lockfile enforcer

### DIFF
--- a/.github/actions/node-setup/action.yml
+++ b/.github/actions/node-setup/action.yml
@@ -1,0 +1,32 @@
+name: Node setup
+runs:
+  using: composite
+  steps:
+    - name: Enable Corepack and set PNPM_HOME
+      shell: bash
+      run: |
+        corepack enable
+        echo "PNPM_HOME=$HOME/.local/share/pnpm" >> $GITHUB_ENV
+        echo "$HOME/.local/share/pnpm" >> $GITHUB_PATH
+    - name: Ensure pnpm
+      shell: bash
+      run: |
+        if ! command -v pnpm >/dev/null 2>&1; then
+          corepack prepare pnpm@latest --activate
+        fi
+    - name: Refresh lockfile if needed
+      shell: bash
+      run: |
+        if ! pnpm install --frozen-lockfile --lockfile-only >/dev/null 2>&1; then
+          echo 'pnpm-lock.yaml is out of sync with package.json. Running pnpm install --no-frozen-lockfile.'
+          pnpm install --no-frozen-lockfile
+        fi
+    - name: Ensure vite in frontend devDependencies
+      shell: bash
+      run: |
+        if [ -f frontend/package.json ]; then
+          if ! node -e "const pkg=require('./frontend/package.json'); process.exit(pkg.devDependencies && pkg.devDependencies.vite ? 0 : 1);"; then
+            echo '::error::frontend workspace missing devDependency "vite". Run "npm i -D vite" in frontend' >&2
+            exit 1
+          fi
+        fi

--- a/.github/workflows/pnpm-lock-enforcer.yml
+++ b/.github/workflows/pnpm-lock-enforcer.yml
@@ -1,0 +1,39 @@
+name: pnpm lockfile enforcer
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    env:
+      HUSKY: 0
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - uses: ./.github/actions/node-setup
+      - name: Refresh lockfile if stale
+        id: refresh
+        run: |
+          if pnpm install --frozen-lockfile --lockfile-only; then
+            echo "updated=false" >> $GITHUB_OUTPUT
+          else
+            pnpm install --no-frozen-lockfile --ignore-scripts
+            echo "updated=true" >> $GITHUB_OUTPUT
+          fi
+      - name: Create Pull Request
+        if: steps.refresh.outputs.updated == 'true'
+        uses: peter-evans/create-pull-request@v6.1.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: refresh pnpm lockfile"
+          title: "chore: refresh pnpm lockfile"
+          body: Refresh pnpm lockfile
+          branch: chore/pnpm-lock-refresh
+          add-paths: pnpm-lock.yaml

--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -19,6 +19,7 @@ jobs:
           node-version: 20
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
+      - uses: ./.github/actions/node-setup
       - uses: ./.github/actions/install-deps
       - name: Get pnpm store directory
         id: pnpm-cache

--- a/.github/workflows/test-rerun.yml
+++ b/.github/workflows/test-rerun.yml
@@ -16,6 +16,7 @@ jobs:
           node-version: 20
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
+      - uses: ./.github/actions/node-setup
       - uses: ./.github/actions/install-deps
       - name: Install dependencies
         run: |

--- a/.github/workflows/test-timeout.yml
+++ b/.github/workflows/test-timeout.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           node-version: 20
           cache: pnpm
+      - uses: ./.github/actions/node-setup
       - name: Install dependencies
         run: |
           corepack enable

--- a/.github/workflows/test-watchdog.yml
+++ b/.github/workflows/test-watchdog.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+      - uses: ./.github/actions/node-setup
 
       - name: Install tooling (root only, no project install)
         run: |


### PR DESCRIPTION
## Summary
- add node-setup composite action to manage pnpm and verify frontend vite
- run node-setup in test workflows
- introduce pnpm lockfile enforcer workflow

## Testing
- `npm run format` (backend)
- `npm test` (backend)
- `SKIP_PW_DEPS=1 npm run ci` (fails: SyntaxError: Implicit map keys need to be followed by map values in .github/actions/secret-sentinel/action.yml)
- `SKIP_PW_DEPS=1 npm run smoke` (fails: Missing frontend build artifact: frontend/dist/index.html)


------
https://chatgpt.com/codex/tasks/task_e_68a7af0eda3c832da72810e5185bf4ae