### PR TITLE
ci(pnpm-bootstrap): ensure pnpm available via corepack / action-setup and unify caching

### DIFF
--- a/.github/workflows/dependency-checker.yml
+++ b/.github/workflows/dependency-checker.yml
@@ -2,7 +2,7 @@ name: dependency-checker
 
 on:
   schedule:
-    - cron: '0 0 * * 0'
+    - cron: "0 0 * * 0"
 
 jobs:
   check:
@@ -12,6 +12,23 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      # >>> BEGIN MANAGED BLOCK: ci-guard:pnpm-bootstrap
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: |
+            pnpm-lock.yaml
+            frontend/pnpm-lock.yaml
+      - name: Enable corepack
+        run: corepack enable
+        shell: bash
+      - name: Ensure pnpm installed (fallback)
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+      # <<< END MANAGED BLOCK: ci-guard:pnpm-bootstrap
 
       - name: Check Node dependencies
         run: |

--- a/.github/workflows/guard-pnpm-bootstrap.yml
+++ b/.github/workflows/guard-pnpm-bootstrap.yml
@@ -1,0 +1,16 @@
+name: pnpm bootstrap guard
+
+on:
+  pull_request:
+
+jobs:
+  pnpm-bootstrap-guard:
+    runs-on:
+      - [self-hosted, linux, aws]
+      - ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5.0.0
+        with:
+          fetch-depth: 0
+      - name: Check pnpm bootstrap block
+        run: node scripts/ci-guard/pnpm-bootstrap/check.js .github/workflows/dependency-checker.yml

--- a/scripts/ci-guard/pnpm-bootstrap/check.js
+++ b/scripts/ci-guard/pnpm-bootstrap/check.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+const fs = require("fs");
+
+const start = "# >>> BEGIN MANAGED BLOCK: ci-guard:pnpm-bootstrap";
+const end = "# <<< END MANAGED BLOCK: ci-guard:pnpm-bootstrap";
+
+function hasBlock(content) {
+  return content.includes(start) && content.includes(end);
+}
+
+function checkFiles(files) {
+  const missing = files.filter((f) => {
+    const text = fs.readFileSync(f, "utf8");
+    return !hasBlock(text);
+  });
+  if (missing.length > 0) {
+    throw new Error(`Missing pnpm bootstrap block in: ${missing.join(", ")}`);
+  }
+}
+
+if (require.main === module) {
+  try {
+    const files = process.argv.slice(2);
+    checkFiles(files);
+  } catch (err) {
+    console.error(err.message);
+    process.exit(1);
+  }
+}
+
+module.exports = { hasBlock, checkFiles };

--- a/tests/ci-guard/pnpm-bootstrap/check.test.js
+++ b/tests/ci-guard/pnpm-bootstrap/check.test.js
@@ -1,0 +1,25 @@
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const {
+  checkFiles,
+} = require("../../../scripts/ci-guard/pnpm-bootstrap/check.js");
+
+describe("pnpm bootstrap guard", () => {
+  test("passes when block present", () => {
+    const file = path.join(os.tmpdir(), "good-workflow.yml");
+    fs.writeFileSync(
+      file,
+      "# >>> BEGIN MANAGED BLOCK: ci-guard:pnpm-bootstrap\n# <<< END MANAGED BLOCK: ci-guard:pnpm-bootstrap\n",
+    );
+    expect(() => checkFiles([file])).not.toThrow();
+    fs.unlinkSync(file);
+  });
+
+  test("fails when block missing", () => {
+    const file = path.join(os.tmpdir(), "bad-workflow.yml");
+    fs.writeFileSync(file, "name: test");
+    expect(() => checkFiles([file])).toThrow("Missing pnpm bootstrap block");
+    fs.unlinkSync(file);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure dependency checker workflow sets up pnpm via corepack and pnpm/action-setup
- add guard workflow to verify pnpm bootstrap blocks
- add pnpm bootstrap guard script and tests

## Testing
- `npm run format` (passed)
- `npm test` (failed: SyntaxError in various workflow YAML files)
- `npx jest tests/ci-guard/pnpm-bootstrap/check.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68a8a633ddd0832d8332023c7f611b1b