### PR TITLE
ci: enforce reusable diagnostics

### DIFF
--- a/.github/actions/collect-diag/action.yml
+++ b/.github/actions/collect-diag/action.yml
@@ -1,0 +1,20 @@
+name: Collect Diagnostics
+description: Gather logs and repo snapshot robustly.
+runs:
+  using: "composite"
+  steps:
+    - shell: bash
+      run: |
+        set -euo pipefail
+        mkdir -p ci/diag
+        if command -v dmesg >/dev/null 2>&1; then dmesg | tail -n 200 > ci/diag/dmesg.txt 2>/dev/null || true; fi
+        if command -v journalctl >/dev/null 2>&1; then journalctl -xe --no-pager | tail -n 400 > ci/diag/journal.txt 2>/dev/null || true; fi
+        git log -n 5 --oneline > ci/diag/gitlog.txt 2>/dev/null || true
+        for d in frontend backend; do [ -d "$d" ] && cp -R "$d" "ci/diag/$d" 2>/dev/null || true; done
+    - uses: actions/upload-artifact@v4.4.0
+      if: always()
+      with:
+        name: diag-${{ github.job }}-${{ github.run_id }}
+        path: |
+          ci/diag
+          !ci/diag/**/node_modules/**

--- a/.github/workflows/diag-audit.yml
+++ b/.github/workflows/diag-audit.yml
@@ -1,0 +1,16 @@
+name: diag usage audit
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.7
+      - uses: actions/setup-node@v4.0.2
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run ci:diag-audit

--- a/.github/workflows/reusable-test-job.yml
+++ b/.github/workflows/reusable-test-job.yml
@@ -71,18 +71,5 @@ jobs:
       - name: Run lane command
         if: ${{ inputs.suite != 'e2e' || !cancelled() }}
         run: ${{ inputs.command }}
-      - name: Bundle lane diagnostics
+      - uses: ./.github/actions/collect-diag
         if: ${{ failure() || cancelled() }}
-        run: |
-          mkdir -p ci/diag
-          dmesg | tail -n 200 > ci/diag/dmesg.txt 2>/dev/null || true
-          journalctl -xe --no-pager | tail -n 400 > ci/diag/journal.txt 2>/dev/null || true
-          git log -n 5 --oneline > ci/diag/gitlog.txt
-          cp -r frontend  ci/diag/frontend 2>/dev/null || true
-          cp -r backend   ci/diag/backend  2>/dev/null || true
-      - uses: actions/upload-artifact@v4
-        if: ${{ failure() || cancelled() }}
-        with:
-          name: lane-diag-${{ github.job }}
-          path: ci/diag
-          retention-days: 7

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,6 +81,7 @@
         "toml": "^3.0.0",
         "tsconfig-strictest": "^1.0.0-beta.1",
         "tslib": "^2.8.1",
+        "tsx": "^4.20.4",
         "typescript": "^5.8.3",
         "vitest": "^2.1.1",
         "wait-on": "^8.0.3",
@@ -14442,7 +14443,6 @@
       "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
       },
@@ -22533,7 +22533,6 @@
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
@@ -25388,6 +25387,26 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.20.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.4.tgz",
+      "integrity": "sha512-yyxBKfORQ7LuRt/BQKBXrpcq59ZvSW0XxwfjAt3w2/8PmdxaFzijtMhTawprSHhpzeM5BgU2hXHG3lklIERZXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/tunnel": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,9 @@
     "test:regression": "npm run test:backend:regression && npm run test:frontend:regression && npm run test:ci:regression && npm run test:e2e:regression",
     "ci:probe": "bash -O globstar -c 'env -u npm_config_prefix node --test tests/ci/**/*.test.js'",
     "ci:summary": "node scripts/ci/print-suite-summary.js",
