### PR TITLE
ci: track spot runner metrics and ensure warm capacity

### DIFF
--- a/.github/workflows/ci-queue-metrics.yml
+++ b/.github/workflows/ci-queue-metrics.yml
@@ -1,0 +1,42 @@
+name: CI Queue Metrics
+
+on:
+  schedule:
+    - cron: '*/10 * * * *'
+  workflow_dispatch:
+
+env:
+  HUSKY: 0
+
+jobs:
+  record:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Gather queue metrics
+        id: gather
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const runners = await github.paginate(
+              github.rest.actions.listSelfHostedRunnersForRepo,
+              { owner, repo }
+            );
+            const spotOnline = runners.filter(r =>
+              r.status === 'online' && r.labels.some(l => l.name === 'aws-spot-x64')
+            ).length;
+            const { data: runs } = await github.rest.actions.listWorkflowRunsForRepo({
+              owner,
+              repo,
+              per_page: 100,
+              status: 'in_progress'
+            });
+            const fallbackUsage = runs.filter(r => (r.runner_name || '').includes('GitHub')).length;
+            core.setOutput('spot_online', spotOnline);
+            core.setOutput('fallback_usage', fallbackUsage);
+      - name: Emit metrics
+        run: |
+          echo "spot_online=${{ steps.gather.outputs.spot_online }}" >> $GITHUB_STEP_SUMMARY
+          echo "fallback_usage=${{ steps.gather.outputs.fallback_usage }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/selfhosted-prefer.yml
+++ b/.github/workflows/selfhosted-prefer.yml
@@ -7,8 +7,27 @@ on:
 jobs:
   choose:
     runs-on: ${{ inputs.fallback }}
+    timeout-minutes: 2
     steps:
+      - name: Check spot runners
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runners = await github.paginate(
+              github.rest.actions.listSelfHostedRunnersForRepo,
+              { owner: context.repo.owner, repo: context.repo.repo }
+            );
+            const available = runners.some(r =>
+              r.status === 'online' && r.labels.some(l => l.name === inputs.label)
+            );
+            core.setOutput('available', available);
       - id: decide
-        run: echo "label=${{ inputs.label }}" >> $GITHUB_OUTPUT
+        run: |
+          if [[ "${{ steps.check.outputs.available }}" == "true" ]]; then
+            echo "label=${{ inputs.label }}" >> $GITHUB_OUTPUT
+          else
+            echo "label=${{ inputs.fallback }}" >> $GITHUB_OUTPUT
+          fi
     outputs:
       label: ${{ steps.decide.outputs.label }}

--- a/.github/workflows/selfhosted-probe.yml
+++ b/.github/workflows/selfhosted-probe.yml
@@ -7,7 +7,8 @@ on:
     - cron: "*/15 * * * *"
 
 env:
-  MIN_RUNNERS: ${{ vars.MIN_SELF_HOSTED_RUNNERS || 1 }}
+  # Ensure at least two warm runners are always online
+  MIN_RUNNERS: ${{ vars.MIN_SELF_HOSTED_RUNNERS || 2 }}
 
 jobs:
   probe-selfhosted:


### PR DESCRIPTION
## Summary
- add scheduled `ci-queue-metrics.yml` workflow to record spot vs fallback runner usage
- ensure at least two warm self-hosted runners via `selfhosted-probe.yml`
- enhance `selfhosted-prefer.yml` to check for spot availability and fallback within 2 minutes

## Testing
- `npm run format` (backend)
- `npm test` (backend)
- `SKIP_PW_DEPS=1 npm run ci` *(fails: existing YAML syntax errors)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a8404341a0832da10ab793894db78c