### PR TITLE
feat: add secret management infrastructure

### DIFF
--- a/.github/actions/secret-sync/action.yml
+++ b/.github/actions/secret-sync/action.yml
@@ -1,0 +1,58 @@
+name: 'secret-sync'
+description: 'Sync GitHub secrets to AWS SSM Parameter Store or Secrets Manager'
+inputs:
+  force:
+    description: 'Set to true to write secrets. Defaults to dry run.'
+    required: false
+    default: 'false'
+  ssm-prefix:
+    description: 'Base path for SSM parameters'
+    required: false
+    default: '/mvp'
+  ssm:
+    description: 'Space separated list of SSM secret names (relative to prefix)'
+    required: false
+    default: ''
+  secrets-manager:
+    description: 'Space separated list of Secrets Manager secret names (relative to prefix)'
+    required: false
+    default: ''
+runs:
+  using: 'composite'
+  steps:
+    - name: Sync SSM parameters
+      shell: bash
+      run: |
+        set -euo pipefail
+        for name in ${{ inputs.ssm }}; do
+          value="${!name:-}"
+          path="${{ inputs.ssm-prefix }}/$name"
+          if aws ssm get-parameter --name "$path" >/dev/null 2>&1; then
+            echo "SSM parameter $path exists"
+            continue
+          fi
+          if [[ "${{ inputs.force }}" == "true" ]]; then
+            echo "Creating $path"
+            aws ssm put-parameter --name "$path" --type SecureString --value "$value"
+          else
+            echo "Dry run: would create $path"
+          fi
+        done
+    - name: Sync Secrets Manager
+      shell: bash
+      run: |
+        set -euo pipefail
+        for name in ${{ inputs['secrets-manager'] }}; do
+          value="${!name:-}"
+          full="${{ inputs.ssm-prefix }}/$name"
+          if aws secretsmanager describe-secret --secret-id "$full" >/dev/null 2>&1; then
+            echo "Secrets Manager $full exists"
+            continue
+          fi
+          if [[ "${{ inputs.force }}" == "true" ]]; then
+            echo "Creating $full"
+            aws secretsmanager create-secret --name "$full" --secret-string "$value"
+          else
+            echo "Dry run: would create $full"
+          fi
+        done

--- a/.github/workflows/secrets-sentinel.yml
+++ b/.github/workflows/secrets-sentinel.yml
@@ -1,0 +1,41 @@
+name: secrets sentinel
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  diff:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-east-1
+          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE }}
+          role-session-name: secrets-sentinel
+      - name: Check secrets
+        shell: bash
+        run: |
+          set -euo pipefail
+          expected_ssm=$(jq -r '.ssm[]' infra/secrets/expected.json)
+          expected_sm=$(jq -r '.secretsmanager[]' infra/secrets/expected.json)
+          existing_ssm=$(aws ssm describe-parameters --parameter-filters Key=Name,Option=BeginsWith,Values=/mvp/ --query 'Parameters[].Name' --output text || true)
+          existing_sm=$(aws secretsmanager list-secrets --query 'SecretList[].Name' --output text || true)
+          missing=""
+          for name in $expected_ssm; do
+            full="/mvp/$name"
+            if ! grep -q "$full" <<<"$existing_ssm"; then
+              missing="$missing $full"
+            fi
+          done
+          for name in $expected_sm; do
+            full="/mvp/$name"
+            if ! grep -q "$full" <<<"$existing_sm"; then
+              missing="$missing $full"
+            fi
+          done
+          if [[ -n "$missing" ]]; then
+            echo "::warning::Missing secrets:$missing"
+          fi

--- a/infra/secrets/expected.json
+++ b/infra/secrets/expected.json
@@ -1,0 +1,10 @@
+{
+  "ssm": [
+    "shared/PLACEHOLDER",
+    "frontend/PLACEHOLDER",
+    "backend/PLACEHOLDER"
+  ],
+  "secretsmanager": [
+    "STRIPE_SECRET_KEY"
+  ]
+}

--- a/infra/secrets/main.tf
+++ b/infra/secrets/main.tf
@@ -1,0 +1,57 @@
+terraform {
+  required_version = ">= 1.0.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+variable "aws_region" {
+  type        = string
+  description = "AWS region for secrets"
+  default     = "us-east-1"
+}
+
+locals {
+  expected = jsondecode(file("${path.module}/expected.json"))
+}
+
+resource "aws_ssm_parameter" "shared" {
+  for_each = toset([for name in local.expected.ssm : name if startswith(name, "shared/")])
+  name  = "/mvp/${each.value}"
+  type  = "SecureString"
+  value = "placeholder"
+}
+
+resource "aws_ssm_parameter" "frontend" {
+  for_each = toset([for name in local.expected.ssm : name if startswith(name, "frontend/")])
+  name  = "/mvp/${each.value}"
+  type  = "SecureString"
+  value = "placeholder"
+}
+
+resource "aws_ssm_parameter" "backend" {
+  for_each = toset([for name in local.expected.ssm : name if startswith(name, "backend/")])
+  name  = "/mvp/${each.value}"
+  type  = "SecureString"
+  value = "placeholder"
+}
+
+resource "aws_secretsmanager_secret" "high" {
+  for_each = toset(local.expected.secretsmanager)
+  name = "/mvp/${each.value}"
+}
+
+output "ssm_parameters" {
+  value = [aws_ssm_parameter.shared, aws_ssm_parameter.frontend, aws_ssm_parameter.backend]
+}
+
+output "secretsmanager_secrets" {
+  value = aws_secretsmanager_secret.high
+}


### PR DESCRIPTION
## Summary
- provision SSM and Secrets Manager entries for MVP app
- add secret-sync composite action to map GitHub secrets
- add secrets sentinel workflow to warn on missing secrets

## Testing
- `npm run format` (backend)
- `npm test` (backend)
- `SKIP_PW_DEPS=1 npm run ci` *(fails: .github workflow YAML syntax errors)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: .github workflow YAML syntax errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a84929f03c832d9b30b3c5e29947e8