### PR TITLE
ci: validate GitHub actions

### DIFF
--- a/.github/actions/ensure-pnpm/action.yml
+++ b/.github/actions/ensure-pnpm/action.yml
@@ -1,4 +1,5 @@
 name: Ensure pnpm
+description: Ensure pnpm and Node caching
 inputs:
   cache-dependency-path:
     description: Optional path to lockfile for caching

--- a/.github/actions/frontend-build/action.yml
+++ b/.github/actions/frontend-build/action.yml
@@ -1,4 +1,5 @@
 name: Frontend Build
+description: Build frontend and upload dist artifact
 inputs:
   frontend-dir:
     description: Path to the frontend project
@@ -8,14 +9,14 @@ inputs:
     default: build
 outputs:
   dist-exists:
-    description: 'true if dist/index.html exists'
+    description: "true if dist/index.html exists"
     value: ${{ steps.check-dist.outputs.dist-exists }}
 runs:
   using: composite
   steps:
     - uses: actions/setup-node@v4
       with:
-        node-version: '20'
+        node-version: "20"
         cache: pnpm
         cache-dependency-path: ${{ inputs.frontend-dir }}/pnpm-lock.yaml
     - uses: ./.github/actions/setup-pnpm

--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -1,4 +1,5 @@
 name: Install deps
+description: Install global CLI dependencies
 runs:
   using: composite
   steps:

--- a/.github/actions/node-setup/action.yml
+++ b/.github/actions/node-setup/action.yml
@@ -1,4 +1,5 @@
 name: Node setup
+description: Prepare Node environment and pnpm
 runs:
   using: composite
   steps:

--- a/.github/actions/pnpm-safe-install/action.yml
+++ b/.github/actions/pnpm-safe-install/action.yml
@@ -1,4 +1,5 @@
 name: pnpm safe install
+description: Install dependencies with corepack pnpm
 runs:
   using: composite
   steps:

--- a/.github/actions/sccache/action.yml
+++ b/.github/actions/sccache/action.yml
@@ -1,4 +1,5 @@
 name: Setup sccache
+description: Configure sccache for Rust builds
 runs:
   using: composite
   steps:

--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -1,4 +1,5 @@
 name: Setup pnpm
+description: Configure pnpm via corepack
 runs:
   using: composite
   steps:

--- a/.github/workflows/ci-validate-actions.yml
+++ b/.github/workflows/ci-validate-actions.yml
@@ -1,0 +1,23 @@
+name: ci:validate-actions
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  validate:
+    name: ci:validate-actions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5.0.0
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version: 20
+      - name: Install dependencies
+        run: npm ci
+      - name: Install yamllint
+        run: pip install yamllint
+      - name: Run action tests
+        run: node scripts/run-jest.js tests/validate-actions.test.js

--- a/tests/validate-actions.test.js
+++ b/tests/validate-actions.test.js
@@ -1,0 +1,27 @@
+const glob = require("glob");
+const fs = require("fs");
+const { parse } = require("yaml");
+const { execFileSync } = require("child_process");
+
+describe("GitHub actions definitions", () => {
+  const actionFiles = glob.sync(".github/actions/**/action.y?(a)ml");
+
+  test("yamllint parses all action files", () => {
+    for (const file of actionFiles) {
+      execFileSync("yamllint", ["-d", "{rules: {}}", file]);
+    }
+  });
+
+  test("actions have required fields", () => {
+    for (const file of actionFiles) {
+      const data = parse(fs.readFileSync(file, "utf8"));
+      expect(data.name).toBeTruthy();
+      expect(data.description).toBeTruthy();
+      expect(data.runs).toBeTruthy();
+      if (data.runs && data.runs.using === "composite") {
+        expect(Array.isArray(data.runs.steps)).toBe(true);
+        expect(data.runs.steps.length).toBeGreaterThan(0);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add jest suite to lint and validate GitHub Action definitions
- ensure every internal action declares required metadata
- run action validation in dedicated ci:validate-actions workflow

## Testing
- `npm run format`
- `npm test`
- `node scripts/run-jest.js tests/validate-actions.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a85d96118c832d87b5e8f41be7b1c9