### PR TITLE
ci: add secret sentinel audit tests

### DIFF
--- a/.github/workflows/guard-secret-sentinel.yml
+++ b/.github/workflows/guard-secret-sentinel.yml
@@ -1,0 +1,14 @@
+name: guard-secret-sentinel
+
+on: [pull_request, push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.7
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm test -- tests/ci-guard/secret-sentinel/audit.test.ts

--- a/scripts/ci-guard/secret-sentinel/audit.ts
+++ b/scripts/ci-guard/secret-sentinel/audit.ts
@@ -1,0 +1,59 @@
+import { spawnSync, SpawnSyncReturns } from "node:child_process";
+
+interface AuditOptions {
+  useInputVars?: boolean;
+  summaryFile?: string;
+}
+
+export interface AuditResult {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+/**
+ * Runs the secret sentinel step in a child process.
+ * @param varsRaw Raw env var names string.
+ * @param env Environment map for the child process.
+ * @param options Control env var names and summary file.
+ */
+export function audit(
+  varsRaw: string,
+  env: NodeJS.ProcessEnv = {},
+  options: AuditOptions = {},
+): AuditResult {
+  const step =
+    `const fs=require('node:fs');\n` +
+    `const varsRaw=process.env.VARS_RAW ?? process.env.INPUT_VARS ?? '';\n` +
+    `const names=varsRaw.split(/[\\s,]+/).map(v=>v.trim()).filter(Boolean);\n` +
+    `const missing=[...new Set(names)].filter(n=>!process.env[n]);\n` +
+    `if(missing.length){\n` +
+    `  console.log(missing.join('\\n'));\n` +
+    `  if(process.env.GITHUB_STEP_SUMMARY){\n` +
+    `    fs.writeFileSync(process.env.GITHUB_STEP_SUMMARY, missing.join('\\n'));\n` +
+    `  }\n` +
+    `  process.exit(1);\n` +
+    `}`;
+
+  const childEnv: NodeJS.ProcessEnv = { ...process.env, ...env };
+  if (options.useInputVars) {
+    childEnv.INPUT_VARS = varsRaw;
+  } else {
+    childEnv.VARS_RAW = varsRaw;
+  }
+  if (options.summaryFile) {
+    childEnv.GITHUB_STEP_SUMMARY = options.summaryFile;
+  }
+
+  const result: SpawnSyncReturns<string> = spawnSync(
+    process.execPath,
+    ["-e", step],
+    { env: childEnv, encoding: "utf8" },
+  );
+
+  return {
+    code: result.status,
+    stdout: result.stdout.trim(),
+    stderr: result.stderr.trim(),
+  };
+}

--- a/tests/ci-guard/secret-sentinel/audit.test.ts
+++ b/tests/ci-guard/secret-sentinel/audit.test.ts
@@ -1,0 +1,87 @@
+import { audit } from "../../../scripts/ci-guard/secret-sentinel/audit";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+describe("secret-sentinel audit", () => {
+  test("space-separated names, all present -> exit 0", () => {
+    const res = audit("FOO BAR", { FOO: "x", BAR: "y" });
+    expect(res.code).toBe(0);
+    expect(res.stdout).toBe("");
+  });
+
+  test("newline-separated names, one missing -> exit 1, name listed", () => {
+    const res = audit("FOO\nBAR", { FOO: "x" });
+    expect(res.code).toBe(1);
+    expect(res.stdout).toBe("BAR");
+  });
+
+  test("comma-separated names supported", () => {
+    let res = audit("FOO,BAR", { FOO: "1", BAR: "2" });
+    expect(res.code).toBe(0);
+    res = audit("FOO,BAR", { FOO: "1" });
+    expect(res.code).toBe(1);
+    expect(res.stdout).toBe("BAR");
+  });
+
+  test("mixed whitespace & commas parse correctly", () => {
+    const res = audit("FOO, BAR\nBAZ", { FOO: "a", BAR: "b", BAZ: "c" });
+    expect(res.code).toBe(0);
+  });
+
+  test("empty VARS_RAW -> exit 0", () => {
+    const res = audit("", {});
+    expect(res.code).toBe(0);
+  });
+
+  test("duplicate names de-duplicated; single report", () => {
+    const res = audit("FOO FOO BAR", { BAR: "1" });
+    expect(res.code).toBe(1);
+    expect(res.stdout).toBe("FOO");
+  });
+
+  test("names with stray commas/spaces trimmed and handled", () => {
+    const res = audit(" FOO , , BAR ", { BAR: "1" });
+    expect(res.code).toBe(1);
+    expect(res.stdout).toBe("FOO");
+  });
+
+  test("very long list (50+) still fast and correct", () => {
+    const names = Array.from({ length: 60 }, (_, i) => `VAR${i}`);
+    const env: Record<string, string> = {};
+    names.slice(0, -1).forEach((n) => {
+      env[n] = "1";
+    });
+    const res = audit(names.join(" "), env);
+    expect(res.code).toBe(1);
+    expect(res.stdout).toBe(names[names.length - 1]);
+  });
+
+  test("env contains empty string -> treated as missing", () => {
+    const res = audit("FOO BAR", { FOO: "", BAR: "1" });
+    expect(res.code).toBe(1);
+    expect(res.stdout).toBe("FOO");
+  });
+
+  test("non-ASCII env var values handled", () => {
+    const res = audit("UNICODE", { UNICODE: "déjà" });
+    expect(res.code).toBe(0);
+  });
+
+  test("composite action variant resolves inputs.vars", () => {
+    const res = audit(
+      "FOO BAR",
+      { FOO: "1", BAR: "2" },
+      { useInputVars: true },
+    );
+    expect(res.code).toBe(0);
+  });
+
+  test("summary output written on failure", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "summary-"));
+    const file = join(tmp, "out.md");
+    const res = audit("FOO", {}, { summaryFile: file });
+    expect(res.code).toBe(1);
+    expect(readFileSync(file, "utf8").trim()).toBe("FOO");
+  });
+});


### PR DESCRIPTION
## Summary
- add audit harness for secret sentinel step with env validation
- cover secret sentinel parsing edge cases with 12 tests
- run secret sentinel tests in dedicated workflow

## Testing
- `node scripts/run-jest.js tests/ci-guard/secret-sentinel/audit.test.ts`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: SyntaxError in existing workflow YAML)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a529cbe4832db7700647fce6fa36