### PR TITLE
ci: trigger workflows on any branch

### DIFF
--- a/.github/workflows/ci-fast-lane.yml
+++ b/.github/workflows/ci-fast-lane.yml
@@ -1,5 +1,7 @@
 name: CI Fast Lane
 on:
+  push:
+    branches: ["**"]
   pull_request:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci-full-lane.yml
+++ b/.github/workflows/ci-full-lane.yml
@@ -1,10 +1,8 @@
 name: CI Full Lane
 on:
-  pull_request:
   push:
-    branches:
-      - dev
-      - "00000production"
+    branches: ["**"]
+  pull_request:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -1,14 +1,9 @@
 name: CI Full Lane
 
 on:
-  pull_request:
-    branches:
-      - dev
-      - '00000production'
   push:
-    branches:
-      - dev
-      - '00000production'
+    branches: ["**"]
+  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, dev, 00000production]
+    branches: ["**"]
     # paths: # temporarily broadened to restore coverage
     #   - frontend/**
     #   - backend/**
@@ -13,7 +13,6 @@ on:
     #   - pnpm-lock.yaml
     #   - .github/workflows/**
   pull_request:
-    branches: [main, dev, 00000production]
     # paths: # temporarily broadened to restore coverage
     #   - frontend/**
     #   - backend/**


### PR DESCRIPTION
## Summary
- trigger ci fast lane on any branch push or pull request
- run ci full lane and ci full workflows on push/pr for all branches
- broaden base CI workflow to run for any branch push or pull request

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `cd backend && npm run format`
- `cd backend && npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: SyntaxError in multiple workflow YAML files)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a89ecf70fc832db211d6e2ecf9067f