### PR TITLE
ci: add runner parity check

### DIFF
--- a/.github/workflows/runner-parity.yml
+++ b/.github/workflows/runner-parity.yml
@@ -1,0 +1,136 @@
+name: Runner parity check
+
+on:
+  pull_request:
+    branches: [main, dev, 00000production]
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+jobs:
+  github:
+    name: GitHub hosted
+    runs-on: ubuntu-latest
+    outputs:
+      result: ${{ steps.smoke.outputs.result }}
+      versions: ${{ steps.versions.outputs.json }}
+    steps:
+      - uses: actions/checkout@v5.0.0
+      - uses: actions/setup-node@v4.0.3
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        id: build
+        run: npm run build
+        continue-on-error: true
+      - name: Test
+        id: test
+        run: npm test --maxWorkers=2
+        continue-on-error: true
+      - name: Collect versions
+        id: versions
+        run: |
+          node <<'NODE' >> "$GITHUB_OUTPUT"
+          const os=require('os');
+          const cp=require('child_process');
+          const data={
+            node: process.version,
+            npm: cp.execSync('npm -v').toString().trim(),
+            pnpm: (()=>{try{return cp.execSync('pnpm -v').toString().trim()}catch(e){return ''}})(),
+            python: cp.execSync('python3 --version').toString().trim(),
+            os: `${os.type()} ${os.release()}`
+          };
+          require('fs').writeFileSync('env.json', JSON.stringify(data, null, 2));
+          console.log('json='+JSON.stringify(data));
+          NODE
+      - name: Determine result
+        id: smoke
+        run: |
+          if [ "${{ steps.build.outcome }}" = success ] && [ "${{ steps.test.outcome }}" = success ]; then
+            echo "result=success" >> "$GITHUB_OUTPUT"
+          else
+            echo "result=failure" >> "$GITHUB_OUTPUT"
+          fi
+
+  aws:
+    name: AWS hosted
+    runs-on: [self-hosted, linux, aws]
+    outputs:
+      result: ${{ steps.smoke.outputs.result }}
+      versions: ${{ steps.versions.outputs.json }}
+    steps:
+      - uses: actions/checkout@v5.0.0
+      - uses: actions/setup-node@v4.0.3
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        id: build
+        run: npm run build
+        continue-on-error: true
+      - name: Test
+        id: test
+        run: npm test --maxWorkers=2
+        continue-on-error: true
+      - name: Collect versions
+        id: versions
+        run: |
+          node <<'NODE' >> "$GITHUB_OUTPUT"
+          const os=require('os');
+          const cp=require('child_process');
+          const data={
+            node: process.version,
+            npm: cp.execSync('npm -v').toString().trim(),
+            pnpm: (()=>{try{return cp.execSync('pnpm -v').toString().trim()}catch(e){return ''}})(),
+            python: cp.execSync('python3 --version').toString().trim(),
+            os: `${os.type()} ${os.release()}`
+          };
+          require('fs').writeFileSync('env.json', JSON.stringify(data, null, 2));
+          console.log('json='+JSON.stringify(data));
+          NODE
+      - name: Determine result
+        id: smoke
+        run: |
+          if [ "${{ steps.build.outcome }}" = success ] && [ "${{ steps.test.outcome }}" = success ]; then
+            echo "result=success" >> "$GITHUB_OUTPUT"
+          else
+            echo "result=failure" >> "$GITHUB_OUTPUT"
+          fi
+
+  compare:
+    name: Compare
+    runs-on: ubuntu-latest
+    needs: [github, aws]
+    if: always()
+    steps:
+      - uses: actions/setup-node@v4.0.3
+        with:
+          node-version: 20
+      - name: Compare runners
+        run: |
+          node <<'NODE'
+          const fs=require('fs');
+          const gh=JSON.parse(process.env.GH_VERSIONS);
+          const aws=JSON.parse(process.env.AWS_VERSIONS);
+          const result={
+            github:{result: process.env.GH_RESULT, ...gh},
+            aws:{result: process.env.AWS_RESULT, ...aws}
+          };
+          result.match = JSON.stringify(result.github)===JSON.stringify(result.aws);
+          fs.writeFileSync('runner-parity.json', JSON.stringify(result, null, 2));
+          if(!result.match) process.exit(1);
+          NODE
+        env:
+          GH_RESULT: ${{ needs.github.outputs.result }}
+          GH_VERSIONS: ${{ needs.github.outputs.versions }}
+          AWS_RESULT: ${{ needs.aws.outputs.result }}
+          AWS_VERSIONS: ${{ needs.aws.outputs.versions }}
+      - uses: actions/upload-artifact@v4.3.4
+        with:
+          name: runner-parity
+          path: runner-parity.json


### PR DESCRIPTION
## Summary
- add runner-parity workflow to compare GitHub-hosted and AWS-hosted runners

## Testing
- `npm run format` (backend)
- `npm test` (backend)
- `SKIP_PW_DEPS=1 npm run ci` *(fails: YAML syntax errors)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a8403a3154832d8115bd00ab49b5b3