### PR TITLE
ci: enforce self-hosted runners

### DIFF
--- a/.github/workflows/_reusable-node.yml
+++ b/.github/workflows/_reusable-node.yml
@@ -22,7 +22,7 @@ jobs:
   build:
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Checkout
         if: ${{ inputs.sparse-checkout == '' }}

--- a/.github/workflows/_setup.yml
+++ b/.github/workflows/_setup.yml
@@ -28,7 +28,7 @@ jobs:
     needs: labels
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -17,7 +17,7 @@ jobs:
   actionlint:
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/affected.yml
+++ b/.github/workflows/affected.yml
@@ -14,7 +14,7 @@ jobs:
   affected-builds:
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/artifact-guard.yml
+++ b/.github/workflows/artifact-guard.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, ci-small]
     outputs:
       run-id: ${{ steps.lookup.outputs.run-id }}
     steps:

--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -14,7 +14,7 @@ jobs:
   build-artifacts:
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/auto_rebase_merge_queue.yml
+++ b/.github/workflows/auto_rebase_merge_queue.yml
@@ -20,7 +20,7 @@ jobs:
     if: ${{ !startsWith(github.event.pull_request.head.ref, 'codex/') }}
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Heartbeat
         run: |
@@ -54,7 +54,7 @@ jobs:
     if: ${{ needs.rebase.result == 'success' || needs.rebase.result == 'skipped' }}
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/backend-only-ci.yml
+++ b/.github/workflows/backend-only-ci.yml
@@ -31,7 +31,7 @@ jobs:
       needs.preflight.outputs.run_backend == 'true'
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     continue-on-error: true
     strategy:
       fail-fast: true

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -18,7 +18,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v5
@@ -41,7 +41,7 @@ jobs:
     if: github.ref_name == '00000production'
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/binary-scan.yml
+++ b/.github/workflows/binary-scan.yml
@@ -12,7 +12,7 @@ jobs:
   scan:
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-and-artifacts.yml
+++ b/.github/workflows/build-and-artifacts.yml
@@ -20,7 +20,7 @@ jobs:
     if: ${{ inputs.build-frontend }}
     runs-on:
       - [self-hosted, linux, aws, small]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Heartbeat
         run: |
@@ -39,7 +39,7 @@ jobs:
     if: ${{ inputs.build-backend }}
     runs-on:
       - [self-hosted, linux, aws, small]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -18,7 +18,7 @@ jobs:
   build:
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     if: ${{ matrix.node != 22 || contains(github.event.pull_request.labels.*.name,
       'full-matrix') }}
     continue-on-error: ${{ matrix.node == 22 }}

--- a/.github/workflows/cache-primer.yml
+++ b/.github/workflows/cache-primer.yml
@@ -15,7 +15,7 @@ jobs:
   root-cache:
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Heartbeat
         run: |
@@ -32,7 +32,7 @@ jobs:
   backend-cache:
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Heartbeat
         run: |
@@ -49,7 +49,7 @@ jobs:
   frontend-cache:
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4

--- a/.github/workflows/cache-validator.yml
+++ b/.github/workflows/cache-validator.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 15
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/cf-dist-fallback.yml
+++ b/.github/workflows/cf-dist-fallback.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, ci-small]
     steps:
       - uses: actions/checkout@v5.0.0
       - uses: actions/setup-node@v4.4.0

--- a/.github/workflows/cf-pages-preview.yml
+++ b/.github/workflows/cf-pages-preview.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 15
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/check-watchdog.yml
+++ b/.github/workflows/check-watchdog.yml
@@ -14,7 +14,7 @@ jobs:
   watch:
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     continue-on-error: true
     timeout-minutes: 8
     permissions:

--- a/.github/workflows/ci-aggregate.yml
+++ b/.github/workflows/ci-aggregate.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   safety:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, ci-small]
     steps:
       - uses: actions/checkout@v4
       - name: Ensure core workflows present
@@ -23,7 +23,7 @@ jobs:
           done
           [ $missing -eq 0 ] || { echo "❌ Missing required workflows"; exit 1; }
   manifest:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, ci-small]
     needs: safety
     steps:
       - name: Print trigger context

--- a/.github/workflows/ci-audit.yml
+++ b/.github/workflows/ci-audit.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   audit:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, ci-small]
     steps:
       - id: audit
         uses: GrantBirki/auditor-action@v4.4.2