-    "test:inventory": "vitest run -t test-inventory"
+    "test:inventory": "vitest run -t test-inventory",
+    "ci:diag-audit": "tsx scripts/ci/diag-usage-audit.ts",
+    "test:diag-audit": "vitest run -t diag-audit"
   },
   "babel": {
     "presets": [
@@ -186,6 +188,7 @@
     "toml": "^3.0.0",
     "tsconfig-strictest": "^1.0.0-beta.1",
     "tslib": "^2.8.1",
+    "tsx": "^4.20.4",
     "typescript": "^5.8.3",
     "vitest": "^2.1.1",
     "wait-on": "^8.0.3",

--- a/scripts/ci/diag-usage-audit.ts
+++ b/scripts/ci/diag-usage-audit.ts
@@ -1,0 +1,32 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import fg from 'fast-glob';
+
+const patterns = [/mkdir\s+-p\s+ci\/diag/, /journalctl/, /\bdmesg\b/];
+
+export function scanWorkflows(root = process.cwd()): string[] {
+  const workflowDir = path.join(root, '.github', 'workflows');
+  const files = fg.sync('**/*.{yml,yaml}', { cwd: workflowDir, absolute: true });
+  const offenders: string[] = [];
+
+  for (const file of files) {
+    const lines = fs.readFileSync(file, 'utf8').split(/\r?\n/);
+    lines.forEach((line, idx) => {
+      if (patterns.some((p) => p.test(line))) {
+        offenders.push(`${path.relative(root, file)}:${idx + 1}`);
+      }
+    });
+  }
+  return offenders;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const offenders = scanWorkflows();
+  if (offenders.length) {
+    console.error(
+      'Inline diagnostic collection detected. Use ./.github/actions/collect-diag instead:\n' +
+        offenders.join('\n'),
+    );
+    process.exitCode = 1;
+  }
+}

--- a/tests/ci/__fixtures__/diag-usage-audit/bad.yml
+++ b/tests/ci/__fixtures__/diag-usage-audit/bad.yml
@@ -1,0 +1,4 @@
+jobs:
+  test:
+    steps:
+      - run: mkdir -p ci/diag

--- a/tests/ci/__fixtures__/diag-usage-audit/good.yml
+++ b/tests/ci/__fixtures__/diag-usage-audit/good.yml
@@ -1,0 +1,4 @@
+jobs:
+  test:
+    steps:
+      - uses: ./.github/actions/collect-diag

--- a/tests/ci/diag-usage-audit.test.ts
+++ b/tests/ci/diag-usage-audit.test.ts
@@ -1,0 +1,30 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { describe, expect, test } from 'vitest';
+import { scanWorkflows } from '../../scripts/ci/diag-usage-audit';
+
+const fixtures = path.resolve(__dirname, '__fixtures__', 'diag-usage-audit');
+
+describe('diag-audit', () => {
+  test('flags inline diagnostics', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'diag-'));
+    const wfDir = path.join(tmp, '.github', 'workflows');
+    fs.mkdirSync(wfDir, { recursive: true });
+    const bad = fs.readFileSync(path.join(fixtures, 'bad.yml'), 'utf8');
+    fs.writeFileSync(path.join(wfDir, 'bad.yml'), bad);
+    const offenders = scanWorkflows(tmp);
+    expect(offenders.length).toBe(1);
+    expect(offenders[0]).toMatch(/bad.yml:4/);
+  });
+
+  test('passes when no inline diagnostics', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'diag-'));
+    const wfDir = path.join(tmp, '.github', 'workflows');
+    fs.mkdirSync(wfDir, { recursive: true });
+    const good = fs.readFileSync(path.join(fixtures, 'good.yml'), 'utf8');
+    fs.writeFileSync(path.join(wfDir, 'good.yml'), good);
+    const offenders = scanWorkflows(tmp);
+    expect(offenders).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add collect-diag composite action for consistent diagnostics
- audit workflows for inline diagnostic commands
- test and workflow to enforce using the composite action

## Testing
- `npm run ci:diag-audit`
- `npx vitest run tests/ci/diag-usage-audit.test.ts`
- `npm run format` (backend)
- `npm test` (backend) *(fails: setup ran but suite did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a0433b74832d9dd7ce9b6827055b