### PR TITLE
feat: add ephemeral AWS runner infra

### DIFF
--- a/.github/workflows/runner-probe.yml
+++ b/.github/workflows/runner-probe.yml
@@ -1,0 +1,14 @@
+name: Runner probe
+
+on:
+  workflow_dispatch:
+
+jobs:
+  probe:
+    runs-on: [self-hosted, linux, aws-ephemeral]
+    steps:
+      - name: Print system info
+        run: |
+          uname -a
+          cat /etc/os-release
+          echo "Runner context: ${{ toJSON(runner) }}"

--- a/docs/ci/runners.md
+++ b/docs/ci/runners.md
@@ -50,3 +50,26 @@ automatic scale down on idle runners help keep usage minimal.
 The userdata script obtains an ephemeral registration token for every instance
 at boot. Repository registration tokens can be rotated from the GitHub UI or by
 regenerating the PAT used by the bootstrapping script.
+
+## Bump capacity
+
+Ephemeral runners live in an Auto Scaling Group with a desired capacity of zero.
+To queue jobs, increase the group's size and scale back down when finished.
+
+### Terraform
+
+```bash
+cd infra/runners
+terraform apply -var="desired_capacity=2"
+```
+
+### AWS CLI
+
+```bash
+aws autoscaling set-desired-capacity \
+  --auto-scaling-group-name aws-ephemeral-runner \
+  --desired-capacity 2
+```
+
+Replace `2` with the number of runners you need and set it back to `0` to turn
+them off.

--- a/infra/runners/main.tf
+++ b/infra/runners/main.tf
@@ -1,0 +1,99 @@
+provider "aws" {}
+
+data "aws_ami" "al2023" {
+  owners      = ["137112412989"]
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-*-x86_64"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+}
+
+resource "aws_cloudwatch_log_group" "runner" {
+  name              = "/github/runner"
+  retention_in_days = 14
+}
+
+data "aws_iam_policy_document" "assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "runner" {
+  name_prefix        = "aws-ephemeral-runner-"
+  assume_role_policy = data.aws_iam_policy_document.assume.json
+}
+
+data "aws_iam_policy_document" "runner" {
+  statement {
+    actions   = ["ssm:GetParameter"]
+    resources = ["*"]
+  }
+
+  statement {
+    actions = ["logs:CreateLogStream", "logs:PutLogEvents"]
+    resources = [
+      aws_cloudwatch_log_group.runner.arn,
+      "${aws_cloudwatch_log_group.runner.arn}:*"
+    ]
+  }
+}
+
+resource "aws_iam_policy" "runner" {
+  name   = "aws-ephemeral-runner"
+  policy = data.aws_iam_policy_document.runner.json
+}
+
+resource "aws_iam_role_policy_attachment" "runner" {
+  role       = aws_iam_role.runner.name
+  policy_arn = aws_iam_policy.runner.arn
+}
+
+resource "aws_iam_instance_profile" "runner" {
+  name_prefix = "aws-ephemeral-runner-"
+  role        = aws_iam_role.runner.name
+}
+
+resource "aws_ssm_parameter" "config" {
+  name  = "/github/runner/config"
+  type  = "String"
+  value = jsonencode({
+    repo_url   = var.repo_url
+    token_path = var.token_path
+  })
+}
+
+resource "aws_launch_template" "runner" {
+  name_prefix   = "aws-ephemeral-runner-"
+  image_id      = data.aws_ami.al2023.id
+  instance_type = var.instance_type
+  user_data     = base64encode(templatefile("${path.module}/user-data.sh", { ssm_param = aws_ssm_parameter.config.name }))
+  iam_instance_profile { name = aws_iam_instance_profile.runner.name }
+  instance_market_options {
+    market_type = "spot"
+  }
+}
+
+resource "aws_autoscaling_group" "runner" {
+  name                      = "aws-ephemeral-runner"
+  min_size                  = 0
+  max_size                  = 5
+  desired_capacity          = var.desired_capacity
+  vpc_zone_identifier       = var.subnet_ids
+  launch_template {
+    id      = aws_launch_template.runner.id
+    version = "$Latest"
+  }
+  new_instances_protected_from_scale_in = false
+}

--- a/infra/runners/user-data.sh
+++ b/infra/runners/user-data.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+
+yum update -y
+yum install -y curl jq tar
+
+# Fetch repo and token info from SSM
+CONFIG=$(aws ssm get-parameter --name "${ssm_param}" --query 'Parameter.Value' --output text)
+REPO_URL=$(echo "$CONFIG" | jq -r '.repo_url')
+TOKEN_URL=$(echo "$CONFIG" | jq -r '.token_path')
+
+cd /opt
+curl -fsSL https://github.com/actions/runner/releases/latest/download/actions-runner-linux-x64.tar.gz | tar xz
+cd actions-runner
+
+TOKEN=$(curl -fsSL -X POST "$TOKEN_URL" | jq -r '.token')
+./config.sh --url "$REPO_URL" --token "$TOKEN" --labels "self-hosted,linux,aws-ephemeral" --unattended --ephemeral
+./run.sh --once
+shutdown -h now

--- a/infra/runners/variables.tf
+++ b/infra/runners/variables.tf
@@ -1,0 +1,26 @@
+variable "repo_url" {
+  description = "GitHub repository URL"
+  type        = string
+}
+
+variable "token_path" {
+  description = "API endpoint to request a runner registration token"
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "Subnets where runners should launch"
+  type        = list(string)
+}
+
+variable "instance_type" {
+  description = "Runner EC2 instance type"
+  type        = string
+  default     = "t3.large"
+}
+
+variable "desired_capacity" {
+  description = "Desired runner count"
+  type        = number
+  default     = 0
+}

--- a/infra/runners/versions.tf
+++ b/infra/runners/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- provision ephemeral self-hosted runners via Terraform
- add runner probe workflow
- document how to bump runner capacity

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*


------
https://chatgpt.com/codex/tasks/task_e_68a8491d8a4c832da81d9270c4f0721a