### PR TITLE
ci(windows-cancel-guard): prevent unintended cancellation and ensure parity bootstrap

### DIFF
--- a/.github/workflows/guard-windows-cancel-guard.yml
+++ b/.github/workflows/guard-windows-cancel-guard.yml
@@ -1,0 +1,14 @@
+name: guard windows cancel guard
+on: [pull_request, push]
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: corepack enable
+      - run: npm ci
+      - run: npx ts-node --transpile-only scripts/ci-guard/windows-cancel-guard/audit.ts
+      - run: node scripts/run-jest.js tests/ci-guard/windows-cancel-guard/audit.test.ts

--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -7,11 +7,30 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v4
+# >>> BEGIN MANAGED BLOCK: ci-guard:windows-cancel-guard
+      - name: Setup Node (Windows)
+        if: startsWith(runner.os, 'Windows')
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+      - name: Enable Corepack (Windows)
+        if: startsWith(runner.os, 'Windows')
+        shell: pwsh
+        run: corepack enable
+      - name: Ensure pnpm (Windows fallback)
+        if: startsWith(runner.os, 'Windows')
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+# <<< END MANAGED BLOCK: ci-guard:windows-cancel-guard
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -36,3 +55,13 @@ jobs:
           run: >-
             pnpm test -- --json --outputFile=test-results.json
           results-file: test-results.json
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-${{ runner.os }}
+          path: test-results.json
+      - name: Cancellation probe
+        if: always()
+        shell: bash
+        run: echo "job.status=${{ job.status }} conclusion=${{ job.conclusion }}"

--- a/scripts/ci-guard/windows-cancel-guard/audit.ts
+++ b/scripts/ci-guard/windows-cancel-guard/audit.ts
@@ -1,0 +1,74 @@
+import fs from "fs";
+import path from "path";
+import yaml from "yaml";
+
+interface Step {
+  name?: string;
+  if?: string;
+  uses?: string;
+  [key: string]: any;
+}
+
+interface Job {
+  [key: string]: any;
+  steps?: Step[];
+}
+
+function hasWindows(value: any): boolean {
+  if (typeof value === "string") return /windows/i.test(value);
+  if (Array.isArray(value)) return value.some(hasWindows);
+  return false;
+}
+
+const errors: string[] = [];
+const repoRoot = process.cwd();
+const workflowsDir = path.join(repoRoot, ".github", "workflows");
+const wfFiles = fs.existsSync(workflowsDir)
+  ? fs
+      .readdirSync(workflowsDir)
+      .filter((f) => f.endsWith(".yml") || f.endsWith(".yaml"))
+  : [];
+
+for (const wfFile of wfFiles) {
+  const wfPath = path.join(workflowsDir, wfFile);
+  let wf: any;
+  try {
+    wf = yaml.parse(fs.readFileSync(wfPath, "utf8"));
+  } catch (e: any) {
+    errors.push(`${wfFile}: failed to parse - ${e.message}`);
+    continue;
+  }
+  const jobs: Record<string, Job> = wf.jobs || {};
+  for (const [jobName, job] of Object.entries(jobs)) {
+    let isWindows = false;
+    if (hasWindows(job["runs-on"])) isWindows = true;
+    const matrixOs = job.strategy?.matrix?.os;
+    if (hasWindows(matrixOs)) isWindows = true;
+    if (!isWindows) continue;
+
+    if (job.strategy && job.strategy["fail-fast"] !== false) {
+      errors.push(`${wfFile} > ${jobName}: strategy.fail-fast must be false`);
+    }
+    const steps: Step[] = job.steps || [];
+    function find(name: string, cond: string) {
+      return steps.some((s) => s.name === name && s.if === cond);
+    }
+    if (
+      !(
+        find("Setup Node (Windows)", "startsWith(runner.os, 'Windows')") &&
+        find("Enable Corepack (Windows)", "startsWith(runner.os, 'Windows')") &&
+        find("Ensure pnpm (Windows fallback)", "startsWith(runner.os, 'Windows')")
+      )
+    ) {
+      errors.push(`${wfFile} > ${jobName}: missing Windows bootstrap block`);
+    }
+    if (!find("Cancellation probe", "always()")) {
+      errors.push(`${wfFile} > ${jobName}: missing Cancellation probe step`);
+    }
+  }
+}
+
+if (errors.length) {
+  console.error(errors.join("\n"));
+  process.exit(1);
+}

--- a/tests/ci-guard/windows-cancel-guard/audit.test.ts
+++ b/tests/ci-guard/windows-cancel-guard/audit.test.ts
@@ -1,0 +1,53 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { spawnSync } from "child_process";
+
+const script = path.resolve(
+  __dirname,
+  "../../../scripts/ci-guard/windows-cancel-guard/audit.ts",
+);
+const tsNode = [
+  "-y",
+  "ts-node",
+  "--transpile-only",
+  "--compiler-options",
+  JSON.stringify({ module: "commonjs", moduleResolution: "node" }),
+  script,
+];
+
+function run(cwd: string) {
+  return spawnSync("npx", tsNode, { cwd, encoding: "utf8" });
+}
+
+function writeFile(dir: string, file: string, content: string) {
+  const full = path.join(dir, file);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content);
+}
+
+describe("windows cancel guard", () => {
+  test("windows job with guard passes", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "win-pass-"));
+    writeFile(tmp, "pnpm-lock.yaml", "");
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `name: t\njobs:\n  build:\n    runs-on: ${{ matrix.os }}\n    strategy:\n      fail-fast: false\n      matrix:\n        os: [ubuntu-latest, windows-latest]\n    steps:\n      - uses: actions/checkout@v4\n# >>> BEGIN MANAGED BLOCK: ci-guard:windows-cancel-guard\n      - name: Setup Node (Windows)\n        if: startsWith(runner.os, 'Windows')\n        uses: actions/setup-node@v4\n        with:\n          node-version: 20\n          cache: pnpm\n          cache-dependency-path: pnpm-lock.yaml\n      - name: Enable Corepack (Windows)\n        if: startsWith(runner.os, 'Windows')\n        shell: pwsh\n        run: corepack enable\n      - name: Ensure pnpm (Windows fallback)\n        if: startsWith(runner.os, 'Windows')\n        uses: pnpm/action-setup@v4\n        with:\n          run_install: false\n# <<< END MANAGED BLOCK: ci-guard:windows-cancel-guard\n      - name: Cancellation probe\n        if: always()\n        shell: bash\n        run: echo ok\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).toBe(0);
+  });
+
+  test("missing windows block fails", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "win-fail-"));
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `name: t\njobs:\n  build:\n    runs-on: windows-latest\n    steps:\n      - run: echo hi\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).not.toBe(0);
+    expect(res.stderr + res.stdout).toMatch(/missing Windows bootstrap/);
+  });
+});


### PR DESCRIPTION
## Summary
- add windows-specific pnpm bootstrap steps and cancellation probe to test-matrix workflow
- introduce windows cancellation guard script with tests
- wire guard into CI via dedicated workflow

## Testing
- `curl -I https://registry.npmjs.org`
- `curl -I https://cdn.playwright.dev`
- `npm run validate-env` *(fails: Invalid package.json)*
- `SKIP_PW_DEPS=1 npm run setup` *(fails: Invalid package.json)*
- `npm run format` *(fails: Error parsing package.json)*
- `npm test` *(fails: Error parsing package.json)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Invalid package.json)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Invalid package.json)*
- `node scripts/run-jest.js tests/ci-guard/windows-cancel-guard/audit.test.ts` *(fails: Error parsing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b445059c832d94ccefb043f2ec6b