### PR TITLE
ci: add toolbox and impact map actions

### DIFF
--- a/.github/actions/ci-impact-map/action.yml
+++ b/.github/actions/ci-impact-map/action.yml
@@ -1,0 +1,39 @@
+name: CI Impact Map
+description: Determine impacted test suites
+inputs:
+  base-ref:
+    description: Base ref for diff
+    required: false
+  head-ref:
+    description: Head ref for diff
+    required: false
+outputs:
+  backend:
+    value: ${{ steps.map.outputs.backend }}
+  frontend:
+    value: ${{ steps.map.outputs.frontend }}
+  e2e:
+    value: ${{ steps.map.outputs.e2e }}
+  docs:
+    value: ${{ steps.map.outputs.docs }}
+  infra:
+    value: ${{ steps.map.outputs.infra }}
+runs:
+  using: composite
+  steps:
+    - name: Determine git range
+      id: range
+      shell: bash
+      run: |
+        base="${{ inputs.base-ref || github.event.pull_request.base.sha || github.base_ref || 'origin/main' }}"
+        head="${{ inputs.head-ref || github.sha }}"
+        echo "BASE_SHA=$base" >> "$GITHUB_ENV"
+        echo "HEAD_SHA=$head" >> "$GITHUB_ENV"
+    - id: map
+      shell: bash
+      run: |
+        node scripts/ci/impact-map.js > out.txt
+        cat out.txt
+        while IFS='=' read -r k v; do
+          echo "$k=$v" >> "$GITHUB_OUTPUT"
+        done < out.txt

--- a/.github/actions/ci-toolbox/action.yml
+++ b/.github/actions/ci-toolbox/action.yml
@@ -1,0 +1,82 @@
+name: CI Toolbox
+description: Common setup for CI jobs
+inputs:
+  shard-index:
+    description: Optional shard index
+    required: false
+  shard-total:
+    description: Optional shard total
+    required: false
+outputs:
+  step-timeout-min:
+    value: ${{ steps.defaults.outputs.timeout }}
+  fail-fast:
+    value: ${{ steps.defaults.outputs.fail-fast }}
+  concurrency-group:
+    value: ${{ steps.defaults.outputs.group }}
+  package-manager:
+    value: ${{ steps.pm.outputs.manager }}
+runs:
+  using: composite
+  steps:
+    - id: defaults
+      shell: bash
+      run: |
+        echo "CI_STEP_TIMEOUT_MIN=30" >> "$GITHUB_ENV"
+        echo "timeout=30" >> "$GITHUB_OUTPUT"
+        echo "fail-fast=false" >> "$GITHUB_OUTPUT"
+        echo "group=${{ github.workflow }}-${{ github.ref }}" >> "$GITHUB_OUTPUT"
+    - id: pm
+      name: Detect package manager
+      shell: bash
+      run: |
+        corepack enable
+        if [ -f pnpm-lock.yaml ]; then
+          if ! command -v pnpm >/dev/null 2>&1; then
+            corepack prepare pnpm@latest --activate
+          fi
+          echo "manager=pnpm" >> "$GITHUB_OUTPUT"
+        elif [ -f yarn.lock ]; then
+          echo "manager=yarn" >> "$GITHUB_OUTPUT"
+        else
+          echo "manager=npm" >> "$GITHUB_OUTPUT"
+        fi
+    - name: Cache node modules
+      uses: actions/cache@v4
+      with:
+        path: |
+          node_modules
+          backend/node_modules
+          frontend/node_modules
+        key: ${{ steps.pm.outputs.manager }}-${{ hashFiles('**/pnpm-lock.yaml', '**/package-lock.json', '**/yarn.lock') }}-${{ runner.os }}
+    - name: Cache Playwright browsers
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-${{ hashFiles('**/pnpm-lock.yaml', '**/package-lock.json', '**/yarn.lock') }}-${{ runner.os }}
+    - name: Restore failed test artifacts
+      uses: actions/cache/restore@v4
+      with:
+        path: |
+          jest-failed.json
+          playwright-failed.txt
+        key: failed-${{ github.job }}-${{ github.run_id }}
+        restore-keys: failed-${{ github.job }}-
+    - name: Save failed test artifacts
+      if: always()
+      uses: actions/cache/save@v4
+      with:
+        path: |
+          jest-failed.json
+          playwright-failed.txt
+        key: failed-${{ github.job }}-${{ github.run_id }}
+    - name: Compute shard variables
+      shell: bash
+      run: |
+        idx="${{ inputs.shard-index }}"
+        total="${{ inputs.shard-total }}"
+        if [ -z "$idx" ]; then idx="${{ env.TEST_SHARD_INDEX:-1 }}"; fi
+        if [ -z "$total" ]; then total="${{ env.TEST_SHARD_TOTAL:-1 }}"; fi
+        echo "TEST_SHARD_INDEX=$idx" >> "$GITHUB_ENV"
+        echo "TEST_SHARD_TOTAL=$total" >> "$GITHUB_ENV"
+        echo "Shard $idx/$total"

