### PR TITLE
ci: add guardrails and chaos tooling for AWS runners

### DIFF
--- a/.github/workflows/ci-runner-chaos-monkey.yml
+++ b/.github/workflows/ci-runner-chaos-monkey.yml
@@ -1,0 +1,29 @@
+name: CI runner chaos monkey
+
+on:
+  workflow_dispatch:
+
+jobs:
+  chaos:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Terminate random runner
+        env:
+          AWS_REGION: us-east-1
+        run: |
+          INSTANCES=$(aws ec2 describe-instances --filters "Name=tag:GitHubRunner,Values=true" --query 'Reservations[].Instances[].InstanceId' --output text)
+          if [ -z "$INSTANCES" ]; then
+            echo "No self-hosted runners found" >&2
+            exit 1
+          fi
+          TARGET=$(echo "$INSTANCES" | tr '\t' '\n' | shuf -n1)
+          aws ec2 terminate-instances --instance-ids "$TARGET"
+          echo "Terminated $TARGET" >> $GITHUB_STEP_SUMMARY
+      - name: Wait for replacement
+        run: sleep 60
+      - name: Verify autoscaler replacement
+        env:
+          AWS_REGION: us-east-1
+        run: |
+          COUNT=$(aws ec2 describe-instances --filters "Name=tag:GitHubRunner,Values=true" --query 'Reservations[].Instances[?State.Name==`running`].InstanceId' --output text | wc -w)
+          echo "Running instances: $COUNT" >> $GITHUB_STEP_SUMMARY

--- a/docs/ci/runners-security.md
+++ b/docs/ci/runners-security.md
@@ -1,0 +1,16 @@
+# Runner security
+
+## Limit job hooks
+
+Configure the runner hooks so that no secrets are exposed. Set the following environment variables for each runner:
+
+```sh
+export ACTIONS_RUNNER_HOOK_JOB_STARTED="printf '%s %s' \"$GITHUB_RUN_ID\" \"$GITHUB_JOB\""
+export ACTIONS_RUNNER_HOOK_JOB_COMPLETED="printf '%s %s $GITHUB_JOB_STATUS' \"$GITHUB_RUN_ID\" \"$GITHUB_JOB\""
+```
+
+These hooks emit only metadata and avoid leaking repository secrets.
+
+## Container isolation
+
+Do not mount the host Docker socket into job containers for untrusted pull requests. Building or testing unreviewed code with access to the host daemon can allow privilege escalation.

--- a/infra/aws/github-runners/health/runner-heartbeat.py
+++ b/infra/aws/github-runners/health/runner-heartbeat.py
@@ -1,0 +1,59 @@
+import os
+import time
+import logging
+from typing import List
+
+import boto3
+import requests
+
+GITHUB_API = "https://api.github.com"
+OWNER = os.environ["GITHUB_OWNER"]
+REPO = os.environ["GITHUB_REPO"]
+TOKEN = os.environ["GITHUB_TOKEN"]
+STALE_MINUTES = int(os.environ.get("STALE_MINUTES", "30"))
+
+_ec2 = boto3.client("ec2")
+
+
+def _deregister_runner(runner_id: int, headers: dict) -> None:
+    requests.delete(
+        f"{GITHUB_API}/repos/{OWNER}/{REPO}/actions/runners/{runner_id}",
+        headers=headers,
+        timeout=10,
+    )
+
+
+def lambda_handler(event, context):
+    """Terminate stale GitHub runners and deregister them."""
+    headers = {
+        "Authorization": f"Bearer {TOKEN}",
+        "Accept": "application/vnd.github+json",
+    }
+
+    resp = requests.get(
+        f"{GITHUB_API}/repos/{OWNER}/{REPO}/actions/runners",
+        headers=headers,
+        timeout=10,
+    )
+    resp.raise_for_status()
+    runners: List[dict] = resp.json().get("runners", [])
+
+    now = time.time()
+    stale: List[str] = []
+
+    for runner in runners:
+        last_seen = runner.get("last_seen_at")
+        if not last_seen:
+            continue
+        last = time.mktime(time.strptime(last_seen, "%Y-%m-%dT%H:%M:%SZ"))
+        if runner.get("status") != "online" and now - last > STALE_MINUTES * 60:
+            instance_id = runner.get("name")
+            logging.info("Terminating stale runner %s", instance_id)
+            try:
+                _ec2.terminate_instances(InstanceIds=[instance_id])
+            except Exception as exc:  # pragma: no cover
+                logging.error("Failed to terminate %s: %s", instance_id, exc)
+            _deregister_runner(runner["id"], headers)
+            stale.append(instance_id)
+
+    return {"terminated": stale}

