### PR TITLE
ci: add pnpm policy workflow

### DIFF
--- a/.github/workflows/pnpm-policy.yml
+++ b/.github/workflows/pnpm-policy.yml
@@ -1,0 +1,32 @@
+name: pnpm policy
+
+on:
+  push:
+    branches:
+      - dev
+      - 00000production
+  pull_request:
+    branches:
+      - dev
+      - 00000production
+  workflow_call:
+
+jobs:
+  enforce:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5.0.0
+      - name: prevent mixed package managers
+        run: |
+          if [ -f package-lock.json ] && [ -f pnpm-lock.yaml ]; then
+            echo "Error: both package-lock.json and pnpm-lock.yaml exist." >&2
+            exit 1
+          fi
+      - name: enable corepack
+        run: corepack enable
+      - uses: pnpm/action-setup@v4.1.0
+        with:
+          version: 9
+          run_install: false
+      - name: install dependencies
+        run: pnpm install --no-frozen-lockfile


### PR DESCRIPTION
## Summary
- add pnpm policy workflow enforcing corepack, pnpm@9 and lockfile checks

## Testing
- `npm run format`
- `npm test`
- `npm run ci` *(fails: SyntaxError: Nested mappings are not allowed in compact mappings)*
- `npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html. Run 'npm run build' and retry)*

------
https://chatgpt.com/codex/tasks/task_e_68a83f3550f0832d80aedc4f816b2fdd