### PR TITLE
ci: add pnpm monorepo install guard

### DIFF
--- a/.github/workflows/guard-pnpm-monorepo-install.yml
+++ b/.github/workflows/guard-pnpm-monorepo-install.yml
@@ -1,0 +1,18 @@
+name: Guard pnpm monorepo install
+on: [pull_request, push]
+
+jobs:
+  pnpm-monorepo-install:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.7
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version: 20
+      - run: corepack enable
+      - uses: pnpm/action-setup@v4.1.0
+        with:
+          version: 10.11.0
+      - run: pnpm install --frozen-lockfile
+      - run: node scripts/ci-guard/pnpm-monorepo-install/audit.ts
+      - run: node scripts/run-jest.js tests/ci-guard/pnpm-monorepo-install/audit.test.ts

--- a/scripts/ci-guard/pnpm-monorepo-install/audit.ts
+++ b/scripts/ci-guard/pnpm-monorepo-install/audit.ts
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+// @ts-check
+const fs = require("fs");
+const path = require("path");
+const yaml = require("yaml");
+
+const repoRoot = process.cwd();
+const workflowsDir = path.join(repoRoot, ".github", "workflows");
+const stateDir = path.join(repoRoot, "ci-guard", "pnpm-monorepo-install");
+const rootsFile = path.join(stateDir, "roots.txt");
+const summaryFile = path.join(stateDir, "summary.json");
+
+function normalize(p) {
+  return (
+    p
+      .replace(/\\/g, "/")
+      .replace(/\/+$|^\.\//g, "")
+      .trim() || "."
+  );
+}
+
+function discoverRoots() {
+  /** @type {string[]} */
+  const roots = [];
+  const ignore = new Set(["node_modules", ".git"]);
+  if (fs.existsSync(path.join(repoRoot, "package.json"))) roots.push(".");
+  /** @param {string} dir */
+  function walk(dir) {
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (ignore.has(entry.name)) continue;
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (fs.existsSync(path.join(full, "package.json"))) {
+          roots.push(path.relative(repoRoot, full) || ".");
+        }
+        walk(full);
+      }
+    }
+  }
+  walk(repoRoot);
+  fs.mkdirSync(stateDir, { recursive: true });
+  fs.writeFileSync(rootsFile, roots.join("\n"));
+  return roots;
+}
+
+function readRoots() {
+  if (fs.existsSync(rootsFile)) {
+    return fs.readFileSync(rootsFile, "utf8").split(/\r?\n/).filter(Boolean);
+  }
+  return discoverRoots();
+}
+
+/**
+ * @param {any} job
+ * @param {string} jobName
+ * @param {string} wfName
+ * @param {string[]} roots
+ * @param {any[]} violations
+ */
+function auditJob(job, jobName, wfName, roots, violations) {
+  const wfDefault = job.workflowDefault || ".";
+  const jobDefault =
+    job.defaults && job.defaults.run && job.defaults.run["working-directory"];
+  let hasNode = false;
+  let hasCorepack = false;
+  let hasPnpmSetup = false;
+  let jobHasPnpm = false;
+  let jobHasNpm = false;
+  const steps = job.steps || [];
+  for (const step of steps) {
+    if (step.uses) {
+      const uses = String(step.uses);
+      if (/actions\/setup-node@/.test(uses)) {
+        const v = step.with && step.with["node-version"];
+        if (v && String(v).startsWith("20")) hasNode = true;
+      }
+      if (/pnpm\/action-setup@/.test(uses)) hasPnpmSetup = true;
+    }
+    if (step.run && /corepack enable/.test(step.run)) hasCorepack = true;
+    if (step.run && /\bnpm\s+(?:ci|install)/.test(step.run)) jobHasNpm = true;
+    if (!step.run || !/\bpnpm install/.test(step.run)) continue;
+    jobHasPnpm = true;
+    const dir = normalize(
+      step["working-directory"] || jobDefault || wfDefault || ".",
+    );
+    const cmd = step.run;
+    if (!/--frozen-lockfile/.test(cmd)) {
+      violations.push({
+        file: wfName,
+        job: jobName,
+        step: step.name || "pnpm install",
+        message: "missing --frozen-lockfile",
+      });
+    }
+    if (!hasNode || !hasCorepack || !hasPnpmSetup) {
+      const missing = [];
+      if (!hasNode) missing.push("setup-node");
+      if (!hasCorepack) missing.push("corepack");
+      if (!hasPnpmSetup) missing.push("pnpm/action-setup");
+      violations.push({
+        file: wfName,
+        job: jobName,
+        step: step.name || "pnpm install",
+        message: `missing bootstrap: ${missing.join(", ")}`,
+      });
+    }
+    if (
+      !dir.includes("${{") &&
+      !roots.includes(dir) &&
+      !(dir === "." && roots.includes("."))
+    ) {
+      violations.push({
+        file: wfName,
+        job: jobName,
+        step: step.name || "pnpm install",
+        message: `install in non-package dir: ${dir}`,
+      });
+    }
+  }
+  if (jobHasNpm && jobHasPnpm) {
+    violations.push({
+      file: wfName,
+      job: jobName,
+      step: "mixed",
+      message: "mixed npm and pnpm installs",
+    });
+  }
+}
+
+function audit() {
+  const roots = readRoots();
+  const violations = [];
+  const files = fs.existsSync(workflowsDir)
+    ? fs.readdirSync(workflowsDir).filter((f) => /\.ya?ml$/.test(f))
+    : [];
+  for (const file of files) {
+    const wfPath = path.join(workflowsDir, file);
+    let wf;
+    try {
+      wf = yaml.parse(fs.readFileSync(wfPath, "utf8"));
+    } catch {
+      continue;
+    }
+    const wfName = wf.name || file;
+    const wfDefault =
+      wf.defaults && wf.defaults.run && wf.defaults.run["working-directory"];
+    const jobs = wf.jobs || {};
+    for (const [jobName, job] of Object.entries(jobs)) {
+      auditJob(
+        { ...job, workflowDefault: wfDefault },
+        jobName,
+        file,
+        roots,
+        violations,
+      );
+    }
+  }
+  fs.mkdirSync(stateDir, { recursive: true });
+  fs.writeFileSync(summaryFile, JSON.stringify({ violations }, null, 2));
+  if (violations.length) {
+    console.error("pnpm monorepo install audit failed");
+    process.exit(1);
+  }
+}
+
+const mode = process.argv[2];
+if (mode === "--discover") {
+  discoverRoots();
+} else {
+  audit();
+}

