### PR TITLE
ci: add metrics emission and SLO guardian

### DIFF
--- a/.github/actions/ci-metrics-emit/action.yml
+++ b/.github/actions/ci-metrics-emit/action.yml
@@ -1,0 +1,48 @@
+name: 'CI Metrics Emit'
+description: 'Emit CI metrics artifact and optionally send to CloudWatch'
+inputs:
+  timings:
+    description: 'Path to job timings JSON'
+    required: true
+  inventory:
+    description: 'Path to ci test inventory'
+    required: false
+    default: ci-test-inventory.json
+runs:
+  using: 'composite'
+  steps:
+    - name: Generate metrics
+      shell: bash
+      run: |
+        set -euo pipefail
+        inventory="${{ inputs.inventory }}"
+        timings="${{ inputs.timings }}"
+        mkdir -p ci/metrics
+        suite_tests=$(jq '[.suites[]?.tests?[]] | length' "$inventory" 2>/dev/null || echo 0)
+        suite_failures=$(jq '[.suites[]?.tests?[] | select(.outcome and .outcome != "success")] | length' "$inventory" 2>/dev/null || echo 0)
+        queued_jobs=$(jq '[.[]] | length' "$timings" 2>/dev/null || echo 0)
+        started_jobs=$(jq '[.[] | select(.started_at != null)] | length' "$timings" 2>/dev/null || echo 0)
+        failed_jobs=$(jq '[.[] | select(.conclusion == "failure")] | length' "$timings" 2>/dev/null || echo 0)
+        succeeded_jobs=$(jq '[.[] | select(.conclusion == "success")] | length' "$timings" 2>/dev/null || echo 0)
+        median_queue=$(jq '[.[] | select(.queued_at and .started_at) | ((.started_at | fromdate) - (.queued_at | fromdate))] | sort | if length>0 then .[length/2] else 0 end' "$timings" 2>/dev/null || echo 0)
+        cat <<METRICS > ci/metrics/series.ndjson
+{"MetricName":"QueuedJobs","Value":$queued_jobs}
+{"MetricName":"StartedJobs","Value":$started_jobs}
+{"MetricName":"FailedJobs","Value":$failed_jobs}
+{"MetricName":"SucceededJobs","Value":$succeeded_jobs}
+{"MetricName":"MedianQueueWaitSeconds","Value":$median_queue}
+{"MetricName":"SuiteTestCount","Value":$suite_tests}
+{"MetricName":"SuiteFailures","Value":$suite_failures}
+METRICS
+        if [[ "${AWS_CI_METRICS:-0}" == "1" ]]; then
+          while read -r line; do
+            name=$(echo "$line" | jq -r .MetricName)
+            value=$(echo "$line" | jq -r .Value)
+            aws cloudwatch put-metric-data --namespace CI/MVPWebsite --metric-data "MetricName=$name,Value=$value" || true
+          done < ci/metrics/series.ndjson
+        fi
+    - name: Upload metrics artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: ci-metrics
+        path: ci/metrics/series.ndjson

--- a/.github/workflows/ci-slo-guardian.yml
+++ b/.github/workflows/ci-slo-guardian.yml
@@ -1,0 +1,65 @@
+name: CI SLO Guardian
+on:
+  pull_request:
+  schedule:
+    - cron: '0 * * * *'
+permissions:
+  actions: read
+  issues: write
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Evaluate SLOs
+        id: eval
+        uses: actions/github-script@v7
+        env:
+          X: 300
+          Y: 95
+        with:
+          script: |
+            const cutoff = Date.now() - 24*60*60*1000;
+            const {owner, repo} = context.repo;
+            const artifacts = await github.paginate(github.rest.actions.listArtifactsForRepo, {owner, repo, per_page: 100});
+            const recent = artifacts.filter(a => a.name === 'ci-metrics' && new Date(a.created_at).getTime() >= cutoff);
+            const metrics = {queue: [], started:0, queued:0, zero:0};
+            for (const art of recent) {
+              const zip = await github.rest.actions.downloadArtifact({owner, repo, artifact_id: art.id, archive_format: 'zip'});
+              const buffer = Buffer.from(zip.data);
+              const zlib = require('node:zlib');
+              const unzip = zlib.unzipSync(buffer);
+              const lines = unzip.toString('utf8').trim().split(/\n/);
+              for (const l of lines) {
+                const m = JSON.parse(l);
+                if (m.MetricName === 'MedianQueueWaitSeconds') metrics.queue.push(m.Value);
+                if (m.MetricName === 'QueuedJobs') metrics.queued += m.Value;
+                if (m.MetricName === 'StartedJobs') metrics.started += m.Value;
+                if (m.MetricName === 'SuiteTestCount' && m.Value === 0) metrics.zero++;
+              }
+            }
+            const p95 = arr => arr.length ? arr.sort((a,b)=>a-b)[Math.floor(arr.length*0.95)] : 0;
+            const q95 = p95(metrics.queue);
+            const startRate = metrics.queued ? (metrics.started/metrics.queued*100) : 0;
+            const breaches = [];
+            if (q95 > parseInt(process.env.X)) breaches.push(`Queue wait P95 ${q95}s > ${process.env.X}s`);
+            if (startRate < parseInt(process.env.Y)) breaches.push(`Start rate ${startRate.toFixed(1)}% < ${process.env.Y}%`);
+            if (metrics.zero > 0) breaches.push(`${metrics.zero} zero-test suites`);
+            core.setOutput('breach', breaches.length ? '1' : '0');
+            core.setOutput('summary', breaches.join('\n'));
+      - name: Open issue on breach
+        if: steps.eval.outputs.breach == '1'
+        uses: actions/github-script@v7
+        env:
+          SUMMARY: ${{ steps.eval.outputs.summary }}
+        with:
+          script: |
+            const {owner, repo} = context.repo;
+            const title = 'ci-slo-breach';
+            const body = `SLO breach detected\n\n${process.env.SUMMARY}`;
+            const issues = await github.paginate(github.rest.issues.listForRepo, {owner, repo, state: 'open'});
+            let issue = issues.find(i => i.title === title);
+            if (issue) {
+              await github.rest.issues.update({owner, repo, issue_number: issue.number, body});
+            } else {
+              await github.rest.issues.create({owner, repo, title, body});
+            }

--- a/docs/ci/metrics.md
+++ b/docs/ci/metrics.md
@@ -1,0 +1,22 @@
+# CI Metrics
+
+The `ci-metrics-emit` action aggregates job timing data and test inventory into a single `ci/metrics/series.ndjson` artifact. The artifact can optionally be published to AWS CloudWatch under the `CI/MVPWebsite` namespace when `AWS_CI_METRICS=1` and an OIDC role is available.
+
+## Dashboard
+
+Below is a minimal Grafana dashboard JSON that reads from CloudWatch and plots basic metrics:
+
+```json
+{
+  "title": "CI Metrics",
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Queued Jobs",
+      "targets": [{ "namespace": "CI/MVPWebsite", "metricName": "QueuedJobs" }]
+    }
+  ]
+}
+```
+
+Import the JSON into Grafana or CloudWatch to visualize queue depths and job health over time.


### PR DESCRIPTION
## Summary
- add ci-metrics-emit composite action to aggregate test and job data
- introduce ci-slo-guardian workflow to watch metrics and open breach issues
- document CI metrics and sample dashboard

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `(cd backend && npm run format)`
- `(cd backend && npm test --silent)` *(partial output; interrupted for brevity)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Error occurred when checking code style in 11 files)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a7afda0db8832d814f80e4ee4f6f81