### PR TITLE
ci: run ci audit via tsx and add smoke test

### DIFF
--- a/.github/workflows/ci-audit.yml
+++ b/.github/workflows/ci-audit.yml
@@ -9,11 +9,12 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: "20"
+          cache: "npm"
       - run: node --version
+      - run: npm ci
       - name: Run audit
-        run: |
-          node scripts/ci-audit.ts
+        run: npm run ci:audit
       - name: Upload audit artifact
         if: always()
         uses: actions/upload-artifact@v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "react-dom": "^18.2.0",
         "react-places-autocomplete": "^7.3.0",
         "winston": "^3.17.0",
-        "winston-format": "^1.0.1"
+        "winston-format": "^1.0.1",
+        "yaml": "^2.8.0"
       },
       "devDependencies": {
         "@actions/core": "^1.11.1",
@@ -81,9 +82,9 @@
         "toml": "^3.0.0",
         "tsconfig-strictest": "^1.0.0-beta.1",
         "tslib": "^2.8.1",
+        "tsx": "^4.19.0",
         "typescript": "^5.8.3",
-        "wait-on": "^8.0.3",
-        "yaml": "^2.8.0"
+        "wait-on": "^8.0.3"
       },
       "engines": {
         "node": ">=20 <21"
@@ -13954,7 +13955,6 @@
       "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
       },
@@ -22013,7 +22013,6 @@
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
@@ -24772,6 +24771,26 @@
       "dev": true,
       "license": "0BSD"
     },
+    "node_modules/tsx": {
+      "version": "4.20.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.4.tgz",
+      "integrity": "sha512-yyxBKfORQ7LuRt/BQKBXrpcq59ZvSW0XxwfjAt3w2/8PmdxaFzijtMhTawprSHhpzeM5BgU2hXHG3lklIERZXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
     "node_modules/tunnel": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
@@ -25963,7 +25982,6 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
       "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -103,7 +103,8 @@
     "test:e2e:regression": "playwright test --config tests/playwright.config.ts",
     "test:regression": "npm run test:backend:regression && npm run test:frontend:regression && npm run test:ci:regression && npm run test:e2e:regression",
     "ci:probe": "bash -O globstar -c 'env -u npm_config_prefix node --test tests/ci/**/*.test.js'",
-    "ci:summary": "node scripts/ci/print-suite-summary.js"
+    "ci:summary": "node scripts/ci/print-suite-summary.js",
+    "ci:audit": "tsx scripts/ci-audit.ts"
   },
   "babel": {
     "presets": [
@@ -187,7 +188,7 @@
     "tslib": "^2.8.1",
     "typescript": "^5.8.3",
     "wait-on": "^8.0.3",
-    "yaml": "^2.8.0"
+    "tsx": "^4.19.0"
   },
   "husky": {
     "hooks": {
@@ -210,6 +211,7 @@
     "react-dom": "^18.2.0",
     "react-places-autocomplete": "^7.3.0",
     "winston": "^3.17.0",
-    "winston-format": "^1.0.1"
+    "winston-format": "^1.0.1",
+    "yaml": "^2.8.0"
   }
 }

--- a/scripts/ci-audit.ts
+++ b/scripts/ci-audit.ts
@@ -2,10 +2,24 @@
 // @ts-check
 const fs = require("fs");
 const path = require("path");
-const yaml = require("yaml");
+let yaml;
+try {
+  yaml = require("yaml");
+} catch (err) {
+  console.error(
+    'ci-audit: missing required dependency "yaml". Did you run `npm ci`?',
+  );
+  process.exit(2);
+}
 
 const repoRoot = path.resolve(__dirname, "..");
 const workflowsDir = path.join(repoRoot, ".github", "workflows");
+if (!fs.existsSync(workflowsDir)) {
+  console.error(
+    "ci-audit: .github/workflows directory not found; cannot audit CI coverage.",
+  );
+  process.exit(2);
+}
 const ciDir = path.join(repoRoot, "ci");
 const TEST_KEYWORDS = [
   "jest",

--- a/tests/ci-audit.smoke.test.ts
+++ b/tests/ci-audit.smoke.test.ts
@@ -1,0 +1,54 @@
+import { mkdtempSync, rmSync, writeFileSync, cpSync, mkdirSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import { spawnSync } from "child_process";
+
+const repoRoot = path.join(__dirname, "..");
+const nodeModules = path.join(repoRoot, "node_modules");
+const binPath = path.join(nodeModules, ".bin");
+
+function createTempRepo() {
+  const tmp = mkdtempSync(path.join(tmpdir(), "ci-audit-"));
+  mkdirSync(path.join(tmp, "scripts"), { recursive: true });
+  cpSync(
+    path.join(repoRoot, "scripts", "ci-audit.ts"),
+    path.join(tmp, "scripts", "ci-audit.ts"),
+  );
+  cpSync(path.join(repoRoot, ".github"), path.join(tmp, ".github"), {
+    recursive: true,
+  });
+  writeFileSync(
+    path.join(tmp, "package.json"),
+    JSON.stringify({ scripts: { "ci:audit": "tsx scripts/ci-audit.ts" } }),
+  );
+  return tmp;
+}
+
+function runAudit(cwd: string, nodePath: string) {
+  return spawnSync("npm", ["run", "ci:audit"], {
+    cwd,
+    env: {
+      ...process.env,
+      NODE_PATH: nodePath,
+      PATH: `${binPath}${path.delimiter}${process.env.PATH}`,
+    },
+    encoding: "utf8",
+  });
+}
+
+test("ci:audit succeeds with dependencies", () => {
+  const tmp = createTempRepo();
+  const res = runAudit(tmp, nodeModules);
+  rmSync(tmp, { recursive: true, force: true });
+  expect(res.status).toBe(0);
+});
+
+test("ci:audit fails when yaml is missing", () => {
+  const tmp = createTempRepo();
+  const res = runAudit(tmp, path.join(tmp, "empty"));
+  rmSync(tmp, { recursive: true, force: true });
+  expect(res.status).not.toBe(0);
+  expect(res.stderr + res.stdout).toMatch(
+    /missing required dependency "yaml"/i,
+  );
+});


### PR DESCRIPTION
## Summary
- ensure `ci-audit` script exits if `yaml` or workflow config is missing
- run `ci-audit` via `tsx` in npm script and workflow
- add regression test for missing `yaml` dependency

## Testing
- `npm run format --prefix backend`
- `npx prettier -w scripts/ci-audit.ts tests/ci-audit.smoke.test.ts .github/workflows/ci-audit.yml package.json`
- `npm test --prefix backend`
- `node scripts/run-jest.js tests/ci-audit.smoke.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a88fc5cd78832dbd48b20e6b8c5746