### PR TITLE
ci: add OIDC-based self-hosted capacity orchestrator and safe fallback

### DIFF
--- a/.github/ci/selfhosted-config.yml
+++ b/.github/ci/selfhosted-config.yml
@@ -1,0 +1,4 @@
+aws_region: us-east-1
+asg_name: MVP-GH-Runners
+target_labels: [self-hosted, linux, x64, mvp-gh-runner]
+max_queue_minutes: 5

--- a/.github/workflows/_ci-shared.yml
+++ b/.github/workflows/_ci-shared.yml
@@ -1,0 +1,34 @@
+name: Shared CI runner with fallback
+
+on:
+  workflow_call:
+    inputs:
+      run:
+        description: Script to run
+        required: false
+        type: string
+        default: echo "heartbeat"
+
+jobs:
+  try-self-hosted:
+    runs-on: [self-hosted, linux, x64, mvp-gh-runner]
+    timeout-minutes: ${{ vars.MAX_QUEUE_MINUTES || 5 }}
+    continue-on-error: true
+    outputs:
+      started: ${{ steps.started.outputs.ok || '' }}
+    steps:
+      - name: Heartbeat
+        id: started
+        run: |
+          echo "ok=true" >> "$GITHUB_OUTPUT"
+          ${{ inputs.run }}
+      - name: Using self-hosted
+        run: echo "✅ used self-hosted runner" >> "$GITHUB_STEP_SUMMARY"
+  fallback:
+    needs: try-self-hosted
+    if: needs.try-self-hosted.outputs.started != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - run: ${{ inputs.run }}
+      - name: Using fallback
+        run: echo "⚠️ self-hosted unavailable, ran on ubuntu-latest" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/queue-probe.yml
+++ b/.github/workflows/queue-probe.yml
@@ -3,7 +3,6 @@ name: Queue Probe
 env:
   HUSKY: 0
 
-
 on:
   pull_request:
   workflow_dispatch:
@@ -16,13 +15,6 @@ permissions: {}
 
 jobs:
   probe:
-    runs-on:
-      - [self-hosted, linux, aws]
-      - ubuntu-latest
-    continue-on-error: true
-    timeout-minutes: 5
-    steps:
-      - name: Heartbeat
-        run: |
-          while true; do date; sleep 120; done &
-      - run: echo "hello $GITHUB_RUN_ID"
+    uses: ./.github/workflows/_ci-shared.yml
+    with:
+      run: echo "hello $GITHUB_RUN_ID"

--- a/.github/workflows/scale-in-idle.yml
+++ b/.github/workflows/scale-in-idle.yml
@@ -1,0 +1,63 @@
+name: Scale in self-hosted runners when idle
+
+on:
+  workflow_dispatch:
+    inputs:
+      idle_minutes:
+        description: Minutes to consider idle
+        required: false
+        default: 15
+        type: number
+  schedule:
+    - cron: "*/15 * * * *"
+
+env:
+  CONFIG_FILE: .github/ci/selfhosted-config.yml
+  AWS_ROLE_TO_ASSUME: ${{ vars.AWS_ROLE_TO_ASSUME || env.AWS_ROLE_TO_ASSUME }}
+
+jobs:
+  scale-in:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Read config
+        id: cfg
+        run: |
+          ASG_NAME=$(grep '^asg_name:' "$CONFIG_FILE" | awk '{print $2}')
+          REGION=$(grep '^aws_region:' "$CONFIG_FILE" | awk '{print $2}')
+          echo "asg_name=$ASG_NAME" >> "$GITHUB_OUTPUT"
+          echo "region=$REGION" >> "$GITHUB_OUTPUT"
+      - name: Configure AWS
+        uses: aws-actions/configure-aws-credentials@v4.0.1
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ steps.cfg.outputs.region }}
+      - name: Check recent activity
+        id: active
+        uses: actions/github-script@v7.0.1
+        env:
+          MINUTES: ${{ inputs.idle_minutes || 15 }}
+        with:
+          script: |
+            const minutes = parseInt(process.env.MINUTES, 10);
+            const since = new Date(Date.now() - minutes*60*1000).toISOString();
+            const runs = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 100,
+              status: 'in_progress'
+            });
+            const active = runs.some(r => new Date(r.created_at) > since);
+            core.setOutput('active', active);
+      - name: Scale in if idle
+        if: steps.active.outputs.active != 'true'
+        run: |
+          ASG=${{ steps.cfg.outputs.asg_name }}
+          REGION=${{ steps.cfg.outputs.region }}
+          MIN_SIZE=$(aws autoscaling describe-auto-scaling-groups --auto-scaling-group-names "$ASG" --query 'AutoScalingGroups[0].MinSize' --region "$REGION" --output text)
+          TARGET=$(( MIN_SIZE>0 ? MIN_SIZE : 0 ))
+          echo "Setting desired capacity to $TARGET"
+          aws autoscaling set-desired-capacity --auto-scaling-group-name "$ASG" --desired-capacity "$TARGET" --region "$REGION" || echo "Scale-in skipped"
+      - name: Skip scale in
+        if: steps.active.outputs.active == 'true'
+        run: echo "Workflows active, keeping capacity"