--- a/.github/workflows/ci-env.yml
+++ b/.github/workflows/ci-env.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 15
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/ci-fast-lane.yml
+++ b/.github/workflows/ci-fast-lane.yml
@@ -1,0 +1,28 @@
+name: CI Fast Lane
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint:
+    uses: ./.github/workflows/reusable-selfhosted.yml
+    with:
+      name: lint
+      wd: .
+      cmd: npm run lint
+      labels: ci-small
+  unit:
+    uses: ./.github/workflows/reusable-selfhosted.yml
+    with:
+      name: unit
+      wd: .
+      cmd: npm test
+      labels: ci-medium
+  build:
+    uses: ./.github/workflows/reusable-selfhosted.yml
+    with:
+      name: build
+      wd: .
+      cmd: npm run build
+      labels: ci-medium

--- a/.github/workflows/ci-full-lane.yml
+++ b/.github/workflows/ci-full-lane.yml
@@ -1,0 +1,29 @@
+name: CI Full Lane
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  backend:
+    uses: ./.github/workflows/reusable-selfhosted.yml
+    with:
+      name: backend
+      wd: backend
+      cmd: npm test
+      labels: ci-medium
+  frontend:
+    uses: ./.github/workflows/reusable-selfhosted.yml
+    with:
+      name: frontend
+      wd: frontend
+      cmd: npm test
+      labels: ci-medium
+  e2e:
+    uses: ./.github/workflows/reusable-selfhosted.yml
+    with:
+      name: e2e
+      wd: e2e
+      cmd: npm test
+      labels: ci-large
+      shards: 4

--- a/.github/workflows/ci-full-suite-compat.yml
+++ b/.github/workflows/ci-full-suite-compat.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   summarize:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, ci-small]
     steps:
       - uses: actions/checkout@v5
       - name: gather

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   gate:
     name: gate
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, ci-small]
     steps:
       - uses: actions/checkout@v4
       - name: Check CI suites

--- a/.github/workflows/ci-probe.yml
+++ b/.github/workflows/ci-probe.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   verify-checks:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, ci-small]
     permissions:
       checks: read
       statuses: read

--- a/.github/workflows/ci-queue-monitor.yml
+++ b/.github/workflows/ci-queue-monitor.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 15
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     permissions:
       actions: write
       pull-requests: write

--- a/.github/workflows/ci-rerun-slow.yml
+++ b/.github/workflows/ci-rerun-slow.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 15
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     outputs:
       duration: ${{ steps.duration.outputs.value }}
     steps:
@@ -47,7 +47,7 @@ jobs:
     timeout-minutes: 15
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     env:
       PORT: 3000
       DB_URL: postgres://user:pass@localhost:5432/testdb
@@ -101,7 +101,7 @@ jobs:
     timeout-minutes: 15
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     needs: [coverage, e2e]
     steps:
       - name: Heartbeat

--- a/.github/workflows/ci-router.yml
+++ b/.github/workflows/ci-router.yml
@@ -27,7 +27,7 @@ jobs:
   ubuntu:
     needs: selfhosted
     if: needs.selfhosted.result == 'failure' || needs.selfhosted.outcome == 'cancelled'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, ci-small]
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/frontend-build

--- a/.github/workflows/ci-sanity.yml
+++ b/.github/workflows/ci-sanity.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   sanity:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, ci-small]
     steps:
       - uses: actions/checkout@v4.3.0
       - uses: actions/setup-node@v4.4.0

--- a/.github/workflows/ci-secrets-sentinel.yml
+++ b/.github/workflows/ci-secrets-sentinel.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   secrets:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, ci-small]
     steps:
       - uses: actions/checkout@v4
       - name: Check required secrets

--- a/.github/workflows/ci-sparse-checkout.yml
+++ b/.github/workflows/ci-sparse-checkout.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-suite-restorer.yml
+++ b/.github/workflows/ci-suite-restorer.yml
@@ -9,7 +9,7 @@ concurrency:
 jobs:
   setup:
     name: Setup toolchain
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, ci-small]
     steps:
       - uses: actions/checkout@v4
       - name: Enable corepack + install pnpm fallback
@@ -27,7 +27,7 @@ jobs:
 
   list-tests:
     name: Inventory tests
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, ci-small]
     needs: setup
     steps:
       - uses: actions/checkout@v4
@@ -56,7 +56,7 @@ jobs:
 
   guard-nonzero:
     name: Guard: fail if any suite is zero
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, ci-small]
     needs: list-tests
     steps:
       - uses: actions/download-artifact@v4
@@ -78,7 +78,7 @@ jobs:
 
   backend-tests:
     name: Backend Jest
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, ci-small]
     needs: guard-nonzero
     steps:
       - uses: actions/checkout@v4
@@ -88,7 +88,7 @@ jobs:
 
   frontend-unit:
     name: Frontend Jest
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, ci-small]
     needs: guard-nonzero
     steps:
       - uses: actions/checkout@v4
