### PR TITLE
feat: add ephemeral aws gh runner infrastructure

### DIFF
--- a/.github/workflows/self-hosted-runner-probe.yml
+++ b/.github/workflows/self-hosted-runner-probe.yml
@@ -1,0 +1,25 @@
+name: self-hosted runner probe
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch:
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - name: list runners
+        uses: actions/github-script@v7.0.1
+        with:
+          script: |
+            const runners = await github.paginate(
+              github.rest.actions.listSelfHostedRunnersForRepo,
+              {owner: context.repo.owner, repo: context.repo.repo}
+            );
+            const online = runners.filter(r => r.labels.some(l => l.name === 'aws') && r.status === 'online');
+            if (online.length === 0) {
+              core.setFailed('no aws runners online');
+            } else {
+              core.info(`aws runners online: ${online.length}`);
+            }

--- a/infra/aws/gh-runner/ec2/runner.tf
+++ b/infra/aws/gh-runner/ec2/runner.tf
@@ -1,0 +1,49 @@
+provider "aws" {
+  region = var.aws_region
+}
+
+data "aws_ami" "amazon_linux" {
+  most_recent = true
+  owners      = ["amazon"]
+  filter {
+    name   = "name"
+    values = ["al2023-ami-*-x86_64"]
+  }
+}
+
+resource "aws_launch_template" "runner" {
+  name_prefix   = "gh-runner-"
+  image_id      = data.aws_ami.amazon_linux.id
+  instance_type = "t3.small"
+
+  iam_instance_profile {
+    name = aws_iam_instance_profile.runner.name
+  }
+
+  user_data = filebase64("${path.module}/../scripts/userdata.sh")
+}
+
+resource "aws_iam_instance_profile" "runner" {
+  name = "gh-runner-profile"
+  role = aws_iam_role.github_runners.name
+}
+
+resource "aws_autoscaling_group" "runner" {
+  name                      = "gh-runner-asg"
+  min_size                  = 0
+  max_size                  = 2
+  desired_capacity          = 1
+  vpc_zone_identifier       = var.subnet_ids
+  launch_template {
+    id      = aws_launch_template.runner.id
+    version = "$Latest"
+  }
+  lifecycle {
+    create_before_destroy = true
+  }
+  tag {
+    key                 = "Name"
+    value               = "gh-runner"
+    propagate_at_launch = true
+  }
+}

--- a/infra/aws/gh-runner/iam/oidc.tf
+++ b/infra/aws/gh-runner/iam/oidc.tf
@@ -1,0 +1,30 @@
+provider "aws" {
+  region = var.aws_region
+}
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_iam_openid_connect_provider" "github" {
+  url             = "https://token.actions.githubusercontent.com"
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+}
+
+resource "aws_iam_role" "github_runners" {
+  name = "GitHubRunnersRole"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = { Federated = aws_iam_openid_connect_provider.github.arn }
+      Action   = "sts:AssumeRoleWithWebIdentity"
+      Condition = {
+        StringLike = {
+          "token.actions.githubusercontent.com:sub" = "repo:${var.github_repository}:*"
+        }
+      }
+    }]
+  })
+
+  managed_policy_arns = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"]
+}

--- a/infra/aws/gh-runner/outputs.tf
+++ b/infra/aws/gh-runner/outputs.tf
@@ -1,0 +1,7 @@
+output "runner_label" {
+  value = var.runner_label
+}
+
+output "runner_role_arn" {
+  value = aws_iam_role.github_runners.arn
+}

--- a/infra/aws/gh-runner/scripts/userdata.sh
+++ b/infra/aws/gh-runner/scripts/userdata.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+trap '/opt/actions-runner/svc.sh stop || true; /opt/actions-runner/svc.sh uninstall || true' EXIT
+
+# Install Node.js 20 and pnpm 9
+curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
+apt-get update
+apt-get install -y nodejs docker.io jq
+npm install -g pnpm@9
+
+# Install Playwright dependencies
+npx --yes playwright install-deps
+
+# Download and install GitHub Actions runner
+RUNNER_VERSION="2.317.0"
+useradd -m runner || true
+cd /opt
+curl -L -o actions-runner.tar.gz https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz
+mkdir -p actions-runner
+cd actions-runner
+tar xzf ../actions-runner.tar.gz
+./bin/installdependencies.sh
+
+# Assume role to retrieve registration token from SSM
+ROLE_ARN="${RUNNER_ROLE_ARN}"
+CREDS=$(aws sts assume-role --role-arn "$ROLE_ARN" --role-session-name github-runner)
+export AWS_ACCESS_KEY_ID=$(echo "$CREDS" | jq -r .Credentials.AccessKeyId)
+export AWS_SECRET_ACCESS_KEY=$(echo "$CREDS" | jq -r .Credentials.SecretAccessKey)
+export AWS_SESSION_TOKEN=$(echo "$CREDS" | jq -r .Credentials.SessionToken)
+TOKEN=$(aws ssm get-parameter --name /github/runner/token --with-decryption --query Parameter.Value --output text)
+
+# Configure runner as ephemeral
+./config.sh --url https://github.com/${GITHUB_OWNER}/${GITHUB_REPO} \
+  --token "$TOKEN" \
+  --labels "${RUNNER_LABEL},linux" \
+  --unattended --ephemeral
+./svc.sh install
+./svc.sh start

--- a/infra/aws/gh-runner/variables.tf
+++ b/infra/aws/gh-runner/variables.tf
@@ -1,0 +1,21 @@
+variable "aws_region" {
+  description = "AWS region to deploy runners"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "github_repository" {
+  description = "Owner/repo for runner registration"
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "List of subnet IDs for the ASG"
+  type        = list(string)
+}
+
+variable "runner_label" {
+  description = "Label applied to GitHub runner"
+  type        = string
+  default     = "aws"
+}


### PR DESCRIPTION
## Summary
- provision AWS IAM role and OIDC provider for GitHub runners
- bootstrap autoscaling group of ephemeral runners with install script
- probe workflow alerts if no `aws` labeled runners online

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: SyntaxError in existing workflow YAML)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a83e182b6c832d8c5d78f47bde2b10