### PR TITLE
chore: add Cloudflare Pages project name

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,1 +1,9 @@
+name = "print2"
 pages_build_output_dir = "frontend/dist"
+compatibility_date = "2025-08-22"
+
+[env.preview]
+name = "print2"
+
+[env.production]
+name = "print2"


### PR DESCRIPTION
## Summary
- add Cloudflare Pages `name` and compatibility date to wrangler config
- configure preview and production environments for the same Pages project

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `cd backend && npm run format`
- `cd backend && npm test` *(fails: ESLint plugin `context.getScope` not a function)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: prettier/YAML syntax errors)*
- `npm run build` *(fails: @vitejs/plugin-react ESM cannot be loaded by require)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a8481c67d4832d8f883c7452996e35