### PR TITLE
fix: repair secret sentinel action

### DIFF
--- a/.github/actions/secret-sentinel/action.yml
+++ b/.github/actions/secret-sentinel/action.yml
@@ -1,29 +1,21 @@
 name: Secret Sentinel
-description: Check presence of CI secrets
+description: Fails if required secrets/vars are missing
 inputs:
   vars:
-    description: Space-separated list of environment variable names
+    description: "Space-delimited list of env var names to check"
     required: true
-outputs:
-  missing:
-    description: JSON array of missing variables
-    value: ${{ steps.check.outputs.missing }}
 runs:
-  using: composite
+  using: "composite"
   steps:
-    - id: check
+    - name: Check required environment variables
       shell: bash
       run: |
         python - <<'PY'
-import os, json
-vars = "${{ inputs.vars }}".split()
-missing = []
-for v in vars:
-    if os.getenv(v):
-        print(f"✅ {v}")
-    else:
-        print(f"❌ {v}")
-        missing.append(v)
-with open(os.environ["GITHUB_OUTPUT"], "a") as fh:
-    fh.write(f"missing={json.dumps(missing)}\n")
-PY
+        import os, json, sys
+        names = "${{ inputs.vars }}".split()
+        missing = [n for n in names if not os.getenv(n)]
+        if missing:
+            print("Missing required environment variables:", ", ".join(missing))
+            sys.exit(1)
+        print("All required environment variables are present.")
+        PY


### PR DESCRIPTION
## Summary
- fix secret-sentinel composite action YAML to properly verify required environment variables

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- ⚠️ `npm run format` (hung installing dependencies)
- ⚠️ `npm test` (failed: ENOENT rename cache)
- ⚠️ `SKIP_PW_DEPS=1 npm run ci` (failed: ENOTEMPTY node_modules)
- ⚠️ `SKIP_PW_DEPS=1 npm run smoke` (missing frontend build artifact)


------
https://chatgpt.com/codex/tasks/task_e_68a7b1d4cd9c832dab9177d539be90a6