### PR TITLE
ci: route core jobs to gha self-hosted

### DIFF
--- a/.github/workflows/backend-only-ci.yml
+++ b/.github/workflows/backend-only-ci.yml
@@ -11,9 +11,7 @@ on:
   workflow_dispatch:
 
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+concurrency: repo-ci
 
 permissions:
   contents: read
@@ -29,9 +27,7 @@ jobs:
     needs: preflight
     if: github.event_name == 'workflow_dispatch' ||
       needs.preflight.outputs.run_backend == 'true'
-    runs-on:
-      - [self-hosted, linux, aws]
-      - ubuntu-latest
+    runs-on: [self-hosted, linux, x64, gha]
     continue-on-error: true
     strategy:
       fail-fast: true

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -13,14 +13,12 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+concurrency: repo-ci
 
 jobs:
   docs:
     name: CI Full Lane / docs
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, gha]
     steps:
       - uses: actions/checkout@v5.0.0
       - uses: actions/setup-node@v4.4.0
@@ -49,7 +47,7 @@ jobs:
 
   lint:
     name: CI Full Lane / lint
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, gha]
     steps:
       - uses: actions/checkout@v5.0.0
       - uses: actions/setup-node@v4.4.0
@@ -81,7 +79,7 @@ jobs:
 
   typecheck:
     name: CI Full Lane / typecheck
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, gha]
     steps:
       - uses: actions/checkout@v5.0.0
       - uses: actions/setup-node@v4.4.0
@@ -116,7 +114,7 @@ jobs:
 
   unit:
     name: CI Full Lane / unit
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, gha]
     steps:
       - uses: actions/checkout@v5.0.0
       - uses: actions/setup-node@v4.4.0
@@ -158,7 +156,7 @@ jobs:
 
   frontend:
     name: CI Full Lane / frontend
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, gha]
     steps:
       - uses: actions/checkout@v5.0.0
       - uses: actions/setup-node@v4.4.0
@@ -198,7 +196,7 @@ jobs:
     name: CI Full Lane / e2e
     needs: [lint, typecheck, unit]
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, gha]
     steps:
       - uses: actions/checkout@v5.0.0
       - uses: actions/setup-node@v4.4.0

--- a/.github/workflows/ci-sanity.yml
+++ b/.github/workflows/ci-sanity.yml
@@ -5,6 +5,8 @@ on:
   pull_request:
     branches: [dev, 00000production]
 
+concurrency: repo-ci
+
 jobs:
   sanity:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -7,15 +7,11 @@ on:
   push:
   pull_request:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+concurrency: repo-ci
 
 jobs:
   e2e:
-    runs-on:
-      - [self-hosted, linux, aws]
-      - ubuntu-latest
+    runs-on: [self-hosted, linux, x64, gha]
     timeout-minutes: 30
     retries: 2
     steps:

--- a/.github/workflows/runner-parity-guard.yml
+++ b/.github/workflows/runner-parity-guard.yml
@@ -1,0 +1,34 @@
+name: Runner parity guard
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency: repo-ci
+
+jobs:
+  parity:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check runner parity
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const run_id = process.env.GITHUB_RUN_ID;
+            const pages = await github.paginate(github.rest.actions.listJobsForWorkflowRun, { owner, repo, run_id });
+            const mismatches = [];
+            for (const job of pages) {
+              const labels = job.labels || [];
+              const expectedSelf = labels.includes('self-hosted');
+              const runnerName = job.runner_name || '';
+              const actualSelf = runnerName && !runnerName.startsWith('GitHub Actions');
+              if (expectedSelf !== actualSelf) {
+                mismatches.push(`${job.name} expected ${expectedSelf ? 'self-hosted' : 'hosted'} but ran on ${actualSelf ? 'self-hosted' : 'hosted'}`);
+              }
+            }
+            if (mismatches.length) {
+              core.setFailed('Runner parity mismatch:\n' + mismatches.join('\n'));
+            }


### PR DESCRIPTION
## Summary
- use repo-wide concurrency group for key CI workflows
- run lint/unit/e2e/docs/frontend/backend jobs on `[self-hosted, linux, x64, gha]`
- add runner parity guard to ensure jobs execute on expected runner class

## Testing
- `npm run validate-env`
- `curl -I https://registry.npmjs.org`
- `curl -I https://cdn.playwright.dev`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: falls back to setup and exits before running tests)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: dependencies missing)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: missing frontend build artifact / npm ci error)*

------
https://chatgpt.com/codex/tasks/task_e_68a85f2bb230832d929ebca8905b2191