### PR TITLE
ci: add slash commands and cache warmup

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,13 +1,18 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base"],
-  "lockFileMaintenance": {
-    "enabled": true
-  },
+  "schedule": ["before 6am on monday"],
+  "timezone": "UTC",
   "packageRules": [
     {
-      "matchManagers": ["npm"],
-      "schedule": ["after 10pm every weekday", "before 5am every weekday"],
-      "stabilityDays": 1
+      "matchManagers": ["npm", "pnpm", "github-actions"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    },
+    {
+      "matchPackageNames": ["wrangler"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
     }
   ]
 }

--- a/.github/workflows/actions-ci-lint.yml
+++ b/.github/workflows/actions-ci-lint.yml
@@ -1,0 +1,16 @@
+name: actions-ci-lint
+
+on:
+  push:
+    paths:
+      - ".github/workflows/*.yml"
+  pull_request:
+    paths:
+      - ".github/workflows/*.yml"
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.7
+      - uses: rhysd/actionlint@v1.7.7

--- a/.github/workflows/cache-warmup.yml
+++ b/.github/workflows/cache-warmup.yml
@@ -1,0 +1,22 @@
+name: cache-warmup
+
+on:
+  schedule:
+    - cron: "0 3 * * 0"
+  workflow_dispatch:
+
+jobs:
+  warmup:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4.1.7
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version-file: ".nvmrc"
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            backend/package-lock.json
+      - run: npm ci
+      - run: npm ci --prefix backend
+      - run: npx playwright install --with-deps

--- a/.github/workflows/ci-slash-commands.yml
+++ b/.github/workflows/ci-slash-commands.yml
@@ -1,0 +1,68 @@
+name: ci-slash-commands
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  ci-slash-commands:
+    if: startsWith(github.event.comment.body, '/ci ')
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      checks: read
+      issues: read
+      pull-requests: read
+    steps:
+      - name: Parse command
+        id: cmd
+        run: |
+          body="${{ github.event.comment.body }}"
+          if [[ "$body" == '/ci rerun failed' ]]; then
+            echo "name=rerun" >> "$GITHUB_OUTPUT"
+          elif [[ "$body" == '/ci why' ]]; then
+            echo "name=why" >> "$GITHUB_OUTPUT"
+          elif [[ "$body" == '/ci heavy' ]]; then
+            echo "name=heavy" >> "$GITHUB_OUTPUT"
+          else
+            echo "name=unknown" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Rerun failed jobs
+        if: steps.cmd.outputs.name == 'rerun'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pr=${{ github.event.issue.number }}
+          branch=$(gh pr view "$pr" --json headRefName -q .headRefName)
+          run_id=$(gh run list --branch "$branch" --status failure --limit 1 --json databaseId -q '.[0].databaseId')
+          if [ -n "$run_id" ]; then
+            gh run rerun "$run_id" --failed
+          else
+            echo "No failed runs found" >&2
+          fi
+      - name: Analyze path filters
+        if: steps.cmd.outputs.name == 'why'
+        uses: dorny/paths-filter@v3.0.2
+        id: paths
+        with:
+          list-files: shell
+          filters: |
+            backend:
+              - 'backend/**'
+            frontend:
+              - 'frontend/**'
+            docs:
+              - 'docs/**'
+      - name: Explain trigger
+        if: steps.cmd.outputs.name == 'why'
+        run: |
+          echo "Trigger: $GITHUB_EVENT_NAME"
+          echo "Changed paths:\n${{ steps.paths.outputs.summary }}"
+      - name: Run heavy suites
+        if: steps.cmd.outputs.name == 'heavy'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pr=${{ github.event.issue.number }}
+          branch=$(gh pr view "$pr" --json headRefName -q .headRefName)
+          gh workflow run ci.yml -r "$branch" -f heavy=true

--- a/docs/ci/runbook.md
+++ b/docs/ci/runbook.md
@@ -1,0 +1,27 @@
+# CI Runbook
+
+## Lockfile mismatch
+
+If `npm ci` complains about missing packages, run:
+
+```sh
+npm install
+```
+
+then commit the updated lockfile.
+
+## Vite missing
+
+When builds fail with `vite: command not found`, install frontend deps:
+
+```sh
+npm ci --prefix frontend
+```
+
+## LFS pointers in repository
+
+If files show Git LFS pointers instead of content, fetch them with:
+
+```sh
+git lfs pull
+```

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,0 @@
-{
-  "extends": ["config:base"],
-  "schedule": ["before 6am on monday"],
-  "timezone": "UTC"
-}


### PR DESCRIPTION
## Summary
- add issue comment workflow for /ci commands
- lint workflows with actionlint
- warm node and Playwright caches on schedule
- document common CI failures and fixes
- manage GitHub Actions and npm/pnpm deps via Renovate

## Testing
- `npm run format` (backend)
- `npm test` (backend)
- `SKIP_PW_DEPS=1 npm run ci` *(fails: YAML syntax errors in existing workflows)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a7aff46334832dab89f338a1db382f