### PR TITLE
ci: add diagnostic shell guard

### DIFF
--- a/.github/workflows/guard-diag-shell-fix.yml
+++ b/.github/workflows/guard-diag-shell-fix.yml
@@ -1,0 +1,22 @@
+name: diag-shell-fix guard
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npx ts-node --transpile-only scripts/ci-guard/diag-shell-fix/audit.ts
+      - run: node scripts/run-jest.js tests/ci-guard/diag-shell-fix/audit.test.ts
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: diag-shell-fix-audit
+          path: diag-shell-fix-audit-summary.json

--- a/scripts/ci-guard/diag-shell-fix/audit.ts
+++ b/scripts/ci-guard/diag-shell-fix/audit.ts
@@ -1,0 +1,199 @@
+import fs from "fs";
+import path from "path";
+import yaml from "yaml";
+
+const allowed = new Set(["bash", "sh", "pwsh", "powershell", "cmd"]);
+
+export interface AuditError {
+  file: string;
+  job: string;
+  step: string;
+  message: string;
+}
+
+function isDiagnostic(step: any): boolean {
+  const content = `${step.name || ""} ${step.run || ""}`;
+  return /dmesg|journalctl|git log|cp .*ci\/diag/.test(content);
+}
+
+function isWindowsJob(job: any): boolean {
+  const runsOn = job["runs-on"];
+  if (Array.isArray(runsOn)) {
+    return runsOn.some((r) => /windows/i.test(r));
+  }
+  return /windows/i.test(String(runsOn || ""));
+}
+
+export function audit(
+  dir = path.join(process.cwd(), ".github", "workflows"),
+): AuditError[] {
+  const errors: AuditError[] = [];
+  if (!fs.existsSync(dir)) return errors;
+  const files = fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith(".yml") || f.endsWith(".yaml"));
+
+  for (const file of files) {
+    const full = path.join(dir, file);
+    const doc = yaml.parse(fs.readFileSync(full, "utf8"));
+    const jobs = doc?.jobs || {};
+    for (const [jobName, job] of Object.entries<any>(jobs)) {
+      const steps = job.steps || [];
+      let mkdirSeen = false;
+      for (let i = 0; i < steps.length; i++) {
+        const step: any = steps[i];
+        const stepName = step.name || `step ${i}`;
+        const shell = step.shell;
+        const run: string = step.run || "";
+
+        // track mkdir
+        if (/mkdir -p ci\/diag/.test(run)) {
+          mkdirSeen = true;
+        }
+
+        // generic shell validation
+        if (shell && typeof shell === "string" && !shell.includes("{0}")) {
+          const base = shell.split(" ")[0];
+          if (allowed.has(base) && shell.trim() !== base) {
+            if (!isDiagnostic(step)) {
+              errors.push({
+                file,
+                job: jobName,
+                step: stepName,
+                message: `move shell flags into run: ${shell}`,
+              });
+            }
+          } else if (!allowed.has(shell)) {
+            errors.push({
+              file,
+              job: jobName,
+              step: stepName,
+              message: `invalid shell: ${shell}`,
+            });
+          }
+        }
+
+        const diag = isDiagnostic(step);
+        if (!diag) continue;
+        const windows = isWindowsJob(job);
+        if (!windows) {
+          if (shell !== "bash") {
+            errors.push({
+              file,
+              job: jobName,
+              step: stepName,
+              message: "diagnostic step requires shell: bash",
+            });
+          }
+
+          if (!mkdirSeen) {
+            errors.push({
+              file,
+              job: jobName,
+              step: stepName,
+              message: "missing mkdir -p ci/diag",
+            });
+          }
+
+          if (
+            /dmesg/.test(run) &&
+            !(
+              /command -v dmesg/.test(run) || /dmesg[^\n]*\|\|\s*true/.test(run)
+            )
+          ) {
+            errors.push({
+              file,
+              job: jobName,
+              step: stepName,
+              message: "dmesg not guarded",
+            });
+          }
+          if (
+            /journalctl/.test(run) &&
+            !(
+              /command -v journalctl/.test(run) ||
+              /journalctl[^\n]*\|\|\s*true/.test(run)
+            )
+          ) {
+            errors.push({
+              file,
+              job: jobName,
+              step: stepName,
+              message: "journalctl not guarded",
+            });
+          }
+          if (
+            /git log/.test(run) &&
+            !(
+              /command -v git/.test(run) || /git log[^\n]*\|\|\s*true/.test(run)
+            )
+          ) {
+            errors.push({
+              file,
+              job: jobName,
+              step: stepName,
+              message: "git log not guarded",
+            });
+          }
+          if (/cp .*ci\/diag/.test(run) && !/\[ -[df] .*\]/.test(run)) {
+            errors.push({
+              file,
+              job: jobName,
+              step: stepName,
+              message: "cp to ci/diag not guarded",
+            });
+          }
+
+          const upload = steps
+            .slice(i + 1)
+            .find((s: any) => s.uses === "actions/upload-artifact@v4");
+          if (!upload) {
+            errors.push({
+              file,
+              job: jobName,
+              step: stepName,
+              message: "missing upload-artifact@v4",
+            });
+          } else {
+            if (!upload.if || !/always\(\)/.test(upload.if)) {
+              errors.push({
+                file,
+                job: jobName,
+                step: stepName,
+                message: "upload-artifact missing if: always()",
+              });
+            }
+            const pathInput = upload.with && upload.with.path;
+            if (!pathInput || !/ci\/diag/.test(pathInput)) {
+              errors.push({
+                file,
+                job: jobName,
+                step: stepName,
+                message: "upload-artifact missing ci/diag path",
+              });
+            }
+          }
+        }
+      }
+    }
+  }
+  return errors;
+}
+
+if (require.main === module) {
+  const errors = audit();
+  fs.writeFileSync(
+    "diag-shell-fix-audit-summary.json",
+    JSON.stringify(errors, null, 2),
+    "utf8",
+  );
+  if (errors.length) {
+    for (const e of errors) {
+      console.error(`${e.file} > ${e.job} > ${e.step}: ${e.message}`);
+    }
+    console.error(`${errors.length} error(s) found`);
+    process.exit(1);
+  } else {
+    console.log("No issues found");
+  }
+}

