### PR TITLE
ci(frontend-smoke-artifact): build & verify dist before smoke

### DIFF
--- a/.github/workflows/guard-frontend-smoke-artifact.yml
+++ b/.github/workflows/guard-frontend-smoke-artifact.yml
@@ -1,0 +1,21 @@
+name: Frontend Smoke Artifact Guard
+
+on:
+  pull_request:
+  push:
+    branches:
+      - dev
+      - "00000production"
+
+jobs:
+  verify:
+    runs-on:
+      - [self-hosted, linux, aws]
+      - ubuntu-latest
+    steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
+      - uses: actions/checkout@v5
+      - name: Verify artifact block
+        run: node scripts/ci-guard/frontend-smoke-artifact/verify.js

--- a/.github/workflows/pipeline-smoke.yml
+++ b/.github/workflows/pipeline-smoke.yml
@@ -15,8 +15,49 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  frontend-build:
+    timeout-minutes: 15
+    runs-on:
+      - [self-hosted, linux, aws]
+      - ubuntu-latest
+    steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
+      - uses: actions/checkout@v5
+      # >>> BEGIN MANAGED BLOCK: ci-guard:frontend-smoke-artifact
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: corepack enable
+        shell: bash
+      - uses: pnpm/action-setup@v4
+        with: { run_install: false }
+      - name: Install deps (frontend)
+        working-directory: frontend
+        run: pnpm install --frozen-lockfile
+        shell: bash
+      - name: Build frontend
+        working-directory: frontend
+        run: pnpm run build
+        shell: bash
+      - name: Verify build artifact
+        run: |
+          set -euo pipefail
+          test -f frontend/dist/index.html || { echo "::error::frontend/dist/index.html missing"; exit 2; }
+        shell: bash
+      - name: Upload frontend artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-dist
+          path: frontend/dist
+      # <<< END MANAGED BLOCK: ci-guard:frontend-smoke-artifact
+
   smoke_test:
     timeout-minutes: 15
+    needs: frontend-build
     runs-on:
       - [self-hosted, linux, aws]
       - ubuntu-latest
@@ -40,6 +81,16 @@ jobs:
           while true; do date; sleep 120; done &
       - name: Checkout code
         uses: actions/checkout@v5
+      # >>> BEGIN MANAGED BLOCK: ci-guard:frontend-smoke-artifact
+      - name: Download frontend artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: frontend-dist
+          path: frontend/dist
+      - name: Re-verify artifact
+        run: test -f frontend/dist/index.html
+        shell: bash
+      # <<< END MANAGED BLOCK: ci-guard:frontend-smoke-artifact
 
       - name: Load Stripe env
         run: node scripts/ci-env-preflight.js
@@ -52,13 +103,7 @@ jobs:
         with:
           node-version: 20
       - name: Install dependencies
-        run: |
-          npm ci
-          npm ci --prefix frontend
-          npm run build --prefix frontend
-
-      - name: Ensure frontend build output exists
-        run: test -f frontend/dist/index.html
+        run: npm ci
 
       - name: Run smoke tests
         run: npm run smoke

--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -30,9 +30,50 @@ jobs:
             frontend:
               - 'frontend/**'
 
-  backend-smoke:
+  frontend-build:
     timeout-minutes: 15
     needs: changes
+    runs-on:
+      - [self-hosted, linux, aws]
+      - ubuntu-latest
+    steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
+      - uses: actions/checkout@v4
+      # >>> BEGIN MANAGED BLOCK: ci-guard:frontend-smoke-artifact
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: corepack enable
+        shell: bash
+      - uses: pnpm/action-setup@v4
+        with: { run_install: false }
+      - name: Install deps (frontend)
+        working-directory: frontend
+        run: pnpm install --frozen-lockfile
+        shell: bash
+      - name: Build frontend
+        working-directory: frontend
+        run: pnpm run build
+        shell: bash
+      - name: Verify build artifact
+        run: |
+          set -euo pipefail
+          test -f frontend/dist/index.html || { echo "::error::frontend/dist/index.html missing"; exit 2; }
+        shell: bash
+      - name: Upload frontend artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-dist
+          path: frontend/dist
+      # <<< END MANAGED BLOCK: ci-guard:frontend-smoke-artifact
+
+  backend-smoke:
+    timeout-minutes: 15
+    needs: [changes, frontend-build]
     runs-on:
       - [self-hosted, linux, aws]
       - ubuntu-latest