--- a/tests/ci-guard/pnpm-monorepo-install/audit.test.ts
+++ b/tests/ci-guard/pnpm-monorepo-install/audit.test.ts
@@ -1,0 +1,207 @@
+import { mkdtempSync, writeFileSync, mkdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
+
+const SCRIPT = join(
+  __dirname,
+  "..",
+  "..",
+  "..",
+  "scripts",
+  "ci-guard",
+  "pnpm-monorepo-install",
+  "audit.ts",
+);
+
+function fixture(setup: (dir: string) => void) {
+  const dir = mkdtempSync(join(tmpdir(), "pnpm-guard-"));
+  setup(dir);
+  return dir;
+}
+
+function run(dir: string, args: string[] = []) {
+  return spawnSync("node", [SCRIPT, ...args], { cwd: dir, encoding: "utf8" });
+}
+
+describe("pnpm monorepo install audit", () => {
+  test("t1 root package.json present, install at root -> pass", () => {
+    const dir = fixture((d) => {
+      writeFileSync(join(d, "package.json"), "{}");
+      mkdirSync(join(d, ".github", "workflows"), { recursive: true });
+      writeFileSync(
+        join(d, ".github", "workflows", "wf.yml"),
+        `jobs:\n  build:\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n      - run: corepack enable\n      - uses: pnpm/action-setup@v4\n      - run: pnpm install --frozen-lockfile\n`,
+      );
+    });
+    const r = run(dir);
+    expect(r.status).toBe(0);
+  });
+
+  test("t2 no root package.json, install at root -> fail", () => {
+    const dir = fixture((d) => {
+      mkdirSync(join(d, ".github", "workflows"), { recursive: true });
+      writeFileSync(
+        join(d, ".github", "workflows", "wf.yml"),
+        `jobs:\n  build:\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n      - run: corepack enable\n      - uses: pnpm/action-setup@v4\n      - run: pnpm install --frozen-lockfile\n`,
+      );
+    });
+    const r = run(dir);
+    expect(r.status).toBe(1);
+  });
+
+  test("t3 frontend+backend present, installs in both -> pass", () => {
+    const dir = fixture((d) => {
+      mkdirSync(join(d, "frontend"), { recursive: true });
+      writeFileSync(join(d, "frontend", "package.json"), "{}");
+      mkdirSync(join(d, "backend"), { recursive: true });
+      writeFileSync(join(d, "backend", "package.json"), "{}");
+      mkdirSync(join(d, ".github", "workflows"), { recursive: true });
+      writeFileSync(
+        join(d, ".github", "workflows", "wf.yml"),
+        `jobs:\n  build:\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n      - run: corepack enable\n      - uses: pnpm/action-setup@v4\n      - run: pnpm install --frozen-lockfile\n        working-directory: frontend\n      - run: pnpm install --frozen-lockfile\n        working-directory: backend\n`,
+      );
+    });
+    const r = run(dir);
+    expect(r.status).toBe(0);
+  });
+
+  test("t4 only frontend present, install only in frontend -> pass", () => {
+    const dir = fixture((d) => {
+      mkdirSync(join(d, "frontend"), { recursive: true });
+      writeFileSync(join(d, "frontend", "package.json"), "{}");
+      mkdirSync(join(d, ".github", "workflows"), { recursive: true });
+      writeFileSync(
+        join(d, ".github", "workflows", "wf.yml"),
+        `jobs:\n  build:\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n      - run: corepack enable\n      - uses: pnpm/action-setup@v4\n      - run: pnpm install --frozen-lockfile\n        working-directory: frontend\n`,
+      );
+    });
+    const r = run(dir);
+    expect(r.status).toBe(0);
+  });
+
+  test("t5 missing bootstrap -> fail", () => {
+    const dir = fixture((d) => {
+      writeFileSync(join(d, "package.json"), "{}");
+      mkdirSync(join(d, ".github", "workflows"), { recursive: true });
+      writeFileSync(
+        join(d, ".github", "workflows", "wf.yml"),
+        `jobs:\n  build:\n    steps:\n      - run: pnpm install --frozen-lockfile\n`,
+      );
+    });
+    const r = run(dir);
+    expect(r.status).toBe(1);
+  });
+
+  test("t6 missing --frozen-lockfile -> fail", () => {
+    const dir = fixture((d) => {
+      writeFileSync(join(d, "package.json"), "{}");
+      mkdirSync(join(d, ".github", "workflows"), { recursive: true });
+      writeFileSync(
+        join(d, ".github", "workflows", "wf.yml"),
+        `jobs:\n  build:\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n      - run: corepack enable\n      - uses: pnpm/action-setup@v4\n      - run: pnpm install\n`,
+      );
+    });
+    const r = run(dir);
+    expect(r.status).toBe(1);
+  });
+
+  test("t7 mixed npm & pnpm installs in same job -> fail", () => {
+    const dir = fixture((d) => {
+      writeFileSync(join(d, "package.json"), "{}");
+      mkdirSync(join(d, ".github", "workflows"), { recursive: true });
+      writeFileSync(
+        join(d, ".github", "workflows", "wf.yml"),
+        `jobs:\n  build:\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n      - run: corepack enable\n      - uses: pnpm/action-setup@v4\n      - run: pnpm install --frozen-lockfile\n      - run: npm install\n`,
+      );
+    });
+    const r = run(dir);
+    expect(r.status).toBe(1);
+  });
+
+  test("t8 matrix job with some entries only frontend -> pass", () => {
+    const dir = fixture((d) => {
+      mkdirSync(join(d, "frontend"), { recursive: true });
+      writeFileSync(join(d, "frontend", "package.json"), "{}");
+      mkdirSync(join(d, "backend"), { recursive: true });
+      writeFileSync(join(d, "backend", "package.json"), "{}");
+      mkdirSync(join(d, ".github", "workflows"), { recursive: true });
+      writeFileSync(
+        join(d, ".github", "workflows", "wf.yml"),
+        `jobs:\n  build:\n    strategy:\n      matrix:\n        dir: [frontend, backend]\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n      - run: corepack enable\n      - uses: pnpm/action-setup@v4\n      - run: pnpm install --frozen-lockfile\n        working-directory: \${{ matrix.dir }}\n`,
+      );
+    });
+    const r = run(dir);
+    expect(r.status).toBe(0);
+  });
+
+  test("t9 discovery writes roots.txt; runner reads it -> pass", () => {
+    const dir = fixture((d) => {
+      mkdirSync(join(d, "frontend"), { recursive: true });
+      writeFileSync(join(d, "frontend", "package.json"), "{}");
+      mkdirSync(join(d, ".github", "workflows"), { recursive: true });
+      writeFileSync(
+        join(d, ".github", "workflows", "wf.yml"),
+        `jobs:\n  build:\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n      - run: corepack enable\n      - uses: pnpm/action-setup@v4\n      - run: pnpm install --frozen-lockfile\n        working-directory: frontend\n`,
+      );
+    });
+    const discover = run(dir, ["--discover"]);
+    expect(discover.status).toBe(0);
+    const roots = readFileSync(
+      join(dir, "ci-guard", "pnpm-monorepo-install", "roots.txt"),
+      "utf8",
+    );
+    expect(roots.trim()).toBe("frontend");
+    const audit = run(dir);
+    expect(audit.status).toBe(0);
+  });
+
+  test("t10 exotic path apps/web recognized -> pass", () => {
+    const dir = fixture((d) => {
+      mkdirSync(join(d, "apps", "web"), { recursive: true });
+      writeFileSync(join(d, "apps", "web", "package.json"), "{}");
+      mkdirSync(join(d, ".github", "workflows"), { recursive: true });
+      writeFileSync(
+        join(d, ".github", "workflows", "wf.yml"),
+        `jobs:\n  build:\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n      - run: corepack enable\n      - uses: pnpm/action-setup@v4\n      - run: pnpm install --frozen-lockfile\n        working-directory: apps/web\n`,
+      );
+    });
+    const r = run(dir);
+    expect(r.status).toBe(0);
+  });
+
+  test("t11 windows paths normalized -> pass", () => {
+    const dir = fixture((d) => {
+      mkdirSync(join(d, "frontend"), { recursive: true });
+      writeFileSync(join(d, "frontend", "package.json"), "{}");
+      mkdirSync(join(d, ".github", "workflows"), { recursive: true });
+      writeFileSync(
+        join(d, ".github", "workflows", "wf.yml"),
+        `jobs:\n  build:\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n      - run: corepack enable\n      - uses: pnpm/action-setup@v4\n      - run: pnpm install --frozen-lockfile\n        working-directory: frontend\\\\\n`,
+      );
+    });
+    const r = run(dir);
+    expect(r.status).toBe(0);
+  });
+
+  test("t12 summary aggregates offending steps", () => {
+    const dir = fixture((d) => {
+      mkdirSync(join(d, ".github", "workflows"), { recursive: true });
+      writeFileSync(
+        join(d, ".github", "workflows", "wf.yml"),
+        `jobs:\n  bad1:\n    steps:\n      - run: pnpm install\n  bad2:\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n      - run: corepack enable\n      - uses: pnpm/action-setup@v4\n      - run: pnpm install --frozen-lockfile\n      - run: npm install\n`,
+      );
+    });
+    const r = run(dir);
+    expect(r.status).toBe(1);
+    const summary = JSON.parse(
+      readFileSync(
+        join(dir, "ci-guard", "pnpm-monorepo-install", "summary.json"),
+        "utf8",
+      ),
+    );
+    expect(summary.violations.length).toBeGreaterThanOrEqual(2);
+    expect(summary.violations.some((v: any) => v.job === "bad1")).toBe(true);
+    expect(summary.violations.some((v: any) => v.job === "bad2")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- audit GitHub workflows for safe pnpm installs in monorepos
- test guard against various install scenarios
- wire audit and tests into CI workflow

## Testing
- `npm run format` (backend)
- `npm test` (backend) *(fails: process terminated)*
- `node scripts/run-jest.js tests/ci-guard/pnpm-monorepo-install/audit.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a8a7c18d08832d899388b92e00025d