### PR TITLE
ci: probe self-hosted runner availability

### DIFF
--- a/.github/workflows/ci-full-lane.yml
+++ b/.github/workflows/ci-full-lane.yml
@@ -9,6 +9,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
+  probe:
+    runs-on: ubuntu-latest
+    outputs:
+      labels: ${{ steps.probe.outputs.labels }}
+    steps:
+      - name: Probe self-hosted runners
+        id: probe
+        run: |
+          gh api repos/${{ github.repository }}/actions/runners --jq '.runners[].labels[].name' > labels.txt
+          echo "labels=$(tr '\n' ' ' < labels.txt)" >> "$GITHUB_OUTPUT"
   lint:
     uses: ./.github/workflows/reusable-test-job.yml
     with:
@@ -20,10 +30,12 @@ jobs:
       suite: typecheck
       command: npm run typecheck
   unit:
+    needs: probe
     uses: ./.github/workflows/reusable-test-job.yml
     with:
       suite: unit
       command: npm test
+      runner-labels: ${{ needs.probe.outputs.labels }}
   backend:
     uses: ./.github/workflows/reusable-test-job.yml
     with:
@@ -31,21 +43,26 @@ jobs:
       command: npm test -- --backend
       use-self-hosted: true
   frontend:
+    needs: probe
     uses: ./.github/workflows/reusable-test-job.yml
     with:
       suite: frontend
       command: npm test -- --frontend
+      runner-labels: ${{ needs.probe.outputs.labels }}
   e2e:
+    needs: probe
     uses: ./.github/workflows/reusable-test-job.yml
     with:
       suite: e2e
       command: npm run test:e2e
-      use-self-hosted: true
+      runner-labels: ${{ needs.probe.outputs.labels }}
   docs:
+    needs: probe
     uses: ./.github/workflows/reusable-test-job.yml
     with:
       suite: docs
       command: npm test -- --docs
+      runner-labels: ${{ needs.probe.outputs.labels }}
   infra:
     uses: ./.github/workflows/reusable-test-job.yml
     with:

--- a/.github/workflows/reusable-test-job.yml
+++ b/.github/workflows/reusable-test-job.yml
@@ -16,6 +16,10 @@ on:
         required: false
         type: boolean
         default: false
+      runner-labels:
+        required: false
+        type: string
+        default: ''
       shard-total:
         required: false
         type: number
@@ -26,7 +30,7 @@ on:
 jobs:
   test:
     name: ${{ inputs.suite }}
-    runs-on: ${{ inputs.use-self-hosted && 'self-hosted' || 'ubuntu-latest' }}
+    runs-on: ${{ (inputs.use-self-hosted || contains(inputs.runner-labels, 'self-hosted')) && fromJson('["self-hosted","linux","aws"]') || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
     timeout-minutes: 30


### PR DESCRIPTION
## Summary
- detect available self-hosted runners and expose labels to jobs
- allow reusable test job to choose self-hosted or ubuntu runners based on probe

## Testing
- `npm run format`
- `npm test`
- `npm run ci` *(fails: SyntaxError parsing existing YAML files)*
- `npm run smoke` *(fails: SyntaxError parsing existing YAML files)*

------
https://chatgpt.com/codex/tasks/task_e_68a83e1354f0832d967ebb4c3666e455