### PR TITLE
ci: add AWS runner heartbeat workflow

### DIFF
--- a/.github/workflows/aws-runner-heartbeat.yml
+++ b/.github/workflows/aws-runner-heartbeat.yml
@@ -1,0 +1,51 @@
+name: AWS runner heartbeat
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
+
+jobs:
+  decide:
+    name: Determine runner
+    runs-on: ubuntu-latest
+    outputs:
+      runner: ${{ steps.set-runner.outputs.runner }}
+      online: ${{ steps.set-runner.outputs.online }}
+    steps:
+      - id: set-runner
+        uses: actions/github-script@v7.0.1
+        with:
+          script: |
+            const {data} = await github.rest.actions.listSelfHostedRunnersForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 100
+            });
+            const online = data.runners.filter(r => r.status === 'online').length;
+            core.info(`Online self-hosted runners: ${online}`);
+            core.setOutput('online', String(online));
+            const runner = online > 0 ? '["self-hosted","linux","aws"]' : 'ubuntu-latest';
+            core.setOutput('runner', runner);
+
+  heartbeat:
+    needs: decide
+    runs-on: ${{ fromJSON(needs.decide.outputs.runner) }}
+    steps:
+      - name: Run heartbeat
+        uses: actions/github-script@v7.0.1
+        with:
+          script: |
+            const online = Number('${{ needs.decide.outputs.online }}');
+            core.info(`Online self-hosted runners: ${online}`);
+            await new Promise(r => setTimeout(r, 5000));
+            if (online === 0) {
+              const {data: labels} = await github.rest.issues.listLabelsForRepo({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                per_page: 100
+              });
+              if (labels.some(l => l.name === 'require-self-hosted')) {
+                core.setFailed('No self-hosted runners online and repo is labeled require-self-hosted');
+              }
+            }


### PR DESCRIPTION
## Summary
- add scheduled heartbeat workflow to report AWS self-hosted runner availability

## Testing
- `npm run format`
```
> backend@1.0.0 preformat
> node ../scripts/ensure-root-deps.js

> backend@1.0.0 format
> sh -c 'cd .. && node scripts/ensure-root-deps.js && prettier --log-level warn --write "**/*.{js,jsx,json,md}" --ignore-path .prettierignore'
```
- `npm test`
```
PASS tests/stripe-route-types.test.ts
  stripe route type checks
    ✓ checkout request body and response types (1490 ms)
    ✓ webhook request body and response types (1102 ms)
```
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Error occurred when checking code style in 11 files)*
```
Error occurred when checking code style in 11 files.
```
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html)*
```
Missing frontend build artifact: frontend/dist/index.html. Run 'npm run build' and retry
```

------
https://chatgpt.com/codex/tasks/task_e_68a83f19ca48832da3ec322bc1e95cea