### PR TITLE
ci: add pnpm bootstrap guard

### DIFF
--- a/.github/workflows/guard-pnpm-bootstrap.yml
+++ b/.github/workflows/guard-pnpm-bootstrap.yml
@@ -1,0 +1,14 @@
+name: guard pnpm bootstrap
+on: [pull_request, push]
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: corepack enable
+      - run: npm ci
+      - run: npx ts-node --transpile-only scripts/ci-guard/pnpm-bootstrap/audit.ts
+      - run: node scripts/run-jest.js tests/ci-guard/pnpm-bootstrap/audit.test.ts

--- a/scripts/ci-guard/pnpm-bootstrap/audit.ts
+++ b/scripts/ci-guard/pnpm-bootstrap/audit.ts
@@ -1,0 +1,163 @@
+import fs from "fs";
+import path from "path";
+import yaml from "yaml";
+
+interface Step {
+  name?: string;
+  uses?: string;
+  run?: string;
+  with?: Record<string, any>;
+  ["working-directory"]?: string;
+}
+
+interface Job {
+  steps?: Step[];
+  defaults?: { run?: { ["working-directory"]?: string } };
+}
+
+function findFiles(root: string, filename: string): string[] {
+  const out: string[] = [];
+  function walk(dir: string) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (entry.name === "node_modules" || entry.name.startsWith(".git"))
+        continue;
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (entry.isFile() && entry.name === filename) {
+        out.push(path.relative(root, full).replace(/\\/g, "/"));
+      }
+    }
+  }
+  if (fs.existsSync(root)) walk(root);
+  return out;
+}
+
+const repoRoot = process.cwd();
+const workflowsDir = path.join(repoRoot, ".github", "workflows");
+const lockFiles = findFiles(repoRoot, "pnpm-lock.yaml");
+const packageJsons = findFiles(repoRoot, "package.json");
+const pnpmPackages = new Set<string>();
+for (const rel of packageJsons) {
+  const pkgPath = path.join(repoRoot, rel);
+  try {
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+    if (
+      typeof pkg.packageManager === "string" &&
+      pkg.packageManager.startsWith("pnpm@")
+    ) {
+      pnpmPackages.add(path.posix.dirname(rel) || ".");
+    }
+  } catch {}
+}
+
+const errors: string[] = [];
+const pnpmUsageDirs = new Set<string>();
+const wfFiles = fs.existsSync(workflowsDir)
+  ? fs
+      .readdirSync(workflowsDir)
+      .filter((f) => f.endsWith(".yml") || f.endsWith(".yaml"))
+  : [];
+
+for (const wfFile of wfFiles) {
+  const wfPath = path.join(workflowsDir, wfFile);
+  let wf: any;
+  try {
+    wf = yaml.parse(fs.readFileSync(wfPath, "utf8"));
+  } catch (e: any) {
+    errors.push(`${wfFile}: failed to parse - ${e.message}`);
+    continue;
+  }
+  const wfDefaultDir = wf?.defaults?.run?.["working-directory"];
+  const jobs: Record<string, Job> = wf.jobs || {};
+  for (const [jobName, job] of Object.entries(jobs)) {
+    const steps = job.steps || [];
+    let setupIndex = -1;
+    let cachePaths: string[] = [];
+    let corepackIndex = -1;
+    let actionSetupIndex = -1;
+    let actionSetupRunInstall = false;
+    let hasNpmCache = false;
+    const jobDefaultDir = job.defaults?.run?.["working-directory"];
+    steps.forEach((step, idx) => {
+      if (step.uses && /actions\/setup-node@/.test(step.uses)) {
+        const cache = step.with?.cache;
+        if (cache === "pnpm") {
+          setupIndex = idx;
+          const dep = step.with?.["cache-dependency-path"];
+          if (typeof dep === "string") {
+            cachePaths = dep
+              .split(/\n|,/)
+              .map((s: string) => s.trim())
+              .filter(Boolean);
+          }
+        }
+        if (cache === "npm") hasNpmCache = true;
+      }
+      if (
+        typeof step.run === "string" &&
+        step.run.includes("corepack enable")
+      ) {
+        corepackIndex = idx;
+      }
+      if (step.uses && step.uses.startsWith("pnpm/action-setup")) {
+        actionSetupIndex = idx;
+        const ri = step.with?.run_install;
+        actionSetupRunInstall = ri === false || ri === "false";
+      }
+    });
+
+    steps.forEach((step, idx) => {
+      if (typeof step.run !== "string" || !/\bpnpm\b/.test(step.run)) return;
+      const stepDir =
+        step["working-directory"] || jobDefaultDir || wfDefaultDir || ".";
+      const normDir = path.posix.normalize(stepDir);
+      pnpmUsageDirs.add(normDir);
+      const prefix = `${wfFile} > ${jobName} > step ${idx + 1}`;
+      if (setupIndex < 0 || idx <= setupIndex) {
+        errors.push(
+          `${prefix}: missing actions/setup-node with cache:pnpm before pnpm`,
+        );
+      } else {
+        if (
+          cachePaths.length !== lockFiles.length ||
+          lockFiles.some((lf) => !cachePaths.includes(lf))
+        ) {
+          errors.push(
+            `${wfFile} > ${jobName}: cache-dependency-path must include all pnpm-lock.yaml files`,
+          );
+        }
+      }
+      if (corepackIndex < 0 || idx <= corepackIndex) {
+        errors.push(`${prefix}: missing corepack enable before pnpm`);
+      }
+      if (hasNpmCache) {
+        errors.push(`${prefix}: cache: npm present in job using pnpm`);
+      }
+      const pinned = pnpmPackages.has(normDir);
+      if ((actionSetupIndex < 0 || idx <= actionSetupIndex) && !pinned) {
+        errors.push(
+          `${prefix}: missing pnpm/action-setup fallback or packageManager pin`,
+        );
+      }
+      if (actionSetupIndex >= 0 && !actionSetupRunInstall) {
+        errors.push(
+          `${wfFile} > ${jobName} > step ${actionSetupIndex + 1}: pnpm/action-setup must set run_install:false`,
+        );
+      }
+    });
+  }
+}
+
+for (const dir of pnpmPackages) {
+  if (!pnpmUsageDirs.has(dir)) {
+    errors.push(
+      `package.json in ${dir} pins pnpm but no workflow uses pnpm there`,
+    );
+  }
+}
+
+if (errors.length) {
+  console.error(errors.join("\n"));
+  process.exit(1);
+}

