### PR TITLE
ci: add poke workflow

### DIFF
--- a/.github/workflows/ci-poke.yml
+++ b/.github/workflows/ci-poke.yml
@@ -1,0 +1,62 @@
+name: CI Poke
+
+on:
+  workflow_dispatch:
+
+jobs:
+  backend:
+    if: always()
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        shard: [1]
+    steps:
+      - run: echo 'POKE STARTED'
+
+  frontend:
+    if: always()
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        shard: [1]
+    steps:
+      - run: echo 'POKE STARTED'
+
+  e2e:
+    if: always()
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        shard: [1]
+    steps:
+      - run: echo 'POKE STARTED'
+
+  watchdog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const targets = ['backend', 'frontend', 'e2e'];
+            const timeout = 10 * 60 * 1000;
+            const start = Date.now();
+            const sleep = ms => new Promise(r => setTimeout(r, ms));
+            while (Date.now() - start < timeout) {
+              const { data } = await github.rest.actions.listJobsForWorkflowRun({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: context.runId,
+              });
+              const queued = data.jobs.filter(j =>
+                targets.some(t => j.name.startsWith(t)) && j.status === 'queued'
+              );
+              if (!queued.length) {
+                core.info('All jobs started');
+                return;
+              }
+              core.info(`Waiting on: ${queued.map(j => j.name).join(', ')}`);
+              await sleep(30000);
+            }
+            core.setFailed('Jobs queued over 10 minutes without starting');
+


### PR DESCRIPTION
## Summary
- add CI poke workflow to ensure test lanes start and fail if queued >10m

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` (backend)
- `npm test` (backend)
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a85f22f6b8832d92e79ff494bfac26