### PR TITLE
ci: add skip detection audit

### DIFF
--- a/.github/workflows/skip-audit.yml
+++ b/.github/workflows/skip-audit.yml
@@ -1,0 +1,20 @@
+name: Skip Detection Audit
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run ci:skip-audit
+        env:
+          GITHUB_RUN_ID: ${{ github.event.workflow_run.id }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/config/allowed-skips.json
+++ b/config/allowed-skips.json
@@ -1,0 +1,3 @@
+{
+  "allowed": ["deploy-production", "manual-approval"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,6 +81,7 @@
         "toml": "^3.0.0",
         "tsconfig-strictest": "^1.0.0-beta.1",
         "tslib": "^2.8.1",
+        "tsx": "^4.19.0",
         "typescript": "^5.8.3",
         "vitest": "^2.1.1",
         "wait-on": "^8.0.3",
@@ -14442,7 +14443,6 @@
       "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
       },
@@ -22533,7 +22533,6 @@
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
@@ -25388,6 +25387,26 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.20.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.4.tgz",
+      "integrity": "sha512-yyxBKfORQ7LuRt/BQKBXrpcq59ZvSW0XxwfjAt3w2/8PmdxaFzijtMhTawprSHhpzeM5BgU2hXHG3lklIERZXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/tunnel": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,9 @@
     "test:regression": "npm run test:backend:regression && npm run test:frontend:regression && npm run test:ci:regression && npm run test:e2e:regression",
     "ci:probe": "bash -O globstar -c 'env -u npm_config_prefix node --test tests/ci/**/*.test.js'",
     "ci:summary": "node scripts/ci/print-suite-summary.js",
-    "test:inventory": "vitest run -t test-inventory"
+    "test:inventory": "vitest run -t test-inventory",
+    "ci:skip-audit": "tsx scripts/ci/skip-detection-audit.ts",
+    "test:skip-audit": "vitest run -t skip-detection-audit"
   },
   "babel": {
     "presets": [
@@ -189,7 +191,8 @@
     "typescript": "^5.8.3",
     "vitest": "^2.1.1",
     "wait-on": "^8.0.3",
-    "yaml": "^2.8.0"
+    "yaml": "^2.8.0",
+    "tsx": "^4.19.0"
   },
   "husky": {
     "hooks": {

--- a/scripts/ci/skip-detection-audit.ts
+++ b/scripts/ci/skip-detection-audit.ts
@@ -1,0 +1,69 @@
+import fs from "node:fs/promises";
+
+export interface Job {
+  name: string;
+  conclusion: string | null;
+  [key: string]: unknown;
+}
+
+export function auditSkips(jobs: Job[], allowed: string[]): string[] {
+  const allowedSet = new Set(allowed);
+  return jobs
+    .filter((j) => j.conclusion === "skipped")
+    .map((j) => j.name)
+    .filter((name) => !allowedSet.has(name));
+}
+
+async function loadAllowed(
+  file = "config/allowed-skips.json",
+): Promise<string[]> {
+  try {
+    const txt = await fs.readFile(file, "utf8");
+    const data = JSON.parse(txt);
+    return Array.isArray(data.allowed) ? data.allowed : [];
+  } catch {
+    return [];
+  }
+}
+
+async function fetchJobs(
+  runId: string,
+  repo: string,
+  token?: string,
+): Promise<Job[]> {
+  const url = `https://api.github.com/repos/${repo}/actions/runs/${runId}/jobs?per_page=100`;
+  const res = await fetch(url, {
+    headers: token ? { authorization: `Bearer ${token}` } : undefined,
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to fetch jobs: ${res.status} ${res.statusText}`);
+  }
+  const data = await res.json();
+  return Array.isArray(data.jobs) ? data.jobs : [];
+}
+
+async function main(): Promise<void> {
+  const runId = process.env.GITHUB_RUN_ID;
+  const repo = process.env.GITHUB_REPOSITORY;
+  if (!runId || !repo) {
+    console.error("Missing GITHUB_RUN_ID or GITHUB_REPOSITORY");
+    process.exit(1);
+  }
+  const allowed = await loadAllowed();
+  const jobs = await fetchJobs(runId, repo, process.env.GITHUB_TOKEN);
+  const unexpected = auditSkips(jobs, allowed);
+  if (unexpected.length) {
+    console.error(
+      "Unexpected skipped jobs detected:\n" + unexpected.join("\n"),
+    );
+    process.exit(1);
+  }
+  console.log("No unexpected skipped jobs");
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/tests/ci/skip-detection-audit.test.ts
+++ b/tests/ci/skip-detection-audit.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { auditSkips, Job } from "../../scripts/ci/skip-detection-audit";
+
+describe("skip-detection-audit", () => {
+  it("Job runs successfully → pass", () => {
+    const jobs: Job[] = [{ name: "build", conclusion: "success" }];
+    expect(auditSkips(jobs, [])).toEqual([]);
+  });
+
+  it("Job fails → pass (not considered skip)", () => {
+    const jobs: Job[] = [{ name: "build", conclusion: "failure" }];
+    expect(auditSkips(jobs, [])).toEqual([]);
+  });
+
+  it("Job skipped but appears in allowed list → pass", () => {
+    const jobs: Job[] = [{ name: "deploy-production", conclusion: "skipped" }];
+    expect(auditSkips(jobs, ["deploy-production"])).toEqual([]);
+  });
+
+  it("Job skipped not in allowed list → fail", () => {
+    const jobs: Job[] = [{ name: "lint", conclusion: "skipped" }];
+    expect(auditSkips(jobs, [])).toEqual(["lint"]);
+  });
+
+  it("Multiple jobs run/skipped → correct ones flagged", () => {
+    const jobs: Job[] = [
+      { name: "build", conclusion: "success" },
+      { name: "lint", conclusion: "skipped" },
+      { name: "deploy-production", conclusion: "skipped" },
+    ];
+    expect(auditSkips(jobs, ["deploy-production"])).toEqual(["lint"]);
+  });
+
+  it("Conditional job (if: false) → fail unless allowed", () => {
+    const jobs: Job[] = [{ name: "conditional", conclusion: "skipped" }];
+    expect(auditSkips(jobs, [])).toEqual(["conditional"]);
+  });
+
+  it("Aggregate job with if: always() runs even if upstream failed → pass", () => {
+    const jobs: Job[] = [
+      { name: "tests", conclusion: "failure" },
+      { name: "aggregate", conclusion: "success" },
+    ];
+    expect(auditSkips(jobs, [])).toEqual([]);
+  });
+
+  it("Manual-only workflow not triggered → not flagged", () => {
+    const jobs: Job[] = [];
+    expect(auditSkips(jobs, [])).toEqual([]);
+  });
+
+  it("Skip due to missing dependency (needs:) → flagged fail", () => {
+    const jobs: Job[] = [{ name: "needs-job", conclusion: "skipped" }];
+    expect(auditSkips(jobs, [])).toEqual(["needs-job"]);
+  });
+
+  it("Skip due to event type mismatch (branch condition) → flagged fail", () => {
+    const jobs: Job[] = [{ name: "branch-job", conclusion: "skipped" }];
+    expect(auditSkips(jobs, [])).toEqual(["branch-job"]);
+  });
+
+  it("Skip + reason annotated in job summary → pass", () => {
+    const jobs: Job[] = [
+      {
+        name: "manual-approval",
+        conclusion: "skipped",
+        steps: [{ name: "reason", conclusion: "skipped" }],
+      },
+    ];
+    expect(auditSkips(jobs, ["manual-approval"])).toEqual([]);
+  });
+
+  it("End-to-end: matrix build with one skip, one fail, one pass → audit reports correctly", () => {
+    const jobs: Job[] = [
+      { name: "build (node=18)", conclusion: "success" },
+      { name: "build (node=20)", conclusion: "skipped" },
+      { name: "build (node=22)", conclusion: "failure" },
+    ];
+    expect(auditSkips(jobs, [])).toEqual(["build (node=20)"]);
+  });
+});


### PR DESCRIPTION
## Summary
- add script to audit GitHub Actions jobs and flag unexpected skips
- whitelist permitted skipped jobs via config file
- add CI workflow and tests for skip detection

## Testing
- `npm run format` *(fails: SyntaxError in repo YAML)*
- `npm test --prefix backend`
- `npx vitest run tests/ci/skip-detection-audit.test.ts`
- `npm run test:skip-audit` *(fails: Missing optional GLB env vars)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a2989778832dbcb99e355a3ce32c