### PR TITLE
feat: minimal EC2 GitHub runner setup

### DIFF
--- a/docs/self-hosted-minimal.md
+++ b/docs/self-hosted-minimal.md
@@ -1,0 +1,23 @@
+# Minimal self-hosted runner on EC2
+
+Launch an Ubuntu 24.04 instance and supply these tags or environment variables:
+
+- `GITHUB_OWNER` – repository owner
+- `GITHUB_REPO` – repository name
+- `GITHUB_LABELS` – runner labels (default `self-hosted,linux,x64,aws-runner`)
+- `RUNNER_NAME` – runner name (defaults to instance ID)
+- `RUNNER_VERSION` – GitHub runner release version
+- one of `SSM_TOKEN_PATH` (path to registration token in SSM Parameter Store) or `GITHUB_PAT` (personal access token)
+
+If using SSM, attach an IAM role with `ssm:GetParameter` permission for the parameter path.
+
+To bootstrap:
+
+1. Paste [`infra/ec2/user-data.sh`](../infra/ec2/user-data.sh) into the **User data** field when creating the EC2 instance.
+2. After launch, copy [`infra/ec2/systemd/github-runner.service`](../infra/ec2/systemd/github-runner.service) to `/etc/systemd/system/` and run:
+   ```bash
+   sudo systemctl daemon-reload
+   sudo systemctl enable --now github-runner.service
+   ```
+
+The script installs the runner at `/opt/actions-runner`, registers it with GitHub using an ephemeral token, creates a `_work` directory, and logs setup to `/var/log/gh-runner/bootstrap.log`.

--- a/infra/ec2/systemd/github-runner.service
+++ b/infra/ec2/systemd/github-runner.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=GitHub Actions Runner
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/actions-runner
+EnvironmentFile=/opt/actions-runner/.env
+ExecStart=/opt/actions-runner/run.sh
+Restart=always
+
+ExecStop=/bin/bash -c '
+  TOKEN="";
+  if [ -n "$SSM_TOKEN_PATH" ]; then
+    TOKEN=$(aws ssm get-parameter --name "$SSM_TOKEN_PATH" --with-decryption --query Parameter.Value --output text 2>/dev/null || true);
+  elif [ -n "$GITHUB_PAT" ]; then
+    TOKEN=$(curl -fs -X POST -H "Authorization: token $GITHUB_PAT" \
+      "https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/actions/runners/registration-token" | jq -r .token 2>/dev/null || true);
+  fi;
+  [[ -n "$TOKEN" ]] && /opt/actions-runner/config.sh remove --token "$TOKEN" || true
+'
+
+[Install]
+WantedBy=multi-user.target

--- a/infra/ec2/user-data.sh
+++ b/infra/ec2/user-data.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LOG_DIR=/var/log/gh-runner
+mkdir -p "$LOG_DIR"
+exec > >(tee -a "$LOG_DIR/bootstrap.log") 2>&1
+
+IMDS=http://169.254.169.254/latest
+TOKEN="$(curl -s -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 21600" "$IMDS/api/token" || true)"
+
+get_tag() {
+  local key="$1"
+  local val="${!key:-}"
+  if [ -z "$val" ] && [ -n "$TOKEN" ]; then
+    val="$(curl -fs -H "X-aws-ec2-metadata-token: $TOKEN" "$IMDS/meta-data/tags/instance/$key" || true)"
+  fi
+  echo "$val"
+}
+
+GITHUB_OWNER="$(get_tag GITHUB_OWNER)"
+GITHUB_REPO="$(get_tag GITHUB_REPO)"
+GITHUB_LABELS="$(get_tag GITHUB_LABELS)"
+GITHUB_LABELS="${GITHUB_LABELS:-self-hosted,linux,x64,aws-runner}"
+RUNNER_NAME="$(get_tag RUNNER_NAME)"
+if [ -z "$RUNNER_NAME" ] && [ -n "$TOKEN" ]; then
+  RUNNER_NAME="$(curl -fs -H "X-aws-ec2-metadata-token: $TOKEN" "$IMDS/meta-data/instance-id" || true)"
+fi
+RUNNER_VERSION="${RUNNER_VERSION:-2.317.0}"
+
+apt-get update -y
+apt-get install -y curl jq tar >/dev/null
+
+mkdir -p /opt/actions-runner
+cd /opt/actions-runner
+if [ ! -f ./run.sh ]; then
+  curl -L -o actions-runner.tar.gz "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz"
+  tar xzf actions-runner.tar.gz
+  rm actions-runner.tar.gz
+fi
+mkdir -p _work
+
+get_token() {
+  if [ -n "${SSM_TOKEN_PATH:-}" ]; then
+    aws ssm get-parameter --name "$SSM_TOKEN_PATH" --with-decryption --query Parameter.Value --output text
+  elif [ -n "${GITHUB_PAT:-}" ]; then
+    curl -fs -X POST -H "Authorization: token $GITHUB_PAT" \
+      "https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/actions/runners/registration-token" | jq -r .token
+  fi
+}
+
+if [ ! -f .runner ]; then
+  TOKEN_VAL="$(get_token)"
+  if [ -z "$TOKEN_VAL" ]; then
+    echo "Runner token not provided" >&2
+    exit 1
+  fi
+  ./config.sh --url "https://github.com/${GITHUB_OWNER}/${GITHUB_REPO}" \
+    --token "$TOKEN_VAL" \
+    --name "$RUNNER_NAME" \
+    --labels "$GITHUB_LABELS" \
+    --work _work \
+    --ephemeral
+fi
+
+cat > /opt/actions-runner/.env <<ENV
+GITHUB_OWNER=${GITHUB_OWNER}
+GITHUB_REPO=${GITHUB_REPO}
+GITHUB_LABELS=${GITHUB_LABELS}
+RUNNER_NAME=${RUNNER_NAME}
+SSM_TOKEN_PATH=${SSM_TOKEN_PATH:-}
+GITHUB_PAT=${GITHUB_PAT:-}
+ENV
+


### PR DESCRIPTION
## Summary
- add user-data script to install and register an ephemeral GitHub Actions runner on EC2
- provide systemd unit to manage the runner service
- document minimal self-hosted runner setup

## Testing
- `npm run format`
- `npm test` *(fails: root eslint exits 0, backend eslint exits 0, lintingDetailed; STRIPE_SECRET_KEY must be a live secret)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Prettier YAML syntax errors)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*


------
https://chatgpt.com/codex/tasks/task_e_68a87eec52d0832d992b01465e20d418