### PR TITLE
ci: add job timing metrics and queued job scaling

### DIFF
--- a/.github/actions/ci-job-timings/action.yml
+++ b/.github/actions/ci-job-timings/action.yml
@@ -1,0 +1,31 @@
+name: CI Job Timings
+description: Emit per-job queue and run timings as NDJSON
+inputs:
+  timings:
+    description: "Path to job timings JSON"
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Generate per-job metrics
+      shell: bash
+      run: |
+        set -euo pipefail
+        timings="${{ inputs.timings }}"
+        mkdir -p ci/metrics
+        jq -c '.[] | select(.queued_at and .started_at and .completed_at)' "$timings" |
+        while read -r job; do
+          name=$(echo "$job" | jq -r .name | tr ' /' '__')
+          queued=$(( $(echo "$job" | jq -r '.started_at | fromdate') - $(echo "$job" | jq -r '.queued_at | fromdate') ))
+          runtime=$(( $(echo "$job" | jq -r '.completed_at | fromdate') - $(echo "$job" | jq -r '.started_at | fromdate') ))
+          echo "{\"job\":\"$name\",\"queued_seconds\":$queued,\"run_seconds\":$runtime}" > "ci/metrics/$name.ndjson"
+        done
+        echo "job metrics written to ci/metrics/*.ndjson"
+    - name: Verify metrics
+      shell: bash
+      run: test -n "$(ls ci/metrics/*.ndjson 2>/dev/null)"
+    - name: Upload job metrics
+      uses: actions/upload-artifact@v4
+      with:
+        name: ci-job-metrics
+        path: ci/metrics/*.ndjson

--- a/infra/gh-runner-aws/README.md
+++ b/infra/gh-runner-aws/README.md
@@ -27,6 +27,12 @@ This module provisions an ephemeral self-hosted GitHub Actions runner on a singl
    make destroy
    ```
 
+## Metrics and scaling
+
+- A Lambda function (`queue-metric`) polls the repository every minute and pushes a CloudWatch metric `QueuedJobs`.
+- The autoscaling group applies a target tracking policy on this metric: it scales out when queued jobs are present and scales in after 10 minutes of zero queued jobs.
+- Instances are tagged with `runner=gha` for safe identification.
+
 ## Variables
 
 See [`variables.tf`](variables.tf) for customization options including VPC creation, instance type, labels and scheduling.

--- a/infra/gh-runner-aws/lambda/queue-metric.js
+++ b/infra/gh-runner-aws/lambda/queue-metric.js
@@ -1,0 +1,23 @@
+const { Octokit } = require("@octokit/rest");
+const AWS = require("aws-sdk");
+
+exports.handler = async () => {
+  const github = new Octokit({ auth: process.env.GITHUB_TOKEN });
+  const cw = new AWS.CloudWatch();
+
+  const { data } = await github.actions.listWorkflowRunsForRepo({
+    owner: process.env.GITHUB_OWNER,
+    repo: process.env.GITHUB_REPO,
+    status: "queued",
+    per_page: 100,
+  });
+
+  const queued = data.total_count || 0;
+
+  await cw
+    .putMetricData({
+      Namespace: "GitHubActions",
+      MetricData: [{ MetricName: "QueuedJobs", Value: queued, Unit: "Count" }],
+    })
+    .promise();
+};

--- a/infra/gh-runner-aws/main.tf
+++ b/infra/gh-runner-aws/main.tf
@@ -196,7 +196,7 @@ resource "aws_launch_template" "runner" {
   user_data = base64encode(local.user_data)
   tag_specifications {
     resource_type = "instance"
-    tags          = merge(local.tags, { Name = "${var.project}-runner" })
+    tags          = merge(local.tags, { Name = "${var.project}-runner", runner = "gha" })
   }
 }
 
@@ -206,6 +206,7 @@ resource "aws_autoscaling_group" "runner" {
   max_size            = 1
   min_size            = 0
   vpc_zone_identifier = local.subnet_ids
+  default_cooldown    = 600
   launch_template {
     id      = aws_launch_template.runner.id
     version = "$Latest"
@@ -213,6 +214,11 @@ resource "aws_autoscaling_group" "runner" {
   tag {
     key                 = "Name"
     value               = "${var.project}-runner"
+    propagate_at_launch = true
+  }
+  tag {
+    key                 = "runner"
+    value               = "gha"
     propagate_at_launch = true
   }
   lifecycle {
@@ -238,4 +244,85 @@ resource "aws_autoscaling_schedule" "scale_up" {
   desired_capacity       = 1
   recurrence             = "0 6 * * *"
   autoscaling_group_name = aws_autoscaling_group.runner.name
+}
+
+resource "aws_autoscaling_policy" "queued_jobs" {
+  name                   = "${var.project}-queued-jobs"
+  policy_type            = "TargetTrackingScaling"
+  autoscaling_group_name = aws_autoscaling_group.runner.name
+
+  target_tracking_configuration {
+    customized_metric_specification {
+      metric_name = "QueuedJobs"
+      namespace   = "GitHubActions"
+      statistic   = "Average"
+    }
+    target_value = 0.5
+  }
+}
+
+data "archive_file" "queue_metric" {
+  type        = "zip"
+  source_file = "${path.module}/lambda/queue-metric.js"
+  output_path = "${path.module}/lambda/queue-metric.zip"
+}
+
+resource "aws_iam_role" "queue_metric" {
+  name               = "${var.project}-queue-metric-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Effect    = "Allow",
+      Action    = "sts:AssumeRole",
+      Principal = { Service = "lambda.amazonaws.com" }
+    }]
+  })
+  tags = local.tags
+}
+
+resource "aws_iam_role_policy" "queue_metric" {
+  role = aws_iam_role.queue_metric.id
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [{
+      Effect   = "Allow",
+      Action   = ["cloudwatch:PutMetricData"],
+      Resource = "*"
+    }]
+  })
+}
+
+resource "aws_lambda_function" "queue_metric" {
+  function_name    = "${var.project}-queue-metric"
+  filename         = data.archive_file.queue_metric.output_path
+  source_code_hash = data.archive_file.queue_metric.output_base64sha256
+  role             = aws_iam_role.queue_metric.arn
+  handler          = "queue-metric.handler"
+  runtime          = "nodejs20.x"
+  environment {
+    variables = {
+      GITHUB_TOKEN = var.github_token
+      GITHUB_OWNER = var.owner
+      GITHUB_REPO  = var.repo
+    }
+  }
+}
+
+resource "aws_cloudwatch_event_rule" "queue_metric" {
+  name                = "${var.project}-queue-metric"
+  schedule_expression = "rate(1 minute)"
+}
+
+resource "aws_cloudwatch_event_target" "queue_metric" {
+  rule      = aws_cloudwatch_event_rule.queue_metric.name
+  target_id = "queue-metric"
+  arn       = aws_lambda_function.queue_metric.arn
+}
+
+resource "aws_lambda_permission" "queue_metric" {
+  statement_id  = "AllowExecutionFromEvents"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.queue_metric.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.queue_metric.arn
 }

--- a/infra/gh-runner-aws/variables.tf
+++ b/infra/gh-runner-aws/variables.tf
@@ -54,3 +54,8 @@ variable "off_hours" {
   default     = false
   description = "Scale the ASG to zero overnight"
 }
+
+variable "github_token" {
+  type        = string
+  description = "GitHub token for queue metrics lambda"
+}


### PR DESCRIPTION
## Summary
- add composite action to emit per-job timings
- push queued job metrics to CloudWatch and auto-scale runners
- document metrics and scaling for GitHub runners

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Error occurred when checking code style in 9 files.)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a85f356fb0832d9862696944bc1b9c