### PR TITLE
ci: add suites guard workflow

### DIFF
--- a/.github/workflows/ci-suites-guard.yml
+++ b/.github/workflows/ci-suites-guard.yml
@@ -1,0 +1,94 @@
+name: CI Suites Guard
+
+on:
+  pull_request:
+  push:
+    branches:
+      - dev
+      - "00000production"
+
+permissions:
+  checks: read
+  contents: read
+  pull-requests: write
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Compare expected suites
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const yaml = require('yaml');
+            const expectedMap = yaml.parse(fs.readFileSync('ci/expected-suites.yml','utf8'));
+            const required = Object.keys(expectedMap);
+            const sha = context.eventName === 'pull_request' ? context.payload.pull_request.head.sha : context.sha;
+            const { data } = await github.request('GET /repos/{owner}/{repo}/commits/{ref}/check-runs', {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: sha
+            });
+            const actual = data.check_runs.map(r => r.name);
+            const missing = required.filter(s => !actual.includes(s));
+            const rows = [];
+            for (const suite of missing){
+              const wf = expectedMap[suite].workflow;
+              const wfPath = `.github/workflows/${wf}`;
+              let cause;
+              if (!fs.existsSync(wfPath)) {
+                cause = 'no workflow file';
+              } else {
+                const wfYaml = yaml.parse(fs.readFileSync(wfPath,'utf8'));
+                const triggers = wfYaml.on || {};
+                const evt = context.eventName;
+                const hasEvent = (Array.isArray(triggers) && triggers.includes(evt)) || Object.keys(triggers).includes(evt);
+                if (!hasEvent) {
+                  cause = 'event filter';
+                } else if (triggers[evt] && (triggers[evt].paths || triggers[evt]['paths-ignore'])) {
+                  cause = 'path filter';
+                } else {
+                  cause = 'job-level if:';
+                }
+              }
+              rows.push(`| ${suite} | ${wf} | ${cause} |`);
+            }
+            const table = ['| Suite | Workflow | Likely cause |','| --- | --- | --- |',...rows].join('\n');
+            core.setOutput('missing', JSON.stringify(missing));
+            core.setOutput('required', JSON.stringify(required));
+            core.setOutput('table', table);
+      - name: Summary
+        run: echo "${{ steps.check.outputs.table }}" >> $GITHUB_STEP_SUMMARY
+      - name: Upload test inventory
+        if: hashFiles('ci-test-inventory.json') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-test-inventory
+          path: ci-test-inventory.json
+      - name: Comment checklist
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const missing = JSON.parse(process.env.MISSING);
+            const required = JSON.parse(process.env.REQUIRED);
+            const lines = required.map(s => `${missing.includes(s) ? '❌' : '✅'} ${s}`);
+            const body = lines.join('\n');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body
+            });
+          env:
+            MISSING: ${{ steps.check.outputs.missing }}
+            REQUIRED: ${{ steps.check.outputs.required }}
+      - name: Suggest branch protection
+        if: github.ref == 'refs/heads/dev' && steps.check.outputs.missing == '[]'
+        run: scripts/guard/suggest-ci-suites-guard.sh
+      - name: Fail if missing
+        if: steps.check.outputs.missing != '[]'
+        run: exit 1

--- a/ci/expected-suites.yml
+++ b/ci/expected-suites.yml
@@ -1,0 +1,24 @@
+backend-unit:
+  workflow: backend-tests.yml
+backend-integration:
+  workflow: backend-tests.yml
+frontend-jest:
+  workflow: ci.yml
+playwright:
+  workflow: ci.yml
+audit:
+  workflow: ci-audit.yml
+secrets:
+  workflow: secret-scan.yml
+lint:
+  workflow: lint.yml
+typecheck:
+  workflow: typecheck.yml
+size-limit:
+  workflow: size-monitor.yml
+codeql:
+  workflow: codeql-analysis.yml
+coverage:
+  workflow: coverage.yml
+e2e-smoke:
+  workflow: smoke_test.yml

--- a/scripts/guard/suggest-ci-suites-guard.sh
+++ b/scripts/guard/suggest-ci-suites-guard.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "CI Suites Guard passed on dev."
+echo "Consider making \"CI Suites Guard\" a required status check:" 
+echo "Settings > Branches > dev > Require status checks to pass > add 'CI Suites Guard'"


### PR DESCRIPTION
## Summary
- enforce required CI suites via `ci-suites-guard` workflow
- provide helper script to suggest enabling the guard as a required check

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: prettier syntax errors in existing workflow files)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: missing frontend build artifact)*


------
https://chatgpt.com/codex/tasks/task_e_68a7adef17f0832db0e62de14cbb5df6