@@ -98,7 +98,7 @@ jobs:
 
   e2e:
     name: Playwright E2E
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, ci-small]
     needs: [frontend-build]
     steps:
       - uses: actions/checkout@v4
@@ -112,7 +112,7 @@ jobs:
 
   frontend-build:
     name: Frontend build (vite)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, ci-small]
     needs: setup
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-watchdog.yml
+++ b/.github/workflows/ci-watchdog.yml
@@ -25,7 +25,7 @@ jobs:
     if: ${{ github.repository_owner == 'print3git' }}
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     timeout-minutes: 15
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     defaults:
       run:
         working-directory: frontend
@@ -90,7 +90,7 @@ jobs:
     timeout-minutes: 15
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     strategy:
       fail-fast: true
       max-parallel: 2
@@ -166,7 +166,7 @@ jobs:
     timeout-minutes: 15
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     strategy:
       fail-fast: true
       max-parallel: 2
@@ -239,7 +239,7 @@ jobs:
     if: github.event_name == 'push'
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Heartbeat
         id: heartbeat
@@ -298,7 +298,7 @@ jobs:
     if: github.event_name == 'push'
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     needs:
       - test-backend
       - test-frontend
@@ -373,7 +373,7 @@ jobs:
   toolchain-debug:
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     strategy:
       matrix:
         tool: [pnpm, vite, eslint, jest, tsc, wrangler, aws, docker]

--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, ci-small]
     steps:
       - uses: actions/checkout@v4.3.0
       - run: corepack enable || true
@@ -17,7 +17,7 @@ jobs:
 
   deploy:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, ci-small]
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/cloudflare-preview.yml
+++ b/.github/workflows/cloudflare-preview.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 15
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,7 +15,7 @@ jobs:
   analyze:
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
     name: Analyze
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     strategy:
       fail-fast: false
     steps:

--- a/.github/workflows/collect-artifacts.yml
+++ b/.github/workflows/collect-artifacts.yml
@@ -25,7 +25,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -8,7 +8,7 @@ jobs:
     name: Commitlint
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 15
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/coveralls-upload.yml
+++ b/.github/workflows/coveralls-upload.yml
@@ -20,7 +20,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/db-backup.yml
+++ b/.github/workflows/db-backup.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 15
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/debug-queue.yml
+++ b/.github/workflows/debug-queue.yml
@@ -18,6 +18,6 @@ jobs:
     timeout-minutes: 15
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - run: echo "I ran on ${{ runner.os }} with job id ${{ github.run_id }}"

--- a/.github/workflows/dependency-checker.yml
+++ b/.github/workflows/dependency-checker.yml
@@ -8,7 +8,7 @@ jobs:
   check:
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -7,7 +7,7 @@ jobs:
   dependency-review:
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     permissions:
       contents: read
     steps:

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   deploy:
     name: Deploy Pages
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, ci-small]
     steps:
       - uses: actions/checkout@v4.1.7
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
     if: vars.ENABLE_PAGES == '1' && github.event.workflow_run.conclusion == 'success'
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     env:
       WRANGLER_VERSION: 3.72.0
 
@@ -156,7 +156,7 @@ jobs:
     if: vars.ENABLE_PAGES != '1' && github.event.workflow_run.conclusion == 'success'
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/destroy-selfhosted-runner.yml
+++ b/.github/workflows/destroy-selfhosted-runner.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 15
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/diagnostics-dist-check.yml
+++ b/.github/workflows/diagnostics-dist-check.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 15
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     continue-on-error: true
     steps:
       - name: Heartbeat

--- a/.github/workflows/diagnostics.yml
+++ b/.github/workflows/diagnostics.yml
@@ -22,7 +22,7 @@ jobs:
     if: github.event_name != 'pull_request'
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     timeout-minutes: 5
     continue-on-error: true
     steps:
@@ -45,7 +45,7 @@ jobs:
     if: github.event_name != 'pull_request'
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     timeout-minutes: 5
     continue-on-error: true
     steps:
@@ -70,7 +70,7 @@ jobs:
     if: github.event_name != 'pull_request'
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     timeout-minutes: 5
     continue-on-error: true
     env:

--- a/.github/workflows/diff-summary.yml
+++ b/.github/workflows/diff-summary.yml
@@ -11,7 +11,7 @@ jobs:
   diff:
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 15
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     env:
       SKIP_TESTS: 0
     steps:

--- a/.github/workflows/docker-prune.yml
+++ b/.github/workflows/docker-prune.yml
@@ -9,7 +9,7 @@ jobs:
   prune:
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Prune Docker on self-hosted runners
         if: ${{ startsWith(runner.name, 'self-hosted') || contains(runner.labels, 'self-hosted') }}

