### PR TITLE
feat: add aws runners terraform module

### DIFF
--- a/infra/aws-runners/terraform/main.tf
+++ b/infra/aws-runners/terraform/main.tf
@@ -1,0 +1,161 @@
+locals {
+  runner_labels       = ["self-hosted", "linux", "x64", "ephemeral", "aws-ec2"]
+  runner_label_string = join(",", local.runner_labels)
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+resource "aws_iam_openid_connect_provider" "github" {
+  url             = "https://token.actions.githubusercontent.com"
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+}
+
+resource "aws_iam_role" "github" {
+  name = "github-oidc-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Effect = "Allow",
+      Principal = {
+        Federated = aws_iam_openid_connect_provider.github.arn
+      },
+      Action = "sts:AssumeRoleWithWebIdentity",
+      Condition = {
+        StringEquals = { "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com" },
+        StringLike   = { "token.actions.githubusercontent.com:sub" = "repo:${var.github_org}/${var.github_repo}:*" }
+      }
+    }]
+  })
+}
+
+resource "aws_security_group" "runner" {
+  name        = "github-runner-sg"
+  description = "Security group for GitHub Actions runners"
+  vpc_id      = var.vpc_id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_iam_role" "runner" {
+  name = "github-runner-instance-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Effect = "Allow",
+      Principal = { Service = "ec2.amazonaws.com" },
+      Action = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "runner_ssm" {
+  role       = aws_iam_role.runner.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_role_policy" "runner_logs" {
+  name = "github-runner-logs"
+  role = aws_iam_role.runner.id
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Effect   = "Allow",
+      Action   = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"],
+      Resource = "*"
+    }]
+  })
+}
+
+resource "aws_iam_instance_profile" "runner" {
+  name = "github-runner-instance-profile"
+  role = aws_iam_role.runner.name
+}
+
+resource "aws_cloudwatch_log_group" "runner" {
+  name              = "/github/actions-runner"
+  retention_in_days = 14
+}
+
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  owners      = ["099720109477"]
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
+  }
+}
+
+resource "aws_launch_template" "runner" {
+  name_prefix            = "github-runner-"
+  image_id               = data.aws_ami.ubuntu.id
+  instance_type          = var.instance_type
+  vpc_security_group_ids = [aws_security_group.runner.id]
+  iam_instance_profile { name = aws_iam_instance_profile.runner.name }
+
+  user_data = base64encode(templatefile("${path.module}/userdata.sh", {
+    runner_labels         = local.runner_label_string,
+    runner_token_parameter = var.runner_token_ssm_name,
+    runner_url_parameter   = var.runner_url_ssm_name,
+    log_group             = aws_cloudwatch_log_group.runner.name
+  }))
+
+  tag_specifications {
+    resource_type = "instance"
+    tags = {
+      Name = "github-runner"
+    }
+  }
+}
+
+resource "aws_autoscaling_group" "runner" {
+  name                = "github-runner-asg"
+  min_size            = 0
+  desired_capacity    = 0
+  max_size            = var.max_size
+  vpc_zone_identifier = var.subnet_ids
+
+  mixed_instances_policy {
+    launch_template {
+      launch_template_specification {
+        launch_template_id = aws_launch_template.runner.id
+        version            = "$Latest"
+      }
+    }
+    instances_distribution {
+      on_demand_percentage_above_base_capacity = 0
+      spot_allocation_strategy                 = "capacity-optimized"
+    }
+  }
+
+  tag {
+    key                 = "Name"
+    value               = "github-runner"
+    propagate_at_launch = true
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_sns_topic" "lifecycle" {
+  name = "github-runner-lifecycle"
+}
+
+resource "aws_autoscaling_lifecycle_hook" "terminate" {
+  name                   = "github-runner-terminate"
+  autoscaling_group_name = aws_autoscaling_group.runner.name
+  lifecycle_transition   = "autoscaling:EC2_INSTANCE_TERMINATING"
+  default_result         = "CONTINUE"
+  heartbeat_timeout      = 300
+  notification_target_arn = aws_sns_topic.lifecycle.arn
+  notification_metadata   = jsonencode({ action = "deregister" })
+}

--- a/infra/aws-runners/terraform/outputs.tf
+++ b/infra/aws-runners/terraform/outputs.tf
@@ -1,0 +1,4 @@
+output "runner_labels" {
+  description = "Labels applied to the EC2 runners"
+  value       = local.runner_labels
+}

--- a/infra/aws-runners/terraform/userdata.sh
+++ b/infra/aws-runners/terraform/userdata.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -euo pipefail
+exec > >(tee /var/log/github-runner.log) 2>&1
+
+apt-get update
+apt-get install -y curl jq git
+curl -Lo /tmp/amazon-cloudwatch-agent.deb https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb
+dpkg -i /tmp/amazon-cloudwatch-agent.deb
+
+useradd -m runner
+cd /home/runner
+latest=$(curl -s https://api.github.com/repos/actions/runner/releases/latest | jq -r '.tag_name')
+curl -L -o actions-runner.tar.gz https://github.com/actions/runner/releases/download/${latest}/actions-runner-linux-x64-${latest#v}.tar.gz
+tar xzf actions-runner.tar.gz
+rm actions-runner.tar.gz
+chown -R runner:runner /home/runner
+
+token=$(aws ssm get-parameter --name "${runner_token_parameter}" --with-decryption --query 'Parameter.Value' --output text)
+url=$(aws ssm get-parameter --name "${runner_url_parameter}" --query 'Parameter.Value' --output text)
+
+su - runner -c "./config.sh --url $url --token $token --unattended --ephemeral --labels ${runner_labels}"
+su - runner -c "nohup ./run.sh &"
+
+cat >/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json <<CONFIG
+{
+  "logs": {
+    "logs_collected": {
+      "files": {
+        "collect_list": [
+          {
+            "file_path": "/var/log/github-runner.log",
+            "log_group_name": "${log_group}",
+            "log_stream_name": "{instance_id}"
+          }
+        ]
+      }
+    }
+  }
+}
+CONFIG
+
+/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json -s

--- a/infra/aws-runners/terraform/variables.tf
+++ b/infra/aws-runners/terraform/variables.tf
@@ -1,0 +1,43 @@
+variable "github_org" {
+  description = "GitHub organization"
+  type        = string
+}
+
+variable "github_repo" {
+  description = "GitHub repository"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPC ID to launch runners in"
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "Subnets for runner Auto Scaling group"
+  type        = list(string)
+}
+
+variable "instance_type" {
+  description = "EC2 instance type for runners"
+  type        = string
+  default     = "t3.large"
+}
+
+variable "max_size" {
+  description = "Maximum number of runners"
+  type        = number
+  default     = 5
+}
+
+variable "runner_token_ssm_name" {
+  description = "SSM parameter containing the runner registration token"
+  type        = string
+  default     = "/github/runner/token"
+}
+
+variable "runner_url_ssm_name" {
+  description = "SSM parameter containing the runner URL"
+  type        = string
+  default     = "/github/runner/url"
+}

--- a/infra/aws-runners/terraform/versions.tf
+++ b/infra/aws-runners/terraform/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.3.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Terraform setup for AWS EC2 GitHub runners with OIDC trust, CloudWatch logging and lifecycle hooks

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` *(fails: process terminated during dependency install)*
- `npm test` *(fails: setup attempted but not completed)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: dependency installation required)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a7af2483dc832db00224957b046b6c