### PR TITLE
feat: add static frontend deployment

### DIFF
--- a/.github/workflows/deploy-frontend-static.yml
+++ b/.github/workflows/deploy-frontend-static.yml
@@ -1,0 +1,51 @@
+name: Deploy frontend static
+
+env:
+  HUSKY: 0
+  AWS_REGION: ${{ secrets.AWS_REGION }}
+  S3_BUCKET: ${{ secrets.FRONTEND_STATIC_BUCKET }}
+  DISTRIBUTION_ID: ${{ secrets.FRONTEND_STATIC_DISTRIBUTION_ID }}
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'frontend/**'
+      - '.github/workflows/deploy-frontend-static.yml'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on:
+      - [self-hosted, linux, aws, small]
+      - ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
+      - uses: actions/checkout@v5.0.0
+      - run: corepack enable
+      - uses: pnpm/action-setup@v4.0.0
+        with:
+          version: 8.15.8
+      - run: pnpm install --no-frozen-lockfile
+      - run: pnpm run build
+      - run: test -d dist
+      - run: node ../scripts/assert-frontend-dist.js
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4.0.0
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Upload to S3
+        run: |
+          aws s3 sync dist s3://$S3_BUCKET --cache-control "public, max-age=31536000, immutable" --exclude index.html
+          aws s3 cp dist/index.html s3://$S3_BUCKET/index.html --cache-control "public, max-age=300" --metadata-directive REPLACE
+      - name: Invalidate CloudFront
+        run: |
+          aws cloudfront create-invalidation --distribution-id $DISTRIBUTION_ID --paths "/*"
+    timeout-minutes: 30

--- a/infra/frontend-static/main.tf
+++ b/infra/frontend-static/main.tf
@@ -1,0 +1,150 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+provider "aws" {
+  alias  = "us-east-1"
+  region = "us-east-1"
+}
+
+resource "aws_s3_bucket" "this" {
+  bucket = var.bucket_name
+}
+
+resource "aws_s3_bucket_public_access_block" "this" {
+  bucket                  = aws_s3_bucket.this.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_cloudfront_origin_access_control" "this" {
+  name                              = "${var.bucket_name}-oac"
+  description                       = "OAC for ${var.bucket_name}"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+resource "aws_cloudfront_distribution" "this" {
+  enabled             = true
+  default_root_object = "index.html"
+
+  origin {
+    domain_name              = aws_s3_bucket.this.bucket_regional_domain_name
+    origin_id                = aws_s3_bucket.this.id
+    origin_access_control_id = aws_cloudfront_origin_access_control.this.id
+  }
+
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = aws_s3_bucket.this.id
+
+    viewer_protocol_policy = "redirect-to-https"
+    compress               = true
+
+    min_ttl     = 0
+    default_ttl = 3600
+    max_ttl     = 86400
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn            = var.domain_name != "" ? aws_acm_certificate.this[0].arn : null
+    ssl_support_method             = var.domain_name != "" ? "sni-only" : null
+    minimum_protocol_version       = var.domain_name != "" ? "TLSv1.2_2021" : null
+    cloudfront_default_certificate = var.domain_name == "" ? true : null
+  }
+
+  depends_on = var.domain_name != "" ? [aws_acm_certificate_validation.this] : []
+}
+
+resource "aws_s3_bucket_policy" "this" {
+  bucket = aws_s3_bucket.this.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid      = "AllowCloudFrontServicePrincipalReadOnly"
+        Effect   = "Allow"
+        Principal = { Service = "cloudfront.amazonaws.com" }
+        Action   = ["s3:GetObject"]
+        Resource = "${aws_s3_bucket.this.arn}/*"
+        Condition = {
+          StringEquals = {
+            "AWS:SourceArn" = aws_cloudfront_distribution.this.arn
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_acm_certificate" "this" {
+  provider          = aws.us-east-1
+  count             = var.domain_name != "" ? 1 : 0
+  domain_name       = var.domain_name
+  validation_method = "DNS"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "cert_validation" {
+  count   = var.domain_name != "" ? length(aws_acm_certificate.this[0].domain_validation_options) : 0
+  name    = aws_acm_certificate.this[0].domain_validation_options[count.index].resource_record_name
+  type    = aws_acm_certificate.this[0].domain_validation_options[count.index].resource_record_type
+  zone_id = var.hosted_zone_id
+  records = [aws_acm_certificate.this[0].domain_validation_options[count.index].resource_record_value]
+  ttl     = 60
+}
+
+resource "aws_acm_certificate_validation" "this" {
+  provider                = aws.us-east-1
+  count                   = var.domain_name != "" ? 1 : 0
+  certificate_arn         = aws_acm_certificate.this[0].arn
+  validation_record_fqdns = aws_route53_record.cert_validation[*].fqdn
+}
+
+resource "aws_route53_record" "this" {
+  count   = var.domain_name != "" ? 1 : 0
+  name    = var.domain_name
+  zone_id = var.hosted_zone_id
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.this.domain_name
+    zone_id                = aws_cloudfront_distribution.this.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+output "bucket_name" {
+  value = aws_s3_bucket.this.id
+}
+
+output "distribution_id" {
+  value = aws_cloudfront_distribution.this.id
+}
+
+output "distribution_domain" {
+  value = aws_cloudfront_distribution.this.domain_name
+}

--- a/infra/frontend-static/variables.tf
+++ b/infra/frontend-static/variables.tf
@@ -1,0 +1,22 @@
+variable "bucket_name" {
+  type        = string
+  description = "Name of the S3 bucket for static frontend"
+}
+
+variable "aws_region" {
+  type        = string
+  description = "AWS region for the S3 bucket"
+  default     = "us-east-1"
+}
+
+variable "domain_name" {
+  type        = string
+  description = "Optional domain name for the CloudFront distribution"
+  default     = ""
+}
+
+variable "hosted_zone_id" {
+  type        = string
+  description = "Route53 hosted zone ID for domain"
+  default     = ""
+}


### PR DESCRIPTION
## Summary
- provision S3 and CloudFront (OAC) infra for static frontend hosting
- add workflow to build and deploy frontend to S3 and invalidate CloudFront

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html. Run 'npm run build' and retry)*

------
https://chatgpt.com/codex/tasks/task_e_68a84924e4d8832da6ceca37c4b2218e