### PR TITLE
ci: add YAML validation workflow

### DIFF
--- a/.github/workflows/yaml-validate.yml
+++ b/.github/workflows/yaml-validate.yml
@@ -1,0 +1,20 @@
+---
+name: YAML Validate
+on:
+  pull_request:
+  push:
+    branches: [main, dev]
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5.0.0
+      - name: actionlint
+        uses: rhysd/actionlint@v1.7.7
+      - name: Install yamllint
+        run: sudo pip install yamllint
+      - name: yamllint (workflows & actions)
+        run: |
+          yamllint -d '{extends: default, rules: {line-length: {max: 140}}}' \
+            .github/workflows \
+            .github/actions


### PR DESCRIPTION
## Summary
- add workflow to lint workflow and action YAML files with actionlint and yamllint

## Testing
- `npm run format` (backend)
- `npm test` (backend)
- `SKIP_PW_DEPS=1 npm run ci` *(fails: SyntaxError messages while parsing existing workflow YAML)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a7b1dc5f08832d8cae6ce238b31689