### PR TITLE
fix: indent metrics NDJSON lines

### DIFF
--- a/.github/actions/ci-metrics-emit/action.yml
+++ b/.github/actions/ci-metrics-emit/action.yml
@@ -31,14 +31,14 @@ runs:
         median_queue=$(jq '[.[] | select(.queued_at and .started_at) | ((.started_at | fromdate) - (.queued_at | fromdate))] | sort | if length>0 then .[length/2] else 0 end' "$timings" 2>/dev/null || echo 0)
 
         cat > ci/metrics/series.ndjson <<EOF
-{"MetricName":"QueuedJobs","Value":$queued_jobs}
-{"MetricName":"StartedJobs","Value":$started_jobs}
-{"MetricName":"SucceededJobs","Value":$succeeded_jobs}
-{"MetricName":"FailedJobs","Value":$failed_jobs}
-{"MetricName":"MedianQueueSeconds","Value":$median_queue}
-{"MetricName":"SuiteTests","Value":$suite_tests}
-{"MetricName":"SuiteFailures","Value":$suite_failures}
-EOF
+        {"MetricName":"QueuedJobs","Value":$queued_jobs}
+        {"MetricName":"StartedJobs","Value":$started_jobs}
+        {"MetricName":"SucceededJobs","Value":$succeeded_jobs}
+        {"MetricName":"FailedJobs","Value":$failed_jobs}
+        {"MetricName":"MedianQueueSeconds","Value":$median_queue}
+        {"MetricName":"SuiteTests","Value":$suite_tests}
+        {"MetricName":"SuiteFailures","Value":$suite_failures}
+        EOF
 
     - name: Upload metrics artifact
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- fix CI metrics action by indenting NDJSON lines within heredoc

## Testing
- `npm run format` *(fails: SyntaxError: All collection items must start at the same column)*
- `npm test`
- `npm run ci` *(fails: SyntaxError: All collection items must start at the same column)*
- `npm run smoke` *(fails: Nested mappings are not allowed in compact mappings)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a1e1aab0832daba01b622158d335