### PR TITLE
ci: add governance and catalog workflows

### DIFF
--- a/.github/workflows/ci-catalog.yml
+++ b/.github/workflows/ci-catalog.yml
@@ -1,0 +1,26 @@
+name: CI Catalog
+
+on:
+  pull_request:
+    paths:
+      - 'ci/**'
+      - '.github/workflows/**'
+  push:
+    paths:
+      - 'ci/**'
+      - '.github/workflows/**'
+
+jobs:
+  catalog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install deps
+        run: npm ci
+      - name: Build catalog
+        run: npx ts-node scripts/ci/generate-catalog.ts
+      - name: Upload catalog
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-catalog
+          path: docs/ci/catalog.md

--- a/.github/workflows/ci-governance.yml
+++ b/.github/workflows/ci-governance.yml
@@ -1,0 +1,24 @@
+name: CI Governance
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - 'ci/**'
+
+jobs:
+  suites:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install deps
+        run: npm ci
+      - name: Snapshot suites
+        run: npx ts-node scripts/ci/snapshot-suites.ts
+      - name: Diff suites
+        run: |
+          cp ci/expected-suites.yml ci/expected-suites.prev.yml
+          npx ts-node scripts/ci/snapshot-suites.ts
+          diff -u ci/expected-suites.prev.yml ci/expected-suites.yml || true
+      - name: Check required checks
+        run: cat ci/required-checks.yml

--- a/.github/workflows/ci-nightly-full.yml
+++ b/.github/workflows/ci-nightly-full.yml
@@ -1,0 +1,22 @@
+name: CI Nightly Full
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install deps
+        run: npm ci
+      - name: Snapshot suites
+        run: npx ts-node scripts/ci/snapshot-suites.ts
+      - name: Commit update
+        run: |
+          if [ -n "$(git status --porcelain ci/expected-suites.yml)" ]; then
+            git config user.name github-actions
+            git config user.email actions@github.com
+            git commit -am "chore: update expected suites" && git push
+          fi

--- a/ci/expected-suites.yml
+++ b/ci/expected-suites.yml
@@ -1,0 +1,15 @@
+expected:
+  frontend:lint:
+    - frontend:lint
+  frontend:build:
+    - frontend:build
+  frontend:test:
+    - frontend:test
+  backend:test:
+    - backend:test
+  types:check:
+    - types:check
+  e2e:smoke:
+    - e2e:smoke
+  codeql:analyze:
+    - codeql:analyze

--- a/ci/required-checks.yml
+++ b/ci/required-checks.yml
@@ -1,0 +1,6 @@
+required:
+  - Gate
+  - Suites Guard
+  - Full Aggregate
+  - LFS Guard
+  - Cloudflare Deploy

--- a/docs/ci/catalog.md
+++ b/docs/ci/catalog.md
@@ -1,0 +1,8 @@
+# CI Catalog
+
+- **frontend:lint** (lint) — paths: frontend/**
+- **frontend:test** (unit) — paths: frontend/**
+- **backend:test** (unit) — paths: backend/**
+- **types:check** (types)
+- **e2e:smoke** (e2e)
+- **codeql:analyze** (sast)

--- a/scripts/ci/generate-catalog.ts
+++ b/scripts/ci/generate-catalog.ts
@@ -1,0 +1,17 @@
+import { readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+
+const data = JSON.parse(readFileSync(join(__dirname, '..', '..', 'ci', 'catalog.json'), 'utf8')) as {
+  suites: { id: string; type?: string; paths?: string[] }[];
+};
+
+let md = '# CI Catalog\n\n';
+for (const suite of data.suites) {
+  md += `- **${suite.id}** (${suite.type ?? 'unknown'})`;
+  if (suite.paths) {
+    md += ` — paths: ${suite.paths.join(', ')}`;
+  }
+  md += '\n';
+}
+
+writeFileSync(join(__dirname, '..', '..', 'docs', 'ci', 'catalog.md'), md);

--- a/scripts/ci/snapshot-suites.ts
+++ b/scripts/ci/snapshot-suites.ts
@@ -1,0 +1,24 @@
+import { readdirSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { parse, stringify } from 'yaml';
+
+const workflowsDir = join(__dirname, '..', '..', '.github', 'workflows');
+const mapping: Record<string, string[]> = {};
+
+for (const file of readdirSync(workflowsDir)) {
+  if (!file.endsWith('.yml') && !file.endsWith('.yaml')) continue;
+  try {
+    const content = parse(readFileSync(join(workflowsDir, file), 'utf8')) as any;
+    if (content && content.jobs) {
+      for (const jobName of Object.keys(content.jobs)) {
+        if (!mapping[jobName]) mapping[jobName] = [jobName];
+      }
+    }
+  } catch {
+    // skip files that cannot be parsed
+    continue;
+  }
+}
+
+const out = stringify({ expected: mapping });
+writeFileSync(join(__dirname, '..', '..', 'ci', 'expected-suites.yml'), out);


### PR DESCRIPTION
## Summary
- generate expected suites snapshot script and required checks list
- add CI governance workflow and nightly updater
- publish CI catalog docs via workflow

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` (backend)
- `npm test` (backend)
- `SKIP_PW_DEPS=1 npm run ci` *(fails: SyntaxError: Nested mappings are not allowed in compact mappings)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html)*

------
https://chatgpt.com/codex/tasks/task_e_68a7aff0631c832db3b9a8b34496eb71