### PR TITLE
feat: add aws runner autoscaler

### DIFF
--- a/.github/workflows/runner-autoscaler-deploy.yml
+++ b/.github/workflows/runner-autoscaler-deploy.yml
@@ -1,0 +1,31 @@
+name: Runner Autoscaler Deploy
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v5.0.0
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3.1.2
+      - name: Terraform init
+        working-directory: infra/aws-runners/autoscaler
+        run: terraform init
+      - name: Terraform apply
+        working-directory: infra/aws-runners/autoscaler
+        env:
+          TF_VAR_github_owner: ${{ github.repository_owner }}
+          TF_VAR_github_repo: ${{ github.event.repository.name }}
+          TF_VAR_github_token: ${{ secrets.GH_RUNNER_TOKEN }}
+          TF_VAR_asg_name: ${{ secrets.RUNNER_ASG_NAME }}
+          TF_VAR_max_runners: ${{ secrets.RUNNER_MAX }}
+          TF_VAR_burst_multiplier: ${{ secrets.RUNNER_BURST }}
+          TF_VAR_label_quotas: ${{ secrets.RUNNER_LABEL_QUOTAS }}
+        run: terraform apply -auto-approve

--- a/infra/aws-runners/autoscaler/README.md
+++ b/infra/aws-runners/autoscaler/README.md
@@ -1,0 +1,7 @@
+# Runner autoscaler
+
+Provisions a Lambda function invoked every minute via EventBridge. The function
+checks the repository's queued workflow jobs and scales an Auto Scaling Group
+so its desired capacity is the lesser of the queued jobs and the configured
+maximum. When no jobs are queued the group scales to zero. A `burst_multiplier`
+allows overprovisioning and `label_quotas` caps runner counts per job label.

--- a/infra/aws-runners/autoscaler/lambda.py
+++ b/infra/aws-runners/autoscaler/lambda.py
@@ -1,0 +1,58 @@
+import json
+import math
+import os
+from typing import Dict
+
+import boto3
+import requests
+
+
+GITHUB_API = "https://api.github.com"
+
+
+def fetch_queue(owner: str, repo: str, token: str) -> Dict[str, int]:
+    """Return queued job counts grouped by label."""
+    url = f"{GITHUB_API}/repos/{owner}/{repo}/actions/runners/queue"
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+    }
+    resp = requests.get(url, headers=headers, timeout=10)
+    resp.raise_for_status()
+    data = resp.json()
+    counts: Dict[str, int] = {}
+    for job in data.get("workflow_job_runs", []):
+        for label in job.get("labels", []):
+            counts[label] = counts.get(label, 0) + 1
+    return counts
+
+
+def scale_asg(asg_name: str, desired: int) -> None:
+    client = boto3.client("autoscaling")
+    client.update_auto_scaling_group(
+        AutoScalingGroupName=asg_name, DesiredCapacity=desired
+    )
+
+
+def handler(event, context):  # pragma: no cover - Lambda entrypoint
+    owner = os.environ["GITHUB_OWNER"]
+    repo = os.environ["GITHUB_REPO"]
+    token = os.environ["GITHUB_TOKEN"]
+    asg = os.environ["ASG_NAME"]
+    max_runners = int(os.environ.get("MAX_RUNNERS", "1"))
+    burst = float(os.environ.get("BURST_MULTIPLIER", "1"))
+    quotas = json.loads(os.environ.get("LABEL_QUOTAS", "{}"))
+
+    counts = fetch_queue(owner, repo, token)
+    queued_total = sum(counts.values())
+
+    desired = 0
+    for label, count in counts.items():
+        limit = quotas.get(label, max_runners)
+        desired += min(math.ceil(count * burst), limit)
+
+    desired = min(desired, max_runners)
+    if queued_total == 0:
+        desired = 0
+
+    scale_asg(asg, int(desired))

--- a/infra/aws-runners/autoscaler/main.tf
+++ b/infra/aws-runners/autoscaler/main.tf
@@ -1,0 +1,83 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+locals {
+  lambda_zip = data.archive_file.lambda.output_path
+}
+
+data "archive_file" "lambda" {
+  type        = "zip"
+  source_dir  = "${path.module}"
+  excludes    = ["main.tf", "variables.tf", "README.md", "outputs.tf"]
+  output_path = "${path.module}/lambda.zip"
+}
+
+resource "aws_iam_role" "autoscaler" {
+  name               = "runner-autoscaler-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = { Service = "lambda.amazonaws.com" }
+      Action = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "autoscaler" {
+  name = "runner-autoscaler-policy"
+  role = aws_iam_role.autoscaler.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect   = "Allow"
+      Action   = ["autoscaling:UpdateAutoScalingGroup", "autoscaling:DescribeAutoScalingGroups"],
+      Resource = "*"
+    }]
+  })
+}
+
+resource "aws_lambda_function" "autoscaler" {
+  function_name = "runner-autoscaler"
+  role          = aws_iam_role.autoscaler.arn
+  handler       = "lambda.handler"
+  runtime       = "python3.11"
+  filename      = local.lambda_zip
+
+  environment {
+    variables = {
+      GITHUB_OWNER     = var.github_owner
+      GITHUB_REPO      = var.github_repo
+      GITHUB_TOKEN     = var.github_token
+      ASG_NAME         = var.asg_name
+      MAX_RUNNERS      = tostring(var.max_runners)
+      BURST_MULTIPLIER = tostring(var.burst_multiplier)
+      LABEL_QUOTAS     = jsonencode(var.label_quotas)
+    }
+  }
+}
+
+resource "aws_cloudwatch_event_rule" "autoscaler" {
+  name                = "runner-autoscaler-schedule"
+  schedule_expression = "rate(1 minute)"
+}
+
+resource "aws_cloudwatch_event_target" "autoscaler" {
+  rule      = aws_cloudwatch_event_rule.autoscaler.name
+  target_id = "runner-autoscaler"
+  arn       = aws_lambda_function.autoscaler.arn
+}
+
+resource "aws_lambda_permission" "events" {
+  statement_id  = "AllowExecutionFromEvents"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.autoscaler.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.autoscaler.arn
+}

--- a/infra/aws-runners/autoscaler/variables.tf
+++ b/infra/aws-runners/autoscaler/variables.tf
@@ -1,0 +1,31 @@
+variable "github_owner" {
+  type = string
+}
+
+variable "github_repo" {
+  type = string
+}
+
+variable "github_token" {
+  type      = string
+  sensitive = true
+}
+
+variable "asg_name" {
+  type = string
+}
+
+variable "max_runners" {
+  type    = number
+  default = 1
+}
+
+variable "burst_multiplier" {
+  type    = number
+  default = 1
+}
+
+variable "label_quotas" {
+  type    = map(number)
+  default = {}
+}


### PR DESCRIPTION
## Summary
- add Lambda-based autoscaler that scales AWS runner ASG by queued jobs
- provision autoscaler via Terraform and deploy workflow

## Testing
- `npm run format`
- `npm test`
- `npm run ci` *(fails: SyntaxError in multiple workflow YAML files)*
- `npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a7af2cc44c832d81dfbd38f32f31d8