### PR TITLE
ci: add test watchdog

### DIFF
--- a/.github/workflows/test-watchdog.yml
+++ b/.github/workflows/test-watchdog.yml
@@ -1,37 +1,73 @@
-name: Test Watchdog
-on:
-  push:
-    branches: [dev, 00000production]
-  pull_request:
-    branches: [dev, 00000production]
+name: Test Watchdog (list & compare)
 
-concurrency:
-  group: ci-${{ github.ref }}-test-watchdog
-  cancel-in-progress: true
+on:
+  pull_request:
+  push:
+  schedule:
+    - cron: "17 3 * * *" # nightly sanity
 
 jobs:
-  watchdog:
+  list-current:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.1.7
         with:
           fetch-depth: 0
-
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v4.0.3
         with:
           node-version: 20
-      - uses: ./.github/actions/node-setup
-
-      - name: Install tooling (root only, no project install)
+      - name: List tests
+        run: node scripts/list-tests.ts
+      - uses: actions/upload-artifact@v4.3.4
+        if: always()
+        with:
+          name: test-list-current
+          path: test-inventory/current.json
+  baseline-on-default:
+    if: github.ref != 'refs/heads/dev' # default branch assumed dev; adjust only here if needed
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.7
+        with:
+          ref: dev
+          fetch-depth: 0
+      - uses: actions/setup-node@v4.0.3
+        with:
+          node-version: 20
+      - name: List tests (baseline)
         run: |
-          npm i -D -E glob@10 yaml@2 chalk@5
-
-      - name: Run test discovery watchdog
+          node scripts/list-tests.ts
+          mkdir -p test-inventory
+          mv test-inventory/current.json test-inventory/baseline.json
+      - uses: actions/upload-artifact@v4.3.4
+        if: always()
+        with:
+          name: test-list-baseline
+          path: test-inventory/baseline.json
+  compare:
+    needs: [list-current, baseline-on-default]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4.1.8
+        with:
+          name: test-list-current
+          path: .
+      - uses: actions/download-artifact@v4.1.8
+        with:
+          name: test-list-baseline
+          path: .
+      - name: Compare lists
+        run: |
+          node -e "
+          const fs=require('fs');
+          const cur=JSON.parse(fs.readFileSync('test-inventory/current.json','utf8'));
+          const base=fs.existsSync('test-inventory/baseline.json')?JSON.parse(fs.readFileSync('test-inventory/baseline.json','utf8')):{totals:{count:0},packages:{}};
+          const drop = (base.totals.count||0) - (cur.totals.count||0);
+          const THRESH=parseInt(process.env.ALLOWABLE_DROP||'0',10);
+          function summarize(o){return Object.fromEntries(Object.entries(o.packages||{}).map(([k,v])=>[k,v.count]));}
+          console.log('Baseline total:', base.totals.count,'Current total:',cur.totals.count,'Drop:',drop);
+          console.log('Per-package baseline:', summarize(base));
+          console.log('Per-package current :', summarize(cur));
+          if (drop>THRESH){console.error('Test count dropped more than threshold:',drop,'>',THRESH); process.exit(1);}"
         env:
-          GITHUB_EVENT_NAME: ${{ github.event_name }}
-          GITHUB_REF: ${{ github.ref }}
-          GITHUB_SHA: ${{ github.sha }}
-          COMMIT_MSG: ${{ github.event.head_commit.message || github.event.pull_request.title }}
-        run: node scripts/ci/test-watchdog.mjs
+          ALLOWABLE_DROP: "0"