--- a/tests/ci-guard/diag-shell-fix/audit.test.ts
+++ b/tests/ci-guard/diag-shell-fix/audit.test.ts
@@ -1,0 +1,130 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { audit } from "../../../scripts/ci-guard/diag-shell-fix/audit";
+
+function setup(content: string | Record<string, string>): string {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "audit-"));
+  const dir = path.join(tmp, ".github", "workflows");
+  fs.mkdirSync(dir, { recursive: true });
+  if (typeof content === "string") {
+    fs.writeFileSync(path.join(dir, "wf.yml"), content);
+  } else {
+    for (const [name, data] of Object.entries(content)) {
+      fs.writeFileSync(path.join(dir, name), data);
+    }
+  }
+  return dir;
+}
+
+describe("diag-shell-fix audit", () => {
+  test("t1 valid collector passes", () => {
+    const dir = setup(
+      `name: test\njobs:\n  collect:\n    runs-on: ubuntu-latest\n    steps:\n      - run: mkdir -p ci/diag\n      - name: logs\n        shell: bash\n        run: |\n          set -euo pipefail\n          command -v dmesg >/dev/null && dmesg > ci/diag/d.log || true\n      - uses: actions/upload-artifact@v4\n        if: always()\n        with:\n          path: ci/diag\n`,
+    );
+    expect(audit(dir)).toHaveLength(0);
+  });
+
+  test("t2 invalid shell fails", () => {
+    const dir = setup(
+      `name: bad\njobs:\n  j:\n    runs-on: ubuntu-latest\n    steps:\n      - name: step\n        shell: /usr/bin/bash -e\n        run: echo hi\n`,
+    );
+    const errs = audit(dir);
+    expect(errs[0].message).toMatch(/invalid shell/);
+    expect(errs[0].file).toBe("wf.yml");
+  });
+
+  test("t3 collector missing mkdir fails", () => {
+    const dir = setup(
+      `name: bad\njobs:\n  j:\n    runs-on: ubuntu-latest\n    steps:\n      - name: logs\n        shell: bash\n        run: dmesg > ci/diag/d.log || true\n      - uses: actions/upload-artifact@v4\n        if: always()\n        with:\n          path: ci/diag\n`,
+    );
+    const errs = audit(dir);
+    expect(errs.some((e) => e.message.includes("missing mkdir"))).toBe(true);
+  });
+
+  test("t4 collector missing upload fails", () => {
+    const dir = setup(
+      `name: bad\njobs:\n  j:\n    runs-on: ubuntu-latest\n    steps:\n      - run: mkdir -p ci/diag\n      - name: logs\n        shell: bash\n        run: command -v dmesg >/dev/null && dmesg > ci/diag/d.log || true\n`,
+    );
+    const errs = audit(dir);
+    expect(
+      errs.some((e) => e.message.includes("missing upload-artifact")),
+    ).toBe(true);
+  });
+
+  test("t5 upload missing if always fails", () => {
+    const dir = setup(
+      `name: bad\njobs:\n  j:\n    runs-on: ubuntu-latest\n    steps:\n      - run: mkdir -p ci/diag\n      - name: logs\n        shell: bash\n        run: command -v dmesg >/dev/null && dmesg > ci/diag/d.log || true\n      - uses: actions/upload-artifact@v4\n        with:\n          path: ci/diag\n`,
+    );
+    const errs = audit(dir);
+    expect(errs.some((e) => e.message.includes("if: always"))).toBe(true);
+  });
+
+  test("t6 dmesg without guard fails", () => {
+    const dir = setup(
+      `name: bad\njobs:\n  j:\n    runs-on: ubuntu-latest\n    steps:\n      - run: mkdir -p ci/diag\n      - name: logs\n        shell: bash\n        run: dmesg > ci/diag/d.log\n      - uses: actions/upload-artifact@v4\n        if: always()\n        with:\n          path: ci/diag\n`,
+    );
+    const errs = audit(dir);
+    expect(errs.some((e) => e.message.includes("dmesg not guarded"))).toBe(
+      true,
+    );
+  });
+
+  test("t7 journalctl without guard fails", () => {
+    const dir = setup(
+      `name: bad\njobs:\n  j:\n    runs-on: ubuntu-latest\n    steps:\n      - run: mkdir -p ci/diag\n      - name: logs\n        shell: bash\n        run: journalctl -xe > ci/diag/j.log\n      - uses: actions/upload-artifact@v4\n        if: always()\n        with:\n          path: ci/diag\n`,
+    );
+    const errs = audit(dir);
+    expect(errs.some((e) => e.message.includes("journalctl not guarded"))).toBe(
+      true,
+    );
+  });
+
+  test("t8a guarded cp passes", () => {
+    const dir = setup(
+      `name: good\njobs:\n  j:\n    runs-on: ubuntu-latest\n    steps:\n      - run: mkdir -p ci/diag\n      - name: copy\n        shell: bash\n        run: |\n          [ -d backend ] && cp -r backend ci/diag/backend\n      - uses: actions/upload-artifact@v4\n        if: always()\n        with:\n          path: ci/diag\n`,
+    );
+    expect(audit(dir)).toHaveLength(0);
+  });
+
+  test("t8b unguarded cp fails", () => {
+    const dir = setup(
+      `name: bad\njobs:\n  j:\n    runs-on: ubuntu-latest\n    steps:\n      - run: mkdir -p ci/diag\n      - name: copy\n        shell: bash\n        run: cp -r backend ci/diag/backend\n      - uses: actions/upload-artifact@v4\n        if: always()\n        with:\n          path: ci/diag\n`,
+    );
+    const errs = audit(dir);
+    expect(
+      errs.some((e) => e.message.includes("cp to ci/diag not guarded")),
+    ).toBe(true);
+  });
+
+  test("t9 aggregates errors across workflows", () => {
+    const dir = setup({
+      "a.yml": `name: a\njobs:\n  j:\n    runs-on: ubuntu-latest\n    steps:\n      - run: mkdir -p ci/diag\n      - name: logs\n        shell: bash\n        run: dmesg > ci/diag/d.log\n      - uses: actions/upload-artifact@v4\n        if: always()\n        with:\n          path: ci/diag\n`,
+      "b.yml": `name: b\njobs:\n  j:\n    runs-on: ubuntu-latest\n    steps:\n      - run: mkdir -p ci/diag\n      - name: logs\n        shell: bash\n        run: journalctl -xe > ci/diag/j.log\n      - uses: actions/upload-artifact@v4\n        if: always()\n        with:\n          path: ci/diag\n`,
+    });
+    const errs = audit(dir);
+    expect(errs.length).toBe(2);
+  });
+
+  test("t10 non-diagnostic shell flags fail", () => {
+    const dir = setup(
+      `name: bad\njobs:\n  j:\n    runs-on: ubuntu-latest\n    steps:\n      - name: step\n        shell: bash -e\n        run: echo hi\n`,
+    );
+    const errs = audit(dir);
+    expect(errs[0].message).toMatch(/move shell flags/);
+  });
+
+  test("t11 matrix job passes", () => {
+    const dir = setup(
+      `name: good\njobs:\n  j:\n    runs-on: ubuntu-latest\n    strategy:\n      matrix:\n        node: [20]\n    steps:\n      - run: mkdir -p ci/diag\n      - name: logs\n        shell: bash\n        run: command -v dmesg >/dev/null && dmesg > ci/diag/d.log || true\n      - uses: actions/upload-artifact@v4\n        if: always()\n        with:\n          path: ci/diag\n`,
+    );
+    expect(audit(dir)).toHaveLength(0);
+  });
+
+  test("t12 windows job ignored", () => {
+    const dir = setup(
+      `name: win\njobs:\n  j:\n    runs-on: windows-latest\n    steps:\n      - name: logs\n        shell: pwsh\n        run: Get-EventLog System\n`,
+    );
+    expect(audit(dir)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- audit workflow files for invalid shells and brittle diagnostics
- exercise new guard with tests and CI workflow

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format --prefix backend`
- `npx prettier scripts/ci-guard/diag-shell-fix/audit.ts tests/ci-guard/diag-shell-fix/audit.test.ts .github/workflows/guard-diag-shell-fix.yml -w`
- `node scripts/run-jest.js tests/ci-guard/diag-shell-fix/audit.test.ts`
- `SKIP_PW_DEPS=1 npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_68a8a6dc46a8832d9c6ad32bc4073258