### PR TITLE
ci: upload Playwright trace on failure

### DIFF
--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -32,4 +32,53 @@ jobs:
             backend/package-lock.json
             frontend/package-lock.json
       - run: npm run setup
-      - run: npm run e2e
+      - name: Create CI Playwright config
+        run: |
+          cat <<'EOF' > playwright.config.ci.ts
+          import { defineConfig } from '@playwright/test';
+          const baseURL = process.env.PLAYWRIGHT_BASE_URL || 'http://localhost:3000';
+          export default defineConfig({
+            testDir: 'e2e',
+            timeout: 30_000,
+            retries: 2,
+            workers: '50%',
+            forbidOnly: true,
+            use: {
+              baseURL,
+              headless: true,
+              ignoreHTTPSErrors: true,
+              trace: 'retain-on-failure',
+            },
+            webServer: process.env.PLAYWRIGHT_BASE_URL
+              ? undefined
+              : {
+                  command: 'node scripts/dev-server.js',
+                  port: 3000,
+                  timeout: 120_000,
+                  reuseExistingServer: true,
+                },
+          });
+          EOF
+      - run: npm run e2e -- --config=playwright.config.ci.ts
+      - name: Upload Playwright trace
+        if: failure()
+        id: upload-trace
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-trace
+          path: test-results/**/trace.zip
+          if-no-files-found: warn
+      - name: Comment trace link
+        if: failure() && github.event.pull_request
+        env:
+          TRACE_URL: ${{ steps.upload-trace.outputs['artifact-url'] }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `Playwright trace: https://trace.playwright.dev/?trace=${process.env.TRACE_URL}`,
+            });


### PR DESCRIPTION
## Summary
- generate temporary Playwright config for CI with retries, 50% workers, 30s timeout, and forbidOnly
- upload Playwright traces on failure and comment with a trace viewer link

## Testing
- `npm run format --prefix backend` *(failed: dependency installation long / interrupted)*
- `npm test --prefix backend` *(failed: setup reran and tests aborted)*
- `npx prettier .github/workflows/e2e-playwright.yml -w`


------
https://chatgpt.com/codex/tasks/task_e_68a83f0b5044832d833da5795a865014