### PR TITLE
ci: record queue metrics

### DIFF
--- a/.github/workflows/ci-queue-metrics.yml
+++ b/.github/workflows/ci-queue-metrics.yml
@@ -1,0 +1,86 @@
+name: CI Queue Metrics
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+env:
+  HUSKY: 0
+
+permissions:
+  actions: write
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  record:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
+      - name: Record metrics
+        id: record
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const {owner, repo} = context.repo;
+            const run = context.payload.workflow_run;
+            const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {owner, repo, run_id: run.id});
+            const lines = [];
+            let alert = false;
+            for (const j of jobs) {
+              const delay = j.started_at && j.created_at ? (Date.parse(j.started_at) - Date.parse(j.created_at)) : 0;
+              lines.push({runId: run.id, runAttempt: run.run_attempt, jobId: j.id, jobName: j.name, jobStartDelayMs: delay});
+              if (delay > 5 * 60 * 1000) alert = true;
+            }
+            const summaryLines = lines.map(l => `${l.jobName}: ${l.jobStartDelayMs}ms`).join('\n');
+            core.summary.addHeading('Queue times').addCodeBlock(summaryLines, 'text');
+            await core.summary.write();
+            const { data: { artifacts } } = await github.rest.actions.listArtifactsForRepo({owner, repo, per_page: 100});
+            const existing = artifacts.find(a => a.name === 'ci-queue-metrics');
+            let content = '';
+            if (existing) {
+              const zip = await github.rest.actions.downloadArtifact({owner, repo, artifact_id: existing.id, archive_format: 'zip'});
+              const buffer = Buffer.from(zip.data);
+              const zlib = require('node:zlib');
+              const unzip = zlib.unzipSync(buffer);
+              content = unzip.toString('utf8');
+              await github.rest.actions.deleteArtifact({owner, repo, artifact_id: existing.id});
+            }
+            const fs = require('fs');
+            fs.writeFileSync('ci-queue-metrics.json', content + lines.map(l => JSON.stringify(l)).join('\n') + '\n');
+            core.setOutput('alert', alert ? '1' : '0');
+            core.setOutput('prs', JSON.stringify(run.pull_requests || []));
+            core.setOutput('summary', summaryLines);
+      - name: Upload metrics
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-queue-metrics
+          path: ci-queue-metrics.json
+          retention-days: 30
+      - name: Signal slow queue
+        if: steps.record.outputs.alert == '1'
+        uses: actions/github-script@v7
+        env:
+          PRS: ${{ steps.record.outputs.prs }}
+          SUMMARY: ${{ steps.record.outputs.summary }}
+        with:
+          script: |
+            const prs = JSON.parse(process.env.PRS);
+            const {owner, repo} = context.repo;
+            for (const pr of prs) {
+              try {
+                await github.rest.issues.addLabels({owner, repo, issue_number: pr.number, labels: ['runner-needed']});
+              } catch (e) {
+                if (e.status === 404) {
+                  await github.rest.issues.createLabel({owner, repo, name: 'runner-needed', color: 'B60205'});
+                  await github.rest.issues.addLabels({owner, repo, issue_number: pr.number, labels: ['runner-needed']});
+                } else {
+                  throw e;
+                }
+              }
+              await github.rest.issues.createComment({owner, repo, issue_number: pr.number, body: `@example/devops\n${process.env.SUMMARY}`});
+            }


### PR DESCRIPTION
## Summary
- track job start delays for CI workflow
- label PRs needing more runners when queue delay exceeds threshold

## Testing
- `npm run format` (backend)
- `npm test` (backend)
- `npm run ci` *(fails: YAML syntax errors)*
- `npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a83f15a0f4832db4750d209b5c0e67