### PR TITLE
ci: add ripgrep usage audit

### DIFF
--- a/.github/workflows/aws-gap-report.yml
+++ b/.github/workflows/aws-gap-report.yml
@@ -18,6 +18,7 @@ jobs:
         id: generate
         run: |
           set -euo pipefail
+          command -v rg >/dev/null 2>&1 || rg() { grep "$@"; }
           REPORT=aws-gap-report.md
           echo "### AWS Gap Report" > "$REPORT"
           echo >> "$REPORT"
@@ -25,7 +26,7 @@ jobs:
 
           echo "#### CI Runners" >> "$REPORT"
           oidc=$(rg -l "id-token" .github/workflows || true)
-          self_hosted=$(rg -n "runs-on: *.*self-hosted" -g "*.yml" .github/workflows || true)
+          self_hosted=$(rg -n "runs-on: *.*self-hosted" .github/workflows/*.yml || true)
           ubuntu_latest=$(rg -l "runs-on: ubuntu-latest" .github/workflows || true)
           if [ -n "$oidc" ]; then echo "- [x] OIDC role present" >> "$REPORT"; else echo "- [ ] OIDC role present" >> "$REPORT"; blockers=$((blockers+1)); fi
           if [ -n "$self_hosted" ]; then echo "- self-hosted labels present" >> "$REPORT"; echo "\n\`\`\`\n$self_hosted\n\`\`\`" >> "$REPORT"; else echo "- self-hosted labels missing" >> "$REPORT"; fi

--- a/.github/workflows/tools-usage-audit.yml
+++ b/.github/workflows/tools-usage-audit.yml
@@ -1,0 +1,15 @@
+name: Tools Usage Audit
+
+on: [pull_request, push]
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run ci:tools-audit
+      - run: npm run test:tools-audit

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,6 +81,7 @@
         "toml": "^3.0.0",
         "tsconfig-strictest": "^1.0.0-beta.1",
         "tslib": "^2.8.1",
+        "tsx": "^4.19.0",
         "typescript": "^5.8.3",
         "vitest": "^2.1.1",
         "wait-on": "^8.0.3",
@@ -14442,7 +14443,6 @@
       "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
       },
@@ -22533,7 +22533,6 @@
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
@@ -25388,6 +25387,26 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.20.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.4.tgz",
+      "integrity": "sha512-yyxBKfORQ7LuRt/BQKBXrpcq59ZvSW0XxwfjAt3w2/8PmdxaFzijtMhTawprSHhpzeM5BgU2hXHG3lklIERZXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/tunnel": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -104,6 +104,8 @@
     "test:regression": "npm run test:backend:regression && npm run test:frontend:regression && npm run test:ci:regression && npm run test:e2e:regression",
     "ci:probe": "bash -O globstar -c 'env -u npm_config_prefix node --test tests/ci/**/*.test.js'",
     "ci:summary": "node scripts/ci/print-suite-summary.js",
+    "ci:tools-audit": "tsx scripts/ci/tools-usage-audit.ts",
+    "test:tools-audit": "vitest run -t tools-usage-audit",
     "test:inventory": "vitest run -t test-inventory"
   },
   "babel": {
@@ -187,6 +189,7 @@
     "tsconfig-strictest": "^1.0.0-beta.1",
     "tslib": "^2.8.1",
     "typescript": "^5.8.3",
+    "tsx": "^4.19.0",
     "vitest": "^2.1.1",
     "wait-on": "^8.0.3",
     "yaml": "^2.8.0"

--- a/scripts/ci/tools-usage-audit.ts
+++ b/scripts/ci/tools-usage-audit.ts
@@ -1,0 +1,136 @@
+import fs from "fs";
+import path from "path";
+import yaml from "yaml";
+
+interface Violation {
+  file: string;
+  job: string;
+  step: string;
+  message: string;
+}
+
+const ALLOWED_SHELLS = new Set(["bash", "sh", "pwsh", "powershell", "cmd"]);
+
+const INSTALL_RE =
+  /(apt(?:-get)?|apk|dnf|yum|brew|choco)\s+install\s+[^\n]*ripgrep/;
+const ALIAS_RE = /(rg\s*\(\)\s*\{|alias\s+rg=)/;
+const WRAPPER_L_RE = /l_only\s*\(\)\s*\{/;
+const WRAPPER_N_RE = /n_only\s*\(\)\s*\{/;
+const RG_FLAG_GLOB_RE = /(\s|^)--?g(?:lob)?\b/;
+
+export function audit(
+  dir = path.join(process.cwd(), ".github/workflows"),
+): Violation[] {
+  const files = fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith(".yml") || f.endsWith(".yaml"));
+  const violations: Violation[] = [];
+
+  for (const file of files) {
+    const fullPath = path.join(dir, file);
+    const docs = yaml.parseAllDocuments(fs.readFileSync(fullPath, "utf8"));
+    for (const doc of docs) {
+      if (doc.errors.length) continue;
+      const data = doc.toJS() as any;
+      if (!data || !data.jobs) continue;
+      for (const [jobName, job] of Object.entries<any>(data.jobs)) {
+        const steps = job.steps || [];
+        let installed = false;
+        let hasAlias = false;
+        const wrappers = new Set<string>();
+        for (let i = 0; i < steps.length; i++) {
+          const step = steps[i] as any;
+          const name = step.name || `step_${i}`;
+          const shell = step.shell as string | undefined;
+          const run = step.run as string | undefined;
+
+          if (shell && !ALLOWED_SHELLS.has(shell)) {
+            violations.push({
+              file,
+              job: jobName,
+              step: name,
+              message: `invalid shell ${shell}`,
+            });
+          }
+
+          if (!run) continue;
+          const lines = run.split("\n");
+          for (const rawLine of lines) {
+            const line = rawLine.trim();
+            if (!line) continue;
+
+            if (INSTALL_RE.test(line)) installed = true;
+            if (ALIAS_RE.test(line)) hasAlias = true;
+            if (WRAPPER_L_RE.test(line)) wrappers.add("l_only");
+            if (WRAPPER_N_RE.test(line)) wrappers.add("n_only");
+
+            const GREP_GLOB_RE = /grep\b[^\n]*\s--?g(?:lob)?\b/;
+            if (GREP_GLOB_RE.test(line)) {
+              violations.push({
+                file,
+                job: jobName,
+                step: name,
+                message: "ripgrep-only flag used with grep",
+              });
+            }
+
+            if (/l_only\b/.test(line) && !wrappers.has("l_only")) {
+              violations.push({
+                file,
+                job: jobName,
+                step: name,
+                message: "l_only used without definition",
+              });
+            }
+            if (/n_only\b/.test(line) && !wrappers.has("n_only")) {
+              violations.push({
+                file,
+                job: jobName,
+                step: name,
+                message: "n_only used without definition",
+              });
+            }
+
+            if (
+              /\brg\b/.test(line) &&
+              !/rg\s*\(\)/.test(line) &&
+              !/^alias\s+rg=/.test(line) &&
+              !/(command -v|which) rg/.test(line)
+            ) {
+              if (!installed && !hasAlias) {
+                violations.push({
+                  file,
+                  job: jobName,
+                  step: name,
+                  message: "rg used without install or alias",
+                });
+              }
+              if (hasAlias && RG_FLAG_GLOB_RE.test(line)) {
+                violations.push({
+                  file,
+                  job: jobName,
+                  step: name,
+                  message: "ripgrep-only flags used with grep fallback",
+                });
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return violations;
+}
+
+if (require.main === module) {
+  const violations = audit();
+  const out = { violations };
+  const json = JSON.stringify(out, null, 2);
+  if (violations.length) {
+    console.error(json);
+    process.exit(1);
+  } else {
+    console.log(json);
+  }
+}

--- a/tests/ci/tools-usage-audit.test.ts
+++ b/tests/ci/tools-usage-audit.test.ts
@@ -1,0 +1,135 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { describe, expect, test } from "vitest";
+import { audit } from "../../scripts/ci/tools-usage-audit";
+
+function writeWorkflow(dir: string, content: string, name = "wf.yml"): string {
+  const file = path.join(dir, name);
+  fs.writeFileSync(file, content);
+  return file;
+}
+
+describe("tools usage audit", () => {
+  test("rg used + apt install present → pass", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "wf-"));
+    writeWorkflow(
+      dir,
+      `name: t\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - name: install\n        run: sudo apt-get install ripgrep\n      - name: search\n        run: rg foo\n`,
+    );
+    expect(audit(dir)).toEqual([]);
+  });
+
+  test("rg used + wrapper alias provided → pass", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "wf-"));
+    writeWorkflow(
+      dir,
+      `name: t\njobs:\n  build:\n    steps:\n      - name: search\n        run: |\n          command -v rg >/dev/null || rg() { grep "$@"; }\n          rg foo\n`,
+    );
+    expect(audit(dir)).toEqual([]);
+  });
+
+  test("rg used with neither install nor alias → fail", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "wf-"));
+    writeWorkflow(
+      dir,
+      `name: t\njobs:\n  build:\n    steps:\n      - name: bad\n        run: rg foo\n`,
+    );
+    const res = audit(dir);
+    expect(res).toHaveLength(1);
+    expect(res[0]).toMatchObject({ job: "build", step: "bad" });
+  });
+
+  test("grep fallback with -l/-n only → pass", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "wf-"));
+    writeWorkflow(
+      dir,
+      `name: t\njobs:\n  build:\n    steps:\n      - name: search\n        run: |\n          command -v rg >/dev/null || rg() { grep "$@"; }\n          rg -n foo\n          rg -l foo\n`,
+    );
+    expect(audit(dir)).toEqual([]);
+  });
+
+  test("grep fallback with ripgrep-only -g glob → fail", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "wf-"));
+    writeWorkflow(
+      dir,
+      `name: t\njobs:\n  build:\n    steps:\n      - name: search\n        run: |\n          command -v rg >/dev/null || rg() { grep "$@"; }\n          rg -g '*.ts' foo\n`,
+    );
+    const res = audit(dir);
+    expect(res.some((v) => v.message.includes("ripgrep-only"))).toBe(true);
+  });
+
+  test("valid shell (bash) → pass", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "wf-"));
+    writeWorkflow(
+      dir,
+      `name: t\njobs:\n  build:\n    steps:\n      - name: ok\n        shell: bash\n        run: echo hi\n`,
+    );
+    expect(audit(dir)).toEqual([]);
+  });
+
+  test("invalid shell string with flags → fail", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "wf-"));
+    writeWorkflow(
+      dir,
+      `name: t\njobs:\n  build:\n    steps:\n      - name: bad\n        shell: "/usr/bin/bash -e"\n        run: echo hi\n`,
+    );
+    const res = audit(dir);
+    expect(res).toHaveLength(1);
+    expect(res[0].message).toMatch(/invalid shell/);
+  });
+
+  test("macOS runner with alias → pass", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "wf-"));
+    writeWorkflow(
+      dir,
+      `name: t\njobs:\n  build:\n    runs-on: macos-latest\n    steps:\n      - run: |\n          command -v rg >/dev/null || rg() { grep "$@"; }\n          rg foo\n`,
+    );
+    expect(audit(dir)).toEqual([]);
+  });
+
+  test("multiple rg steps with early install → pass", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "wf-"));
+    writeWorkflow(
+      dir,
+      `name: t\njobs:\n  build:\n    steps:\n      - run: sudo apt-get install ripgrep\n      - run: rg first\n      - run: rg second\n`,
+    );
+    expect(audit(dir)).toEqual([]);
+  });
+
+  test("job without rg unaffected → pass", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "wf-"));
+    writeWorkflow(
+      dir,
+      `name: t\njobs:\n  build:\n    steps:\n      - run: echo hi\n`,
+    );
+    expect(audit(dir)).toEqual([]);
+  });
+
+  test("wrapper functions l_only/n_only present when used → pass", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "wf-"));
+    writeWorkflow(
+      dir,
+      `name: t\njobs:\n  build:\n    steps:\n      - run: |\n          command -v rg >/dev/null || { l_only(){ grep -l "$@"; }; n_only(){ grep -n "$@"; }; }\n          l_only foo\n          n_only foo\n`,
+    );
+    expect(audit(dir)).toEqual([]);
+  });
+
+  test("summarize violations across multiple workflows", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "wf-"));
+    writeWorkflow(
+      dir,
+      `name: t\njobs:\n  a:\n    steps:\n      - run: rg foo\n`,
+      "a.yml",
+    );
+    writeWorkflow(
+      dir,
+      `name: t\njobs:\n  b:\n    steps:\n      - shell: "/bin/bash -e"\n        run: echo hi\n`,
+      "b.yml",
+    );
+    const res = audit(dir);
+    expect(res).toHaveLength(2);
+    const files = res.map((r) => r.file).sort();
+    expect(files).toEqual(["a.yml", "b.yml"]);
+  });
+});


### PR DESCRIPTION
## Summary
- add tools-usage auditor for ripgrep with shell and grep flag checks
- cover auditor with dedicated vitest suite
- guard AWS gap report against missing rg

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci:tools-audit`
- `npx vitest run tests/ci/tools-usage-audit.test.ts`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: SyntaxError in existing workflows)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: SyntaxError in existing workflows)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a1f2f814832dab595d40edb3bc91