### PR TITLE
ci: publish suites count badge

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -26,7 +26,7 @@ jobs:
             const path = require('path');
             const { execSync } = require('child_process');
             const expected = JSON.parse(fs.readFileSync(path.join(process.env.GITHUB_WORKSPACE, 'ci/expected-jobs.json'), 'utf8'));
-            const suites = expected.suites || expected;
+            const suites = expected.suites || expected.expected || expected;
             const { owner, repo } = context.repo;
             const sha = context.payload.pull_request ? context.payload.pull_request.head.sha : context.sha;
 
@@ -67,6 +67,12 @@ jobs:
               table.push({ suiteName, ran, conclusion, testsExecuted });
             }
 
+            fs.writeFileSync('suites-count.json', JSON.stringify({
+              schemaVersion: 1,
+              label: 'ci suites',
+              message: String(suites.length)
+            }));
+
             core.summary.addHeading('CI Suite Summary');
             core.summary.addTable([
               [{ data: 'Suite', header: true }, { data: 'Ran', header: true }, { data: 'Conclusion', header: true }, { data: 'Tests', header: true }],
@@ -77,3 +83,9 @@ jobs:
             if (table.some(t => !t.ran || t.conclusion !== 'success' || t.testsExecuted === 0)) {
               core.setFailed('One or more expected suites missing, failed, or executed zero tests.');
             }
+      - name: Upload suites count
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-suites-count
+          path: suites-count.json

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![Lint](https://github.com/OWNER/REPO/actions/workflows/lint.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/lint.yml)
 [![Tests](https://github.com/OWNER/REPO/actions/workflows/backend-tests.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/backend-tests.yml)
 [![CI](https://github.com/OWNER/REPO/actions/workflows/ci.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/ci.yml)
+[![CI Suites Guard](https://github.com/OWNER/REPO/actions/workflows/ci-gate.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/ci-gate.yml)
+![CI Suites](https://img.shields.io/endpoint?url=https://nightly.link/OWNER/REPO/workflows/ci-gate.yml/dev/ci-suites-count.json)
 [![npm version](https://img.shields.io/npm/v/mvp-website.svg)](https://www.npmjs.com/package/mvp-website)
 [![Coverage Status](https://coveralls.io/repos/github/OWNER/REPO/badge.svg?branch=main)](https://coveralls.io/github/OWNER/REPO?branch=main)
 [![Frontend Coverage](https://github.com/OWNER/REPO/actions/workflows/coverage.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/coverage.yml)


### PR DESCRIPTION
## Summary
- expose CI suites count via shields-compatible artifact in CI Gate
- surface CI Gate and suites count badges in README

## Testing
- `npm run validate-env`
- `npm run setup`
- `npm run format` *(fails: tarball data seems corrupted)*
- `npm test` *(fails: tarball data for strip-final-newline seems corrupted)*
- `npm run smoke` *(fails: ENOENT during npm cache rename)*
- `npm run ci` *(fails: dependencies missing during install)*

------
https://chatgpt.com/codex/tasks/task_e_68a7af1d6de8832d85b8b19e5e5ffdfc