--- a/infra/aws/github-runners/terraform/guardrails.tf
+++ b/infra/aws/github-runners/terraform/guardrails.tf
@@ -1,0 +1,144 @@
+variable "max_desired_capacity" {
+  description = "Maximum desired capacity for runner Auto Scaling group"
+  type        = number
+  default     = 5
+}
+
+variable "budget_threshold" {
+  description = "Monthly cost forecast threshold for alerts (USD)"
+  type        = number
+  default     = 100
+}
+
+variable "alarm_email" {
+  description = "Email address for budget alerts"
+  type        = string
+  default     = ""
+}
+
+variable "scale_down_cron" {
+  description = "Cron expression for nightly scale down"
+  type        = string
+  default     = "0 0 * * *"
+}
+
+variable "scale_up_cron" {
+  description = "Cron expression for morning scale up"
+  type        = string
+  default     = "0 8 * * *"
+}
+
+variable "scale_timezone" {
+  description = "Time zone for scaling actions"
+  type        = string
+  default     = "UTC"
+}
+
+variable "cache_bucket" {
+  description = "Optional S3 bucket for runner cache"
+  type        = string
+  default     = ""
+}
+
+variable "strict_egress" {
+  description = "Restrict egress traffic to allow list"
+  type        = bool
+  default     = false
+}
+
+resource "aws_autoscaling_schedule" "scale_to_zero" {
+  scheduled_action_name  = "scale-down-night"
+  autoscaling_group_name = module.github_runners.autoscaling_group_name
+  min_size               = 0
+  max_size               = var.max_desired_capacity
+  desired_capacity       = 0
+  recurrence             = var.scale_down_cron
+  time_zone              = var.scale_timezone
+}
+
+resource "aws_autoscaling_schedule" "scale_up_morning" {
+  scheduled_action_name  = "scale-up-day"
+  autoscaling_group_name = module.github_runners.autoscaling_group_name
+  min_size               = 0
+  max_size               = var.max_desired_capacity
+  desired_capacity       = var.min_runners
+  recurrence             = var.scale_up_cron
+  time_zone              = var.scale_timezone
+}
+
+resource "aws_sns_topic" "budget" {
+  name = "github-runner-budget"
+}
+
+resource "aws_sns_topic_subscription" "budget_email" {
+  count     = var.alarm_email == "" ? 0 : 1
+  topic_arn = aws_sns_topic.budget.arn
+  protocol  = "email"
+  endpoint  = var.alarm_email
+}
+
+resource "aws_budgets_budget" "monthly" {
+  name         = "github-runner-budget"
+  budget_type  = "COST"
+  time_unit    = "MONTHLY"
+  limit_amount = var.budget_threshold
+  limit_unit   = "USD"
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    notification_type          = "FORECASTED"
+    threshold                  = var.budget_threshold
+    threshold_type             = "ABSOLUTE_VALUE"
+    subscriber_sns_topic_arns  = [aws_sns_topic.budget.arn]
+  }
+}
+
+data "aws_iam_policy_document" "runner" {
+  statement {
+    actions   = ["actions:GenerateRunnerToken"]
+    resources = ["*"]
+  }
+
+  statement {
+    actions   = ["logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"]
+    resources = ["*"]
+  }
+
+  dynamic "statement" {
+    for_each = var.cache_bucket == "" ? [] : [1]
+    content {
+      actions   = ["s3:GetObject", "s3:ListBucket"]
+      resources = [
+        "arn:aws:s3:::${var.cache_bucket}",
+        "arn:aws:s3:::${var.cache_bucket}/*",
+      ]
+    }
+  }
+}
+
+resource "aws_iam_policy" "runner" {
+  name   = "github-runner-restricted"
+  policy = data.aws_iam_policy_document.runner.json
+}
+
+resource "aws_iam_role_policy_attachment" "runner" {
+  role       = module.github_runners.runner_role_name
+  policy_arn = aws_iam_policy.runner.arn
+}
+
+locals {
+  allowed_cidrs = [
+    "140.82.112.0/20",   # GitHub
+    "104.16.0.0/13",     # npm registry / CDN
+    "185.199.108.0/22",  # GitHub user content / Playwright CDN
+  ]
+}
+
+resource "aws_security_group_rule" "egress" {
+  type              = "egress"
+  security_group_id = module.github_runners.runner_security_group_id
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = var.strict_egress ? local.allowed_cidrs : ["0.0.0.0/0"]
+}


### PR DESCRIPTION
## Summary
- add Terraform guardrails for AWS GitHub runners
- Lambda to cull stale runners
- chaos monkey workflow
- document runner security hooks

## Testing
- `npm run format`
- `npm test` *(truncated output; long-running)*
- `npm run ci` *(failed: terminated during `format:check`)*
- `npm run smoke` *(failed: Missing frontend build artifact: frontend/dist/index.html)*

------
https://chatgpt.com/codex/tasks/task_e_68a7afdd30ac832d9245bad121bcfa62