### PR TITLE
ci: add watchdog for expected checks

### DIFF
--- a/.github/workflows/ci-watchdog.yml
+++ b/.github/workflows/ci-watchdog.yml
@@ -1,40 +1,42 @@
 name: CI Watchdog
 
-env:
-  HUSKY: 0
-
 on:
   workflow_run:
-    workflows: ["CI", "build", "test"]
+    workflows: ["CI Full Lane"]
     types: [completed]
-  schedule:
-    - cron:  '0 */3 * * *'
 
 permissions:
-  contents: write
-  issues: write
-  pull-requests: write
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  actions: read
+  checks: read
+  contents: read
 
 jobs:
-  scan:
-    timeout-minutes: 15
-    if: ${{ github.repository_owner == 'print3git' }}
-    runs-on:
-      - [self-hosted, linux, aws]
-      - ubuntu-latest
+  verify:
+    runs-on: ubuntu-latest
     steps:
-      - name: Heartbeat
-        run: |
-          while true; do date; sleep 120; done &
       - uses: actions/checkout@v5
-      - uses: actions/setup-node@v4
+      - name: Ensure required checks ran
+        uses: actions/github-script@v7
         with:
-          node-version: 20
-      - run: npm install --no-audit --no-fund
-      - run: node scripts/ci_watchdog.js
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const expected = JSON.parse(fs.readFileSync('scripts/ci/expected-checks.json', 'utf8')).checks;
+            const run_id = context.payload.workflow_run.id;
+            const run = await github.rest.actions.getWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id
+            });
+            const sha = run.data.head_sha;
+            const { data: { check_runs } } = await github.rest.checks.listForRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: sha,
+              per_page: 100
+            });
+            const names = check_runs.map(c => c.name);
+            const missing = expected.filter(n => !names.includes(n));
+            const skipped = check_runs.filter(c => expected.includes(c.name) && c.conclusion === 'skipped').map(c => c.name);
+            if (missing.length || skipped.length) {
+              core.setFailed(`Missing checks: ${missing.join(', ')}. Skipped checks: ${skipped.join(', ')}`);
+            }

--- a/package.json
+++ b/package.json
@@ -202,6 +202,12 @@
     "*.ts": [
       "eslint --fix",
       "prettier --log-level warn --write"
+    ],
+    "scripts/ci/expected-checks.json": [
+      "node scripts/ci/update-expected-checks.js --check"
+    ],
+    ".github/workflows/ci-full-lane.yml": [
+      "node scripts/ci/update-expected-checks.js --check"
     ]
   },
   "dependencies": {

--- a/scripts/ci/expected-checks.json
+++ b/scripts/ci/expected-checks.json
@@ -1,0 +1,13 @@
+{
+  "checks": [
+    "CI Full Lane / lint",
+    "CI Full Lane / typecheck",
+    "CI Full Lane / unit",
+    "CI Full Lane / backend",
+    "CI Full Lane / frontend",
+    "CI Full Lane / e2e",
+    "CI Full Lane / docs",
+    "CI Full Lane / infra",
+    "CodeQL / analyze"
+  ]
+}

--- a/scripts/ci/update-expected-checks.js
+++ b/scripts/ci/update-expected-checks.js
@@ -1,0 +1,34 @@
+const { readFileSync, writeFileSync } = require("node:fs");
+const yaml = require("yaml");
+
+const WORKFLOWS = [
+  ".github/workflows/ci-full-lane.yml",
+  ".github/workflows/codeql.yml",
+];
+
+function extractChecks(file) {
+  const doc = yaml.parse(readFileSync(file, "utf8"));
+  const name = doc.name;
+  const jobs = Object.keys(doc.jobs || {});
+  return jobs.map((j) => `${name} / ${j}`);
+}
+
+const result = { checks: WORKFLOWS.flatMap(extractChecks) };
+
+if (process.argv.includes("--check")) {
+  const current = JSON.parse(
+    readFileSync("scripts/ci/expected-checks.json", "utf8"),
+  );
+  if (JSON.stringify(current) !== JSON.stringify(result)) {
+    console.error(
+      "scripts/ci/expected-checks.json is out of date. Run `node scripts/ci/update-expected-checks.js` to regenerate.",
+    );
+    process.exit(1);
+  }
+} else {
+  writeFileSync(
+    "scripts/ci/expected-checks.json",
+    JSON.stringify(result, null, 2) + "\n",
+  );
+  console.log("updated expected checks");
+}

--- a/scripts/ci/update-expected-checks.ts
+++ b/scripts/ci/update-expected-checks.ts
@@ -1,0 +1,34 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import yaml from "yaml";
+
+const WORKFLOWS = [
+  ".github/workflows/ci-full-lane.yml",
+  ".github/workflows/codeql.yml",
+];
+
+function extractChecks(file: string): string[] {
+  const doc = yaml.parse(readFileSync(file, "utf8"));
+  const name = doc.name as string;
+  const jobs = Object.keys(doc.jobs || {});
+  return jobs.map((j) => `${name} / ${j}`);
+}
+
+const result = { checks: WORKFLOWS.flatMap(extractChecks) };
+
+if (process.argv.includes("--check")) {
+  const current = JSON.parse(
+    readFileSync("scripts/ci/expected-checks.json", "utf8"),
+  );
+  if (JSON.stringify(current) !== JSON.stringify(result)) {
+    console.error(
+      "scripts/ci/expected-checks.json is out of date. Run `node scripts/ci/update-expected-checks.js` to regenerate.",
+    );
+    process.exit(1);
+  }
+} else {
+  writeFileSync(
+    "scripts/ci/expected-checks.json",
+    JSON.stringify(result, null, 2) + "\n",
+  );
+  console.log("updated expected checks");
+}


### PR DESCRIPTION
## Summary
- ensure CI run completes with all expected checks using workflow_run watchdog
- track expected CI checks in versioned JSON and regenerate via script
- enforce expected checks sync at commit time

## Testing
- `npm run validate-env`
- `npx prettier --write .github/workflows/ci-watchdog.yml scripts/ci/update-expected-checks.ts scripts/ci/update-expected-checks.js scripts/ci/expected-checks.json package.json`
- `npm test --prefix backend`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: SyntaxError in various workflow YAML files)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a83e0af6b8832d947bae60802d3d9d