### PR TITLE
ci: add Full Lane Sentry workflow

### DIFF
--- a/.github/workflows/full-lane-sentry.yml
+++ b/.github/workflows/full-lane-sentry.yml
@@ -1,0 +1,45 @@
+name: Full Lane Sentry
+on:
+  pull_request:
+  push:
+  workflow_dispatch:
+
+jobs:
+  sentry:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/github-script@v7
+        id: fetch
+        with:
+          script: |
+            const core = require('@actions/core');
+            const github = require('@actions/github');
+            // Read the current run jobs/timings via the REST API and assert that
+            // the following checks exist and are NOT in "skipped" or "cancelled" and have at least 1 step:
+            const required = [
+              'CI Full Lane / backend',
+              'CI Full Lane / frontend',
+              'CI Full Lane / e2e',
+              'CI Full Lane / docs'
+            ];
+            const {owner, repo} = github.context.repo;
+            const runId = github.context.runId;
+            const octo = github.getOctokit(process.env.GITHUB_TOKEN || process.env.GITHUB_PAT || process.env.GITHUB_WORKSPACE_TOKEN);
+            // Try to list jobs for this run:
+            const jobs = await octo.rest.actions.listJobsForWorkflowRun({owner, repo, run_id: runId});
+            const missing = [];
+            const bad = [];
+            for (const name of required) {
+              const job = jobs.data.jobs.find(j => j.name.includes(name));
+              if (!job) { missing.push(name); continue; }
+              if (['queued','in_progress'].includes(job.status)) continue; // still running
+              if (['skipped','cancelled'].includes(job.conclusion)) bad.push(`${name} concluded=${job.conclusion}`);
+              if (!job.steps || job.steps.length===0) bad.push(`${name} had zero steps`);
+            }
+            if (missing.length || bad.length) {
+              core.setFailed(`Lane Sentry: Problems found.\nMissing: ${missing.join(', ') || '(none)'}\nBad: ${bad.join('; ') || '(none)'}`);
+            } else {
+              core.notice('Lane Sentry OK: all Full Lane jobs present with steps.');
+            }


### PR DESCRIPTION
## Summary
- add workflow that asserts Full Lane jobs ran and weren't skipped

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `cd backend && npm run format`
- `cd backend && npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: YAML lint errors)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a84d7d9c94832d8fbc59671bdf37ca