--- a/.github/workflows/docs-automerge.yml
+++ b/.github/workflows/docs-automerge.yml
@@ -11,7 +11,7 @@ jobs:
   automerge:
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/endpoint-health.yml
+++ b/.github/workflows/endpoint-health.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 15
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/ensure_server_boots_185ecc2b50.yml
+++ b/.github/workflows/ensure_server_boots_185ecc2b50.yml
@@ -19,7 +19,7 @@ jobs:
       max-parallel: 2
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     env:
       STRIPE_TEST_KEY: ${{ secrets.STRIPE_TEST_KEY }}
       # Fallback DB connection so check-env.sh passes

--- a/.github/workflows/env-parity.yml
+++ b/.github/workflows/env-parity.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 15
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/eslint-diagnostics.yml
+++ b/.github/workflows/eslint-diagnostics.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 15
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     continue-on-error: true
     steps:
       - name: Heartbeat

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -28,7 +28,7 @@ jobs:
     needs: labels
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -18,7 +18,7 @@ jobs:
   build:
     runs-on:
       - [self-hosted, linux, aws, small]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     defaults:
       run:
         working-directory: frontend

--- a/.github/workflows/frontend-dist-check.yml
+++ b/.github/workflows/frontend-dist-check.yml
@@ -18,7 +18,7 @@ jobs:
     if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     runs-on:
       - [self-hosted, linux, aws, small]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/frontend-dry-build.yml
+++ b/.github/workflows/frontend-dry-build.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 15
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/frontend-local-build.yml
+++ b/.github/workflows/frontend-local-build.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 15
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/glb-ci-alerts-938dhf.yml
+++ b/.github/workflows/glb-ci-alerts-938dhf.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 15
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     env:
       PORT: 3000
       DB_URL: postgres://user:pass@localhost:5432/testdb

--- a/.github/workflows/glb-tests.yml
+++ b/.github/workflows/glb-tests.yml
@@ -29,7 +29,7 @@ jobs:
     timeout-minutes: 15
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Heartbeat
         run: |
@@ -55,7 +55,7 @@ jobs:
     needs: unit-tests
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     env:
       PORT: 3000
       DB_URL: postgres://user:pass@localhost:5432/testdb

--- a/.github/workflows/go-cache.yml
+++ b/.github/workflows/go-cache.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     env:
       GO_VERSION: '1.22'
     steps:

--- a/.github/workflows/guardrails.yml
+++ b/.github/workflows/guardrails.yml
@@ -7,7 +7,7 @@ jobs:
   guardrails:
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/healthz-contract.yml
+++ b/.github/workflows/healthz-contract.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 15
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/jest-open-handles.yml
+++ b/.github/workflows/jest-open-handles.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 15
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     continue-on-error: true
     steps:
       - name: Heartbeat

--- a/.github/workflows/json-validate.yml
+++ b/.github/workflows/json-validate.yml
@@ -9,7 +9,7 @@ jobs:
   json-validate:
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - uses: actions/checkout@v5.0.0
       - uses: actions/setup-node@v4.0.2

--- a/.github/workflows/junit-artifacts.yml
+++ b/.github/workflows/junit-artifacts.yml
@@ -7,7 +7,7 @@ jobs:
   upload:
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,7 +11,7 @@ jobs:
   label:
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - uses: actions/labeler@v5
         with:

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 15
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     outputs:
       runs_on: ${{ steps.choose.outputs.runs_on }}
     steps:
@@ -31,7 +31,7 @@ jobs:
           script: |
             const useSelf = Boolean(inputs.use_self_hosted);
             if (!useSelf) {
-              core.setOutput('runs_on', 'ubuntu-latest');
+              core.setOutput('runs_on', '["self-hosted","linux","x64","ci-small"]');
               return;
             }
             const runners = await github.paginate(github.rest.actions.listSelfHostedRunnersForRepo, {
@@ -39,5 +39,5 @@ jobs:
               repo: context.repo.repo,
             });
             const hasAws = runners.some(r => r.status === 'online' && r.labels.some(l => l.name === 'aws'));
-            core.setOutput('runs_on', hasAws ? '["self-hosted","aws"]' : 'ubuntu-latest');
+            core.setOutput('runs_on', hasAws ? '["self-hosted","aws"]' : '["self-hosted","linux","x64","ci-small"]');
 

--- a/.github/workflows/large-file-guard.yml
+++ b/.github/workflows/large-file-guard.yml
@@ -7,7 +7,7 @@ jobs:
   large-file-guard:
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - uses: actions/checkout@v5.0.0
         with:

--- a/.github/workflows/lfs-guard.yml
+++ b/.github/workflows/lfs-guard.yml
@@ -2,7 +2,7 @@ name: LFS guard / lfs-guard
 on: [pull_request, push]
 jobs:
   lfs:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, ci-small]
     steps:
       - uses: actions/checkout@v5.0.0
         with: { fetch-depth: 0 }

