### PR TITLE
ci: fix step structure in setup workflow

### DIFF
--- a/.github/workflows/_setup.yml
+++ b/.github/workflows/_setup.yml
@@ -42,9 +42,10 @@ jobs:
             package-lock.json
             backend/package-lock.json
             frontend/package-lock.json
-        - run: npm ci
-        - run: npm run ci:build-scripts
-        - run: npm ci --prefix frontend
-        - run: npm ci --prefix backend
-      - run: ${{ inputs.run }}
+      - run: npm ci
+      - run: npm run ci:build-scripts
+      - run: npm ci --prefix frontend
+      - run: npm ci --prefix backend
+      - name: Execute caller command
+        run: ${{ inputs.run }}
     timeout-minutes: 15


### PR DESCRIPTION
## Summary
- fix run/uses steps in reusable setup workflow

## Testing
- `npm run format`
- `npm test` (fails: context.getScope is not a function)
- `SKIP_PW_DEPS=1 npm run ci` (fails: Error occurred when checking code style in 10 files.)
- `SKIP_PW_DEPS=1 npm run smoke` (fails: Missing frontend build artifact: frontend/dist/index.html. Run 'npm run build' and retry)


------
https://chatgpt.com/codex/tasks/task_e_68a7b1e66874832dad547a8bf54f4040