### PR TITLE
ci: add composite action manifest audit

### DIFF
--- a/.github/workflows/composite-action-audit.yml
+++ b/.github/workflows/composite-action-audit.yml
@@ -1,0 +1,22 @@
+name: Composite action audit
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run ci:action-audit
+      - run: npm run test:action-audit
+      - name: Upload audit summary
+        uses: actions/upload-artifact@v4
+        with:
+          name: composite-action-audit
+          path: composite-action-audit-summary.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,6 +81,7 @@
         "toml": "^3.0.0",
         "tsconfig-strictest": "^1.0.0-beta.1",
         "tslib": "^2.8.1",
+        "tsx": "^4.20.4",
         "typescript": "^5.8.3",
         "vitest": "^2.1.1",
         "wait-on": "^8.0.3",
@@ -14442,7 +14443,6 @@
       "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
       },
@@ -22533,7 +22533,6 @@
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
@@ -25388,6 +25387,26 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.20.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.4.tgz",
+      "integrity": "sha512-yyxBKfORQ7LuRt/BQKBXrpcq59ZvSW0XxwfjAt3w2/8PmdxaFzijtMhTawprSHhpzeM5BgU2hXHG3lklIERZXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/tunnel": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,9 @@
     "test:regression": "npm run test:backend:regression && npm run test:frontend:regression && npm run test:ci:regression && npm run test:e2e:regression",
     "ci:probe": "bash -O globstar -c 'env -u npm_config_prefix node --test tests/ci/**/*.test.js'",
     "ci:summary": "node scripts/ci/print-suite-summary.js",
