### PR TITLE
ci: add Cloudflare env alias scripts

### DIFF
--- a/.github/actions/node-setup/action.yml
+++ b/.github/actions/node-setup/action.yml
@@ -2,6 +2,9 @@ name: Node setup
 runs:
   using: composite
   steps:
+    - name: Setup env aliases
+      shell: bash
+      run: echo "BASH_ENV=$GITHUB_WORKSPACE/scripts/env/aliases.sh" >> "$GITHUB_ENV"
     - name: Enable Corepack and set PNPM_HOME
       shell: bash
       run: |

--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -2,6 +2,9 @@ name: Setup pnpm
 runs:
   using: composite
   steps:
+    - name: Setup env aliases
+      shell: bash
+      run: echo "BASH_ENV=$GITHUB_WORKSPACE/scripts/env/aliases.sh" >> "$GITHUB_ENV"
     - run: corepack enable
       shell: bash
     - run: corepack prepare pnpm@9.0.0 --activate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ concurrency:
 
 env:
   HUSKY: 0
+  BASH_ENV: scripts/env/aliases.sh
 
 jobs:
   build:

--- a/.github/workflows/cloudflare-pages-artifact.yml
+++ b/.github/workflows/cloudflare-pages-artifact.yml
@@ -5,6 +5,9 @@ on:
     branches: [dev]
   pull_request:
 
+env:
+  BASH_ENV: scripts/env/aliases.sh
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/cloudflare-pages-deploy.yml
+++ b/.github/workflows/cloudflare-pages-deploy.yml
@@ -5,21 +5,18 @@ on:
     branches: [00000production]
   workflow_dispatch:
 
+env:
+  BASH_ENV: scripts/env/aliases.sh
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID || secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CF_PAGES_API_TOKEN: ${{ secrets.CF_PAGES_API_TOKEN || secrets.CLOUDFLARE_API_TOKEN }}
+      CF_PAGES_PROJECT: ${{ secrets.CF_PAGES_PROJECT || secrets.CLOUDFLARE_PAGES_PROJECT }}
     steps:
       - uses: actions/checkout@v5
-      - name: Map env vars
-        run: |
-          node -e "const m=require('./ci/cloudflare/vars-alias.map.json');for(const [t,aliases] of Object.entries(m)){for(const a of aliases){const v=process.env[a];if(v){console.log(`${t}=${v}`);break;}}}" >> $GITHUB_ENV
-        env:
-          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          CF_PAGES_API_TOKEN: ${{ secrets.CF_PAGES_API_TOKEN }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CF_PAGES_PROJECT: ${{ secrets.CF_PAGES_PROJECT }}
-          CLOUDFLARE_PAGES_PROJECT: ${{ secrets.CLOUDFLARE_PAGES_PROJECT }}
       - uses: actions/download-artifact@v4
         with:
           name: frontend-dist

--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -4,6 +4,9 @@ on:
     branches: [00000production]
   workflow_dispatch:
 
+env:
+  BASH_ENV: scripts/env/aliases.sh
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/cloudflare-preview.yml
+++ b/.github/workflows/cloudflare-preview.yml
@@ -4,10 +4,13 @@ on:
   pull_request:
     branches: [main]
     paths:
-      - 'frontend/**'
-      - '!docs/**'
-      - 'package.json'
+      - "frontend/**"
+      - "!docs/**"
+      - "package.json"
   workflow_dispatch:
+
+env:
+  BASH_ENV: scripts/env/aliases.sh
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -2,6 +2,7 @@ name: Node CI
 
 env:
   HUSKY: 0
+  BASH_ENV: scripts/env/aliases.sh
 
 
 on:

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -2,6 +2,7 @@ name: Pages Deploy
 
 env:
   HUSKY: 0
+  BASH_ENV: scripts/env/aliases.sh
 
 on:
   push:

--- a/scripts/env/aliases.sh
+++ b/scripts/env/aliases.sh
@@ -1,0 +1,15 @@
+# shellcheck shell=bash
+# Cloudflare env aliases
+alias_pairs=(
+  CF_ACCOUNT_ID:CLOUDFLARE_ACCOUNT_ID
+  CF_PAGES_API_TOKEN:CLOUDFLARE_API_TOKEN
+  CF_PAGES_PROJECT:CLOUDFLARE_PAGES_PROJECT
+)
+for pair in "${alias_pairs[@]}"; do
+  IFS=: read -r primary secondary <<<"$pair"
+  value="${!primary:-${!secondary-}}"
+  if [ -n "$value" ]; then
+    export "$primary"="$value"
+    export "$secondary"="$value"
+  fi
+done

--- a/scripts/env/aliases.ts
+++ b/scripts/env/aliases.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from "fs";
+import { dirname, resolve } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const mapPath = resolve(__dirname, "../../ci/cloudflare/vars-alias.map.json");
+const aliasMap: Record<string, string[]> = JSON.parse(
+  readFileSync(mapPath, "utf8"),
+);
+
+for (const names of Object.values(aliasMap)) {
+  const value = names.map((n) => process.env[n]).find(Boolean);
+  if (value) {
+    for (const name of names) {
+      process.env[name] = value;
+    }
+  }
+}
+
+export {};


### PR DESCRIPTION
## Summary
- add bash/ts scripts that alias Cloudflare env vars
- source env aliases for Node and PNPM steps via BASH_ENV
- drop manual Cloudflare mapping in Pages deploy workflow

## Testing
- `npm run setup` (with `SKIP_PW_DEPS=1`)
- `npm run format` (backend)
- `npm test` (backend)
- `npm run ci` *(fails: SyntaxError: Nested mappings are not allowed in compact mappings)*
- `npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html)*

------
https://chatgpt.com/codex/tasks/task_e_68a83f31517c832db0ea00cb2a0e0717