### PR TITLE
ci(minimal): scale on queue + reusable self-hosted wrapper with fallback

### DIFF
--- a/.github/ci/selfhosted-min.yml
+++ b/.github/ci/selfhosted-min.yml
@@ -1,0 +1,8 @@
+aws_region: us-east-1
+asg_name: MVP-GH-Runners
+labels:
+  - self-hosted
+  - linux
+  - x64
+  - aws-runner
+queue_timeout_minutes: 5

--- a/.github/workflows/_ci-try-selfhosted.yml
+++ b/.github/workflows/_ci-try-selfhosted.yml
@@ -1,0 +1,55 @@
+name: _ci-try-selfhosted
+
+on:
+  workflow_call:
+    inputs:
+      job-name:
+        required: true
+        type: string
+      steps:
+        required: true
+        type: string
+
+jobs:
+  config:
+    runs-on: ubuntu-latest
+    outputs:
+      labels: ${{ steps.read.outputs.labels }}
+      timeout: ${{ steps.read.outputs.timeout }}
+    steps:
+      - uses: actions/checkout@v5
+      - name: Read config
+        id: read
+        run: |
+          pip install pyyaml >/dev/null
+          python <<'PY'
+import yaml, json, os
+with open('.github/ci/selfhosted-min.yml') as f:
+    c = yaml.safe_load(f)
+print(f"labels={json.dumps(c['labels'])}", file=open(os.environ['GITHUB_OUTPUT'], 'a'))
+print(f"timeout={c['queue_timeout_minutes']}", file=open(os.environ['GITHUB_OUTPUT'], 'a'))
+PY
+
+  try-self-hosted:
+    name: ${{ inputs.job-name }} (self-hosted)
+    needs: config
+    runs-on: ${{ fromJson(needs.config.outputs.labels) }}
+    timeout-minutes: ${{ needs.config.outputs.timeout }}
+    outputs:
+      fell_back: ${{ steps.flag.outputs.fell_back }}
+    steps:
+      - name: Run steps
+        run: ${{ inputs.steps }}
+      - name: Mark
+        if: always()
+        id: flag
+        run: echo "fell_back=false" >> $GITHUB_OUTPUT
+
+  fallback:
+    name: ${{ inputs.job-name }} (fallback)
+    needs: try-self-hosted
+    if: needs.try-self-hosted.outputs.fell_back != 'false'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run steps
+        run: ${{ inputs.steps }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,12 @@ env:
   BASH_ENV: scripts/env/aliases.sh
 
 jobs:
+  self-hosted-minimal:
+    uses: ./.github/workflows/_ci-try-selfhosted.yml
+    with:
+      job-name: self-hosted-minimal
+      steps: |
+        echo "self-hosted wrapper active"
   build:
     timeout-minutes: 15
     runs-on:

--- a/.github/workflows/scale-on-queue.yml
+++ b/.github/workflows/scale-on-queue.yml
@@ -1,0 +1,58 @@
+name: scale-on-queue
+
+on:
+  workflow_job:
+    types: [queued]
+
+jobs:
+  scale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Read config
+        id: cfg
+        run: |
+          pip install pyyaml >/dev/null
+          python <<'PY'
+import yaml, json, os
+with open('.github/ci/selfhosted-min.yml') as f:
+    c = yaml.safe_load(f)
+region = os.environ.get('AWS_REGION_OVERRIDE') or c['aws_region']
+asg = os.environ.get('ASG_NAME_OVERRIDE') or c['asg_name']
+print(f"region={region}", file=open(os.environ['GITHUB_OUTPUT'], 'a'))
+print(f"asg={asg}", file=open(os.environ['GITHUB_OUTPUT'], 'a'))
+print(f"labels={json.dumps(c['labels'])}", file=open(os.environ['GITHUB_OUTPUT'], 'a'))
+PY
+        env:
+          AWS_REGION_OVERRIDE: ${{ vars.AWS_REGION }}
+          ASG_NAME_OVERRIDE: ${{ vars.ASG_NAME }}
+      - name: Check labels
+        id: match
+        run: |
+          python <<'PY'
+import json, os
+cfg = set(json.loads(os.environ['CONFIG_LABELS']))
+job = set(json.loads(os.environ['JOB_LABELS']))
+print(f"match={str(bool(cfg & job)).lower()}", file=open(os.environ['GITHUB_OUTPUT'], 'a'))
+PY
+        env:
+          CONFIG_LABELS: ${{ steps.cfg.outputs.labels }}
+          JOB_LABELS: ${{ toJson(github.event.workflow_job.labels) }}
+      - name: Configure AWS creds
+        if: steps.match.outputs.match == 'true'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ steps.cfg.outputs.region }}
+      - name: Scale ASG
+        if: steps.match.outputs.match == 'true'
+        env:
+          ASG: ${{ steps.cfg.outputs.asg }}
+          AWS_REGION: ${{ steps.cfg.outputs.region }}
+        run: |
+          current=$(aws autoscaling describe-auto-scaling-groups --auto-scaling-group-names "$ASG" --query "AutoScalingGroups[0].DesiredCapacity" --output text)
+          if [ "$current" -lt 1 ]; then
+            aws autoscaling set-desired-capacity --auto-scaling-group-name "$ASG" --desired-capacity 1 --honor-cooldown
+          else
+            echo "Capacity already $current, not scaling"
+          fi

--- a/docs/self-hosted-minimal.md
+++ b/docs/self-hosted-minimal.md
@@ -1,0 +1,7 @@
+# Self-hosted minimal
+
+Set the repo or environment variable `AWS_ROLE_TO_ASSUME` to your OIDC role ARN.
+
+Optionally override defaults with `ASG_NAME` and `AWS_REGION` variables.
+
+Jobs using the reusable wrapper first try the self-hosted runner and fall back to `ubuntu-latest` if they don't start within the configured queue timeout.


### PR DESCRIPTION
## Summary
- add minimal self-hosted runner config
- scale AWS runner ASG when matching jobs queue
- reusable self-hosted job wrapper with ubuntu fallback

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` (in `backend/`)
- `npm test` (in `backend/`)
- `SKIP_PW_DEPS=1 npm run ci` *(fails: SyntaxError in existing workflow files)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a87ef5e31c832d88baf5ed3092b74c