### PR TITLE
ci: add frontend smoke artifact guard

### DIFF
--- a/.github/workflows/guard-frontend-smoke-artifact.yml
+++ b/.github/workflows/guard-frontend-smoke-artifact.yml
@@ -1,0 +1,15 @@
+name: frontend smoke artifact guard
+
+on: [pull_request, push]
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: node scripts/ci-guard/frontend-smoke-artifact/audit.js
+      - run: node scripts/run-jest.js tests/ci-guard/frontend-smoke-artifact/audit.test.ts

--- a/scripts/ci-guard/frontend-smoke-artifact/audit.js
+++ b/scripts/ci-guard/frontend-smoke-artifact/audit.js
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+// @ts-check
+const fs = require("fs");
+const path = require("path");
+const yaml = require("yaml");
+
+/**
+ * Audit the given workflow files.
+ * @param {string[]} files
+ * @returns {{ok:boolean, files: Record<string, any>}}
+ */
+function auditFiles(files) {
+  const summary = { ok: true, files: {} };
+  for (const file of files) {
+    const content = fs.readFileSync(file, "utf8");
+    const doc = yaml.parse(content) || {};
+    const jobs = doc.jobs || {};
+    const fileSummary = { ok: true, jobs: {} };
+    for (const [jobName, job] of Object.entries(jobs)) {
+      const steps = Array.isArray(job.steps) ? job.steps : [];
+      const jobSummary = { ok: true, errors: [] };
+      const stepTexts = steps.map((s) => JSON.stringify(s));
+      const referencesDist = stepTexts.some(
+        (t) => t && t.includes("frontend/dist"),
+      );
+      if (!referencesDist) {
+        fileSummary.jobs[jobName] = jobSummary;
+        continue;
+      }
+      const downloadStep = steps.find(
+        (s) =>
+          typeof s.uses === "string" &&
+          s.uses.includes("actions/download-artifact") &&
+          s.with &&
+          typeof s.with.name === "string" &&
+          s.with.name.startsWith("frontend-dist"),
+      );
+      if (downloadStep) {
+        fileSummary.jobs[jobName] = jobSummary;
+        continue;
+      }
+      const buildIdx = steps.findIndex(
+        (s) =>
+          typeof s.run === "string" && /pnpm\s+(build|run\s+build)/.test(s.run),
+      );
+      if (buildIdx === -1) {
+        jobSummary.ok = false;
+        jobSummary.errors.push("missing build step");
+        fileSummary.ok = summary.ok = false;
+        fileSummary.jobs[jobName] = jobSummary;
+        continue;
+      }
+      const buildStep = steps[buildIdx];
+      if (buildStep["working-directory"] !== "frontend") {
+        jobSummary.ok = false;
+        jobSummary.errors.push("build step must run in frontend directory");
+      }
+      if (/\bnpm\b/.test(buildStep.run)) {
+        jobSummary.ok = false;
+        jobSummary.errors.push("build must use pnpm");
+      }
+      const verifyIdx = steps.findIndex(
+        (s) =>
+          typeof s.run === "string" &&
+          s.run.includes("frontend/dist/index.html") &&
+          /test\s+-f/.test(s.run),
+      );
+      if (verifyIdx === -1 || verifyIdx < buildIdx) {
+        jobSummary.ok = false;
+        jobSummary.errors.push("missing verify step");
+      }
+      const nodeStep = steps
+        .slice(0, buildIdx)
+        .find(
+          (s) =>
+            typeof s.uses === "string" &&
+            s.uses.startsWith("actions/setup-node") &&
+            s.with &&
+            (String(s.with["node-version"] || "").includes("20") ||
+              String(s.with["node-version"] || "").includes("${{")),
+        );
+      if (!nodeStep) {
+        jobSummary.ok = false;
+        jobSummary.errors.push("missing Node 20 setup");
+      } else if (nodeStep.with && nodeStep.with.cache !== "pnpm") {
+        jobSummary.ok = false;
+        jobSummary.errors.push("setup-node cache must be pnpm");
+      }
+      const corepackIdx = steps.findIndex(
+        (s) => typeof s.run === "string" && s.run.trim() === "corepack enable",
+      );
+      if (corepackIdx === -1 || corepackIdx > buildIdx) {
+        jobSummary.ok = false;
+        jobSummary.errors.push("missing corepack enable before build");
+      }
+      const pnpmSetupIdx = steps.findIndex(
+        (s) =>
+          typeof s.uses === "string" && s.uses.startsWith("pnpm/action-setup"),
+      );
+      if (pnpmSetupIdx === -1 || pnpmSetupIdx > buildIdx) {
+        jobSummary.ok = false;
+        jobSummary.errors.push("missing pnpm/action-setup before build");
+      } else if (
+        steps[pnpmSetupIdx].with &&
+        "version" in steps[pnpmSetupIdx].with
+      ) {
+        jobSummary.ok = false;
+        jobSummary.errors.push("pnpm/action-setup must not pin version");
+      }
+      if (!jobSummary.ok) fileSummary.ok = summary.ok = false;
+      fileSummary.jobs[jobName] = jobSummary;
+    }
+    summary.files[file] = fileSummary;
+  }
+  return summary;
+}
+
+function main() {
+  const repoRoot = process.cwd();
+  const args = process.argv.slice(2);
+  let files;
+  if (args.length) {
+    files = args;
+  } else {
+    const wfDir = path.join(repoRoot, ".github", "workflows");
+    files = fs
+      .readdirSync(wfDir)
+      .filter((f) => f.endsWith(".yml"))
+      .map((f) => path.join(wfDir, f));
+  }
+  const summary = auditFiles(files);
+  console.log(JSON.stringify(summary, null, 2));
+  if (!summary.ok) process.exit(1);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { auditFiles };

--- a/scripts/ci-guard/frontend-smoke-artifact/audit.ts
+++ b/scripts/ci-guard/frontend-smoke-artifact/audit.ts
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+// @ts-check
+const fs = require("fs");
+const path = require("path");
+const yaml = require("yaml");
+
+/**
+ * Audit the given workflow files.
+ * @param {string[]} files
+ * @returns {{ok:boolean, files: Record<string, any>}}
+ */
+function auditFiles(files) {
+  const summary = { ok: true, files: {} };
+  for (const file of files) {
+    const content = fs.readFileSync(file, "utf8");
+    const doc = yaml.parse(content) || {};
+    const jobs = doc.jobs || {};
+    const fileSummary = { ok: true, jobs: {} };
+    for (const [jobName, job] of Object.entries(jobs)) {
+      const steps = Array.isArray(job.steps) ? job.steps : [];
+      const jobSummary = { ok: true, errors: [] };
+      const stepTexts = steps.map((s) => JSON.stringify(s));
+      const referencesDist = stepTexts.some(
+        (t) => t && t.includes("frontend/dist"),
+      );
+      if (!referencesDist) {
+        fileSummary.jobs[jobName] = jobSummary;
+        continue;
+      }
+      const downloadStep = steps.find(
+        (s) =>
+          typeof s.uses === "string" &&
+          s.uses.includes("actions/download-artifact") &&
+          s.with &&
+          typeof s.with.name === "string" &&
+          s.with.name.startsWith("frontend-dist"),
+      );
+      if (downloadStep) {
+        fileSummary.jobs[jobName] = jobSummary;
+        continue;
+      }
+      const buildIdx = steps.findIndex(
+        (s) =>
+          typeof s.run === "string" && /pnpm\s+(build|run\s+build)/.test(s.run),
+      );
+      if (buildIdx === -1) {
+        jobSummary.ok = false;
+        jobSummary.errors.push("missing build step");
+        fileSummary.ok = summary.ok = false;
+        fileSummary.jobs[jobName] = jobSummary;
+        continue;
+      }
+      const buildStep = steps[buildIdx];
+      if (buildStep["working-directory"] !== "frontend") {
+        jobSummary.ok = false;
+        jobSummary.errors.push("build step must run in frontend directory");
+      }
+      if (/\bnpm\b/.test(buildStep.run)) {
+        jobSummary.ok = false;
+        jobSummary.errors.push("build must use pnpm");
+      }
+      const verifyIdx = steps.findIndex(
+        (s) =>
+          typeof s.run === "string" &&
+          s.run.includes("frontend/dist/index.html") &&
+          /test\s+-f/.test(s.run),
+      );
+      if (verifyIdx === -1 || verifyIdx < buildIdx) {
+        jobSummary.ok = false;
+        jobSummary.errors.push("missing verify step");
+      }
+      const nodeStep = steps
+        .slice(0, buildIdx)
+        .find(
+          (s) =>
+            typeof s.uses === "string" &&
+            s.uses.startsWith("actions/setup-node") &&
+            s.with &&
+            (String(s.with["node-version"] || "").includes("20") ||
+              String(s.with["node-version"] || "").includes("${{")),
+        );
+      if (!nodeStep) {
+        jobSummary.ok = false;
+        jobSummary.errors.push("missing Node 20 setup");
+      } else if (nodeStep.with && nodeStep.with.cache !== "pnpm") {
+        jobSummary.ok = false;
+        jobSummary.errors.push("setup-node cache must be pnpm");
+      }
+      const corepackIdx = steps.findIndex(
+        (s) => typeof s.run === "string" && s.run.trim() === "corepack enable",
+      );
+      if (corepackIdx === -1 || corepackIdx > buildIdx) {
+        jobSummary.ok = false;
+        jobSummary.errors.push("missing corepack enable before build");
+      }
+      const pnpmSetupIdx = steps.findIndex(
+        (s) =>
+          typeof s.uses === "string" && s.uses.startsWith("pnpm/action-setup"),
+      );
+      if (pnpmSetupIdx === -1 || pnpmSetupIdx > buildIdx) {
+        jobSummary.ok = false;
+        jobSummary.errors.push("missing pnpm/action-setup before build");
+      } else if (
+        steps[pnpmSetupIdx].with &&
+        "version" in steps[pnpmSetupIdx].with
+      ) {
+        jobSummary.ok = false;
+        jobSummary.errors.push("pnpm/action-setup must not pin version");
+      }
+      if (!jobSummary.ok) fileSummary.ok = summary.ok = false;
+      fileSummary.jobs[jobName] = jobSummary;
+    }
+    summary.files[file] = fileSummary;
+  }
+  return summary;
+}
+
+function main() {
+  const repoRoot = process.cwd();
+  const args = process.argv.slice(2);
+  let files;
+  if (args.length) {
+    files = args;
+  } else {
+    const wfDir = path.join(repoRoot, ".github", "workflows");
+    files = fs
+      .readdirSync(wfDir)
+      .filter((f) => f.endsWith(".yml"))
+      .map((f) => path.join(wfDir, f));
+  }
+  const summary = auditFiles(files);
+  console.log(JSON.stringify(summary, null, 2));
+  if (!summary.ok) process.exit(1);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { auditFiles };

--- a/tests/ci-guard/frontend-smoke-artifact/audit.test.ts
+++ b/tests/ci-guard/frontend-smoke-artifact/audit.test.ts
@@ -1,0 +1,123 @@
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { auditFiles } from '../../../scripts/ci-guard/frontend-smoke-artifact/audit';
+
+function wf(content: string): string {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'wf-'));
+  const file = path.join(dir, 'flow.yml');
+  writeFileSync(file, content);
+  return file;
+}
+
+describe('frontend smoke artifact audit', () => {
+  test('t1 build and verify pass', () => {
+    const file = wf(`jobs:\n  smoke:\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n          cache: pnpm\n      - run: corepack enable\n      - uses: pnpm/action-setup@v4\n      - run: pnpm build\n        working-directory: frontend\n      - run: test -f frontend/dist/index.html\n        working-directory: frontend\n      - run: cat frontend/dist/index.html\n`);
+    const res = auditFiles([file]);
+    expect(res.ok).toBe(true);
+  });
+
+  test('t2 download artifact pass', () => {
+    const file = wf(`jobs:\n  smoke:\n    steps:\n      - uses: actions/download-artifact@v4\n        with:\n          name: frontend-dist\n          path: frontend/dist\n      - run: ls frontend/dist\n`);
+    const res = auditFiles([file]);
+    expect(res.ok).toBe(true);
+  });
+
+  test('t3 missing build and download fail', () => {
+    const file = wf(`jobs:\n  smoke:\n    steps:\n      - run: echo none\n      - run: ls frontend/dist\n`);
+    const res = auditFiles([file]);
+    expect(res.ok).toBe(false);
+  });
+
+  test('t4 wrong artifact name fail', () => {
+    const file = wf(`jobs:\n  smoke:\n    steps:\n      - uses: actions/download-artifact@v4\n        with:\n          name: wrong\n          path: frontend/dist\n      - run: ls frontend/dist\n`);
+    const res = auditFiles([file]);
+    expect(res.ok).toBe(false);
+  });
+
+  test('t5 npm build fails', () => {
+    const file = wf(`jobs:\n  smoke:\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n          cache: pnpm\n      - run: corepack enable\n      - uses: pnpm/action-setup@v4\n      - run: npm run build\n        working-directory: frontend\n      - run: test -f frontend/dist/index.html\n        working-directory: frontend\n      - run: cat frontend/dist/index.html\n`);
+    const res = auditFiles([file]);
+    expect(res.ok).toBe(false);
+  });
+
+  test('t6 missing corepack enable fails', () => {
+    const file = wf(`jobs:\n  smoke:\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n          cache: pnpm\n      - uses: pnpm/action-setup@v4\n      - run: pnpm build\n        working-directory: frontend\n      - run: test -f frontend/dist/index.html\n        working-directory: frontend\n      - run: cat frontend/dist/index.html\n`);
+    const res = auditFiles([file]);
+    expect(res.ok).toBe(false);
+  });
+
+  test('t7 missing working-directory fails', () => {
+    const file = wf(`jobs:\n  smoke:\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n          cache: pnpm\n      - run: corepack enable\n      - uses: pnpm/action-setup@v4\n      - run: pnpm build\n      - run: test -f frontend/dist/index.html\n        working-directory: frontend\n      - run: cat frontend/dist/index.html\n`);
+    const res = auditFiles([file]);
+    expect(res.ok).toBe(false);
+  });
+
+  test('t8 missing verify step fails', () => {
+    const file = wf(`jobs:\n  smoke:\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n          cache: pnpm\n      - run: corepack enable\n      - uses: pnpm/action-setup@v4\n      - run: pnpm build\n        working-directory: frontend\n      - run: cat frontend/dist/index.html\n`);
+    const res = auditFiles([file]);
+    expect(res.ok).toBe(false);
+  });
+
+  test('t9 build job with needs pass', () => {
+    const file = wf(`jobs:\n  build:\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n          cache: pnpm\n      - run: corepack enable\n      - uses: pnpm/action-setup@v4\n      - run: pnpm build\n        working-directory: frontend\n      - run: test -f frontend/dist/index.html\n        working-directory: frontend\n      - uses: actions/upload-artifact@v4\n        with:\n          name: frontend-dist\n          path: frontend/dist\n  smoke:\n    needs: build\n    steps:\n      - uses: actions/download-artifact@v4\n        with:\n          name: frontend-dist\n          path: frontend/dist\n      - run: ls frontend/dist\n`);
+    const res = auditFiles([file]);
+    expect(res.ok).toBe(true);
+  });
+
+  test('t10 matrix build artifacts pass', () => {
+    const expr = '${{ matrix.node }}';
+    const file = wf(
+      [
+        'jobs:',
+        '  build:',
+        '    strategy:',
+        '      matrix:',
+        '        node: [18,20]',
+        '    steps:',
+        '      - uses: actions/setup-node@v4',
+        '        with:',
+        `          node-version: ${expr}`,
+        '          cache: pnpm',
+        '      - run: corepack enable',
+        '      - uses: pnpm/action-setup@v4',
+        '      - run: pnpm build',
+        '        working-directory: frontend',
+        '      - run: test -f frontend/dist/index.html',
+        '        working-directory: frontend',
+        '      - uses: actions/upload-artifact@v4',
+        '        with:',
+        `          name: frontend-dist-${expr}`,
+        '          path: frontend/dist',
+        '  smoke:',
+        '    needs: build',
+        '    strategy:',
+        '      matrix:',
+        '        node: [18,20]',
+        '    steps:',
+        '      - uses: actions/download-artifact@v4',
+        '        with:',
+        `          name: frontend-dist-${expr}`,
+        '          path: frontend/dist',
+        '      - run: ls frontend/dist',
+      ].join('\n'),
+    );
+    const res = auditFiles([file]);
+    expect(res.ok).toBe(true);
+  });
+
+  test('t11 wrong cache fails', () => {
+    const file = wf(`jobs:\n  smoke:\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n          cache: npm\n      - run: corepack enable\n      - uses: pnpm/action-setup@v4\n      - run: pnpm build\n        working-directory: frontend\n      - run: test -f frontend/dist/index.html\n        working-directory: frontend\n      - run: cat frontend/dist/index.html\n`);
+    const res = auditFiles([file]);
+    expect(res.ok).toBe(false);
+  });
+
+  test('t12 summary json returned', () => {
+    const file = wf(`jobs:\n  smoke:\n    steps:\n      - run: ls frontend/dist\n`);
+    const res = auditFiles([file]);
+    expect(res.ok).toBe(false);
+    const entries = Object.entries(res.files[file].jobs);
+    expect(entries.length).toBe(1);
+    expect(entries[0][1].errors.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add audit to enforce verified frontend dist or artifact download
- cover frontend smoke artifact scenarios with unit tests
- wire guard into dedicated workflow

## Testing
- `npm run format --prefix backend`
- `node scripts/run-jest.js tests/ci-guard/frontend-smoke-artifact/audit.test.ts`
- `npm run ci` *(fails: SyntaxError in existing workflow YAML)*
- `npm run smoke` *(fails: SyntaxError in existing workflow YAML)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a3d5bcec832db587b71ffa545b84