### PR TITLE
ci: add aws ec2 runner provisioning

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -7,6 +7,21 @@ on:
       - 00000production
 
 jobs:
+  provision:
+    uses: ./.github/workflows/aws-ec2-runner.yml
+    secrets: inherit
+
+  tests:
+    needs: provision
+    runs-on: [self-hosted, linux, aws-ec2]
+    steps:
+      - uses: actions/checkout@v4.1.6
+      - uses: actions/setup-node@v4.0.3
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm test
   fastlane:
     uses: ./.github/workflows/_aws-fastlane.yml
     secrets: inherit

--- a/.github/workflows/ci-full-lane.yml
+++ b/.github/workflows/ci-full-lane.yml
@@ -9,6 +9,21 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
+  provision:
+    uses: ./.github/workflows/aws-ec2-runner.yml
+    secrets: inherit
+
+  tests:
+    needs: provision
+    runs-on: [self-hosted, linux, aws-ec2]
+    steps:
+      - uses: actions/checkout@v4.1.6
+      - uses: actions/setup-node@v4.0.3
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm test
   lint:
     uses: ./.github/workflows/reusable-test-job.yml
     with:


### PR DESCRIPTION
## Summary
- provision AWS EC2 self-hosted runners in key workflows
- run tests on the new self-hosted runner label

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Nested mappings are not allowed in compact mappings)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a862242d30832d8f6bdcf0c67e13aa