### PR TITLE
ci: add AWS sanity and runner label checks

### DIFF
--- a/.github/workflows/ci-aws-sanity.yml
+++ b/.github/workflows/ci-aws-sanity.yml
@@ -1,0 +1,34 @@
+name: AWS CI Sanity
+on:
+  schedule: [{ cron: "0 * * * *" }]
+  workflow_dispatch: {}
+jobs:
+  sanity:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check OIDC wiring
+        id: gate
+        run: |
+          if [[ -z "${{ vars.AWS_ROLE_TO_ASSUME || '' }}" ]]; then
+            echo "no_role=1" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Skip if no role
+        if: steps.gate.outputs.no_role == '1'
+        run: echo "Skipping: AWS role not configured."
+      - name: Configure AWS
+        if: steps.gate.outputs.no_role != '1'
+        uses: aws-actions/configure-aws-credentials@v4.3.1
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME }}
+          aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
+      - name: Assert ASG exists (soft)
+        if: steps.gate.outputs.no_role != '1'
+        shell: bash
+        run: |
+          set -euo pipefail
+          ASG="${{ vars.ASG_NAME || 'MVP-GH-Runners' }}"
+          aws autoscaling describe-auto-scaling-groups --auto-scaling-group-names "$ASG" >/dev/null || {
+            echo "::warning::ASG '$ASG' not found (skipping)."
+            exit 0
+          }
+          echo "ASG $ASG found."

--- a/.github/workflows/ci-runner-labels.yml
+++ b/.github/workflows/ci-runner-labels.yml
@@ -1,0 +1,21 @@
+name: Runner Label Guard
+on: { workflow_dispatch: {} }
+jobs:
+  guard:
+    runs-on: [self-hosted, linux, x64, aws-runner]
+    steps:
+      - name: Print labels
+        run: |
+          echo "Labels: $RUNNER_LABELS"
+      - name: Check expected labels
+        shell: bash
+        run: |
+          set -euo pipefail
+          exp="self-hosted,linux,x64,aws-runner"
+          # Normalize
+          got="$(tr ' ' '\n' <<<"$RUNNER_LABELS" | paste -sd, -)"
+          if [[ "$got" != *"self-hosted"* || "$got" != *"linux"* || "$got" != *"x64"* || "$got" != *"aws-runner"* ]]; then
+            echo "::error::Runner labels do not include expected set: $exp (got: $got)"
+            exit 1
+          fi
+          echo "Labels OK."


### PR DESCRIPTION
## Summary
- add scheduled AWS sanity check workflow to verify autoscaling group presence
- add runner label guard to ensure self-hosted runners carry expected labels

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(reports existing YAML syntax errors)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*


------
https://chatgpt.com/codex/tasks/task_e_68a8848de040832d98db73ea04ca8d72