### PR TITLE
docs: add CI infrastructure overview

### DIFF
--- a/docs/ci/README.md
+++ b/docs/ci/README.md
@@ -1,0 +1,27 @@
+# CI infrastructure overview
+
+```mermaid
+flowchart LR
+    gha[GitHub Actions] -->|OIDC auth| role[Assume AWS role]
+    role --> tf[Terraform apply]
+    tf --> asg[EC2 Auto Scaling Group]
+    asg --> runner[Self-hosted runners]
+    runner --> gha
+```
+
+## terraform apply steps
+
+1. **OIDC role** – ensure GitHub Actions can assume the AWS role via OpenID Connect.
+2. **Auto Scaling Group (ASG)** – apply the module that provisions the runner instances.
+3. **Autoscaler** – deploy the Lambda or controller that scales instances based on queue depth.
+
+## Cost notes
+
+- Target **Spot** instances to minimize compute cost.
+- Configure scaling policies so the group can **scale to zero** when idle.
+
+## Adding a new suite
+
+1. Edit `expected-suites.yml` with the new suite name.
+2. Allow the discovery job to regenerate lists automatically.
+3. Verify the guard step passes in CI to ensure the suite is recognized.


### PR DESCRIPTION
## Summary
- document CI infrastructure with diagram, terraform steps, cost notes, and suite guidance

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npm run smoke` *(fails: Missing frontend build artifact)*
- `npm run build` *(fails: '@vitejs/plugin-react' resolved to an ESM file)*
- `npm run diagnose`


------
https://chatgpt.com/codex/tasks/task_e_68a7af3993f8832d98d1d35c87336bb1