### PR TITLE
ci: add coverage workflow and size-limit checks

### DIFF
--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -1,0 +1,56 @@
+name: ci-coverage
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.6
+      - name: Use Node.js
+        uses: actions/setup-node@v4.0.3
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: lint placeholder
+        run: echo "lint step placeholder"
+      - name: Run backend tests
+        run: npm run coverage --prefix backend
+      - name: Run frontend tests
+        run: npm test --prefix frontend -- --coverage --runInBand
+      - name: Merge coverage
+        run: |
+          npx lcov-result-merger "backend/coverage/lcov.info" "frontend/coverage/lcov.info" > coverage/lcov.info
+      - name: Enforce coverage thresholds
+        run: node scripts/enforce-test-coverage.mjs
+        env:
+          COVERAGE_THRESHOLDS_PATH: ci/coverage-thresholds.json
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4.3.1
+        with:
+          name: lcov
+          path: coverage/lcov.info
+
+  size-limit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.6
+      - name: Use Node.js
+        uses: actions/setup-node@v4.0.3
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Run size-limit
+        uses: andresz1/action-size-limit@v2.7.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          config_path: ci/size-limit.config.cjs

--- a/ci/coverage-thresholds.json
+++ b/ci/coverage-thresholds.json
@@ -1,0 +1,6 @@
+{
+  "branches": 70,
+  "functions": 75,
+  "lines": 80,
+  "statements": 80
+}

--- a/ci/expected-jobs.json
+++ b/ci/expected-jobs.json
@@ -6,6 +6,8 @@
     "backend:test",
     "types:check",
     "e2e:smoke",
-    "codeql:analyze"
+    "codeql:analyze",
+    "coverage",
+    "size-limit"
   ]
 }

--- a/ci/size-limit.config.cjs
+++ b/ci/size-limit.config.cjs
@@ -1,0 +1,10 @@
+const { file } = require("@size-limit/file");
+
+module.exports = [
+  {
+    name: "frontend bundle",
+    path: "frontend/dist/assets/*.js",
+    limit: "200 KB",
+    plugins: [file],
+  },
+];

--- a/scripts/enforce-test-coverage.mjs
+++ b/scripts/enforce-test-coverage.mjs
@@ -5,7 +5,16 @@ async function main() {
   const pkg = JSON.parse(
     await readFile(new URL("../package.json", import.meta.url)),
   );
-  const thresholds = pkg.coverageThreshold || {};
+  const thresholds = process.env.COVERAGE_THRESHOLDS_PATH
+    ? JSON.parse(
+        await readFile(
+          new URL(
+            `../${process.env.COVERAGE_THRESHOLDS_PATH}`,
+            import.meta.url,
+          ),
+        ),
+      )
+    : pkg.coverageThreshold || {};
   const lcov = await readFile(
     new URL("../coverage/lcov.info", import.meta.url),
     "utf8",


### PR DESCRIPTION
## Summary
- add coverage workflow merging backend and frontend coverage and enforcing thresholds
- track bundle size with size-limit and comment on regressions
- allow external coverage threshold configuration

## Testing
- `npm test --prefix backend` (fails: linting diagnostics)
- `npm run format`
- `SKIP_PW_DEPS=1 npm run ci` (fails: formatting check)
- `SKIP_PW_DEPS=1 npm run smoke` (fails: Missing frontend build artifact)


------
https://chatgpt.com/codex/tasks/task_e_68a7af11fb2c832db7c4b8f64661d211