--- a/.github/workflows/license-scan.yml
+++ b/.github/workflows/license-scan.yml
@@ -10,7 +10,7 @@ jobs:
   scan:
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - uses: actions/checkout@v5
       - name: Install licensee

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -18,7 +18,7 @@ jobs:
     if: ${{ github.event.deployment_status.environment == 'preview' }}
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 15
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/lockfile-drift.yml
+++ b/.github/workflows/lockfile-drift.yml
@@ -12,7 +12,7 @@ jobs:
   lockfile-drift:
     runs-on:
       - [self-hosted, linux, aws, small]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v5.0.0

--- a/.github/workflows/md-link-check.yml
+++ b/.github/workflows/md-link-check.yml
@@ -9,7 +9,7 @@ jobs:
   md-link-check:
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - uses: actions/checkout@v5.0.0
       - name: Check markdown links

--- a/.github/workflows/nightly-warmup.yml
+++ b/.github/workflows/nightly-warmup.yml
@@ -8,7 +8,7 @@ jobs:
   nightly-cache-warmup:
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/nock-report.yml
+++ b/.github/workflows/nock-report.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 15
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -32,7 +32,7 @@ jobs:
   build:
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     env:
       PORT: 3000
       CI_REQUIRE_EXTERNAL: '0'

--- a/.github/workflows/nx-optional.yml
+++ b/.github/workflows/nx-optional.yml
@@ -10,7 +10,7 @@ jobs:
   nx:
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/openapi-lint.yml
+++ b/.github/workflows/openapi-lint.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 15
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/ops-report.yml
+++ b/.github/workflows/ops-report.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 15
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/package-helm.yml
+++ b/.github/workflows/package-helm.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 15
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -18,7 +18,7 @@ jobs:
     name: Pages config validate
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     env:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
       CLOUDFLARE_API_TOKEN: ${{ secrets.CF_PAGES_API_TOKEN }}
@@ -46,7 +46,7 @@ jobs:
     needs: validate
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     env:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
       CLOUDFLARE_API_TOKEN: ${{ secrets.CF_PAGES_API_TOKEN }}

--- a/.github/workflows/pages-preflight.yml
+++ b/.github/workflows/pages-preflight.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 5
     runs-on:
       - [self-hosted, linux, aws, small]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4

--- a/.github/workflows/pages-url-comment.yml
+++ b/.github/workflows/pages-url-comment.yml
@@ -15,7 +15,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion != 'cancelled' }}
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/pipeline-deadlock-check.yml
+++ b/.github/workflows/pipeline-deadlock-check.yml
@@ -16,7 +16,7 @@ jobs:
   deadlock:
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     timeout-minutes: 1
     steps:
       - name: Heartbeat

--- a/.github/workflows/pipeline-smoke.yml
+++ b/.github/workflows/pipeline-smoke.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 15
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     env:
       STRIPE_TEST_KEY: ${{ secrets.STRIPE_TEST_KEY }}
       DB_URL: ${{ secrets.DB_URL }}

--- a/.github/workflows/playwright-browsers-cache.yml
+++ b/.github/workflows/playwright-browsers-cache.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 15
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/pnpm-guard.yml
+++ b/.github/workflows/pnpm-guard.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   install:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, ci-small]
     steps:
       - run: corepack enable
       - uses: pnpm/action-setup@v4.0.0

--- a/.github/workflows/pnpm-lock-sync.yml
+++ b/.github/workflows/pnpm-lock-sync.yml
@@ -13,7 +13,7 @@ jobs:
         (github.event.action == 'labeled' && github.event.label.name == 'sync-lock') ||
         (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'sync-lock'))
       ))
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, ci-small]
     env:
       HUSKY: 0
     steps:

--- a/.github/workflows/pnpm-sentinel.yml
+++ b/.github/workflows/pnpm-sentinel.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   sentinel:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, ci-small]
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/post-mortem-report.yml
+++ b/.github/workflows/post-mortem-report.yml
@@ -11,7 +11,7 @@ jobs:
   fail-test:
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     timeout-minutes: 40
     steps:
       - name: Intentionally fail

--- a/.github/workflows/pr-path-filters.yml
+++ b/.github/workflows/pr-path-filters.yml
@@ -10,7 +10,7 @@ jobs:
   lint-typecheck:
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - uses: actions/checkout@v5.0.0
       - uses: actions/setup-node@v4

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -34,7 +34,7 @@ jobs:
     timeout-minutes: 15
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
     steps:

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 15
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     env:
       PORT: 3000
     steps:

--- a/.github/workflows/printclub-reminders.yml
+++ b/.github/workflows/printclub-reminders.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 15
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/priority.yml
+++ b/.github/workflows/priority.yml
@@ -18,7 +18,7 @@ jobs:
   lint-fast:
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v5
@@ -38,7 +38,7 @@ jobs:
   smoke-api:
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v5
@@ -58,7 +58,7 @@ jobs:
     name: Gate
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     needs: [lint-fast, smoke-api]
     if: ${{ always() }}
     steps:

--- a/.github/workflows/prod-env-guard.yml
+++ b/.github/workflows/prod-env-guard.yml
@@ -7,7 +7,7 @@ jobs:
   deploy:
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     environment:
       name: production
       reviewers:

--- a/.github/workflows/provision-selfhosted-runner.yml
+++ b/.github/workflows/provision-selfhosted-runner.yml
@@ -29,7 +29,7 @@ jobs:
     timeout-minutes: 15
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/python-pip.yml
+++ b/.github/workflows/python-pip.yml
@@ -10,7 +10,7 @@ jobs:
   install:
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     strategy:
       matrix:
         python-version: ["3.10", "3.11"]

--- a/.github/workflows/queue-probe.yml
+++ b/.github/workflows/queue-probe.yml
@@ -18,7 +18,7 @@ jobs:
   probe:
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     continue-on-error: true
     timeout-minutes: 5
     steps:

--- a/.github/workflows/queue-watchdog.yml
+++ b/.github/workflows/queue-watchdog.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   watchdog:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, ci-small]
     continue-on-error: true
     steps:
       - uses: print3d/queue-watchdog@v0

--- a/.github/workflows/regression-guard.yml
+++ b/.github/workflows/regression-guard.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 15
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -17,7 +17,7 @@ jobs:
     name: Backend Unit (Node ${{ matrix.node }})
     runs-on:
       - [self-hosted, linux, aws]
-      - ${{ github.event_name == 'workflow_dispatch' && inputs.runner || 'ubuntu-latest' }}
+      - ${{ github.event_name == 'workflow_dispatch' && inputs.runner || '[self-hosted, linux, x64, ci-small]' }}
     strategy:
       fail-fast: false
       matrix:
@@ -43,7 +43,7 @@ jobs:
     name: Backend Integration (Node ${{ matrix.node }})
     runs-on:
       - [self-hosted, linux, aws]
-      - ${{ github.event_name == 'workflow_dispatch' && inputs.runner || 'ubuntu-latest' }}
+      - ${{ github.event_name == 'workflow_dispatch' && inputs.runner || '[self-hosted, linux, x64, ci-small]' }}
     strategy:
       fail-fast: false
       matrix:
@@ -69,7 +69,7 @@ jobs:
     name: Frontend (Node ${{ matrix.node }})
     runs-on:
       - [self-hosted, linux, aws]
-      - ${{ github.event_name == 'workflow_dispatch' && inputs.runner || 'ubuntu-latest' }}
+      - ${{ github.event_name == 'workflow_dispatch' && inputs.runner || '[self-hosted, linux, x64, ci-small]' }}
     strategy:
       fail-fast: false
       matrix:
@@ -96,7 +96,7 @@ jobs:
     name: E2E (${{ matrix.browser }})
     runs-on:
       - [self-hosted, linux, aws]
-      - ${{ github.event_name == 'workflow_dispatch' && inputs.runner || 'ubuntu-latest' }}
+      - ${{ github.event_name == 'workflow_dispatch' && inputs.runner || '[self-hosted, linux, x64, ci-small]' }}
     strategy:
       fail-fast: false
       matrix:
@@ -120,7 +120,7 @@ jobs:
     name: CI/CD Selftest
     runs-on:
       - [self-hosted, linux, aws]
-      - ${{ github.event_name == 'workflow_dispatch' && inputs.runner || 'ubuntu-latest' }}
+      - ${{ github.event_name == 'workflow_dispatch' && inputs.runner || '[self-hosted, linux, x64, ci-small]' }}
     steps:
       - uses: actions/checkout@v5.0.0
       - uses: actions/setup-node@v4.4.0
@@ -142,7 +142,7 @@ jobs:
     name: Summary
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     needs:
       - backend-unit
       - backend-integration

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -9,7 +9,7 @@ jobs:
   update_release_draft:
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - uses: release-drafter/release-drafter@v5
         env:

