### PR TITLE
ci: add self-hosted latency canary

### DIFF
--- a/.github/actions/canary-latency/action.yml
+++ b/.github/actions/canary-latency/action.yml
@@ -1,0 +1,41 @@
+name: Canary Latency
+description: Measure queued->start latency for this job and assert SLO
+inputs:
+  threshold_seconds:
+    description: Max allowed queued->start latency
+    required: true
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        set -euo pipefail
+        RUN_ID="${GITHUB_RUN_ID}"
+        REPO="${GITHUB_REPOSITORY}"
+        PAGE=1
+        tmp="$(mktemp)"
+        # Fetch jobs for this run
+        gh api -H "Accept: application/vnd.github+json" \
+          "/repos/${REPO}/actions/runs/${RUN_ID}/jobs?per_page=100" > "$tmp"
+        # Identify *this* job by name/id
+        this_id="${{ github.job }}"
+        # Best effort: pick the job with the same name first; fallback to first job
+        jq '.jobs[0] as $first
+            | (.jobs[] | select(.name == env.this_id)) // $first' \
+            "$tmp" > "$tmp.job"
+        queued_at=$(jq -r '.queued_at // empty' "$tmp.job")
+        started_at=$(jq -r '.started_at // empty' "$tmp.job")
+        if [[ -z "${queued_at}" || -z "${started_at}" ]]; then
+          echo "No timing data yet; treating as high latency."
+          echo "latency_seconds=9999" >> "$GITHUB_OUTPUT"
+          exit 1
+        fi
+        q=$(date -u -d "$queued_at" +%s)
+        s=$(date -u -d "$started_at" +%s)
+        latency=$(( s - q ))
+        echo "latency_seconds=$latency" >> "$GITHUB_OUTPUT"
+        echo "Latency: $latency s (threshold ${{ inputs.threshold_seconds }} s)"
+        if (( latency > ${{ inputs.threshold_seconds }} )); then
+          echo "Latency SLO breached"
+          exit 1
+        fi

--- a/.github/workflows/ci-canary.yml
+++ b/.github/workflows/ci-canary.yml
@@ -1,0 +1,75 @@
+name: CI Canary (Self-hosted start latency)
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+    inputs:
+      threshold_seconds:
+        description: "SLO (seconds)"
+        default: "120"
+        required: false
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    outputs:
+      has_runner: ${{ steps.detect.outputs.has_runner }}
+    steps:
+      - id: detect
+        shell: bash
+        env:
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          data=$(gh api -H "Accept: application/vnd.github+json" \
+            "/repos/$REPO/actions/runners")
+          found=$(echo "$data" | jq '[.runners[] | (.labels | map(.name))] | map([index("self-hosted"), index("linux"), index("x64"), index("aws-runner")] | all(. != null)) | any')
+          if [[ "$found" == "true" ]]; then
+            echo "has_runner=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No matching self-hosted runner; skipping." >&2
+            echo "has_runner=false" >> "$GITHUB_OUTPUT"
+          fi
+  canary:
+    name: selfhosted-canary
+    needs: check
+    if: needs.check.outputs.has_runner == 'true'
+    runs-on: [self-hosted, linux, x64, aws-runner]
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Prove the runner does minimal work
+        run: |
+          uname -a
+          echo "Self-hosted canary OK"
+      - name: Assert latency SLO
+        id: slo
+        uses: ./.github/actions/canary-latency
+        with:
+          threshold_seconds: ${{ inputs.threshold_seconds || vars.CI_SLO_START_SECONDS || '120' }}
+      - name: Upload timings artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: canary-timings
+          path: |
+            $GITHUB_STEP_SUMMARY
+      - name: Comment PR with latency
+        if: github.event_name == 'workflow_dispatch' && github.event.pull_request.number
+        uses: actions/github-script@v7
+        env:
+          LATENCY: ${{ steps.slo.outputs.latency_seconds }}
+          RESULT: ${{ steps.slo.outcome }}
+        with:
+          script: |
+            const body = `${process.env.RESULT === 'success' ? '✅' : '❌'} self-hosted latency ${process.env.LATENCY}s`;
+            await github.rest.issues.createComment({
+              ...context.repo,
+              issue_number: context.payload.pull_request.number,
+              body
+            });
+  control:
+    name: control-ubuntu
+    needs: canary
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - run: echo "Control path (repo ok)."

--- a/ci/canary/README.md
+++ b/ci/canary/README.md
@@ -1,0 +1,20 @@
+# CI Canary
+
+Proves a self-hosted runner starts quickly.
+
+- Runs every 30 minutes and on demand via `workflow_dispatch`.
+- Targets labels `self-hosted`, `linux`, `x64`, and `aws-runner`.
+- Uses a composite action that calls the GitHub API for `workflow_job` data.
+- Computes the time from `queued_at` to `started_at`.
+- Fails if latency exceeds `CI_SLO_START_SECONDS` (default 120s).
+- Override the SLO by passing `threshold_seconds` input on dispatch.
+- If no matching runner exists, the canary job is skipped harmlessly.
+- A `control-ubuntu` job runs on `ubuntu-latest` to show the repo builds.
+- The canary step uploads a `canary-timings` artifact.
+- Download the artifact to inspect measured timings in the summary.
+- When dispatched from a pull request, the workflow comments the latency.
+- Useful for catching runner outages or misconfigured labels early.
+- Environment variables:
+  - `CI_SLO_START_SECONDS` — override default start latency SLO.
+- Artifacts live under the run's "Artifacts" section in GitHub Actions.
+- Delete old artifacts to keep the repository tidy.


### PR DESCRIPTION
## Summary
- add composite action to measure job start latency
- schedule CI canary workflow to prove self-hosted runners start promptly
- document canary usage and knobs

## Testing
- `npm run format` (backend)  
- `npm test` (backend)  
- `npm run ci` *(fails: SyntaxError in several workflow YAML files)*  
- `npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a8847121fc832d9d650f1b53812d01