### PR TITLE
ci: add parity guard workflow

### DIFF
--- a/.github/workflows/ci-parity-guard.yml
+++ b/.github/workflows/ci-parity-guard.yml
@@ -1,0 +1,80 @@
+name: CI parity guard
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  parity-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Inventory workflows
+        id: inventory
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { execSync } = require('child_process');
+            const yaml = require('js-yaml');
+
+            function inventory(ref) {
+              const files = execSync(`git ls-tree -r --name-only ${ref} .github/workflows`, { encoding: 'utf8' })
+                .trim()
+                .split('\n')
+                .filter(Boolean);
+              let total = 0;
+              let ubuntu = 0;
+              const pending = [];
+              for (const file of files) {
+                const content = execSync(`git show ${ref}:${file}`, { encoding: 'utf8' });
+                const doc = yaml.load(content);
+                if (!doc?.jobs) continue;
+                for (const [jobName, job] of Object.entries(doc.jobs)) {
+                  total++;
+                  const runsOn = job['runs-on'];
+                  const usesUbuntu = Array.isArray(runsOn)
+                    ? runsOn.includes('ubuntu-latest')
+                    : runsOn === 'ubuntu-latest';
+                  const usesSelfHosted = Array.isArray(runsOn)
+                    ? runsOn.includes('self-hosted')
+                    : runsOn === 'self-hosted';
+                  if (usesUbuntu && !usesSelfHosted) {
+                    ubuntu++;
+                    pending.push(`${file}:${jobName}`);
+                  }
+                }
+              }
+              return { total, ubuntu, pending };
+            }
+
+            const baseRef = `origin/${{ github.base_ref }}`;
+            execSync(`git fetch origin ${baseRef} --depth=1`);
+            const base = inventory(baseRef);
+            const head = inventory('HEAD');
+            const parity = head.total ? ((head.total - head.ubuntu) / head.total * 100).toFixed(2) : '100';
+            core.setOutput('pending', head.pending.join('\n'));
+            core.setOutput('parity', parity);
+            if (head.ubuntu > base.ubuntu) {
+              core.setFailed(`ubuntu-latest job count increased from ${base.ubuntu} to ${head.ubuntu}`);
+            }
+      - name: Comment parity
+        uses: actions/github-script@v7
+        env:
+          PENDING: ${{ steps.inventory.outputs.pending }}
+          PARITY: ${{ steps.inventory.outputs.parity }}
+        with:
+          script: |
+            const pending = process.env.PENDING ? process.env.PENDING.split('\n').map(j => `- ${j}`).join('\n') : 'None';
+            const body = `CI self-hosted parity: ${process.env.PARITY}%\n\nJobs still on ubuntu-latest:\n${pending}`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body
+            });


### PR DESCRIPTION
## Summary
- add CI parity guard workflow to enforce self-hosted migration

## Testing
- `npm run format`
- `npm test` *(fails: Host system is missing dependencies to run browsers)*
- `npm run ci` *(fails: SyntaxError in existing workflow YAML)*
- `npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html)*

------
https://chatgpt.com/codex/tasks/task_e_68a8492c34f4832dabebb9029ab24ad9