### PR TITLE
ci: guard github-script comment steps

### DIFF
--- a/.github/workflows/check-watchdog.yml
+++ b/.github/workflows/check-watchdog.yml
@@ -19,6 +19,9 @@ jobs:
     timeout-minutes: 8
     permissions:
       checks: read
+      contents: read
+      issues: write
+      pull-requests: write
     steps:
       - name: Heartbeat
         run: |
@@ -68,7 +71,7 @@ jobs:
         if: steps.watch.outcome == 'failure'
         uses: actions/github-script@v7.0.1
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ github.token }}
           script: |
             const fs = require('fs');
             const pr = context.payload.pull_request?.number;
@@ -77,9 +80,13 @@ jobs:
               return;
             }
             const body = fs.readFileSync('checks.txt', 'utf8');
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: pr,
-              body,
-            });
+            try {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr,
+                body,
+              });
+            } catch (e) {
+              core.warning("Comment skipped: insufficient permissions (" + e.message + ")");
+            }

--- a/.github/workflows/ci-canary.yml
+++ b/.github/workflows/ci-canary.yml
@@ -34,6 +34,9 @@ jobs:
     needs: check
     if: needs.check.outputs.has_runner == 'true'
     runs-on: [self-hosted, linux, x64, aws-runner]
+    permissions:
+      issues: write
+      pull-requests: write
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
@@ -59,13 +62,18 @@ jobs:
           LATENCY: ${{ steps.slo.outputs.latency_seconds }}
           RESULT: ${{ steps.slo.outcome }}
         with:
+          github-token: ${{ github.token }}
           script: |
             const body = `${process.env.RESULT === 'success' ? '✅' : '❌'} self-hosted latency ${process.env.LATENCY}s`;
-            await github.rest.issues.createComment({
-              ...context.repo,
-              issue_number: context.payload.pull_request.number,
-              body
-            });
+            try {
+              await github.rest.issues.createComment({
+                ...context.repo,
+                issue_number: context.payload.pull_request.number,
+                body
+              });
+            } catch (e) {
+              core.warning("Comment skipped: insufficient permissions (" + e.message + ")");
+            }
   control:
     name: control-ubuntu
     needs: canary

--- a/.github/workflows/ci-inventory-comment.yml
+++ b/.github/workflows/ci-inventory-comment.yml
@@ -6,13 +6,14 @@ on:
     workflows: ["Full CI Aggregate / all-suites"]
     types: [completed]
 
-permissions:
-  pull-requests: write
-  actions: read
-
 jobs:
   comment:
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - name: Download test inventory artifact
@@ -30,6 +31,7 @@ jobs:
       - name: Comment with suite inventory
         uses: actions/github-script@v7
         with:
+          github-token: ${{ github.token }}
           script: |
             const fs = require('fs');
             const marker = '<!-- ci-inventory-comment -->';
@@ -96,10 +98,14 @@ jobs:
               issue_number: prNumber
             });
             const existing = comments.find(c => c.body.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
-            } else {
-              await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body });
+            try {
+              if (existing) {
+                await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+              } else {
+                await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body });
+              }
+            } catch (e) {
+              core.warning("Comment skipped: insufficient permissions (" + e.message + ")");
             }
 
             return;

--- a/.github/workflows/ci-queue-metrics.yml
+++ b/.github/workflows/ci-queue-metrics.yml
@@ -8,15 +8,14 @@ on:
 env:
   HUSKY: 0
 
-permissions:
-  actions: write
-  contents: read
-  issues: write
-  pull-requests: write
-
 jobs:
   record:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+      issues: write
+      pull-requests: write
     steps:
       - name: Heartbeat
         run: |
@@ -68,6 +67,7 @@ jobs:
           PRS: ${{ steps.record.outputs.prs }}
           SUMMARY: ${{ steps.record.outputs.summary }}
         with:
+          github-token: ${{ github.token }}
           script: |
             const prs = JSON.parse(process.env.PRS);
             const {owner, repo} = context.repo;
@@ -82,5 +82,9 @@ jobs:
                   throw e;
                 }
               }
-              await github.rest.issues.createComment({owner, repo, issue_number: pr.number, body: `@example/devops\n${process.env.SUMMARY}`});
+              try {
+                await github.rest.issues.createComment({owner, repo, issue_number: pr.number, body: `@example/devops\n${process.env.SUMMARY}`});
+              } catch (e) {
+                core.warning("Comment skipped: insufficient permissions (" + e.message + ")");
+              }
             }

--- a/.github/workflows/ci-queue-monitor.yml
+++ b/.github/workflows/ci-queue-monitor.yml
@@ -21,8 +21,9 @@ jobs:
       - ubuntu-latest
     permissions:
       actions: write
-      pull-requests: write
       contents: read
+      issues: write
+      pull-requests: write
     steps:
       - name: Heartbeat
         run: |
@@ -30,6 +31,7 @@ jobs:
       - name: Check CI queue and cancel obsolete runs
         uses: actions/github-script@v7
         with:
