### PR TITLE
ci(diag-shell-fix): make diagnostics shell valid & resilient

### DIFF
--- a/.github/workflows/guard-diag-shell-fix.yml
+++ b/.github/workflows/guard-diag-shell-fix.yml
@@ -1,0 +1,11 @@
+name: diag shell fix guard
+
+on:
+  pull_request:
+
+jobs:
+  diag-shell-fix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: scripts/ci-guard/diag-shell-fix/scan.sh

--- a/.github/workflows/reusable-test-job.yml
+++ b/.github/workflows/reusable-test-job.yml
@@ -20,6 +20,11 @@ jobs:
       run:
         shell: bash -euo pipefail
     steps:
+      # >>> BEGIN MANAGED BLOCK: ci-guard:diag-shell-fix
+      - name: Shell sanity
+        shell: bash
+        run: echo "bash OK: $(bash --version | head -1)"
+      # <<< END MANAGED BLOCK: ci-guard:diag-shell-fix
       - name: Preflight (print context)
         env:
           GITHUB_REF: ${{ github.ref }}
@@ -71,18 +76,23 @@ jobs:
       - name: Run lane command
         if: ${{ inputs.suite != 'e2e' || !cancelled() }}
         run: ${{ inputs.command }}
-      - name: Bundle lane diagnostics
-        if: ${{ failure() || cancelled() }}
+      # >>> BEGIN MANAGED BLOCK: ci-guard:diag-shell-fix
+      - name: Collect diagnostics
+        if: always()
+        shell: bash
         run: |
+          set -euo pipefail
           mkdir -p ci/diag
-          dmesg | tail -n 200 > ci/diag/dmesg.txt 2>/dev/null || true
-          journalctl -xe --no-pager | tail -n 400 > ci/diag/journal.txt 2>/dev/null || true
-          git log -n 5 --oneline > ci/diag/gitlog.txt
-          cp -r frontend  ci/diag/frontend 2>/dev/null || true
-          cp -r backend   ci/diag/backend  2>/dev/null || true
-      - uses: actions/upload-artifact@v4
-        if: ${{ failure() || cancelled() }}
+          if command -v dmesg >/dev/null 2>&1; then dmesg | tail -n 200 > ci/diag/dmesg.txt 2>/dev/null || true; fi
+          if command -v journalctl >/dev/null 2>&1; then journalctl -xe --no-pager | tail -n 400 > ci/diag/journal.txt 2>/dev/null || true; fi
+          git log -n 5 --oneline > ci/diag/gitlog.txt 2>/dev/null || true
+          for d in frontend backend; do [ -d "$d" ] && cp -R "$d" "ci/diag/$d" 2>/dev/null || true; done
+      - name: Upload diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
         with:
-          name: lane-diag-${{ github.job }}
-          path: ci/diag
-          retention-days: 7
+          name: diag-${{ github.job }}-${{ github.run_id }}
+          path: |
+            ci/diag
+            !ci/diag/**/node_modules/**
+      # <<< END MANAGED BLOCK: ci-guard:diag-shell-fix

--- a/scripts/ci-guard/diag-shell-fix/scan.sh
+++ b/scripts/ci-guard/diag-shell-fix/scan.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Check for invalid shell declarations in diagnostics steps
+if rg -n "shell: /usr/bin/bash -euo pipefail" .github/workflows >/tmp/diag-shell-fix.log; then
+  echo "::error::Found invalid shell declarations:" >&2
+  cat /tmp/diag-shell-fix.log >&2
+  exit 1
+fi

--- a/tests/ci-guard/diag-shell-fix/scan.test.ts
+++ b/tests/ci-guard/diag-shell-fix/scan.test.ts
@@ -1,0 +1,9 @@
+import { execSync } from "child_process";
+import path from "path";
+
+describe("diag shell fix guard", () => {
+  test("no invalid shells", () => {
+    const repoRoot = path.resolve(__dirname, "../../..");
+    execSync("scripts/ci-guard/diag-shell-fix/scan.sh", { cwd: repoRoot, stdio: "inherit" });
+  });
+});


### PR DESCRIPTION
## Summary
- add shell sanity check and resilient diagnostics block
- add guard to ensure no invalid bash flags in workflows

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format`
- `npm test` (backend)
- `node scripts/run-jest.js tests/ci-guard/diag-shell-fix/scan.test.ts`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: SyntaxError in YAML files)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: SyntaxError in YAML files)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a6d77814832d95825ae745adec14