--- a/scripts/list-tests.ts
+++ b/scripts/list-tests.ts
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+// @ts-nocheck
+const { spawnSync } = require("node:child_process");
+const { existsSync, mkdirSync, writeFileSync } = require("node:fs");
+const path = require("node:path");
+
+const repoRoot =
+  spawnSync("git", ["rev-parse", "--show-toplevel"], {
+    encoding: "utf8",
+  }).stdout.trim() || process.cwd();
+
+const packages = {
+  root: ".",
+  frontend: "frontend",
+  backend: "backend",
+  e2e: "e2e",
+};
+
+function run(cmd, args, cwd) {
+  try {
+    const res = spawnSync(cmd, args, { cwd, encoding: "utf8" });
+    if (res.error) throw res.error;
+    if (res.status !== 0) throw new Error(res.stderr || res.stdout);
+    return res.stdout;
+  } catch (err) {
+    console.warn(`[warn] ${cmd} failed in ${cwd}:`, err.message);
+    return "";
+  }
+}
+
+function parseOutput(out) {
+  if (!out) return [];
+  try {
+    const data = JSON.parse(out);
+    const paths = [];
+    const walk = (obj) => {
+      if (!obj) return;
+      if (typeof obj === "string") {
+        if (obj.startsWith("/")) paths.push(obj);
+      } else if (Array.isArray(obj)) {
+        obj.forEach(walk);
+      } else if (typeof obj === "object") {
+        Object.values(obj).forEach(walk);
+      }
+    };
+    walk(data);
+    return paths;
+  } catch {
+    return out
+      .split(/\r?\n/)
+      .map((l) => l.trim())
+      .filter(
+        (l) => l && (l.startsWith("/") || l.match(/\.([cm]?js|tsx?|jsx?)$/)),
+      );
+  }
+}
+
+const results = {};
+const globalSet = new Set();
+
+for (const [name, relDir] of Object.entries(packages)) {
+  const cwd = path.join(repoRoot, relDir);
+  const files = new Set();
+
+  // determine if package has package.json or config
+  const hasPkg =
+    existsSync(path.join(cwd, "package.json")) ||
+    existsSync(path.join(cwd, "jest.config.js")) ||
+    existsSync(path.join(cwd, "vitest.config.ts")) ||
+    existsSync(path.join(cwd, "playwright.config.js")) ||
+    existsSync(path.join(cwd, "playwright.config.ts"));
+  if (!hasPkg) {
+    console.warn(`[warn] skipping ${name}: no config or package.json`);
+    continue;
+  }
+
+  // Jest
+  let out = run("npx", ["--no-install", "jest", "--listTests", "--json"], cwd);
+  parseOutput(out).forEach((p) => files.add(p));
+
+  // Vitest
+  out = run("npx", ["--no-install", "vitest", "list", "--reporter=json"], cwd);
+  if (!out) {
+    out = run("npx", ["--no-install", "vitest", "--list"], cwd);
+  }
+  parseOutput(out).forEach((p) => files.add(p));
+
+  // Playwright
+  const pwArgs = [
+    "--no-install",
+    "playwright",
+    "test",
+    "--list",
+    "--reporter=json",
+  ];
+  if (
+    name === "e2e" &&
+    !existsSync(path.join(cwd, "playwright.config.ts")) &&
+    !existsSync(path.join(cwd, "playwright.config.js"))
+  ) {
+    pwArgs.push(
+      "--config",
+      path.relative(cwd, path.join(repoRoot, "playwright.config.js")),
+    );
+  }
+  out = run("npx", pwArgs, cwd);
+  if (!out) {
+    const fallback = ["--no-install", "playwright", "test", "--list"];
+    if (
+      name === "e2e" &&
+      !existsSync(path.join(cwd, "playwright.config.ts")) &&
+      !existsSync(path.join(cwd, "playwright.config.js"))
+    ) {
+      fallback.push(
+        "--config",
+        path.relative(cwd, path.join(repoRoot, "playwright.config.js")),
+      );
+    }
+    out = run("npx", fallback, cwd);
+  }
+  parseOutput(out).forEach((p) => files.add(p));
+
+  const relFiles = Array.from(files)
+    .map((f) => path.relative(repoRoot, path.resolve(cwd, f)))
+    .sort();
+  relFiles.forEach((f) => globalSet.add(f));
+  results[name] = { count: relFiles.length, files: relFiles };
+}
+
+const output = {
+  generatedAt: new Date().toISOString(),
+  commit: spawnSync("git", ["rev-parse", "HEAD"], {
+    encoding: "utf8",
+  }).stdout.trim(),
+  packages: results,
+  totals: { count: globalSet.size },
+};
+
+const outDir = path.join(repoRoot, "test-inventory");
+mkdirSync(outDir, { recursive: true });
+writeFileSync(
+  path.join(outDir, "current.json"),
+  JSON.stringify(output, null, 2),
+);
+console.log(
+  `Wrote ${globalSet.size} test files to test-inventory/current.json`,
+);

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -15,6 +15,7 @@
     "ci_watchdog.ts",
     "gh-runner-token.ts",
     "ci/scale-signal.ts",
-    "ci/check-lfs.ts"
+    "ci/check-lfs.ts",
+    "list-tests.ts"
   ]
 }


### PR DESCRIPTION
## Summary
- add script to enumerate Jest, Vitest and Playwright tests across packages
- wire up Test Watchdog workflow to compare test inventories

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: .github/actions/ci-metrics-emit/action.yml: SyntaxError: All collection items must start at the same column)*
- `node scripts/list-tests.ts` *(no output; command hung)*

------
https://chatgpt.com/codex/tasks/task_e_68a845bd0cc0832da95c634a84926384