@@ -45,6 +86,16 @@ jobs:
         run: |
           while true; do date; sleep 120; done &
       - uses: actions/checkout@v4
+      # >>> BEGIN MANAGED BLOCK: ci-guard:frontend-smoke-artifact
+      - name: Download frontend artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: frontend-dist
+          path: frontend/dist
+      - name: Re-verify artifact
+        run: test -f frontend/dist/index.html
+        shell: bash
+      # <<< END MANAGED BLOCK: ci-guard:frontend-smoke-artifact
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -70,18 +121,3 @@ jobs:
           sleep 5
           cat /tmp/server.log || true
         shell: bash
-
-  frontend-artifact-check:
-    timeout-minutes: 15
-    needs: [changes, backend-smoke]
-    if: needs.changes.outputs.frontend == 'true'
-    runs-on:
-      - [self-hosted, linux, aws]
-      - ubuntu-latest
-    steps:
-      - name: Heartbeat
-        run: |
-          while true; do date; sleep 120; done &
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/frontend-build
-      - run: test -f frontend/dist/index.html

--- a/scripts/ci-guard/frontend-smoke-artifact/verify.js
+++ b/scripts/ci-guard/frontend-smoke-artifact/verify.js
@@ -1,0 +1,27 @@
+const fs = require("fs");
+const path = require("path");
+
+const repoRoot = path.resolve(__dirname, "../../..");
+const workflows = [
+  ".github/workflows/smoke_test.yml",
+  ".github/workflows/pipeline-smoke.yml",
+];
+
+let ok = true;
+for (const wf of workflows) {
+  const file = path.join(repoRoot, wf);
+  const content = fs.readFileSync(file, "utf8");
+  const hasBuildBlock =
+    /BEGIN MANAGED BLOCK: ci-guard:frontend-smoke-artifact[\s\S]*Upload frontend artifact[\s\S]*END MANAGED BLOCK: ci-guard:frontend-smoke-artifact/.test(
+      content,
+    );
+  const hasDownloadBlock =
+    /BEGIN MANAGED BLOCK: ci-guard:frontend-smoke-artifact[\s\S]*Download frontend artifact[\s\S]*END MANAGED BLOCK: ci-guard:frontend-smoke-artifact/.test(
+      content,
+    );
+  if (!hasBuildBlock || !hasDownloadBlock) {
+    console.error(`Missing managed block in ${wf}`);
+    ok = false;
+  }
+}
+if (!ok) process.exit(1);

--- a/tests/ci-guard/frontend-smoke-artifact/verify.test.js
+++ b/tests/ci-guard/frontend-smoke-artifact/verify.test.js
@@ -1,0 +1,17 @@
+const { spawnSync } = require("child_process");
+const path = require("path");
+const repoRoot = path.resolve(__dirname, "../../..");
+
+test("frontend smoke artifact guard", () => {
+  const script = path.join(
+    repoRoot,
+    "scripts",
+    "ci-guard",
+    "frontend-smoke-artifact",
+    "verify.js",
+  );
+  const result = spawnSync("node", [script], { encoding: "utf8" });
+  if (result.status !== 0) {
+    throw new Error(result.stderr || result.stdout);
+  }
+});


### PR DESCRIPTION
## Summary
- build frontend dist once and upload as artifact
- download and verify frontend dist before smoke tests
- guard workflow ensures managed block presence

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` (backend)
- `npm test` (backend)
- `node scripts/run-jest.js tests/ci-guard/frontend-smoke-artifact/verify.test.js`
- `SKIP_PW_DEPS=1 npm run ci` (fails: SyntaxError in .github/actions/ci-metrics-emit/action.yml)
- `SKIP_PW_DEPS=1 npm run smoke` (fails: SyntaxError in .github/workflows/_ci-try-selfhosted.yml)

------
https://chatgpt.com/codex/tasks/task_e_68a8a3d14648832da8634546f4b98644