### PR TITLE
ci: add LFS pointer test suite

### DIFF
--- a/.github/workflows/lfs-pointer-tests.yml
+++ b/.github/workflows/lfs-pointer-tests.yml
@@ -1,0 +1,14 @@
+name: LFS Pointer Tests
+on: [pull_request, push]
+jobs:
+  lfs-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - run: npm ci || pnpm install || yarn install
+      - run: npm run test:lfs

--- a/package.json
+++ b/package.json
@@ -104,7 +104,8 @@
     "test:regression": "npm run test:backend:regression && npm run test:frontend:regression && npm run test:ci:regression && npm run test:e2e:regression",
     "ci:probe": "bash -O globstar -c 'env -u npm_config_prefix node --test tests/ci/**/*.test.js'",
     "ci:summary": "node scripts/ci/print-suite-summary.js",
-    "test:inventory": "vitest run -t test-inventory"
+    "test:inventory": "vitest run -t test-inventory",
+    "test:lfs": "vitest run -t lfs"
   },
   "babel": {
     "presets": [

--- a/tests/lfs/pointers.test.ts
+++ b/tests/lfs/pointers.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, existsSync } from "fs";
+import { join } from "path";
+
+describe("lfs pointer checks", () => {
+  const root = process.cwd();
+  const attrs = readFileSync(join(root, ".gitattributes"), "utf8");
+
+  it("lfs gitattributes covers img png", () => {
+    const has = /img\/\*\*/.test(attrs) && /\*.png\s+filter=lfs/.test(attrs);
+    expect(has).toBe(true);
+  });
+
+  it("lfs gitattributes covers img jpg", () => {
+    const has = /img\/\*\*/.test(attrs) && /\*.jpg\s+filter=lfs/.test(attrs);
+    expect(has).toBe(true);
+  });
+
+  const files = [
+    "img/boxlogo.png",
+    "img/luckybox-preview.png",
+    "img/print2 logo.png",
+    "img/textlogo.png",
+  ];
+
+  for (const file of files) {
+    it(`lfs pointer present for ${file}`, () => {
+      const filePath = join(root, file);
+      expect(existsSync(filePath)).toBe(true);
+      const firstLine = readFileSync(filePath, "utf8").split("\n")[0];
+      expect(firstLine).toContain("git-lfs");
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add vitest suite to check LFS pointers in `img`
- add `test:lfs` script and workflow running the suite on PRs and pushes

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npx prettier -w package.json .github/workflows/lfs-pointer-tests.yml tests/lfs/pointers.test.ts`
- `npx vitest run tests/lfs/pointers.test.ts` *(fails: expected '\ufffdPNG\r' to contain 'git-lfs')*

------
https://chatgpt.com/codex/tasks/task_e_68a89f7e5aac832dada468e562b5e89b