--- a/.github/workflows/scale-out-on-queue.yml
+++ b/.github/workflows/scale-out-on-queue.yml
@@ -1,0 +1,42 @@
+name: Scale out self-hosted runner on queue
+
+on:
+  workflow_job:
+    types: [queued]
+
+env:
+  CONFIG_FILE: .github/ci/selfhosted-config.yml
+  AWS_ROLE_TO_ASSUME: ${{ vars.AWS_ROLE_TO_ASSUME || env.AWS_ROLE_TO_ASSUME }}
+
+jobs:
+  scale:
+    if: github.event.action == 'queued' && contains(github.event.workflow_job.labels, 'mvp-gh-runner')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Read config
+        id: cfg
+        run: |
+          ASG_NAME=$(grep '^asg_name:' "$CONFIG_FILE" | awk '{print $2}')
+          REGION=$(grep '^aws_region:' "$CONFIG_FILE" | awk '{print $2}')
+          echo "asg_name=$ASG_NAME" >> "$GITHUB_OUTPUT"
+          echo "region=$REGION" >> "$GITHUB_OUTPUT"
+      - name: Configure AWS
+        uses: aws-actions/configure-aws-credentials@v4.0.1
+        with:
+          role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ steps.cfg.outputs.region }}
+      - name: Decide scale
+        run: |
+          ASG=${{ steps.cfg.outputs.asg_name }}
+          REGION=${{ steps.cfg.outputs.region }}
+          IN_SERVICE=$(aws autoscaling describe-auto-scaling-groups --auto-scaling-group-names "$ASG" --query 'AutoScalingGroups[0].Instances[?LifecycleState==`InService`]' --region "$REGION" --output json | jq 'length')
+          MIN_SIZE=$(aws autoscaling describe-auto-scaling-groups --auto-scaling-group-names "$ASG" --query 'AutoScalingGroups[0].MinSize' --region "$REGION" --output text)
+          echo "In-service instances: $IN_SERVICE"
+          if [ "$IN_SERVICE" -ge 1 ]; then
+            echo "Capacity already sufficient"
+            exit 0
+          fi
+          DESIRED=$(( MIN_SIZE>1 ? MIN_SIZE : 1 ))
+          echo "Setting desired capacity to $DESIRED"
+          aws autoscaling set-desired-capacity --auto-scaling-group-name "$ASG" --desired-capacity "$DESIRED" --region "$REGION" || echo "Scale-out skipped (cooldown?)"

--- a/.github/workflows/selfhosted-guard.yml
+++ b/.github/workflows/selfhosted-guard.yml
@@ -1,0 +1,26 @@
+name: Self-hosted workflow guard
+
+on:
+  pull_request:
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Lint workflows for self-hosted usage
+        run: |
+          violations=()
+          for f in .github/workflows/*.yml; do
+            if grep -qE 'name:.*Full (CI|Lane)' "$f"; then
+              if ! grep -q '_ci-shared.yml' "$f" && ! grep -q 'mvp-gh-runner' "$f"; then
+                violations+=("$f")
+              fi
+            fi
+          done
+          if [ ${#violations[@]} -gt 0 ]; then
+            echo "Missing self-hosted reference in: ${violations[*]}" >&2
+            exit 1
+          else
+            echo "Workflows OK"
+          fi

--- a/.github/workflows/selfhosted-probe.yml
+++ b/.github/workflows/selfhosted-probe.yml
@@ -63,6 +63,13 @@ jobs:
           name: probe-${{ github.run_id }}
           path: latency.txt
 
+  probe-mvp-gh-runner:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: [self-hosted, linux, x64, mvp-gh-runner]
+    steps:
+      - name: Runner context
+        run: echo '${{ toJSON(runner) }}'
+
   timeout-notice:
     if: ${{ needs.probe-selfhosted.result != 'success' }}
     needs: probe-selfhosted

--- a/docs/selfhosted-orchestrator.md
+++ b/docs/selfhosted-orchestrator.md
@@ -1,0 +1,33 @@
+# Self-hosted capacity orchestrator
+
+> **AWS setup is manual.** All infrastructure (IAM role, Auto Scaling Group, SSM parameters) must be provisioned outside this repository.
+
+This repository ships a set of GitHub Actions workflows to scale EC2 runners on demand using OIDC.
+
+## Configuration
+
+Set the following repository or environment variables (no secrets required):
+
+- `AWS_ROLE_TO_ASSUME` – IAM role assumed via GitHub OIDC. The role must trust GitHub and allow the permissions below.
+- `ASG_NAME` – Name of the Auto Scaling Group containing the EC2 runner instances (e.g. `MVP-GH-Runners`).
+- `AWS_REGION` – AWS region where the Auto Scaling Group lives (default `us-east-1`).
+
+You can override these at runtime via workflow `env` or `vars` if needed.
+
+### Minimal IAM permissions
+
+The IAM role requires only read and scale permissions:
+
+- `ec2:Describe*`
+- `autoscaling:Describe*`
+- `autoscaling:SetDesiredCapacity`
+
+## Workflows
+
+- `scale-out-on-queue.yml` – bumps the ASG to ensure at least one runner is ready when a job with the `self-hosted, linux, x64, mvp-gh-runner` label is queued.
+- `scale-in-idle.yml` – periodically scales the ASG back to zero when the repository has been idle.
+- `_ci-shared.yml` – reusable workflow that prefers self-hosted runners but cleanly falls back to `ubuntu-latest` after a configurable queue time.
+- `selfhosted-probe.yml` – manually trigger to print runner context and verify wiring.
+- `selfhosted-guard.yml` – lints workflows to ensure Full CI/Lane jobs use the shared workflow or include the self-hosted label set.
+
+These workflows are idempotent and contain no secrets. All AWS-side resources must be created separately.


### PR DESCRIPTION
## Summary
- add config and workflows to scale self-hosted AWS runners on demand
- add reusable CI runner with fallback and guard/probe utilities

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Playwright host dependencies already satisfied, terminated early)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

Skipping updates to other entrypoint workflows (e.g. `ci.yml`) to avoid conflicts.


------
https://chatgpt.com/codex/tasks/task_e_68a8778e049c832d827bb8fabdf774b8