### PR TITLE
ci: add workflow permissions audit

### DIFF
--- a/.github/workflows/permissions-audit.yml
+++ b/.github/workflows/permissions-audit.yml
@@ -1,0 +1,12 @@
+name: Workflow Permissions Audit
+on: [pull_request, push]
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 20 }
+      - run: npm ci
+      - run: npm run ci:permissions-audit
+      - run: npm run test:permissions-audit

--- a/package.json
+++ b/package.json
@@ -104,7 +104,9 @@
     "test:regression": "npm run test:backend:regression && npm run test:frontend:regression && npm run test:ci:regression && npm run test:e2e:regression",
     "ci:probe": "bash -O globstar -c 'env -u npm_config_prefix node --test tests/ci/**/*.test.js'",
     "ci:summary": "node scripts/ci/print-suite-summary.js",
-    "test:inventory": "vitest run -t test-inventory"
+    "test:inventory": "vitest run -t test-inventory",
+    "ci:permissions-audit": "tsx scripts/ci/workflow-permissions-audit.ts",
+    "test:permissions-audit": "vitest run -t permissions-audit"
   },
   "babel": {
     "presets": [

--- a/scripts/ci/workflow-permissions-audit.ts
+++ b/scripts/ci/workflow-permissions-audit.ts
@@ -1,0 +1,64 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { parse } from "yaml";
+
+export async function audit(workflowDir: string): Promise<string[]> {
+  const entries = await fs.readdir(workflowDir);
+  const offenders: string[] = [];
+  for (const file of entries) {
+    if (!file.endsWith(".yml") && !file.endsWith(".yaml")) continue;
+    const full = path.join(workflowDir, file);
+    const content = await fs.readFile(full, "utf8");
+    let workflow: any;
+    try {
+      workflow = parse(content);
+    } catch (err) {
+      console.warn(`Skipping ${file}: ${(err as Error).message}`);
+      continue;
+    }
+    const jobs = workflow?.jobs ?? {};
+    let usesGithubScript = false;
+    for (const job of Object.values(jobs)) {
+      const steps = (job as any)?.steps ?? [];
+      if (
+        steps.some(
+          (s: any) =>
+            typeof s.uses === "string" &&
+            s.uses.startsWith("actions/github-script"),
+        )
+      ) {
+        usesGithubScript = true;
+        break;
+      }
+    }
+    if (usesGithubScript) {
+      const perm = workflow?.permissions ?? {};
+      const hasIssues = perm.issues === "write";
+      const hasPR = perm["pull-requests"] === "write";
+      if (!hasIssues && !hasPR) {
+        offenders.push(file);
+      }
+    }
+  }
+  return offenders;
+}
+
+async function main() {
+  const dir = path.join(process.cwd(), ".github", "workflows");
+  const offenders = await audit(dir);
+  if (offenders.length) {
+    console.error(
+      "Workflows using actions/github-script must declare permissions.issues: write or permissions.pull-requests: write:\n" +
+        offenders.join("\n"),
+    );
+    process.exit(1);
+  }
+  console.log("All workflows have correct permissions");
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/tests/ci/fixtures/workflow-permissions-audit/correct/workflow.yml
+++ b/tests/ci/fixtures/workflow-permissions-audit/correct/workflow.yml
@@ -1,0 +1,11 @@
+name: Correct Permissions
+on: push
+permissions:
+  pull-requests: write
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: console.log('hi')

--- a/tests/ci/fixtures/workflow-permissions-audit/missing/workflow.yml
+++ b/tests/ci/fixtures/workflow-permissions-audit/missing/workflow.yml
@@ -1,0 +1,9 @@
+name: Missing Permissions
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: console.log('hi')

--- a/tests/ci/workflow-permissions-audit.test.ts
+++ b/tests/ci/workflow-permissions-audit.test.ts
@@ -1,0 +1,17 @@
+import { join } from "node:path";
+import { describe, it, expect } from "vitest";
+import { audit } from "../../scripts/ci/workflow-permissions-audit";
+
+describe("permissions-audit", () => {
+  const base = join(__dirname, "fixtures", "workflow-permissions-audit");
+
+  it("fails when permissions missing", async () => {
+    const dir = join(base, "missing");
+    await expect(audit(dir)).resolves.toEqual(["workflow.yml"]);
+  });
+
+  it("passes when permissions present", async () => {
+    const dir = join(base, "correct");
+    await expect(audit(dir)).resolves.toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- audit workflows for github-script permission declarations
- test auditor with fixtures
- run permissions audit in CI

## Testing
- `npm run setup` *(fails: Playwright host dependencies warning, downloads)*
- `cd backend && npm run format`
- `cd backend && npm test` *(fails: linting-diagnostics-9b3adf.test.js root eslint exits 0)*
- `npx -y tsx scripts/ci/workflow-permissions-audit.ts`
- `npx vitest run tests/ci/workflow-permissions-audit.test.ts`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: syntax errors in existing workflow files)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html)*

------
https://chatgpt.com/codex/tasks/task_e_68a89fafc1e4832da19efa10d1fd03f1