### PR TITLE
ci: add secrets audit workflow

### DIFF
--- a/.github/workflows/ci-secrets-audit.yml
+++ b/.github/workflows/ci-secrets-audit.yml
@@ -1,0 +1,82 @@
+name: CI Secrets Audit
+
+on:
+  pull_request:
+  schedule:
+    - cron: '0 3 * * *'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - id: scan
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const dir = '.github/workflows';
+            const secretUsage = {};
+            const varUsage = {};
+            for (const file of fs.readdirSync(dir)) {
+              if (!file.endsWith('.yml') && !file.endsWith('.yaml')) continue;
+              const content = fs.readFileSync(path.join(dir, file), 'utf8');
+              let m;
+              const sRegex = /secrets\.([A-Z0-9_]+)/g;
+              while ((m = sRegex.exec(content)) !== null) {
+                secretUsage[m[1]] ??= new Set();
+                secretUsage[m[1]].add(file);
+              }
+              const vRegex = /vars\.([A-Z0-9_]+)/g;
+              while ((m = vRegex.exec(content)) !== null) {
+                varUsage[m[1]] ??= new Set();
+                varUsage[m[1]].add(file);
+              }
+            }
+            for (const k in secretUsage) secretUsage[k] = [...secretUsage[k]];
+            for (const k in varUsage) varUsage[k] = [...varUsage[k]];
+
+            const {data} = await github.rest.actions.listRepoSecrets({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 100,
+            });
+            const defined = data.secrets.map(s => s.name);
+            const missing = Object.keys(secretUsage).filter(s => !defined.includes(s));
+
+            core.setOutput('secret_usage', JSON.stringify(secretUsage));
+            core.setOutput('var_usage', JSON.stringify(varUsage));
+            core.setOutput('missing', JSON.stringify(missing));
+      - name: Fail if missing secrets
+        if: steps.scan.outputs.missing != '[]'
+        run: |
+          echo "Missing secrets: ${{ steps.scan.outputs.missing }}"
+          exit 1
+      - name: Post usage comment
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const secrets = JSON.parse(process.env.SECRET_USAGE);
+            const vars = JSON.parse(process.env.VAR_USAGE);
+            let body = '### CI secret usage\n';
+            for (const [name, files] of Object.entries(secrets)) {
+              body += `- **${name}**: ${files.join(', ')}\n`;
+            }
+            body += '\n### Repository variables\n';
+            for (const [name, files] of Object.entries(vars)) {
+              body += `- **${name}**: ${files.join(', ')}\n`;
+            }
+            await github.rest.issues.createComment({
+              ...context.repo,
+              issue_number: context.issue.number,
+              body,
+            });
+        env:
+          SECRET_USAGE: ${{ steps.scan.outputs.secret_usage }}
+          VAR_USAGE: ${{ steps.scan.outputs.var_usage }}


### PR DESCRIPTION
## Summary
- audit secrets used across workflow files and comment on PRs
- fail CI if undefined secrets are referenced

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Error occurred when checking code style in 11 files)*

------
https://chatgpt.com/codex/tasks/task_e_68a84047e724832dab7461b75b79d0f5