--- a/.github/workflows/reset-credits.yml
+++ b/.github/workflows/reset-credits.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 15
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/reusable-selfhosted.yml
+++ b/.github/workflows/reusable-selfhosted.yml
@@ -1,0 +1,69 @@
+name: Self-hosted run
+
+on:
+  workflow_call:
+    inputs:
+      name:
+        type: string
+        required: true
+      wd:
+        type: string
+        required: true
+      cmd:
+        type: string
+        required: true
+      labels:
+        type: string
+        default: ci-small
+      timeout-min:
+        type: number
+        default: 30
+      shards:
+        type: number
+        default: 1
+
+jobs:
+  run:
+    runs-on: [self-hosted, linux, x64, ${{ inputs.labels }}]
+    timeout-minutes: ${{ inputs.timeout-min }}
+    strategy:
+      matrix:
+        shard: [1,2,3,4]
+    steps:
+      - name: Skip extra shards
+        if: ${{ matrix.shard > inputs.shards }}
+        run: exit 0
+      - uses: actions/checkout@v5
+      - name: Enable Corepack
+        run: corepack enable
+      - id: pm
+        run: |
+          if [ -f pnpm-lock.yaml ]; then
+            echo "pm=pnpm" >> $GITHUB_OUTPUT
+            echo "lock=pnpm-lock.yaml" >> $GITHUB_OUTPUT
+          else
+            echo "pm=npm" >> $GITHUB_OUTPUT
+            echo "lock=package-lock.json" >> $GITHUB_OUTPUT
+          fi
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: ${{ steps.pm.outputs.pm }}
+          cache-dependency-path: ${{ steps.pm.outputs.lock }}
+      - name: Use package manager
+        run: corepack use ${{ steps.pm.outputs.pm }}
+      - name: Set shard env
+        if: ${{ inputs.shards > 1 }}
+        run: |
+          echo "TEST_TOTAL_SHARDS=${{ inputs.shards }}" >> $GITHUB_ENV
+          echo "TEST_SHARD_INDEX=${{ matrix.shard }}" >> $GITHUB_ENV
+      - name: Run command
+        working-directory: ${{ inputs.wd }}
+        run: ${{ inputs.cmd }}
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.name }}-logs
+          path: artifacts/${{ inputs.name }}-logs

--- a/.github/workflows/runner-scheduler.yml
+++ b/.github/workflows/runner-scheduler.yml
@@ -18,7 +18,7 @@ jobs:
     if: ${{ false }}
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Stop runner service
         run: |
@@ -34,7 +34,7 @@ jobs:
     if: ${{ false }}
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Start instance
         run: aws ec2 start-instances --instance-ids "$RUNNER_INSTANCE_ID"

--- a/.github/workflows/runner-watchdog.yml
+++ b/.github/workflows/runner-watchdog.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 15
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Check self-hosted AWS runner
         id: check

--- a/.github/workflows/rust-sccache.yml
+++ b/.github/workflows/rust-sccache.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - uses: actions/checkout@v5
       - uses: ./.github/actions/sccache

--- a/.github/workflows/schedule-check.yml
+++ b/.github/workflows/schedule-check.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 15
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -17,7 +17,7 @@ jobs:
   scan:
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/selfhosted-enforce.yml
+++ b/.github/workflows/selfhosted-enforce.yml
@@ -1,0 +1,34 @@
+name: Self-hosted enforce
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  enforce:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Ensure self-hosted runners
+        run: |
+          files=$(grep -R "runs-on: .*ubuntu-latest\|runs-on: .*windows-\|runs-on: .*macos-" -n .github/workflows || true | cut -d: -f1 | sort -u)
+          if [ -n "$files" ]; then
+            for f in $files; do
+              if ! grep -q 'allowGithubHosted: true' "$f"; then
+                echo "::error file=$f::All CI must target self-hosted labels. Use `runs-on: [self-hosted, linux, x64, ci-…]`."
+                exit 1
+              fi
+            done
+          fi
+  capacity-ping:
+    runs-on: [self-hosted, linux, x64, ci-small]
+    steps:
+      - name: Check queue time
+        run: |
+          queued=$(date -d '${{ github.run_started_at }}' +%s)
+          start=$(date +%s)
+          delay=$((start - queued))
+          if [ $delay -gt 30 ]; then
+            echo "::warning::Capacity low—ASG will scale."
+          fi
+      - run: echo ok

--- a/.github/workflows/selfhosted-prefer.yml
+++ b/.github/workflows/selfhosted-prefer.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     inputs:
       label: { required: false, type: string, default: "aws-spot-x64" }
-      fallback: { required: false, type: string, default: "ubuntu-latest" }
+      fallback: { required: false, type: string, default: "self-hosted" }
 jobs:
   choose:
     runs-on: ${{ inputs.fallback }}

--- a/.github/workflows/selfhosted-probe.yml
+++ b/.github/workflows/selfhosted-probe.yml
@@ -37,7 +37,7 @@ jobs:
   timeout-notice:
     if: ${{ needs.probe-selfhosted.result != 'success' }}
     needs: probe-selfhosted
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, ci-small]
     steps:
       - name: No runner available
         run: echo "Self-hosted runner not available. Run 'terraform apply' to provision." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/size-monitor.yml
