### PR TITLE
ci: add flaky retries and e2e workflow

### DIFF
--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -1,0 +1,35 @@
+name: e2e Playwright
+
+env:
+  HUSKY: 0
+
+on:
+  push:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    runs-on:
+      - [self-hosted, linux, aws]
+      - ubuntu-latest
+    timeout-minutes: 30
+    retries: 2
+    steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            backend/package-lock.json
+            frontend/package-lock.json
+      - run: npm run setup
+      - run: npm run e2e

--- a/ci/flaky-telemetry-wrapper.js
+++ b/ci/flaky-telemetry-wrapper.js
@@ -1,0 +1,25 @@
+const { afterAll } = require("@jest/globals");
+
+const flakyTests = new Set();
+
+function wrap(original) {
+  return (name, fn, timeout) => {
+    const t = original(name, fn, timeout);
+    if (typeof name === "string" && name.includes("@flaky")) {
+      t.retryTimes(2);
+      flakyTests.add(name);
+    }
+    return t;
+  };
+}
+
+global.test = wrap(global.test);
+global.it = wrap(global.it);
+
+afterAll(() => {
+  if (flakyTests.size) {
+    console.log(`[telemetry] flaky tests: ${flakyTests.size}`);
+  }
+});
+
+module.exports = {};

--- a/ci/jest.config.ci.js
+++ b/ci/jest.config.ci.js
@@ -1,0 +1,10 @@
+const base = require("../jest.config.js");
+
+module.exports = {
+  ...base,
+  retryTimes: 0,
+  setupFilesAfterEnv: [
+    ...(base.setupFilesAfterEnv || []),
+    "<rootDir>/ci/flaky-telemetry-wrapper.js",
+  ],
+};


### PR DESCRIPTION
## Summary
- add CI jest config that retries tests tagged `@flaky`
- track `@flaky` tests separately for telemetry
- run Playwright e2e tests in dedicated workflow with job retries

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: SyntaxError: Nested mappings are not allowed in compact mappings)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html)*

------
https://chatgpt.com/codex/tasks/task_e_68a7af19ef5c832d8e1bc24053504ac7