### PR TITLE
ci: fix invalid shell definitions

### DIFF
--- a/.github/workflows/debug-queue.yml
+++ b/.github/workflows/debug-queue.yml
@@ -20,4 +20,6 @@ jobs:
       - [self-hosted, linux, aws]
       - ubuntu-latest
     steps:
+      - run: echo "Shell=ok"
+        shell: bash
       - run: echo "I ran on ${{ runner.os }} with job id ${{ github.run_id }}"

--- a/.github/workflows/diagnostics.yml
+++ b/.github/workflows/diagnostics.yml
@@ -26,6 +26,8 @@ jobs:
     timeout-minutes: 5
     continue-on-error: true
     steps:
+      - run: echo "Shell=ok"
+        shell: bash
       - name: Heartbeat
         run: |
           while true; do date; sleep 120; done &
@@ -49,6 +51,8 @@ jobs:
     timeout-minutes: 5
     continue-on-error: true
     steps:
+      - run: echo "Shell=ok"
+        shell: bash
       - name: Heartbeat
         run: |
           while true; do date; sleep 120; done &
@@ -76,6 +80,8 @@ jobs:
     env:
       CI_REQUIRE_EXTERNAL: "0"
     steps:
+      - run: echo "Shell=ok"
+        shell: bash
       - name: Heartbeat
         run: |
           while true; do date; sleep 120; done &

--- a/.github/workflows/reusable-test-job.yml
+++ b/.github/workflows/reusable-test-job.yml
@@ -18,14 +18,17 @@ jobs:
       contents: read
     defaults:
       run:
-        shell: bash -euo pipefail
+        shell: bash
     steps:
+      - run: echo "Shell=ok"
+        shell: bash
       - name: Preflight (print context)
         env:
           GITHUB_REF: ${{ github.ref }}
           GITHUB_SHA: ${{ github.sha }}
           NODE_VERSION: 20
         run: |
+          set -euo pipefail
           set -x
           echo "Actor=${GITHUB_ACTOR:-unset} Ref=$GITHUB_REF SHA=$GITHUB_SHA"
           echo "Matrix node=${NODE_VERSION}"
@@ -46,10 +49,12 @@ jobs:
             backend/package-lock.json
             frontend/package-lock.json
       - name: Corepack enable (safe)
-        run: corepack enable || true
+        run: |
+          set -euo pipefail
+          corepack enable || true
       - name: Lane Guard (required files)
         run: |
-          set -e
+          set -euo pipefail
           check() { [ -e "$1" ] || { echo "::error::Missing $1"; exit 86; }; }
           if [[ "${{ inputs.suite }}" == 'backend' ]]; then
             check package.json
@@ -67,13 +72,18 @@ jobs:
           fi
       - name: Enable step debug
         if: ${{ always() }}
-        run: echo "ACTIONS_STEP_DEBUG=true" >> $GITHUB_ENV
+        run: |
+          set -euo pipefail
+          echo "ACTIONS_STEP_DEBUG=true" >> $GITHUB_ENV
       - name: Run lane command
         if: ${{ inputs.suite != 'e2e' || !cancelled() }}
-        run: ${{ inputs.command }}
+        run: |
+          set -euo pipefail
+          ${{ inputs.command }}
       - name: Bundle lane diagnostics
         if: ${{ failure() || cancelled() }}
         run: |
+          set -euo pipefail
           mkdir -p ci/diag
           dmesg | tail -n 200 > ci/diag/dmesg.txt 2>/dev/null || true
           journalctl -xe --no-pager | tail -n 400 > ci/diag/journal.txt 2>/dev/null || true


### PR DESCRIPTION
## Summary
- ensure reusable-test-job uses valid bash shell with pipefail enabled in steps
- add shell guard steps to diagnostics and debug queue workflows

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` (backend)
- `SKIP_PW_DEPS=1 npm test` *(fails: npm ci encountered tar or filesystem errors)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: ENOTEMPTY directory not empty)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a89fe794cc832d868f2701d3604390