### PR TITLE
ci(workflow-map-yaml-dep): add yaml dep + ensure install before mapper

### DIFF
--- a/.github/workflows/ci-inventory.yml
+++ b/.github/workflows/ci-inventory.yml
@@ -12,9 +12,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.1.6
+      # >>> BEGIN MANAGED BLOCK: ci-guard:workflow-map-yaml-dep
       - uses: actions/setup-node@v4.0.2
         with:
           node-version: 20
+          cache: pnpm
+      - run: corepack enable
+        shell: bash
+      - uses: pnpm/action-setup@v4.1.0
+        with:
+          run_install: false
+      - name: Install dev deps
+        run: pnpm install --frozen-lockfile
+        shell: bash
+      # <<< END MANAGED BLOCK: ci-guard:workflow-map-yaml-dep
       - run: node scripts/ci/inventory-tests.js > ci-test-inventory.json
       - run: node scripts/ci/map-workflows.js > ci-workflow-map.json
       - id: compare

--- a/.github/workflows/guard-workflow-map-yaml-dep.yml
+++ b/.github/workflows/guard-workflow-map-yaml-dep.yml
@@ -1,0 +1,22 @@
+name: workflow map yaml dep guard
+on: [push, pull_request]
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.6
+      # >>> BEGIN MANAGED BLOCK: ci-guard:workflow-map-yaml-dep
+      - uses: actions/setup-node@v4.0.2
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: corepack enable
+        shell: bash
+      - uses: pnpm/action-setup@v4.1.0
+        with:
+          run_install: false
+      - name: Install dev deps
+        run: pnpm install --frozen-lockfile
+        shell: bash
+      # <<< END MANAGED BLOCK: ci-guard:workflow-map-yaml-dep
+      - run: node scripts/ci-guard/workflow-map-yaml-dep/run-map-workflows.js

--- a/scripts/ci-guard/workflow-map-yaml-dep/run-map-workflows.js
+++ b/scripts/ci-guard/workflow-map-yaml-dep/run-map-workflows.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+const { spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const repoRoot = path.resolve(__dirname, "..", "..", "..");
+const script = path.join(repoRoot, "scripts", "ci", "map-workflows.js");
+const output = path.join(repoRoot, "ci-workflow-map.json");
+
+const result = spawnSync("node", [script], { cwd: repoRoot, encoding: "utf8" });
+if (result.status !== 0) {
+  process.stderr.write(result.stderr);
+  process.exit(result.status ?? 1);
+}
+fs.writeFileSync(output, result.stdout);

--- a/scripts/ci/map-workflows.js
+++ b/scripts/ci/map-workflows.js
@@ -1,7 +1,15 @@
 #!/usr/bin/env node
 const fs = require("fs");
 const path = require("path");
-const yaml = require("yaml");
+let YAML;
+try {
+  YAML = require("yaml");
+} catch (e) {
+  console.error(
+    'Missing "yaml" module. Ensure devDependencies are installed before running this script.',
+  );
+  process.exit(2);
+}
 
 const repoRoot = path.resolve(__dirname, "..", "..");
 const workflowsDir = path.join(repoRoot, ".github", "workflows");
@@ -29,7 +37,7 @@ for (const file of fs.readdirSync(workflowsDir)) {
   if (!file.endsWith(".yml") && !file.endsWith(".yaml")) continue;
   let doc;
   try {
-    doc = yaml.parse(fs.readFileSync(path.join(workflowsDir, file), "utf8"));
+    doc = YAML.parse(fs.readFileSync(path.join(workflowsDir, file), "utf8"));
   } catch {
     continue;
   }

--- a/tests/ci-guard/workflow-map-yaml-dep/run-map-workflows.test.js
+++ b/tests/ci-guard/workflow-map-yaml-dep/run-map-workflows.test.js
@@ -1,0 +1,20 @@
+const { spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+
+test("workflow mapper runs and outputs map", () => {
+  const repoRoot = path.resolve(__dirname, "..", "..", "..");
+  const script = path.join(
+    repoRoot,
+    "scripts",
+    "ci-guard",
+    "workflow-map-yaml-dep",
+    "run-map-workflows.js",
+  );
+  const out = path.join(repoRoot, "ci-workflow-map.json");
+  if (fs.existsSync(out)) fs.unlinkSync(out);
+  const result = spawnSync("node", [script], { cwd: repoRoot });
+  expect(result.status).toBe(0);
+  expect(fs.existsSync(out)).toBe(true);
+  fs.unlinkSync(out);
+});


### PR DESCRIPTION
## Summary
- handle missing `yaml` module gracefully in workflow mapper
- install dev deps before workflow mapper runs
- guard workflow ensures mapper runs successfully

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: ESLint context.getScope not a function; STRIPE_SECRET_KEY must be a live secret)*
- `node scripts/run-jest.js tests/ci-guard/workflow-map-yaml-dep/run-map-workflows.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68a8a53267d8832da3ae6c7fe7919b3c