+          github-token: ${{ github.token }}
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
@@ -63,7 +65,11 @@ jobs:
             for (const [prNumber, prRuns] of byPr.entries()) {
               if (prRuns.length <= runLimit) continue;
               const body = `CI queue monitor: ${prRuns.length} runs have been queued for over ${thresholdMinutes} minutes. Cancelling older runs to keep the latest run active.`;
-              await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body });
+              try {
+                await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body });
+              } catch (e) {
+                core.warning("Comment skipped: insufficient permissions (" + e.message + ")");
+              }
               prRuns.sort((a,b) => new Date(b.created_at) - new Date(a.created_at));
               const [, ...obsolete] = prRuns;
               for (const run of obsolete) {

--- a/.github/workflows/conflict-radar.yml
+++ b/.github/workflows/conflict-radar.yml
@@ -5,13 +5,13 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pull-requests: write
-
 jobs:
   radar:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4.1.6
@@ -19,6 +19,7 @@ jobs:
         id: radar
         uses: actions/github-script@v7.0.1
         with:
+          github-token: ${{ github.token }}
           script: |
             const since = new Date(Date.now() - 14 * 24 * 60 * 60 * 1000).toISOString();
             const closed = await github.graphql(
@@ -65,12 +66,16 @@ jobs:
                   const files = pr.files.map(f => `\`${f}\``).join(', ');
                   body += `- [ ] [#${pr.number}](${pr.url}) ${pr.title} - ${files}\n`;
                 }
-                await github.rest.issues.createComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: target.number,
-                  body
-                });
+                try {
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: target.number,
+                    body
+                  });
+                } catch (e) {
+                  core.warning("Comment skipped: insufficient permissions (" + e.message + ")");
+                }
               }
             }
       - name: Upload audit file

--- a/.github/workflows/coverage-watchdog.yml
+++ b/.github/workflows/coverage-watchdog.yml
@@ -18,6 +18,7 @@ jobs:
     timeout-minutes: 60
     permissions:
       contents: read
+      issues: write
       pull-requests: write
     steps:
       - name: Heartbeat
@@ -74,17 +75,21 @@ jobs:
         if: github.event.pull_request.number
         uses: actions/github-script@v7.0.1
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ github.token }}
           script: |
             const fs = require('fs');
             const diff = fs.readFileSync('coverage/diff.txt', 'utf8');
             const pr = context.payload.pull_request.number;
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: pr,
-              body: `Coverage diff:\n\n\`\`\`\n${diff}\n\`\`\``
-            });
+            try {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr,
+                body: `Coverage diff:\n\n\`\`\`\n${diff}\n\`\`\``
+              });
+            } catch (e) {
+              core.warning("Comment skipped: insufficient permissions (" + e.message + ")");
+            }
       - name: Upload coverage artifacts
         uses: actions/upload-artifact@v4.3.1
         with:

--- a/.github/workflows/diff-summary.yml
+++ b/.github/workflows/diff-summary.yml
@@ -14,6 +14,7 @@ jobs:
       - ubuntu-latest
     permissions:
       contents: read
+      issues: write
       pull-requests: write
     steps:
       - uses: actions/checkout@v5.0.0
@@ -43,12 +44,16 @@ jobs:
           ADDED: ${{ steps.diff.outputs.added }}
           REMOVED: ${{ steps.diff.outputs.removed }}
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ github.token }}
           script: |
             const body = `Lines added: ${process.env.ADDED}, removed: ${process.env.REMOVED}`;
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body
-            });
+            try {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body
+              });
+            } catch (e) {
+              core.warning("Comment skipped: insufficient permissions (" + e.message + ")");
+            }

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -12,6 +12,10 @@ concurrency: repo-ci
 jobs:
   e2e:
     runs-on: [self-hosted, linux, x64, gha]
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     timeout-minutes: 30
     retries: 2
     steps:
@@ -70,11 +74,15 @@ jobs:
           TRACE_URL: ${{ steps.upload-trace.outputs['artifact-url'] }}
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ github.token }}
           script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `Playwright trace: https://trace.playwright.dev/?trace=${process.env.TRACE_URL}`,
-            });
+            try {
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: `Playwright trace: https://trace.playwright.dev/?trace=${process.env.TRACE_URL}`,
+              });
+            } catch (e) {
+              core.warning("Comment skipped: insufficient permissions (" + e.message + ")");
+            }

--- a/.github/workflows/pages-url-comment.yml
+++ b/.github/workflows/pages-url-comment.yml
@@ -18,6 +18,7 @@ jobs:
       - ubuntu-latest
     permissions:
       contents: read
+      issues: write
       pull-requests: write
     steps:
       - name: Download Pages URL
@@ -38,7 +39,7 @@ jobs:
         env:
           URL: ${{ steps.read.outputs.url }}
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ github.token }}
           script: |
             const pr = context.payload.workflow_run.pull_requests[0];
             if (!pr) {
@@ -46,9 +47,13 @@ jobs:
               return;
             }
             const body = `Cloudflare Pages preview: ${process.env.URL}`;
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: pr.number,
-              body
-            });
+            try {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body
+              });
+            } catch (e) {
+              core.warning("Comment skipped: insufficient permissions (" + e.message + ")");
+            }

--- a/.github/workflows/selfhosted-regression-guard.yml
+++ b/.github/workflows/selfhosted-regression-guard.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   guard:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - name: Check recent feature test
         id: check
@@ -30,11 +33,16 @@ jobs:
         if: steps.check.outputs.recent == 'false'
         uses: actions/github-script@v7.0.1
         with:
+          github-token: ${{ github.token }}
           script: |
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: 'Self-hosted runner feature test has not succeeded in the last 24h. Trigger it via the Actions tab (Self-hosted Runner Feature Test > Run workflow).'
-            });
+            try {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: 'Self-hosted runner feature test has not succeeded in the last 24h. Trigger it via the Actions tab (Self-hosted Runner Feature Test > Run workflow).'
+              });
+            } catch (e) {
+              core.warning("Comment skipped: insufficient permissions (" + e.message + ")");
+            }
             core.setFailed('feature test missing');


### PR DESCRIPTION
## Summary
- ensure comment workflows request issues/pull-requests write
- warn when comment token lacks permission

## Testing
- `npm run format`
- `npm test`
- `npm run ci` *(fails: SyntaxError in YAML config)*
- `npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a89fa75004832dbd3d44d87fd6da32