### PR TITLE
feat: add AWS runner bootstrap and packer workflow

### DIFF
--- a/.github/workflows/packer-build.yml
+++ b/.github/workflows/packer-build.yml
@@ -1,0 +1,37 @@
+name: build-runner-ami
+
+on:
+  workflow_dispatch:
+
+jobs:
+  packer:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v5.0.0
+      - uses: hashicorp/setup-packer@v2.0.0
+      - uses: aws-actions/configure-aws-credentials@v4.3.1
+        with:
+          role-to-assume: ${{ secrets.PACKER_BUILD_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Build AMI
+        id: build
+        run: |
+          packer build -machine-readable infra/aws-runners/packer/template.pkr.hcl | tee packer.log
+          AMI_ID=$(awk -F, '/artifact,0,id/ {print $6}' packer.log | cut -d: -f2 | tail -n1)
+          echo "ami_id=$AMI_ID" >> "$GITHUB_OUTPUT"
+      - name: Update Terraform AMI
+        run: |
+          AMI_ID=${{ steps.build.outputs.ami_id }}
+          sed -i "s|runner_ami_id = \".*\"|runner_ami_id = \"${AMI_ID}\"|" infra/github-actions-runner/ami.auto.tfvars
+      - name: Create PR
+        uses: peter-evans/create-pull-request@v6.0.5
+        with:
+          commit-message: "chore: update runner AMI to ${{ steps.build.outputs.ami_id }}"
+          title: "chore: update runner AMI to ${{ steps.build.outputs.ami_id }}"
+          branch: "ami/${{ steps.build.outputs.ami_id }}"
+          body: "Built new AMI and updated launch template."
+          labels: infrastructure

--- a/infra/aws-runners/packer/template.pkr.hcl
+++ b/infra/aws-runners/packer/template.pkr.hcl
@@ -1,0 +1,36 @@
+variable "region" {
+  type    = string
+  default = "us-east-1"
+}
+
+variable "instance_type" {
+  type    = string
+  default = "t3.medium"
+}
+
+source "amazon-ebs" "runner" {
+  region        = var.region
+  instance_type = var.instance_type
+  ssh_username  = "ubuntu"
+  ami_name      = "gha-runner-{{timestamp}}"
+
+  source_ami_filter {
+    filters = {
+      name                = "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+    }
+    owners      = ["099720109477"]
+    most_recent = true
+  }
+}
+
+build {
+  name    = "runner"
+  sources = ["source.amazon-ebs.runner"]
+
+  provisioner "shell" {
+    environment_vars = ["BUILD_IMAGE=1"]
+    script           = "${path.root}/../userdata/bootstrap.sh"
+  }
+}

--- a/infra/aws-runners/userdata/bootstrap.sh
+++ b/infra/aws-runners/userdata/bootstrap.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RUNNER_VERSION="${RUNNER_VERSION:-2.318.0}"
+REPO="${REPO:-owner/repo}"
+RUNNER_DIR="/opt/actions-runner"
+
+install_deps() {
+  apt-get update
+  apt-get install -y --no-install-recommends curl jq docker.io
+  curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
+  apt-get install -y nodejs
+  corepack enable
+  if [[ "${BUILD_IMAGE:-0}" == "1" ]]; then
+    npx --yes playwright install --with-deps
+  fi
+}
+
+install_runner() {
+  mkdir -p "$RUNNER_DIR"
+  cd "$RUNNER_DIR"
+  curl -fsSL -o actions-runner.tar.gz "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz"
+  tar xzf actions-runner.tar.gz
+  rm actions-runner.tar.gz
+  ./bin/installdependencies.sh
+}
+
+register_runner() {
+  cd "$RUNNER_DIR"
+  GITHUB_TOKEN=$(aws sts assume-role --role-arn "$GITHUB_OIDC_ROLE_ARN" --role-session-name gha-runner --duration-seconds 900 --query 'Credentials.SessionToken' --output text)
+  REG_TOKEN=$(curl -sX POST -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" "https://api.github.com/repos/${REPO}/actions/runners/registration-token" | jq -r .token)
+  ./config.sh --url "https://github.com/${REPO}" --token "$REG_TOKEN" --ephemeral --unattended --labels "${RUNNER_LABELS:-self-hosted,aws}"
+}
+
+run_and_cleanup() {
+  cd "$RUNNER_DIR"
+  ./run.sh --once
+  shutdown -h now
+}
+
+install_deps
+install_runner
+
+if [[ "${BUILD_IMAGE:-0}" != "1" ]]; then
+  register_runner
+  run_and_cleanup
+fi

--- a/infra/github-actions-runner/ami.auto.tfvars
+++ b/infra/github-actions-runner/ami.auto.tfvars
@@ -1,0 +1,1 @@
+runner_ami_id = ""

--- a/infra/github-actions-runner/main.tf
+++ b/infra/github-actions-runner/main.tf
@@ -77,7 +77,7 @@ resource "aws_iam_instance_profile" "runner" {
 
 resource "aws_launch_template" "runner" {
   name_prefix   = "gha-runner-"
-  image_id      = data.aws_ami.al2023.id
+  image_id      = var.runner_ami_id != "" ? var.runner_ami_id : data.aws_ami.al2023.id
   instance_type = var.instance_type
 
   iam_instance_profile {

--- a/infra/github-actions-runner/variables.tf
+++ b/infra/github-actions-runner/variables.tf
@@ -43,3 +43,9 @@ variable "queue_length_metric_name" {
   type    = string
   default = "QueuedJobs"
 }
+
+variable "runner_ami_id" {
+  type        = string
+  description = "AMI ID for GitHub Actions runner; leave empty to use latest Amazon Linux 2023."
+  default     = ""
+}


### PR DESCRIPTION
## Summary
- add bootstrap script to configure ephemeral AWS GitHub runners
- bake runner AMI with Packer and workflow to update launch template AMI

## Testing
- `npm run format`
- `npm test`
- `npm run ci` *(fails: SyntaxError in GitHub workflow YAML)*
- `npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a7af28df74832dbd79f17b5494fe35