+++ b/.github/workflows/size-monitor.yml
@@ -9,7 +9,7 @@ jobs:
   size:
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - uses: actions/checkout@v5
       - name: Record repository size

--- a/.github/workflows/skip-heavy.yml
+++ b/.github/workflows/skip-heavy.yml
@@ -11,7 +11,7 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'skip-heavy')
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - run: |
           echo "skip-heavy label present, skipping heavy workflows"

--- a/.github/workflows/smoke-backend.yml
+++ b/.github/workflows/smoke-backend.yml
@@ -27,7 +27,7 @@ jobs:
     needs: preflight
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     services:
       postgres:
         image: postgres:15
@@ -71,7 +71,7 @@ jobs:
     if: needs.preflight.outputs.run_backend == 'true'
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     timeout-minutes: 5
     services:
       postgres:

--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 15
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     outputs:
       frontend: ${{ steps.filter.outputs.frontend }}
     steps:
@@ -35,7 +35,7 @@ jobs:
     needs: changes
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     env:
       PORT: 3000
       DB_URL: postgres://user:pass@localhost:5432/testdb
@@ -77,7 +77,7 @@ jobs:
     if: needs.changes.outputs.frontend == 'true'
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -10,7 +10,7 @@ jobs:
   codespell:
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - uses: actions/checkout@v5
       - uses: codespell-project/actions-codespell@v2.1

--- a/.github/workflows/submodules-shallow.yml
+++ b/.github/workflows/submodules-shallow.yml
@@ -10,7 +10,7 @@ jobs:
   verify-submodules:
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 15
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/sync-space.yml
+++ b/.github/workflows/sync-space.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 15
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     env:
       STRIPE_TEST_KEY: ${{ secrets.STRIPE_TEST_KEY }}
       PORT: 3000

--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -5,13 +5,7 @@ on:
 
 jobs:
   test:
-    runs-on:
-      - [self-hosted, linux, aws]
-      - ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-
+    runs-on: [self-hosted, linux, x64, ci-small]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/test-rerun.yml
+++ b/.github/workflows/test-rerun.yml
@@ -7,7 +7,7 @@ jobs:
   test:
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/test-timeout.yml
+++ b/.github/workflows/test-timeout.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/test-watchdog.yml
+++ b/.github/workflows/test-watchdog.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   watchdog:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, ci-small]
     permissions:
       contents: read
     steps:

--- a/.github/workflows/turbo-cache.yml
+++ b/.github/workflows/turbo-cache.yml
@@ -8,7 +8,7 @@ jobs:
   turbo:
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/update_locks.yml
+++ b/.github/workflows/update_locks.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 15
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/verify-lockfile.yml
+++ b/.github/workflows/verify-lockfile.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 15
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Heartbeat
         run: |
@@ -61,7 +61,7 @@ jobs:
     if: ${{ needs.verify.result == 'failure' }}
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - uses: actions/checkout@v5
       - run: corepack enable

--- a/.github/workflows/vuln-scan.yml
+++ b/.github/workflows/vuln-scan.yml
@@ -11,7 +11,7 @@ jobs:
   scan:
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - uses: actions/checkout@v5.0.0
       - uses: actions/setup-node@v4.4.0

--- a/.github/workflows/warm-cache.yml
+++ b/.github/workflows/warm-cache.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 15
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Heartbeat
         run: |
@@ -33,7 +33,7 @@ jobs:
     timeout-minutes: 15
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Heartbeat
         run: |
@@ -50,7 +50,7 @@ jobs:
     timeout-minutes: 15
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/web-matrix.yml
+++ b/.github/workflows/web-matrix.yml
@@ -16,7 +16,7 @@ jobs:
   build:
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     strategy:
       fail-fast: false
     steps:

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -11,7 +11,7 @@ jobs:
   yamllint:
     runs-on:
       - [self-hosted, linux, aws]
-      - ubuntu-latest
+      - [self-hosted, linux, x64, ci-small]
     steps:
       - uses: actions/checkout@v4
       - name: Install yamllint

--- a/docs/ci/required-checks.yml
+++ b/docs/ci/required-checks.yml
@@ -1,0 +1,2 @@
+required_checks:
+  - Self-hosted enforce


### PR DESCRIPTION
## Summary
- add reusable self-hosted workflow and self-hosted enforcement
- add self-hosted fast lane and full lane workflows
- require self-hosted enforce check

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html)*


------
https://chatgpt.com/codex/tasks/task_e_68a7b0b9b760832dbb1273e6937969d3