### PR TITLE
ci: add coverage watchdog workflow

### DIFF
--- a/.github/workflows/coverage-watchdog.yml
+++ b/.github/workflows/coverage-watchdog.yml
@@ -1,0 +1,96 @@
+name: Coverage Watchdog
+
+env:
+  HUSKY: 0
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  watchdog:
+    runs-on:
+      - [self-hosted, linux, aws]
+      - ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Run backend coverage
+        run: |
+          npm run coverage --prefix backend
+          mv backend/coverage/lcov.info coverage/backend.lcov
+      - name: Run unit coverage
+        run: |
+          npm test -- --coverage --runInBand
+          mv coverage/lcov.info coverage/unit.lcov
+      - name: Run frontend coverage
+        run: |
+          npm test --prefix frontend -- --coverage --runInBand
+          mv frontend/coverage/lcov.info coverage/frontend.lcov
+      - name: Run e2e coverage
+        run: |
+          npx nyc --reporter=lcov --report-dir=e2e/coverage npm run test:e2e
+          mv e2e/coverage/lcov.info coverage/e2e.lcov
+      - name: Verify coverage reports
+        run: node scripts/verify-coverage-reports.js coverage/backend.lcov coverage/unit.lcov coverage/frontend.lcov coverage/e2e.lcov
+      - name: Merge coverage
+        run: npx lcov-result-merger coverage/backend.lcov coverage/unit.lcov coverage/frontend.lcov coverage/e2e.lcov > coverage/lcov.info
+      - name: Generate main baseline
+        run: |
+          git fetch origin main
+          git worktree add ../main origin/main
+          cd ../main
+          npm ci
+          npm run coverage --prefix backend
+          mv backend/coverage/lcov.info coverage/backend.lcov
+          npm test -- --coverage --runInBand
+          mv coverage/lcov.info coverage/unit.lcov
+          npm test --prefix frontend -- --coverage --runInBand
+          mv frontend/coverage/lcov.info coverage/frontend.lcov
+          npx nyc --reporter=lcov --report-dir=e2e/coverage npm run test:e2e
+          mv e2e/coverage/lcov.info coverage/e2e.lcov
+          npx lcov-result-merger coverage/backend.lcov coverage/unit.lcov coverage/frontend.lcov coverage/e2e.lcov > coverage/lcov.info
+          cd -
+      - name: Compare coverage
+        run: node scripts/coverage-diff.js coverage/lcov.info ../main/coverage/lcov.info
+      - name: Comment coverage diff
+        if: github.event.pull_request.number
+        uses: actions/github-script@v7.0.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const diff = fs.readFileSync('coverage/diff.txt', 'utf8');
+            const pr = context.payload.pull_request.number;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr,
+              body: `Coverage diff:\n\n\`\`\`\n${diff}\n\`\`\``
+            });
+      - name: Upload coverage artifacts
+        uses: actions/upload-artifact@v4.3.1
+        with:
+          name: coverage
+          path: |
+            coverage/*.lcov
+            coverage/lcov.info
+            coverage/diff.txt
+

--- a/scripts/coverage-diff.js
+++ b/scripts/coverage-diff.js
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+const fs = require("fs");
+const path = require("path");
+
+function summarize(lcovPath) {
+  const data = fs.readFileSync(lcovPath, "utf8");
+  const totals = {
+    lines: { found: 0, hit: 0 },
+    functions: { found: 0, hit: 0 },
+    branches: { found: 0, hit: 0 },
+  };
+  for (const record of data.split("end_of_record")) {
+    const lf = record.match(/LF:(\d+)/);
+    const lh = record.match(/LH:(\d+)/);
+    if (lf && lh) {
+      totals.lines.found += Number(lf[1]);
+      totals.lines.hit += Number(lh[1]);
+    }
+    const fnf = record.match(/FNF:(\d+)/);
+    const fnh = record.match(/FNH:(\d+)/);
+    if (fnf && fnh) {
+      totals.functions.found += Number(fnf[1]);
+      totals.functions.hit += Number(fnh[1]);
+    }
+    const brf = record.match(/BRF:(\d+)/);
+    const brh = record.match(/BRH:(\d+)/);
+    if (brf && brh) {
+      totals.branches.found += Number(brf[1]);
+      totals.branches.hit += Number(brh[1]);
+    }
+  }
+  const pct = {
+    lines: totals.lines.found
+      ? (totals.lines.hit / totals.lines.found) * 100
+      : 100,
+    functions: totals.functions.found
+      ? (totals.functions.hit / totals.functions.found) * 100
+      : 100,
+    branches: totals.branches.found
+      ? (totals.branches.hit / totals.branches.found) * 100
+      : 100,
+  };
+  pct.statements = pct.lines;
+  return pct;
+}
+
+const [current, base] = process.argv.slice(2);
+if (!current || !base) {
+  console.error("Usage: coverage-diff <current-lcov> <base-lcov>");
+  process.exit(1);
+}
+const cur = summarize(current);
+const baseline = summarize(base);
+const diffLines = [];
+let failed = false;
+for (const metric of ["lines", "functions", "branches", "statements"]) {
+  const change = cur[metric] - baseline[metric];
+  diffLines.push(
+    `${metric}: ${baseline[metric].toFixed(2)}% -> ${cur[metric].toFixed(2)}% (${change.toFixed(2)}%)`,
+  );
+  if (change < -2) failed = true;
+}
+const output = diffLines.join("\n");
+fs.mkdirSync(path.dirname("coverage/diff.txt"), { recursive: true });
+fs.writeFileSync("coverage/diff.txt", output);
+console.log(output);
+if (failed) {
+  process.exit(1);
+}

--- a/scripts/verify-coverage-reports.js
+++ b/scripts/verify-coverage-reports.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+const fs = require("fs");
+
+const paths = process.argv.slice(2);
+if (paths.length === 0) {
+  console.error("Usage: verify-coverage-reports <file...>");
+  process.exit(1);
+}
+const missing = paths.filter((p) => !fs.existsSync(p));
+if (missing.length) {
+  console.error(`Missing coverage reports:\n${missing.join("\n")}`);
+  process.exit(1);
+}
+console.log("All coverage reports produced.");


### PR DESCRIPTION
## Summary
- add coverage watchdog workflow comparing coverage to main and commenting diff
- add scripts to verify coverage reports and compute coverage changes

## Testing
- `npm run setup`
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: Setup flag missing. Running 'npm run setup'...)*
- `npm run ci` *(fails: process terminated with SIGINT)*
- `npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html)*

------
https://chatgpt.com/codex/tasks/task_e_68a8403ed224832db8fd103e4d9c0560