### PR TITLE
feat: provision GitHub Actions runners on AWS

### DIFF
--- a/.github/workflows/provision-runners.yml
+++ b/.github/workflows/provision-runners.yml
@@ -1,0 +1,52 @@
+name: provision-runners
+
+on:
+  pull_request:
+    paths:
+      - 'infra/terraform/gha-runners/**'
+      - '.github/workflows/provision-runners.yml'
+  push:
+    paths:
+      - 'infra/terraform/gha-runners/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.0
+      - uses: hashicorp/setup-terraform@v2.1.3
+        with:
+          terraform_version: 1.5.7
+      - name: Terraform fmt
+        run: terraform -chdir=infra/terraform/gha-runners fmt -check
+      - name: Terraform validate
+        run: |
+          terraform -chdir=infra/terraform/gha-runners init -backend=false
+          terraform -chdir=infra/terraform/gha-runners validate
+
+  apply:
+    needs: validate
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4.1.0
+      - uses: hashicorp/setup-terraform@v2.1.3
+        with:
+          terraform_version: 1.5.7
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4.0.2
+        with:
+          role-to-assume: ${{ vars.GHA_RUNNERS_ROLE_ARN }}
+          aws-region: us-east-1
+      - name: Terraform init
+        run: terraform -chdir=infra/terraform/gha-runners init -input=false
+      - name: Terraform apply
+        run: terraform -chdir=infra/terraform/gha-runners apply -auto-approve

--- a/infra/terraform/gha-runners/.terraform.lock.hcl
+++ b/infra/terraform/gha-runners/.terraform.lock.hcl
@@ -1,0 +1,66 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/external" {
+  version = "2.3.5"
+  hashes = [
+    "h1:smKSos4zs57pJjQrNuvGBpSWth2el9SgePPbPHo0aps=",
+    "zh:6e89509d056091266532fa64de8c06950010498adf9070bf6ff85bc485a82562",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:86868aec05b58dc0aa1904646a2c26b9367d69b890c9ad70c33c0d3aa7b1485a",
+    "zh:a2ce38fda83a62fa5fb5a70e6ca8453b168575feb3459fa39803f6f40bd42154",
+    "zh:a6c72798f4a9a36d1d1433c0372006cc9b904e8cfd60a2ae03ac5b7d2abd2398",
+    "zh:a8a3141d2fc71c86bf7f3c13b0b3be8a1b0f0144a47572a15af4dfafc051e28a",
+    "zh:aa20a1242eb97445ad26ebcfb9babf2cd675bdb81cac5f989268ebefa4ef278c",
+    "zh:b58a22445fb8804e933dcf835ab06c29a0f33148dce61316814783ee7f4e4332",
+    "zh:cb5626a661ee761e0576defb2a2d75230a3244799d380864f3089c66e99d0dcc",
+    "zh:d1acb00d20445f682c4e705c965e5220530209c95609194c2dc39324f3d4fcce",
+    "zh:d91a254ba77b69a29d8eae8ed0e9367cbf0ea6ac1a85b58e190f8cb096a40871",
+    "zh:f6592327673c9f85cdb6f20336faef240abae7621b834f189c4a62276ea5db41",
+  ]
+}
+
+provider "registry.terraform.io/integrations/github" {
+  version     = "5.45.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:cP5uEN9jpePr+/Kc7OyAZMhysbDhQoLGpLqgQpLFewg=",
+    "zh:2afb8ee5b847071e51d5a39bcad5cf466c4d22452450d37c44a5f9d2eb9879e5",
+    "zh:38d087b88c86ddd63b60d14d613f86a5885d154048098c0484266a9a69018b16",
+    "zh:3e6a787e3e40f1535d85f8dc5f2e8c90242ab8237feebd027f696fa154261394",
+    "zh:55dac5a813b3774b48ca45b8a797c32e6d787d4f282b43b622155cad3daac46a",
+    "zh:563f2782f3c4c584b249c5fa0628951a57b4593f3c5805a4efb6d494f8686716",
+    "zh:677180ec9376d5f926286592998e2864c85f06d6b416c1d89031d817a285c72e",
+    "zh:80eec141fa47131e8f60a6478e51b3a5920efe803444e684f9605fca09a24e34",
+    "zh:8b9f1e1f4b42b51e53767f4f927eabdcefe55fb0369e996ac2a0063148b5e48d",
+    "zh:95627f75848561830f8c20949f024f902a2100a022c68aa8d84320f43e75cc46",
+    "zh:95ac41b99dfca3ce556092e036bb04dc03367d0779071112e59d4bf11259a89d",
+    "zh:9e966482729ba8214b480bdd786aff9a15234e9c093c5406b56ce89ccb07dcab",
+    "zh:b7a9d563613f1b9a233f8f285848cc9d8c08c556aad7ea57cd63e0abb19b10cf",
+    "zh:ce56bb7ca876f47f5beee01de3ab84d27964b972c9adceb8e2f7824891e05c27",
+    "zh:f73e063ad5b84f1943eafb8a52a26dd805d06ac11d6c951175ac76c07187f553",
+  ]
+}

