### PR TITLE
ci: expand inline YAML lists in cache validator workflow

### DIFF
--- a/.github/workflows/cache-validator.yml
+++ b/.github/workflows/cache-validator.yml
@@ -6,9 +6,11 @@ env:
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
   pull_request:
-    branches: [main]
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -18,7 +20,9 @@ jobs:
   validate:
     timeout-minutes: 15
     runs-on:
-      - [self-hosted, linux, aws]
+      - - self-hosted
+        - linux
+        - aws
       - ubuntu-latest
     strategy:
       fail-fast: true


### PR DESCRIPTION
## Summary
- expand inline sequences in cache-validator workflow to use block-style YAML lists

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format`
```
> backend@1.0.0 preformat
> node ../scripts/ensure-root-deps.js

> backend@1.0.0 format
> sh -c 'cd .. && node scripts/ensure-root-deps.js && prettier --log-level warn --write "**/*.{js,jsx,json,md}" --ignore-path .prettierignore'
```
- `npm test`
```
PASS tests/api.test.ts
PASS tests/additionalApi.test.js
PASS tests/analytics.test.js
PASS tests/rewards.test.js
PASS tests/subscriptions.test.js
```
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Error occurred when checking code style in 11 files)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html)*


------
https://chatgpt.com/codex/tasks/task_e_68a7b1ee2a6c832da86951b9143e4abe