--- a/.github/workflows/ci-fast-lane.yml
+++ b/.github/workflows/ci-fast-lane.yml
@@ -1,0 +1,72 @@
+name: CI Fast Lane
+on:
+  pull_request:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  impact:
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.map.outputs.backend }}
+      frontend: ${{ steps.map.outputs.frontend }}
+      e2e: ${{ steps.map.outputs.e2e }}
+      docs: ${{ steps.map.outputs.docs }}
+      infra: ${{ steps.map.outputs.infra }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: map
+        uses: ./.github/actions/ci-impact-map
+  lint:
+    uses: ./.github/workflows/reusable-test-job.yml
+    needs: impact
+    with:
+      suite: lint
+      command: npm run lint
+  typecheck:
+    uses: ./.github/workflows/reusable-test-job.yml
+    needs: impact
+    with:
+      suite: typecheck
+      command: npm run typecheck
+  unit:
+    uses: ./.github/workflows/reusable-test-job.yml
+    needs: impact
+    with:
+      suite: unit
+      command: npm test
+  backend:
+    if: needs.impact.outputs.backend == 'true'
+    uses: ./.github/workflows/reusable-test-job.yml
+    needs: impact
+    with:
+      suite: backend
+      command: npm test -- --backend
+  frontend:
+    if: needs.impact.outputs.frontend == 'true'
+    uses: ./.github/workflows/reusable-test-job.yml
+    needs: impact
+    with:
+      suite: frontend
+      command: npm test -- --frontend
+  e2e:
+    if: needs.impact.outputs.e2e == 'true'
+    uses: ./.github/workflows/reusable-test-job.yml
+    needs: impact
+    with:
+      suite: e2e
+      command: npm run test:e2e
+  docs:
+    if: needs.impact.outputs.docs == 'true'
+    uses: ./.github/workflows/reusable-test-job.yml
+    needs: impact
+    with:
+      suite: docs
+      command: npm test -- --docs
+  infra:
+    if: needs.impact.outputs.infra == 'true'
+    uses: ./.github/workflows/reusable-test-job.yml
+    needs: impact
+    with:
+      suite: infra
+      command: npm test -- --infra

--- a/.github/workflows/ci-full-lane.yml
+++ b/.github/workflows/ci-full-lane.yml
@@ -1,0 +1,53 @@
+name: CI Full Lane
+on:
+  pull_request:
+  push:
+    branches:
+      - dev
+      - '00000production'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  lint:
+    uses: ./.github/workflows/reusable-test-job.yml
+    with:
+      suite: lint
+      command: npm run lint
+  typecheck:
+    uses: ./.github/workflows/reusable-test-job.yml
+    with:
+      suite: typecheck
+      command: npm run typecheck
+  unit:
+    uses: ./.github/workflows/reusable-test-job.yml
+    with:
+      suite: unit
+      command: npm test
+  backend:
+    uses: ./.github/workflows/reusable-test-job.yml
+    with:
+      suite: backend
+      command: npm test -- --backend
+      use-self-hosted: true
+  frontend:
+    uses: ./.github/workflows/reusable-test-job.yml
+    with:
+      suite: frontend
+      command: npm test -- --frontend
+  e2e:
+    uses: ./.github/workflows/reusable-test-job.yml
+    with:
+      suite: e2e
+      command: npm run test:e2e
+      use-self-hosted: true
+  docs:
+    uses: ./.github/workflows/reusable-test-job.yml
+    with:
+      suite: docs
+      command: npm test -- --docs
+  infra:
+    uses: ./.github/workflows/reusable-test-job.yml
+    with:
+      suite: infra
+      command: npm test -- --infra

--- a/.github/workflows/reusable-test-job.yml
+++ b/.github/workflows/reusable-test-job.yml
@@ -1,0 +1,48 @@
+name: Reusable Test Job
+on:
+  workflow_call:
+    inputs:
+      suite:
+        required: true
+        type: string
+      command:
+        required: true
+        type: string
+      working-directory:
+        required: false
+        type: string
+        default: '.'
+      use-self-hosted:
+        required: false
+        type: boolean
+        default: false
+      shard-total:
+        required: false
+        type: number
+      retry-flaky:
+        required: false
+        type: boolean
+        default: false
+jobs:
+  test:
+    name: ${{ inputs.suite }}
+    runs-on: ${{ inputs.use-self-hosted && 'self-hosted' || 'ubuntu-latest' }}
+    strategy:
+      fail-fast: false
+    timeout-minutes: 30
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v4
+      - id: toolbox
+        uses: ./.github/actions/ci-toolbox
+        with:
+          shard-index: ${{ matrix.shard || '' }}
+          shard-total: ${{ inputs.shard-total || '' }}
+      - name: Run tests
+        uses: ./.github/actions/with-test-telemetry
+        with:
+          command: ${{ inputs.command }}
+          working-directory: ${{ inputs.working-directory }}
+          retry: ${{ inputs.retry-flaky }}

--- a/ci/impact-map.yml
+++ b/ci/impact-map.yml
@@ -1,0 +1,16 @@
+backend:
+  - backend/**
+frontend:
+  - frontend/**
+  - src/**
+  - js/**
+e2e:
+  - e2e/**
+  - tests/**
+docs:
+  - docs/**
+  - README.md
+infra:
+  - .github/**
+  - ci/**
+  - scripts/**

--- a/scripts/ci/impact-map.js
+++ b/scripts/ci/impact-map.js
@@ -1,0 +1,43 @@
+const fs = require('fs');
+const { spawnSync } = require('child_process');
+const path = require('path');
+
+function parseMap(file) {
+  const text = fs.readFileSync(file, 'utf8');
+  const map = {};
+  let current;
+  for (const line of text.split(/\r?\n/)) {
+    if (!line.trim() || line.trim().startsWith('#')) continue;
+    if (!line.startsWith(' ')) {
+      current = line.replace(':', '').trim();
+      map[current] = [];
+    } else if (line.trim().startsWith('-')) {
+      map[current].push(line.trim().slice(1).trim());
+    }
+  }
+  return map;
+}
+
+function getChanged(base, head) {
+  const res = spawnSync('git', ['diff', '--name-only', base, head], { encoding: 'utf8' });
+  if (res.status !== 0) throw new Error(res.stderr);
+  return res.stdout.split('\n').filter(Boolean);
+}
+
+const base = process.env.BASE_SHA || 'origin/main';
+const head = process.env.HEAD_SHA || 'HEAD';
+const files = getChanged(base, head);
+const impact = parseMap(path.join('ci', 'impact-map.yml'));
+const suites = { backend: false, frontend: false, e2e: false, docs: false, infra: false };
+
+for (const file of files) {
+  for (const [suite, patterns] of Object.entries(impact)) {
+    if (patterns.some(p => new RegExp('^' + p.replace(/\*\*/g, '.*').replace(/\*/g, '[^/]*')).test(file))) {
+      suites[suite] = true;
+    }
+  }
+}
+
+for (const [k, v] of Object.entries(suites)) {
+  console.log(`${k}=${v}`);
+}

--- a/scripts/ci/retry.sh
+++ b/scripts/ci/retry.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+retries=2
+backoff=5
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --retries)
+      retries="$2"
+      shift 2
+      ;;
+    --backoff)
+      backoff="${2%s}"
+      shift 2
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+cmd=("$@")
+attempt=0
+until "${cmd[@]}"; do
+  status=$?
+  attempt=$((attempt+1))
+  if (( attempt > retries )); then
+    exit $status
+  fi
+  echo "attempt $attempt/$retries failed with $status, retrying in ${backoff}s" >&2
+  sleep "$backoff"
+done


### PR DESCRIPTION
## Summary
- add composite ci-toolbox and ci-impact-map actions
- add retry helper script and impact map config
- add reusable test job and fast/full lane workflows

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` (backend)
- `npm test` (backend)
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Error occurred when checking code style in 11 files)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a7afd5f7c8832d8c3a8c8a3085be0b