### PR TITLE
ci(metrics-action-yaml): fix composite action YAML + add validator

### DIFF
--- a/.github/actions/ci-metrics-emit/action.yml
+++ b/.github/actions/ci-metrics-emit/action.yml
@@ -1,47 +1,43 @@
-name: "CI Metrics Emit"
-description: "Emit CI metrics artifact and optionally send to CloudWatch"
+# >>> BEGIN MANAGED BLOCK: ci-guard:metrics-action-yaml
+name: CI Metrics Emit
+description: Emit CI metrics artifact and optionally send to CloudWatch
 inputs:
   timings:
-    description: "Path to job timings JSON"
+    description: Path to job timings JSON
     required: true
   inventory:
-    description: "Path to CI test inventory"
+    description: Path to CI test inventory
     required: false
-    default: "ci-test-inventory.json"
-
+    default: ci-test-inventory.json
 runs:
-  using: "composite"
+  using: composite
   steps:
     - name: Generate metrics
       shell: bash
       run: |
         set -euo pipefail
-        inventory="${{ inputs.inventory }}"
-        timings="${{ inputs.timings }}"
-
         mkdir -p ci/metrics
-
+        timings="${{ inputs.timings }}"
+        inventory="${{ inputs.inventory }}"
         suite_tests=$(jq '[.suites[]? .tests?[]] | length' "$inventory" 2>/dev/null || echo 0)
         suite_failures=$(jq '[.suites[]? .tests?[] | select(.outcome and .outcome != "success")] | length' "$inventory" 2>/dev/null || echo 0)
-
         queued_jobs=$(jq '[.[]] | length' "$timings" 2>/dev/null || echo 0)
         started_jobs=$(jq '[.[] | select(.started_at != null)] | length' "$timings" 2>/dev/null || echo 0)
         failed_jobs=$(jq '[.[] | select(.conclusion == "failure")] | length' "$timings" 2>/dev/null || echo 0)
         succeeded_jobs=$(jq '[.[] | select(.conclusion == "success")] | length' "$timings" 2>/dev/null || echo 0)
         median_queue=$(jq '[.[] | select(.queued_at and .started_at) | ((.started_at | fromdate) - (.queued_at | fromdate))] | sort | if length>0 then .[length/2] else 0 end' "$timings" 2>/dev/null || echo 0)
-
         cat > ci/metrics/series.ndjson <<EOF
-{"MetricName":"QueuedJobs","Value":$queued_jobs}
-{"MetricName":"StartedJobs","Value":$started_jobs}
-{"MetricName":"SucceededJobs","Value":$succeeded_jobs}
-{"MetricName":"FailedJobs","Value":$failed_jobs}
-{"MetricName":"MedianQueueSeconds","Value":$median_queue}
-{"MetricName":"SuiteTests","Value":$suite_tests}
-{"MetricName":"SuiteFailures","Value":$suite_failures}
-EOF
-
+        {"MetricName":"QueuedJobs","Value":$queued_jobs}
+        {"MetricName":"StartedJobs","Value":$started_jobs}
+        {"MetricName":"FailedJobs","Value":$failed_jobs}
+        {"MetricName":"SucceededJobs","Value":$succeeded_jobs}
+        {"MetricName":"MedianQueueSeconds","Value":$median_queue}
+        {"MetricName":"SuiteTests","Value":$suite_tests}
+        {"MetricName":"SuiteFailures","Value":$suite_failures}
+        EOF
     - name: Upload metrics artifact
       uses: actions/upload-artifact@v4
       with:
         name: ci-metrics
         path: ci/metrics/series.ndjson
+# <<< END MANAGED BLOCK: ci-guard:metrics-action-yaml

--- a/.github/workflows/guard-metrics-action-yaml.yml
+++ b/.github/workflows/guard-metrics-action-yaml.yml
@@ -1,0 +1,20 @@
+name: metrics action yaml guard
+
+env:
+  HUSKY: 0
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.1
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version: 20
+      - run: npx -y @actions/manifest-validation@latest .github/actions/ci-metrics-emit/action.yml
+      - run: npx -y yaml-eslint .github/actions/ci-metrics-emit/action.yml || true


### PR DESCRIPTION
## Summary
- fix metrics composite action manifest
- add CI workflow to validate metrics action YAML

## Testing
- `npm run format` (backend)
- `npm test` (backend)
- `SKIP_PW_DEPS=1 npm run ci` *(fails: SyntaxError in multiple workflow YAMLs)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a3c80bd4832d8a005116a832644a