### PR TITLE
test: validate wrangler config

### DIFF
--- a/ci/impact-map.yml
+++ b/ci/impact-map.yml
@@ -14,3 +14,4 @@ infra:
   - .github/**
   - ci/**
   - scripts/**
+  - wrangler.toml

--- a/scripts/cf/validate-wrangler.ts
+++ b/scripts/cf/validate-wrangler.ts
@@ -1,0 +1,34 @@
+import fs from "fs";
+import path from "path";
+import toml from "toml";
+
+export function validateWrangler(
+  filePath = path.join(__dirname, "..", "..", "wrangler.toml"),
+): void {
+  if (!fs.existsSync(filePath)) {
+    console.log("wrangler.toml not found; skipping");
+    return;
+  }
+  const content = fs.readFileSync(filePath, "utf8");
+  const config = toml.parse(content);
+  const errors: string[] = [];
+  if ("build" in config) {
+    errors.push('remove "build" (Pages uses pages_build_output_dir)');
+  }
+  if (config.pages_build_output_dir !== "frontend/dist") {
+    errors.push('pages_build_output_dir must be "frontend/dist"');
+  }
+  if (errors.length) {
+    throw new Error(`wrangler.toml invalid: ${errors.join(", ")}`);
+  }
+}
+
+if (require.main === module) {
+  try {
+    validateWrangler();
+    console.log("wrangler.toml OK");
+  } catch (err) {
+    console.error((err as Error).message);
+    process.exit(1);
+  }
+}

--- a/tests/ci/wrangler-pages-config.test.js
+++ b/tests/ci/wrangler-pages-config.test.js
@@ -1,39 +1,25 @@
-const test = require("node:test");
-const assert = require("node:assert/strict");
-const fs = require("node:fs");
+const { spawnSync } = require("node:child_process");
 const path = require("node:path");
 
-function parseToml(str) {
-  try {
-    const toml = require("toml");
-    return toml.parse(str);
-  } catch {
-    const out = {};
-    str.split(/\n+/).forEach((line) => {
-      const m = line.match(/^\s*([^#=]+)\s*=\s*"?([^"#]+)"?/);
-      if (m) out[m[1].trim()] = m[2].trim();
-    });
-    return out;
-  }
-}
-
-const wranglerPath = path.join(process.cwd(), "wrangler.toml");
-
-test("wrangler.toml pages config", () => {
-  if (!fs.existsSync(wranglerPath)) {
-    test.skip("no wrangler.toml");
-    return;
-  }
-  const config = parseToml(fs.readFileSync(wranglerPath, "utf8"));
-  const errors = [];
-  if ("build" in config)
-    errors.push('remove "build" (Pages uses pages_build_output_dir)');
-  if (!config.name) errors.push("missing name");
-  if (!config.pages_build_output_dir)
-    errors.push("missing pages_build_output_dir");
-  if (errors.length) {
-    assert.fail(
-      `wrangler.toml invalid: ${errors.join(", ")}. See Cloudflare Pages docs for fixes.`,
+describe("wrangler.toml pages config", () => {
+  test("config valid", () => {
+    const script = path.join(
+      __dirname,
+      "..",
+      "..",
+      "scripts",
+      "cf",
+      "validate-wrangler.ts",
     );
-  }
+    const res = spawnSync(
+      "npx",
+      ["-y", "ts-node", "--transpile-only", script],
+      {
+        encoding: "utf8",
+      },
+    );
+    if (res.status !== 0) {
+      throw new Error((res.stdout + res.stderr).trim());
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- add Cloudflare Pages wrangler validator script
- ensure infra CI runs wrangler config check
- include wrangler.toml in infra impact map

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `node scripts/run-jest.js tests/ci/wrangler-pages-config.test.js`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: root eslint exits 0)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a83f3b0914832da024fcf24f2dbbf5