--- a/tests/ci-guard/pnpm-bootstrap/audit.test.ts
+++ b/tests/ci-guard/pnpm-bootstrap/audit.test.ts
@@ -1,0 +1,242 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { spawnSync } from "child_process";
+
+const script = path.resolve(
+  __dirname,
+  "../../../scripts/ci-guard/pnpm-bootstrap/audit.ts",
+);
+const tsNode = [
+  "-y",
+  "ts-node",
+  "--transpile-only",
+  "--compiler-options",
+  JSON.stringify({ module: "commonjs", moduleResolution: "node" }),
+  script,
+];
+
+function run(cwd: string) {
+  return spawnSync("npx", tsNode, { cwd, encoding: "utf8" });
+}
+
+function writeFile(dir: string, file: string, content: string) {
+  const full = path.join(dir, file);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content);
+}
+
+describe("pnpm bootstrap audit", () => {
+  test("setup-node + corepack + pnpm/action-setup present → pass", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "t1-"));
+    writeFile(
+      tmp,
+      "package.json",
+      JSON.stringify({ packageManager: "pnpm@8.0.0" }),
+    );
+    writeFile(tmp, "pnpm-lock.yaml", "");
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `name: t1\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          cache: pnpm\n          cache-dependency-path: pnpm-lock.yaml\n      - run: corepack enable\n      - uses: pnpm/action-setup@v3\n        with:\n          run_install: false\n      - run: pnpm install\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).toBe(0);
+  });
+
+  test("pnpm used without corepack → fail", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "t2-"));
+    writeFile(
+      tmp,
+      "package.json",
+      JSON.stringify({ packageManager: "pnpm@8.0.0" }),
+    );
+    writeFile(tmp, "pnpm-lock.yaml", "");
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `name: t2\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          cache: pnpm\n          cache-dependency-path: pnpm-lock.yaml\n      - run: pnpm install\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).not.toBe(0);
+    expect(res.stderr + res.stdout).toMatch(/corepack/);
+  });
+
+  test("pnpm used with npm cache → fail", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "t3-"));
+    writeFile(
+      tmp,
+      "package.json",
+      JSON.stringify({ packageManager: "pnpm@8.0.0" }),
+    );
+    writeFile(tmp, "pnpm-lock.yaml", "");
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `name: t3\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          cache: npm\n      - run: corepack enable\n      - run: pnpm install\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).not.toBe(0);
+    expect(res.stderr + res.stdout).toMatch(/cache: npm/);
+  });
+
+  test("pnpm used but no setup-node → fail", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "t4-"));
+    writeFile(
+      tmp,
+      "package.json",
+      JSON.stringify({ packageManager: "pnpm@8.0.0" }),
+    );
+    writeFile(tmp, "pnpm-lock.yaml", "");
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `name: t4\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - run: corepack enable\n      - run: pnpm install\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).not.toBe(0);
+    expect(res.stderr + res.stdout).toMatch(/setup-node/);
+  });
+
+  test("workspace: frontend working-directory respected → pass", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "t5-"));
+    writeFile(tmp, "package.json", "{}");
+    writeFile(tmp, "pnpm-lock.yaml", "");
+    writeFile(
+      tmp,
+      "frontend/package.json",
+      JSON.stringify({ packageManager: "pnpm@8.0.0" }),
+    );
+    writeFile(tmp, "frontend/pnpm-lock.yaml", "");
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `name: t5\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          cache: pnpm\n          cache-dependency-path: |\n            pnpm-lock.yaml\n            frontend/pnpm-lock.yaml\n      - run: corepack enable\n      - run: pnpm install\n        working-directory: frontend\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).toBe(0);
+  });
+
+  test("multiple pnpm-lock.yaml in paths → cache-dependency-path lists both → pass", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "t6-"));
+    writeFile(
+      tmp,
+      "package.json",
+      JSON.stringify({ packageManager: "pnpm@8.0.0" }),
+    );
+    writeFile(tmp, "pnpm-lock.yaml", "");
+    writeFile(tmp, "frontend/pnpm-lock.yaml", "");
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `name: t6\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          cache: pnpm\n          cache-dependency-path: |\n            pnpm-lock.yaml\n            frontend/pnpm-lock.yaml\n      - run: corepack enable\n      - run: pnpm install\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).toBe(0);
+  });
+
+  test("action-setup present, run_install:false respected → pass", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "t7-"));
+    writeFile(tmp, "package.json", JSON.stringify({}));
+    writeFile(tmp, "pnpm-lock.yaml", "");
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `name: t7\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          cache: pnpm\n          cache-dependency-path: pnpm-lock.yaml\n      - run: corepack enable\n      - uses: pnpm/action-setup@v3\n        with:\n          run_install: false\n      - run: pnpm install\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).toBe(0);
+  });
+
+  test("wrong order (pnpm before setup-node) → fail", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "t8-"));
+    writeFile(
+      tmp,
+      "package.json",
+      JSON.stringify({ packageManager: "pnpm@8.0.0" }),
+    );
+    writeFile(tmp, "pnpm-lock.yaml", "");
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `name: t8\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - run: pnpm install\n      - uses: actions/setup-node@v4\n        with:\n          cache: pnpm\n          cache-dependency-path: pnpm-lock.yaml\n      - run: corepack enable\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).not.toBe(0);
+    expect(res.stderr + res.stdout).toMatch(/setup-node/);
+  });
+
+  test("step names arbitrary but content matches → pass", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "t9-"));
+    writeFile(
+      tmp,
+      "package.json",
+      JSON.stringify({ packageManager: "pnpm@8.0.0" }),
+    );
+    writeFile(tmp, "pnpm-lock.yaml", "");
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `name: t9\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - name: foo\n        uses: actions/setup-node@v4\n        with:\n          cache: pnpm\n          cache-dependency-path: pnpm-lock.yaml\n      - name: bar\n        run: corepack enable\n      - name: baz\n        run: pnpm install\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).toBe(0);
+  });
+
+  test("npm-only projects ignored → pass", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "t10-"));
+    writeFile(
+      tmp,
+      "package.json",
+      JSON.stringify({ packageManager: "npm@9.0.0" }),
+    );
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `name: t10\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          cache: npm\n      - run: npm install\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).toBe(0);
+  });
+
+  test("packageManager mismatch (package.json says pnpm but workflows only npm) → fail", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "t11-"));
+    writeFile(
+      tmp,
+      "package.json",
+      JSON.stringify({ packageManager: "pnpm@8.0.0" }),
+    );
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `name: t11\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          cache: npm\n      - run: npm install\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).not.toBe(0);
+    expect(res.stderr + res.stdout).toMatch(/pins pnpm/);
+  });
+
+  test("summary correctly aggregates multiple offending files", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "t12-"));
+    writeFile(
+      tmp,
+      "package.json",
+      JSON.stringify({ packageManager: "pnpm@8.0.0" }),
+    );
+    writeFile(tmp, "pnpm-lock.yaml", "");
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `name: t12a\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - run: pnpm install\n`,
+    );
+    writeFile(
+      tmp,
+      ".github/workflows/b.yml",
+      `name: t12b\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - run: pnpm install\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).not.toBe(0);
+    expect(res.stderr + res.stdout).toMatch(/a.yml/);
+    expect(res.stderr + res.stdout).toMatch(/b.yml/);
+  });
+});


### PR DESCRIPTION
## Summary
- audit workflows for pnpm bootstrap issues (setup-node cache, corepack, action-setup fallback)
- add comprehensive tests covering pnpm bootstrap scenarios
- wire guard into dedicated CI workflow

## Testing
- `npx prettier --no-config -w scripts/ci-guard/pnpm-bootstrap/audit.ts tests/ci-guard/pnpm-bootstrap/audit.test.ts .github/workflows/guard-pnpm-bootstrap.yml`
- `node scripts/run-jest.js tests/ci-guard/pnpm-bootstrap/audit.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a8a637cdb4832d8ccbd681246cd560