### PR TITLE
ci: add skip detection audit

### DIFF
--- a/.github/workflows/skip-audit.yml
+++ b/.github/workflows/skip-audit.yml
@@ -1,0 +1,19 @@
+name: skip-detection-audit
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run ci:skip-audit
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/config/allowed-skips.json
+++ b/config/allowed-skips.json
@@ -1,0 +1,3 @@
+{
+  "allowed": ["deploy-production", "manual-approval"]
+}

--- a/package.json
+++ b/package.json
@@ -106,11 +106,13 @@
     "test:regression": "npm run test:backend:regression && npm run test:frontend:regression && npm run test:ci:regression && npm run test:e2e:regression",
     "ci:probe": "bash -O globstar -c 'env -u npm_config_prefix node --test tests/ci/**/*.test.js'",
     "ci:summary": "node scripts/ci/print-suite-summary.js",
-    "test:lfs": "vitest run -t lfs"
+    "test:lfs": "vitest run -t lfs",
     "ci-gate:audit": "npx -y tsx scripts/ci-gate/audit.ts",
-    "test:ci-gate": "npx -y vitest run tests/ci-gate"
+    "test:ci-gate": "npx -y vitest run tests/ci-gate",
     "test:inventory": "vitest run -t test-inventory",
-    "test:ci-inventory": "vitest run tests/ci-inventory/ci-inventory.test.ts -t ci-inventory"
+    "test:ci-inventory": "vitest run tests/ci-inventory/ci-inventory.test.ts -t ci-inventory",
+    "ci:skip-audit": "tsx scripts/ci/skip-detection-audit.ts",
+    "test:skip-audit": "vitest run --config tests/ci/vitest.skip-detection.config.ts -t skip-detection-audit"
   },
   "babel": {
     "presets": [

--- a/scripts/ci/skip-detection-audit.ts
+++ b/scripts/ci/skip-detection-audit.ts
@@ -1,0 +1,64 @@
+import fs from "fs";
+import path from "path";
+import axios from "axios";
+
+interface Job {
+  name: string;
+  conclusion: string | null;
+}
+
+export function getUnexpectedSkippedJobs(
+  jobs: Job[],
+  allowed: string[],
+): string[] {
+  const skipped = jobs
+    .filter((j) => j.conclusion === "skipped")
+    .map((j) => j.name);
+  return skipped.filter((name) => !allowed.includes(name));
+}
+
+export async function fetchJobs(
+  runId: string,
+  repo: string,
+  token?: string,
+): Promise<Job[]> {
+  const url = `https://api.github.com/repos/${repo}/actions/runs/${runId}/jobs?per_page=100`;
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "User-Agent": "skip-detection-audit",
+  };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  const resp = await axios.get(url, { headers });
+  return resp.data?.jobs || [];
+}
+
+async function main() {
+  const runId = process.env.GITHUB_RUN_ID;
+  const repo = process.env.GITHUB_REPOSITORY;
+  if (!runId || !repo) {
+    console.error("GITHUB_RUN_ID and GITHUB_REPOSITORY must be set");
+    process.exit(1);
+  }
+  const token = process.env.GITHUB_TOKEN;
+  const jobs = await fetchJobs(runId, repo, token);
+  const configPath = path.resolve(__dirname, "../../config/allowed-skips.json");
+  const allowedCfg = JSON.parse(fs.readFileSync(configPath, "utf8")) as {
+    allowed?: string[];
+  };
+  const allowed = allowedCfg.allowed || [];
+  const unexpected = getUnexpectedSkippedJobs(jobs, allowed);
+  if (unexpected.length > 0) {
+    console.error(`Unexpected skipped jobs detected: ${unexpected.join(", ")}`);
+    process.exit(1);
+  }
+  console.log("No unexpected skipped jobs.");
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}
+
+export { main };

--- a/tests/ci/skip-detection-audit.test.ts
+++ b/tests/ci/skip-detection-audit.test.ts
@@ -1,0 +1,77 @@
+import { describe, test, expect } from "vitest";
+import { getUnexpectedSkippedJobs } from "../../scripts/ci/skip-detection-audit";
+
+describe("skip-detection-audit", () => {
+  test("Job runs successfully → pass", () => {
+    const jobs = [{ name: "build", conclusion: "success" }];
+    expect(getUnexpectedSkippedJobs(jobs, [])).toEqual([]);
+  });
+
+  test("Job fails → pass (not considered skip)", () => {
+    const jobs = [{ name: "test", conclusion: "failure" }];
+    expect(getUnexpectedSkippedJobs(jobs, [])).toEqual([]);
+  });
+
+  test("Job skipped but appears in allowed list → pass", () => {
+    const jobs = [{ name: "deploy-production", conclusion: "skipped" }];
+    expect(getUnexpectedSkippedJobs(jobs, ["deploy-production"])).toEqual([]);
+  });
+
+  test("Job skipped not in allowed list → fail", () => {
+    const jobs = [{ name: "lint", conclusion: "skipped" }];
+    expect(getUnexpectedSkippedJobs(jobs, [])).toEqual(["lint"]);
+  });
+
+  test("Multiple jobs run/skipped → correct ones flagged", () => {
+    const jobs = [
+      { name: "build", conclusion: "success" },
+      { name: "deploy-production", conclusion: "skipped" },
+      { name: "lint", conclusion: "skipped" },
+    ];
+    expect(getUnexpectedSkippedJobs(jobs, ["deploy-production"])).toEqual([
+      "lint",
+    ]);
+  });
+
+  test("Conditional job (if: false) → fail unless allowed", () => {
+    const jobs = [{ name: "conditional", conclusion: "skipped" }];
+    expect(getUnexpectedSkippedJobs(jobs, [])).toEqual(["conditional"]);
+  });
+
+  test("Aggregate job with if: always() runs even if upstream failed → pass", () => {
+    const jobs = [
+      { name: "unit", conclusion: "failure" },
+      { name: "aggregate", conclusion: "success" },
+    ];
+    expect(getUnexpectedSkippedJobs(jobs, [])).toEqual([]);
+  });
+
+  test("Manual-only workflow not triggered → not flagged", () => {
+    const jobs: any[] = [];
+    expect(getUnexpectedSkippedJobs(jobs, [])).toEqual([]);
+  });
+
+  test("Skip due to missing dependency (needs:) → flagged fail", () => {
+    const jobs = [{ name: "e2e", conclusion: "skipped" }];
+    expect(getUnexpectedSkippedJobs(jobs, [])).toEqual(["e2e"]);
+  });
+
+  test("Skip due to event type mismatch (branch condition) → flagged fail", () => {
+    const jobs = [{ name: "branch-check", conclusion: "skipped" }];
+    expect(getUnexpectedSkippedJobs(jobs, [])).toEqual(["branch-check"]);
+  });
+
+  test("Skip + reason annotated in job summary → pass", () => {
+    const jobs = [{ name: "docs", conclusion: "success" }];
+    expect(getUnexpectedSkippedJobs(jobs, [])).toEqual([]);
+  });
+
+  test("End-to-end: simulate a matrix build with one skip, one fail, one pass → audit reports correctly", () => {
+    const jobs = [
+      { name: "test (node 18)", conclusion: "skipped" },
+      { name: "test (node 20)", conclusion: "failure" },
+      { name: "test (node 22)", conclusion: "success" },
+    ];
+    expect(getUnexpectedSkippedJobs(jobs, [])).toEqual(["test (node 18)"]);
+  });
+});

--- a/tests/ci/vitest.skip-detection.config.ts
+++ b/tests/ci/vitest.skip-detection.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/ci/skip-detection-audit.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary
- add script to audit skipped jobs in CI and enforce allowed list
- track allowed skipped job names
- exercise skip detection logic with comprehensive vitest coverage
- run skip audit after CI via workflow

## Testing
- `npm run test:skip-audit`


------
https://chatgpt.com/codex/tasks/task_e_68a8b30f4ff4832d99b6a6e4bf2335f8