### PR TITLE
ci: add CF Pages preflight build

### DIFF
--- a/.github/workflows/cf-pages-preflight.yml
+++ b/.github/workflows/cf-pages-preflight.yml
@@ -1,0 +1,47 @@
+name: CF Pages Preflight
+
+env:
+  HUSKY: 0
+
+on:
+  pull_request:
+    paths:
+      - 'frontend/**'
+      - 'wrangler.toml'
+  merge_group:
+    paths:
+      - 'frontend/**'
+      - 'wrangler.toml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build frontend
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v5.0.0
+      - run: corepack enable
+      - uses: pnpm/action-setup@v4.0.0
+        with:
+          version: 8.15.8
+      - run: pnpm install --no-frozen-lockfile
+      - run: pnpm build
+      - name: Ensure dist exists
+        run: |
+          if [ ! -d dist ]; then
+            echo 'dist missing: run build or fix vite' >&2
+            exit 1
+          fi
+      - uses: actions/upload-artifact@v4
+        with:
+          name: frontend-dist
+          path: dist
+    timeout-minutes: 15


### PR DESCRIPTION
## Summary
- build frontend on Cloudflare Pages preflight if frontend or wrangler.toml touched

## Testing
- `npm run format` (backend)
- `npm test` *(fails: setup script tried to reinstall dependencies, aborting)*
- `npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html. Run 'npm run build' and retry)*
- `npm run ci` *(fails: dependencies missing, installation produced tar errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a83f132c40832d9730d381a59f0dd9