### PR TITLE
ci: add workflow structure guard

### DIFF
--- a/.github/workflows/workflow-structure-guard.yml
+++ b/.github/workflows/workflow-structure-guard.yml
@@ -1,0 +1,55 @@
+name: Workflow structure guard
+
+env:
+  HUSKY: 0
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    runs-on:
+      - [self-hosted, linux, aws]
+      - ubuntu-latest
+    steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
+      - uses: actions/checkout@v5
+      - name: Install actionlint
+        run: |
+          if ! command -v actionlint >/dev/null 2>&1; then
+            curl -sSfL https://github.com/rhysd/actionlint/releases/latest/download/actionlint_Linux_x86_64.tar.gz \
+              | sudo tar -xz -C /usr/local/bin actionlint
+          fi
+      - run: actionlint
+
+  workflow-shape-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          npm i -D js-yaml glob
+          node - <<'JS'
+          const fs=require('fs'),yaml=require('js-yaml');const {globSync}=require('glob');
+          const files=globSync('.github/workflows/*.yml');
+          let bad=0;
+          for(const f of files){
+            const doc=yaml.load(fs.readFileSync(f,'utf8'));
+            if(!doc || !doc.jobs){ console.error('Missing jobs in', f); bad++; continue; }
+            for(const [jname,job] of Object.entries(doc.jobs)){
+              const hasRunsOn = !!job['runs-on'];
+              const hasSteps = Array.isArray(job.steps);
+              const strategyOk = job.strategy ? (typeof job.strategy==='object' && !Array.isArray(job.strategy)) : true;
+              if(!hasRunsOn || !hasSteps || !strategyOk){
+                console.error(`Bad job in ${f} -> ${jname}: runs-on=${hasRunsOn}, steps=${hasSteps}, strategyOk=${strategyOk}`);
+                bad++;
+              }
+            }
+          }
+          process.exit(bad?1:0);
+          JS


### PR DESCRIPTION
## Summary
- add workflow guard to lint and validate GitHub workflows

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` (backend)
- `npm test` (backend) *(fails: root eslint exits 0, backend eslint exits 0, root and backend exit codes match, eslint writes log file, health tests, linting errors, etc.)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: format check errors)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: missing frontend build artifact)*


------
https://chatgpt.com/codex/tasks/task_e_68a84c34bf4c832da86f1d9eec6ac84e