-    "test:inventory": "vitest run -t test-inventory"
+    "test:inventory": "vitest run -t test-inventory",
+    "ci:action-audit": "tsx scripts/ci/composite-action-audit.ts",
+    "test:action-audit": "vitest run -t composite-action-audit"
   },
   "babel": {
     "presets": [
@@ -186,6 +188,7 @@
     "toml": "^3.0.0",
     "tsconfig-strictest": "^1.0.0-beta.1",
     "tslib": "^2.8.1",
+    "tsx": "^4.20.4",
     "typescript": "^5.8.3",
     "vitest": "^2.1.1",
     "wait-on": "^8.0.3",

--- a/scripts/ci/composite-action-audit.ts
+++ b/scripts/ci/composite-action-audit.ts
@@ -1,0 +1,201 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import { parseDocument, YAMLMap, YAMLSeq, isMap, LineCounter } from 'yaml';
+
+interface Message {
+  message: string;
+  line?: number;
+}
+
+interface ActionReport {
+  path: string;
+  errors: Message[];
+  warnings: Message[];
+}
+
+interface Summary {
+  actions: ActionReport[];
+  ok: boolean;
+}
+
+interface Options {
+  strict?: boolean;
+  summaryFile?: string;
+}
+
+async function findManifests(root: string): Promise<string[]> {
+  const results: string[] = [];
+  const base = path.join(root, '.github', 'actions');
+
+  async function walk(dir: string) {
+    const entries = await fs.readdir(dir, { withFileTypes: true }).catch(() => []);
+    for (const e of entries) {
+      const full = path.join(dir, e.name);
+      if (e.isDirectory()) await walk(full);
+      else if (e.isFile() && e.name === 'action.yml') results.push(full);
+    }
+  }
+
+  await walk(base);
+  return results.sort();
+}
+
+function lineOf(lineCounter: LineCounter, node: any): number | undefined {
+  if (!node || typeof node.range?.[0] !== 'number') return undefined;
+  return lineCounter.linePos(node.range[0]).line + 1;
+}
+
+export async function auditCompositeActions(
+  root = process.cwd(),
+  options: Options = {}
+): Promise<Summary> {
+  const files = await findManifests(root);
+  const actions: ActionReport[] = [];
+
+  for (const file of files) {
+    const rel = path.relative(root, file);
+    const report: ActionReport = { path: rel, errors: [], warnings: [] };
+    const text = await fs.readFile(file, 'utf8');
+    const lineCounter = new LineCounter();
+    const doc = parseDocument(text, { prettyErrors: false, lineCounter });
+
+    if (doc.errors.length) {
+      for (const err of doc.errors) {
+        const line = err.linePos
+          ? err.linePos.start.line + 1
+          : lineCounter.linePos(err.pos[0]).line + 1;
+        report.errors.push({ message: err.message, line });
+      }
+      actions.push(report);
+      continue;
+    }
+
+    const map = doc.contents as YAMLMap;
+    const data = doc.toJS() as any;
+    const allowedTop = new Set(['name', 'description', 'runs']);
+
+    for (const item of map.items) {
+      const key = String(item.key);
+      if (!allowedTop.has(key)) {
+        report.warnings.push({
+          message: `unknown top-level key: ${key}`,
+          line: lineOf(lineCounter, item.key),
+        });
+      }
+    }
+
+    if (typeof data.name !== 'string') {
+      report.errors.push({
+        message: 'name must be a string',
+        line: lineOf(lineCounter, map.get('name', true)),
+      });
+    }
+
+    if (typeof data.description !== 'string') {
+      report.errors.push({
+        message: 'description must be a string',
+        line: lineOf(lineCounter, map.get('description', true)),
+      });
+    }
+
+    const runsNode = map.get('runs', true);
+    if (!isMap(runsNode)) {
+      report.errors.push({
+        message: 'runs must be a mapping',
+        line: lineOf(lineCounter, runsNode),
+      });
+      actions.push(report);
+      continue;
+    }
+    const runs: any = runsNode.toJSON();
+
+    const usingNode = runsNode.get('using', true);
+    if (usingNode?.toString() !== 'composite') {
+      report.errors.push({
+        message: 'runs.using must be "composite"',
+        line: lineOf(lineCounter, usingNode),
+      });
+    }
+
+    const stepsNode = runsNode.get('steps', true);
+    if (!(stepsNode instanceof YAMLSeq)) {
+      report.errors.push({
+        message: 'runs.steps must be an array',
+        line: lineOf(lineCounter, stepsNode ?? runsNode),
+      });
+    } else {
+      for (const stepNode of stepsNode.items) {
+        const line = lineOf(lineCounter, stepNode);
+        let node: any = stepNode as any;
+        if (node && node.constructor && node.constructor.name === 'Alias' && typeof node.resolve === 'function') {
+          node = node.resolve(doc);
+        }
+        const step: any = node.toJSON();
+        const hasUses = Object.prototype.hasOwnProperty.call(step, 'uses');
+        const hasRun = Object.prototype.hasOwnProperty.call(step, 'run');
+        const hasShell = Object.prototype.hasOwnProperty.call(step, 'shell');
+
+        if (hasUses && (hasRun || hasShell)) {
+          report.errors.push({ message: 'step cannot have both uses and run/shell', line });
+        }
+        if (hasRun && !hasShell) {
+          report.errors.push({ message: 'run step requires shell', line });
+        }
+        if (!hasUses && !hasRun) {
+          report.errors.push({ message: 'step must have uses or run', line });
+        }
+
+        if (hasUses && typeof step.uses === 'string') {
+          if (/^actions\/github-script@/.test(step.uses)) {
+            if (step.script !== undefined) {
+              report.errors.push({
+                message: 'script must be provided under with:',
+                line,
+              });
+            } else if (!step.with || typeof step.with.script !== 'string') {
+              report.errors.push({
+                message: 'github-script steps require with.script',
+                line,
+              });
+            }
+          }
+        }
+
+        if (step.with && typeof step.with === 'object') {
+          for (const [k, v] of Object.entries(step.with)) {
+            if (typeof v !== 'string') {
+              report.errors.push({ message: `with.${k} must be a string`, line });
+            }
+          }
+        }
+      }
+    }
+
+    actions.push(report);
+  }
+
+  const ok = actions.every(
+    (a) => a.errors.length === 0 && (!options.strict || a.warnings.length === 0)
+  );
+
+  const summary: Summary = { actions, ok };
+  if (options.summaryFile) {
+    await fs.writeFile(path.join(root, options.summaryFile), JSON.stringify(summary, null, 2));
+  }
+  return summary;
+}
+
+if (require.main === module) {
+  const strict = process.argv.includes('--strict');
+  const summaryFile = 'composite-action-audit-summary.json';
+  auditCompositeActions(process.cwd(), { strict, summaryFile })
+    .then((summary) => {
+      console.log(JSON.stringify(summary, null, 2));
+      if (!summary.ok) process.exit(1);
+    })
+    .catch((err) => {
+      console.error(err);
+      process.exit(1);
+    });
+}
+

--- a/tests/ci/composite-action-audit.test.ts
+++ b/tests/ci/composite-action-audit.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect } from 'vitest';
+import { auditCompositeActions } from '../../scripts/ci/composite-action-audit';
+import { mkdtempSync, writeFileSync, readFileSync, mkdirSync } from 'fs';
+import path from 'path';
+import os from 'os';
+
+function tempDir() {
+  return mkdtempSync(path.join(os.tmpdir(), 'audit-'));
+}
+
+function writeAction(root: string, name: string, content: string) {
+  const file = path.join(root, '.github', 'actions', name, 'action.yml');
+  mkdirSync(path.dirname(file), { recursive: true });
+  writeFileSync(file, content);
+  return file;
+}
+
+describe('composite-action-audit', () => {
+  it('valid minimal composite action passes and writes summary', async () => {
+    const dir = tempDir();
+    writeAction(
+      dir,
+      'ok',
+      `name: test\ndescription: test\nruns:\n  using: composite\n  steps:\n    - run: echo hi\n      shell: bash\n`
+    );
+    const summary = await auditCompositeActions(dir, { summaryFile: 'out.json' });
+    expect(summary.ok).toBe(true);
+    const stored = JSON.parse(readFileSync(path.join(dir, 'out.json'), 'utf8'));
+    expect(stored).toHaveProperty('actions');
+    expect(stored.actions[0].errors).toHaveLength(0);
+  });
+
+  it('missing colon in a mapping fails with line pointer', async () => {
+    const dir = tempDir();
+    writeAction(
+      dir,
+      'bad',
+      `name: test\ndescription test\n`
+    );
+    const summary = await auditCompositeActions(dir);
+    expect(summary.ok).toBe(false);
+    expect(summary.actions[0].errors[0].line).toBe(3);
+  });
+
+  it('step with both uses and run fails', async () => {
+    const dir = tempDir();
+    writeAction(
+      dir,
+      'mix',
+      `name: t\ndescription: t\nruns:\n  using: composite\n  steps:\n    - uses: actions/checkout@v4\n      run: echo hi\n      shell: bash\n`
+    );
+    const summary = await auditCompositeActions(dir);
+    expect(summary.ok).toBe(false);
+  });
+
+  it('run step missing shell fails', async () => {
+    const dir = tempDir();
+    writeAction(
+      dir,
+      'noshell',
+      `name: t\ndescription: t\nruns:\n  using: composite\n  steps:\n    - run: echo hi\n`
+    );
+    const summary = await auditCompositeActions(dir);
+    expect(summary.ok).toBe(false);
+  });
+
+  it('runs.using not composite fails', async () => {
+    const dir = tempDir();
+    writeAction(
+      dir,
+      'run',
+      `name: t\ndescription: t\nruns:\n  using: node12\n  steps: []\n`
+    );
+    const summary = await auditCompositeActions(dir);
+    expect(summary.ok).toBe(false);
+  });
+
+  it('missing runs.steps array fails', async () => {
+    const dir = tempDir();
+    writeAction(
+      dir,
+      'nosteps',
+      `name: t\ndescription: t\nruns:\n  using: composite\n`
+    );
+    const summary = await auditCompositeActions(dir);
+    expect(summary.ok).toBe(false);
+  });
+
+  it('github-script step with script but no with block fails', async () => {
+    const dir = tempDir();
+    writeAction(
+      dir,
+      'ghscript',
+      `name: t\ndescription: t\nruns:\n  using: composite\n  steps:\n    - uses: actions/github-script@v6\n      script: return 1\n`
+    );
+    const summary = await auditCompositeActions(dir);
+    expect(summary.ok).toBe(false);
+  });
+
+  it('duplicate top-level key fails', async () => {
+    const dir = tempDir();
+    writeAction(
+      dir,
+      'dup',
+      `name: t\ndescription: t\nruns:\n  using: composite\n  steps: []\nruns:\n  using: composite\n  steps: []\n`
+    );
+    const summary = await auditCompositeActions(dir);
+    expect(summary.ok).toBe(false);
+  });
+
+  it('unknown top-level keys produce warnings', async () => {
+    const dir = tempDir();
+    writeAction(
+      dir,
+      'warn',
+      `name: t\ndescription: t\nfoo: bar\nruns:\n  using: composite\n  steps: []\n`
+    );
+    const summary = await auditCompositeActions(dir);
+    expect(summary.ok).toBe(true);
+    expect(summary.actions[0].warnings).toHaveLength(1);
+  });
+
+  it('warnings fail when strict option enabled', async () => {
+    const dir = tempDir();
+    writeAction(
+      dir,
+      'warn',
+      `name: t\ndescription: t\nfoo: bar\nruns:\n  using: composite\n  steps: []\n`
+    );
+    const summary = await auditCompositeActions(dir, { strict: true });
+    expect(summary.ok).toBe(false);
+  });
+
+  it('embedded expressions as strings are allowed', async () => {
+    const dir = tempDir();
+    writeAction(
+      dir,
+      'expr',
+      `name: t\ndescription: t\nruns:\n  using: composite\n  steps:\n    - uses: actions/checkout@v4\n      with:\n        path: "\${{ github.workspace }}"\n`
+    );
+    const summary = await auditCompositeActions(dir);
+    expect(summary.ok).toBe(true);
+  });
+
+  it('yaml anchors and aliases are allowed', async () => {
+    const dir = tempDir();
+    writeAction(
+      dir,
+      'anchor',
+      `name: t\ndescription: t\nruns:\n  using: composite\n  steps:\n    - &step\n      run: echo hi\n      shell: bash\n    - *step\n`
+    );
+    const summary = await auditCompositeActions(dir);
+    expect(summary.ok).toBe(true);
+  });
+
+  it('multi-file scan reports all paths and fails when one invalid', async () => {
+    const dir = tempDir();
+    writeAction(
+      dir,
+      'good',
+      `name: t\ndescription: t\nruns:\n  using: composite\n  steps:\n    - run: echo hi\n      shell: bash\n`
+    );
+    writeAction(
+      dir,
+      'bad',
+      `name: t\ndescription: t\nruns:\n  using: composite\n  steps:\n    - run: echo hi\n`
+    );
+    const summary = await auditCompositeActions(dir);
+    expect(summary.ok).toBe(false);
+    expect(summary.actions).toHaveLength(2);
+  });
+});
+


### PR DESCRIPTION
## Summary
- audit all in-repo composite GitHub Actions and emit JSON report
- add comprehensive tests for composite action validator
- wire composite action audit into CI workflow

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run test:action-audit`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: SyntaxError in existing workflow YAML)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a22ab2c0832d89502263d1be6e1c