--- a/infra/terraform/gha-runners/main.tf
+++ b/infra/terraform/gha-runners/main.tf
@@ -1,0 +1,204 @@
+provider "aws" {
+  region = var.region
+}
+
+provider "github" {
+  token = var.github_token
+  owner = var.repo_owner
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}
+
+resource "aws_security_group" "runner" {
+  name_prefix = "gha-runner-"
+  description = "Security group for GitHub Actions runners"
+  vpc_id      = var.vpc_id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+data "aws_iam_policy_document" "instance_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "runner" {
+  name_prefix        = "gha-runner-"
+  assume_role_policy = data.aws_iam_policy_document.instance_assume.json
+}
+
+resource "aws_iam_role_policy_attachment" "ssm" {
+  role       = aws_iam_role.runner.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_instance_profile" "runner" {
+  name_prefix = "gha-runner-"
+  role        = aws_iam_role.runner.name
+}
+
+resource "aws_iam_openid_connect_provider" "github" {
+  url             = "https://token.actions.githubusercontent.com"
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+}
+
+data "aws_iam_policy_document" "github_assume" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.github.arn]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = ["repo:${var.repo_owner}/${var.repo_name}:*"]
+    }
+  }
+}
+
+resource "aws_iam_role" "github" {
+  name               = "gha-runners-terraform"
+  assume_role_policy = data.aws_iam_policy_document.github_assume.json
+}
+
+resource "aws_iam_role_policy_attachment" "github_admin" {
+  role       = aws_iam_role.github.name
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}
+
+resource "aws_sqs_queue" "scale_requests" {
+  name = "gha-scale-requests"
+}
+
+data "aws_ami" "ubuntu" {
+  owners      = ["099720109477"]
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"]
+  }
+}
+
+resource "aws_launch_template" "runner" {
+  name_prefix   = "gha-runner-"
+  image_id      = data.aws_ami.ubuntu.id
+  instance_type = var.instance_type
+
+  iam_instance_profile {
+    name = aws_iam_instance_profile.runner.name
+  }
+
+  user_data = base64encode(
+    templatefile("${path.module}/userdata.sh", {
+      repo_url     = "https://github.com/${var.repo_owner}/${var.repo_name}"
+      runner_group = var.runner_group
+      github_token = var.github_token
+    })
+  )
+}
+
+resource "aws_autoscaling_group" "runners" {
+  name_prefix         = "gha-runners-"
+  min_size            = 3
+  max_size            = 20
+  desired_capacity    = 3
+  vpc_zone_identifier = var.subnet_ids
+
+  mixed_instances_policy {
+    launch_template {
+      launch_template_specification {
+        launch_template_id = aws_launch_template.runner.id
+        version            = "$Latest"
+      }
+    }
+
+    instances_distribution {
+      on_demand_base_capacity                  = 1
+      on_demand_percentage_above_base_capacity = 0
+      spot_allocation_strategy                 = "capacity-optimized"
+    }
+  }
+
+  tag {
+    key                 = "Name"
+    value               = "gha-runner"
+    propagate_at_launch = true
+  }
+}
+
+resource "aws_autoscaling_policy" "scale_out" {
+  name                   = "gha-runners-scale-out"
+  autoscaling_group_name = aws_autoscaling_group.runners.name
+  policy_type            = "SimpleScaling"
+  adjustment_type        = "ChangeInCapacity"
+  scaling_adjustment     = 1
+  cooldown               = 60
+}
+
+resource "aws_autoscaling_policy" "scale_in" {
+  name                   = "gha-runners-scale-in"
+  autoscaling_group_name = aws_autoscaling_group.runners.name
+  policy_type            = "SimpleScaling"
+  adjustment_type        = "ChangeInCapacity"
+  scaling_adjustment     = -1
+  cooldown               = 300
+}
+
+resource "aws_cloudwatch_metric_alarm" "queue_high" {
+  alarm_name          = "${aws_sqs_queue.scale_requests.name}-high"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = 1
+  metric_name         = "ApproximateNumberOfMessagesVisible"
+  namespace           = "AWS/SQS"
+  period              = 60
+  statistic           = "Average"
+  threshold           = 1
+  dimensions = {
+    QueueName = aws_sqs_queue.scale_requests.name
+  }
+  alarm_actions = [aws_autoscaling_policy.scale_out.arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "queue_low" {
+  alarm_name          = "${aws_sqs_queue.scale_requests.name}-low"
+  comparison_operator = "LessThanOrEqualToThreshold"
+  evaluation_periods  = 1
+  metric_name         = "ApproximateNumberOfMessagesVisible"
+  namespace           = "AWS/SQS"
+  period              = 300
+  statistic           = "Average"
+  threshold           = 0
+  dimensions = {
+    QueueName = aws_sqs_queue.scale_requests.name
+  }
+  alarm_actions = [aws_autoscaling_policy.scale_in.arn]
+}
+data "external" "token" {
+  program = [
+    "bash",
+    "-c",
+    format(
+      "curl -fsSL -X POST -H 'Authorization: Bearer %s' https://api.github.com/repos/%s/%s/actions/runners/registration-token | jq -c '{token: .token}'",
+      var.github_token,
+      var.repo_owner,
+      var.repo_name
+    )
+  ]
+}

--- a/infra/terraform/gha-runners/outputs.tf
+++ b/infra/terraform/gha-runners/outputs.tf
@@ -1,0 +1,12 @@
+output "runner_registration_token" {
+  value     = data.external.token.result.token
+  sensitive = true
+}
+
+output "runner_group_url" {
+  value = "https://github.com/${var.repo_owner}/${var.repo_name}/settings/actions/runners"
+}
+
+output "sqs_queue_url" {
+  value = aws_sqs_queue.scale_requests.url
+}

--- a/infra/terraform/gha-runners/userdata.sh
+++ b/infra/terraform/gha-runners/userdata.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -euxo pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get update
+apt-get install -y curl jq git ca-certificates software-properties-common
+
+if ! command -v docker >/dev/null; then
+  curl -fsSL https://get.docker.com | sh
+  usermod -aG docker ubuntu || true
+fi
+
+curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
+apt-get install -y nodejs
+npm install -g pnpm vite playwright
+npx playwright install --with-deps
+
+RUNNER_VERSION="2.315.0"
+RUNNER_DIR=/opt/actions-runner
+mkdir -p "$RUNNER_DIR"
+cd "$RUNNER_DIR"
+curl -L https://github.com/actions/runner/releases/download/v$${RUNNER_VERSION}/actions-runner-linux-x64-$${RUNNER_VERSION}.tar.gz | tar zx --strip-components=1
+./bin/installdependencies.sh
+
+REPO_URL="${repo_url}"
+RUNNER_GROUP="${runner_group}"
+TOKEN=$(curl -fsSL -X POST -H "Authorization: Bearer ${github_token}" "$${REPO_URL}/actions/runners/registration-token" | jq -r .token)
+
+cleanup() {
+  ./config.sh remove --token "$TOKEN"
+}
+trap 'cleanup; exit 130' INT TERM
+
+./config.sh --url "$REPO_URL" --token "$TOKEN" --runnergroup "$RUNNER_GROUP" --labels self-hosted,linux,x64,gha --ephemeral --unattended
+
+while true; do
+  ./run.sh || true
+  sleep 1
+done

--- a/infra/terraform/gha-runners/variables.tf
+++ b/infra/terraform/gha-runners/variables.tf
@@ -1,0 +1,42 @@
+variable "region" {
+  type    = string
+  default = "us-east-1"
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "VPC where runners will launch"
+}
+
+variable "subnet_ids" {
+  type        = list(string)
+  description = "Subnets for the Auto Scaling Group"
+}
+
+variable "repo_owner" {
+  type        = string
+  description = "GitHub repository owner"
+}
+
+variable "repo_name" {
+  type        = string
+  description = "GitHub repository name"
+}
+
+variable "runner_group" {
+  type        = string
+  description = "GitHub runner group"
+  default     = "Default"
+}
+
+variable "instance_type" {
+  type        = string
+  description = "EC2 instance type"
+  default     = "t3.medium"
+}
+
+variable "github_token" {
+  type        = string
+  description = "GitHub token with admin access to the repository"
+  sensitive   = true
+}

--- a/infra/terraform/gha-runners/versions.tf
+++ b/infra/terraform/gha-runners/versions.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_version = ">= 1.4"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    github = {
+      source  = "integrations/github"
+      version = "~> 5.0"
+    }
+  }
+
+  backend "s3" {
+    bucket  = "gha-runners-tfstate"
+    key     = "terraform.tfstate"
+    region  = "us-east-1"
+    encrypt = true
+  }
+}


### PR DESCRIPTION
## Summary
- add Terraform to provision AWS-based GitHub Actions runners with SQS-driven autoscaling
- bootstrap runners with Node 20, pnpm, Playwright and Docker
- workflow to validate/apply runner infrastructure via OIDC

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: YAML syntax errors in existing workflows)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html)*
- `terraform -chdir=infra/terraform/gha-runners validate`


------
https://chatgpt.com/codex/tasks/task_e_68a85f2797fc832dafeea67e9856a9b2