### PR TITLE
ci(pnpm-monorepo-install): auto-detect package roots and install in the right dirs

### DIFF
--- a/.github/workflows/guard-pnpm-monorepo-install.yml
+++ b/.github/workflows/guard-pnpm-monorepo-install.yml
@@ -1,0 +1,26 @@
+name: guard pnpm monorepo install
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: |
+            pnpm-lock.yaml
+            frontend/pnpm-lock.yaml
+            backend/pnpm-lock.yaml
+      - run: corepack enable
+        shell: bash
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+      - run: node tests/ci-guard/pnpm-monorepo-install/discover.test.js
+        shell: bash

--- a/.github/workflows/pnpm-guard.yml
+++ b/.github/workflows/pnpm-guard.yml
@@ -15,5 +15,44 @@ jobs:
   install:
     runs-on: ubuntu-latest
     steps:
-      - run: corepack enable && pnpm -v
-      - run: pnpm install --no-frozen-lockfile
+      - uses: actions/checkout@v5
+      # >>> BEGIN MANAGED BLOCK: ci-guard:pnpm-monorepo-install
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: |
+            pnpm-lock.yaml
+            frontend/pnpm-lock.yaml
+            backend/pnpm-lock.yaml
+      - run: corepack enable
+        shell: bash
+      - uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+      - name: Discover package roots
+        id: cg-pkg-roots
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p ci-guard/pnpm-monorepo-install
+          roots=()
+          [ -f package.json ] && roots+=(".")
+          [ -f frontend/package.json ] && roots+=("frontend")
+          [ -f backend/package.json ] && roots+=("backend")
+          [ -f apps/web/package.json ] && roots+=("apps/web")
+          [ -f apps/api/package.json ] && roots+=("apps/api")
+          if [ ${#roots[@]} -eq 0 ]; then
+            echo "::error::No package.json found in known locations"; exit 2
+          fi
+          printf '%s\n' "${roots[@]}" > ci-guard/pnpm-monorepo-install/roots.txt
+          echo "count=${#roots[@]}" >> "$GITHUB_OUTPUT"
+      - name: Install dependencies (pnpm)
+        shell: bash
+        run: |
+          set -euo pipefail
+          while read d; do
+            echo "Installing in $d"
+            (cd "$d" && pnpm install --frozen-lockfile)
+          done < ci-guard/pnpm-monorepo-install/roots.txt
+      # <<< END MANAGED BLOCK: ci-guard:pnpm-monorepo-install

--- a/scripts/ci-guard/pnpm-monorepo-install/discover.sh
+++ b/scripts/ci-guard/pnpm-monorepo-install/discover.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+mkdir -p ci-guard/pnpm-monorepo-install
+roots=()
+[ -f package.json ] && roots+=(".")
+[ -f frontend/package.json ] && roots+=("frontend")
+[ -f backend/package.json ] && roots+=("backend")
+[ -f apps/web/package.json ] && roots+=("apps/web")
+[ -f apps/api/package.json ] && roots+=("apps/api")
+if [ ${#roots[@]} -eq 0 ]; then
+  echo "::error::No package.json found in known locations" >&2
+  exit 2
+fi
+printf '%s\n' "${roots[@]}" > ci-guard/pnpm-monorepo-install/roots.txt
+if [ -n "${GITHUB_OUTPUT:-}" ]; then
+  echo "count=${#roots[@]}" >> "$GITHUB_OUTPUT"
+fi
+while read d; do
+  echo "Installing in $d"
+  (cd "$d" && pnpm install --frozen-lockfile)
+done < ci-guard/pnpm-monorepo-install/roots.txt

--- a/tests/ci-guard/pnpm-monorepo-install/discover.test.js
+++ b/tests/ci-guard/pnpm-monorepo-install/discover.test.js
@@ -1,0 +1,42 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+const assert = require('assert');
+
+const repoRoot = path.resolve(__dirname, '../../..');
+const script = path.join(repoRoot, 'scripts/ci-guard/pnpm-monorepo-install/discover.sh');
+
+function makeRepo(structure) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'repo-'));
+  for (const [p, content] of Object.entries(structure)) {
+    const full = path.join(dir, p);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, content);
+  }
+  const binDir = path.join(dir, 'bin');
+  fs.mkdirSync(binDir);
+  const log = path.join(dir, 'pnpm.log');
+  fs.writeFileSync(path.join(binDir, 'pnpm'), `#!/usr/bin/env bash\necho "$PWD" >> "${log}"\n`);
+  fs.chmodSync(path.join(binDir, 'pnpm'), 0o755);
+  return { dir, binDir, log };
+}
+
+function run(structure, expectedDirs, expectedStatus = 0) {
+  const { dir, binDir, log } = makeRepo(structure);
+  const env = { ...process.env, PATH: `${binDir}:${process.env.PATH}` };
+  const res = spawnSync('bash', [script], { cwd: dir, env, encoding: 'utf8' });
+  assert.strictEqual(res.status, expectedStatus, res.stderr);
+  if (expectedStatus === 0) {
+    const called = fs.readFileSync(log, 'utf8').trim().split('\n').map(p => {
+      const rel = path.relative(dir, p);
+      return rel === '' ? '.' : rel;
+    });
+    assert.deepStrictEqual(called.sort(), expectedDirs.sort());
+  }
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+run({ 'package.json': '{}' }, ['.']);
+run({ 'frontend/package.json': '{}', 'backend/package.json': '{}' }, ['frontend', 'backend']);
+run({}, [], 2);


### PR DESCRIPTION
## Summary
- auto-discover package roots before running pnpm install
- test monorepo-aware pnpm install guard logic

## Testing
- `npm run format` *(fails: SyntaxError: All collection items must start at the same column)*
- `npm test`
- `node tests/ci-guard/pnpm-monorepo-install/discover.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a8a7bcbe94832d91de3f249bb17596