### PR TITLE
ci: add package manager policy audit

### DIFF
--- a/.github/workflows/pm-policy-audit.yml
+++ b/.github/workflows/pm-policy-audit.yml
@@ -1,0 +1,18 @@
+name: pm policy audit
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: corepack enable
+      - run: pnpm install --no-frozen-lockfile
+      - run: pnpm run ci:pm-policy

--- a/package.json
+++ b/package.json
@@ -104,7 +104,9 @@
     "test:regression": "npm run test:backend:regression && npm run test:frontend:regression && npm run test:ci:regression && npm run test:e2e:regression",
     "ci:probe": "bash -O globstar -c 'env -u npm_config_prefix node --test tests/ci/**/*.test.js'",
     "ci:summary": "node scripts/ci/print-suite-summary.js",
-    "test:inventory": "vitest run -t test-inventory"
+    "ci:pm-policy": "tsx scripts/ci/pm-policy-audit.ts",
+    "test:inventory": "vitest run -t test-inventory",
+    "test:pm-policy": "vitest run tests/ci/pm-policy-audit.test.ts"
   },
   "babel": {
     "presets": [

--- a/scripts/ci/pm-policy-audit.ts
+++ b/scripts/ci/pm-policy-audit.ts
@@ -1,0 +1,107 @@
+import fs from "node:fs";
+import path from "node:path";
+import { parse } from "yaml";
+
+export function audit(root = process.cwd()): string[] {
+  const errors: string[] = [];
+  const lockCandidates = ["pnpm-lock.yaml", "package-lock.json", "yarn.lock"];
+  const present = lockCandidates.filter((f) =>
+    fs.existsSync(path.join(root, f)),
+  );
+  if (present.length !== 1) {
+    errors.push(
+      `expected exactly one lockfile, found ${present.length}: ${present.join(", ")}`,
+    );
+  }
+  const manager = present[0]?.endsWith("pnpm-lock.yaml")
+    ? "pnpm"
+    : present[0]?.endsWith("package-lock.json")
+      ? "npm"
+      : present[0]?.endsWith("yarn.lock")
+        ? "yarn"
+        : undefined;
+
+  const wfDir = path.join(root, ".github", "workflows");
+  if (fs.existsSync(wfDir)) {
+    const workflowFiles = listYaml(wfDir);
+    for (const file of workflowFiles) {
+      const content = fs.readFileSync(file, "utf8");
+      let doc: any;
+      try {
+        doc = parse(content);
+      } catch (err) {
+        errors.push(
+          `failed to parse ${relative(root, file)}: ${(err as Error).message}`,
+        );
+        continue;
+      }
+      if (!doc?.jobs) continue;
+      for (const [jobName, job] of Object.entries<any>(doc.jobs)) {
+        const steps: any[] = Array.isArray(job.steps) ? job.steps : [];
+        let nodeSeen = false;
+        let corepackSeen = false;
+        for (const step of steps) {
+          const run: string | undefined = step.run;
+          const uses: string | undefined = step.uses;
+          if (manager === "pnpm" && run) {
+            if (/\bnpm ci\b/.test(run)) {
+              errors.push(`${relative(root, file)}:${jobName} uses npm ci`);
+            }
+            if (/\byarn(\s|$)/.test(run)) {
+              errors.push(`${relative(root, file)}:${jobName} uses yarn`);
+            }
+          }
+          if (uses && /^pnpm\/action-setup@/.test(uses)) {
+            if (step.with && step.with.version) {
+              errors.push(
+                `${relative(root, file)}:${jobName} pin pnpm/action-setup version`,
+              );
+            }
+          }
+          if (uses && /^actions\/setup-node@/.test(uses)) {
+            nodeSeen = true;
+            const cache = step.with?.cache;
+            if (cache !== "pnpm") {
+              errors.push(
+                `${relative(root, file)}:${jobName} setup-node cache is '${cache || "undefined"}'`,
+              );
+            }
+          }
+          if (run && /corepack enable/.test(run)) {
+            if (nodeSeen) corepackSeen = true;
+          }
+        }
+        if (nodeSeen && !corepackSeen) {
+          errors.push(
+            `${relative(root, file)}:${jobName} missing corepack enable`,
+          );
+        }
+      }
+    }
+  }
+  return errors;
+}
+
+function listYaml(dir: string): string[] {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const out: string[] = [];
+  for (const e of entries) {
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) out.push(...listYaml(p));
+    else if (e.isFile() && (p.endsWith(".yml") || p.endsWith(".yaml")))
+      out.push(p);
+  }
+  return out;
+}
+
+function relative(root: string, file: string): string {
+  return path.relative(root, file) || file;
+}
+
+if (require.main === module) {
+  const errs = audit();
+  if (errs.length) {
+    console.error(errs.join("\n"));
+    process.exit(1);
+  }
+}

--- a/tests/ci/pm-policy-audit.test.ts
+++ b/tests/ci/pm-policy-audit.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { audit } from "../../scripts/ci/pm-policy-audit";
+
+function setup(files: Record<string, string>): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pm-policy-"));
+  for (const [f, content] of Object.entries(files)) {
+    const full = path.join(dir, f);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, content);
+  }
+  return dir;
+}
+
+describe("pm-policy", () => {
+  it("fails if multiple lockfiles exist", () => {
+    const root = setup({
+      "package.json": JSON.stringify({ packageManager: "pnpm@9" }),
+      "pnpm-lock.yaml": "",
+      "package-lock.json": "",
+      ".github/workflows/a.yml": "name: t\n",
+    });
+    const errs = audit(root);
+    expect(errs.some((e) => e.includes("lockfile"))).toBe(true);
+  });
+
+  it("passes for valid pnpm workflow", () => {
+    const wf = `name: test\njobs:\n  build:\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          cache: pnpm\n      - run: corepack enable\n      - run: pnpm i\n`;
+    const root = setup({
+      "package.json": JSON.stringify({ packageManager: "pnpm@9" }),
+      "pnpm-lock.yaml": "",
+      ".github/workflows/test.yml": wf,
+    });
+    const errs = audit(root);
+    expect(errs).toEqual([]);
+  });
+
+  it("fails on npm ci usage", () => {
+    const wf = `name: t\njobs:\n  j:\n    steps:\n      - run: npm ci\n`;
+    const root = setup({
+      "package.json": JSON.stringify({ packageManager: "pnpm@9" }),
+      "pnpm-lock.yaml": "",
+      ".github/workflows/w.yml": wf,
+    });
+    const errs = audit(root);
+    expect(errs.some((e) => e.includes("npm ci"))).toBe(true);
+  });
+
+  it("fails on yarn usage", () => {
+    const wf = `name: t\njobs:\n  j:\n    steps:\n      - run: yarn install\n`;
+    const root = setup({
+      "package.json": JSON.stringify({ packageManager: "pnpm@9" }),
+      "pnpm-lock.yaml": "",
+      ".github/workflows/w.yml": wf,
+    });
+    const errs = audit(root);
+    expect(errs.some((e) => e.includes("yarn"))).toBe(true);
+  });
+
+  it("fails when pnpm/action-setup sets version", () => {
+    const wf = `name: t\njobs:\n  j:\n    steps:\n      - uses: pnpm/action-setup@v3\n        with:\n          version: 8\n`;
+    const root = setup({
+      "package.json": JSON.stringify({ packageManager: "pnpm@9" }),
+      "pnpm-lock.yaml": "",
+      ".github/workflows/w.yml": wf,
+    });
+    const errs = audit(root);
+    expect(errs.some((e) => e.includes("action-setup"))).toBe(true);
+  });
+
+  it("fails when corepack enable missing", () => {
+    const wf = `name: t\njobs:\n  j:\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          cache: pnpm\n`;
+    const root = setup({
+      "package.json": JSON.stringify({ packageManager: "pnpm@9" }),
+      "pnpm-lock.yaml": "",
+      ".github/workflows/w.yml": wf,
+    });
+    const errs = audit(root);
+    expect(errs.some((e) => e.includes("corepack enable"))).toBe(true);
+  });
+
+  it("fails when setup-node cache is not pnpm", () => {
+    const wf = `name: t\njobs:\n  j:\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          cache: npm\n      - run: corepack enable\n`;
+    const root = setup({
+      "package.json": JSON.stringify({ packageManager: "pnpm@9" }),
+      "pnpm-lock.yaml": "",
+      ".github/workflows/w.yml": wf,
+    });
+    const errs = audit(root);
+    expect(errs.some((e) => e.includes("cache"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add script auditing lockfiles and workflows for package manager policy
- verify auditor with vitest tests
- run audit in dedicated GitHub workflow

## Testing
- `npx prettier -w scripts/ci/pm-policy-audit.ts tests/ci/pm-policy-audit.test.ts .github/workflows/pm-policy-audit.yml package.json`
- `npm run test:pm-policy`


------
https://chatgpt.com/codex/tasks/task_e_68a8a0f032c8832dbc1d66aab7fc5e89