### PR TITLE
ci: add windows cancel guard

### DIFF
--- a/.github/workflows/guard-windows-cancel-guard.yml
+++ b/.github/workflows/guard-windows-cancel-guard.yml
@@ -1,0 +1,14 @@
+name: guard windows cancel guard
+on: [pull_request, push]
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: corepack enable
+      - run: npm ci
+      - run: npx ts-node --transpile-only scripts/ci-guard/windows-cancel-guard/audit.ts
+      - run: node scripts/run-jest.js tests/ci-guard/windows-cancel-guard/audit.test.ts

--- a/scripts/ci-guard/windows-cancel-guard/audit.ts
+++ b/scripts/ci-guard/windows-cancel-guard/audit.ts
@@ -1,0 +1,159 @@
+import fs from "fs";
+import path from "path";
+import yaml from "yaml";
+
+interface Step {
+  name?: string;
+  uses?: string;
+  run?: string;
+  shell?: string;
+  with?: Record<string, any>;
+}
+
+interface Job {
+  "runs-on"?: any;
+  steps?: Step[];
+  strategy?: any;
+  if?: string;
+}
+
+function isWindows(runsOn: any, matrixOs: any): boolean {
+  const test = (v: any) =>
+    typeof v === "string" && v.toLowerCase().includes("windows");
+  if (test(runsOn)) return true;
+  if (Array.isArray(runsOn) && runsOn.some(test)) return true;
+  if (
+    typeof runsOn === "string" &&
+    runsOn.includes("${{") &&
+    Array.isArray(matrixOs)
+  ) {
+    return matrixOs.some(test);
+  }
+  return false;
+}
+
+const repoRoot = process.cwd();
+const workflowsDir = path.join(repoRoot, ".github", "workflows");
+const errors: string[] = [];
+const warnings: string[] = [];
+
+const wfFiles = fs.existsSync(workflowsDir)
+  ? fs
+      .readdirSync(workflowsDir)
+      .filter((f) => f.endsWith(".yml") || f.endsWith(".yaml"))
+  : [];
+
+for (const wfFile of wfFiles) {
+  const wfPath = path.join(workflowsDir, wfFile);
+  let wf: any;
+  try {
+    wf = yaml.parse(fs.readFileSync(wfPath, "utf8"));
+  } catch (e: any) {
+    errors.push(`${wfFile}: failed to parse - ${e.message}`);
+    continue;
+  }
+  const jobs: Record<string, Job> = wf.jobs || {};
+  for (const [jobName, job] of Object.entries(jobs)) {
+    const matrixOs = job.strategy?.matrix?.os;
+    const jobIsWindows = isWindows(job["runs-on"], matrixOs);
+    const lowerName = jobName.toLowerCase();
+
+    if (/(summary|diagnostic)/.test(lowerName)) {
+      if (job.if !== "always()") {
+        errors.push(
+          `${wfFile} > ${jobName}: summary/diagnostic jobs must use if: always()`,
+        );
+      }
+    }
+
+    if (jobIsWindows) {
+      const steps = job.steps || [];
+      let hasSetup = false;
+      let hasCorepack = false;
+      let hasPnpmFallback = false;
+
+      for (const step of steps) {
+        if (step.uses && /actions\/setup-node@/.test(step.uses)) {
+          const nv = step.with?.["node-version"];
+          const cache = step.with?.cache;
+          if (
+            (nv === 20 || nv === "20" || (typeof nv === "string" && nv.startsWith("20"))) &&
+            cache === "pnpm"
+          ) {
+            hasSetup = true;
+            const dep = step.with?.["cache-dependency-path"];
+            if (
+              typeof dep !== "string" ||
+              !dep
+                .split(/\n|,/)
+                .map((s: string) => s.trim())
+                .filter(Boolean)
+                .includes("pnpm-lock.yaml")
+            ) {
+              warnings.push(
+                `${wfFile} > ${jobName}: cache-dependency-path should include pnpm-lock.yaml`,
+              );
+            }
+          } else {
+            errors.push(
+              `${wfFile} > ${jobName}: setup-node must use node-version 20 with cache:pnpm`,
+            );
+          }
+        }
+        if (typeof step.run === "string" && step.run.includes("corepack enable")) {
+          hasCorepack = true;
+          if (step.shell && !/pwsh/i.test(step.shell)) {
+            warnings.push(
+              `${wfFile} > ${jobName}: corepack enable should use pwsh shell`,
+            );
+          }
+        }
+        if (step.uses && step.uses.startsWith("pnpm/action-setup")) {
+          const ri = step.with?.run_install;
+          if (ri === false || ri === "false") {
+            hasPnpmFallback = true;
+          } else {
+            errors.push(
+              `${wfFile} > ${jobName}: pnpm/action-setup must set run_install:false`,
+            );
+          }
+        }
+      }
+
+      if (!hasSetup)
+        errors.push(
+          `${wfFile} > ${jobName}: missing actions/setup-node with node 20 and cache:pnpm`,
+        );
+      if (!hasCorepack)
+        errors.push(`${wfFile} > ${jobName}: missing corepack enable step`);
+      if (!hasPnpmFallback)
+        errors.push(
+          `${wfFile} > ${jobName}: missing pnpm/action-setup fallback`,
+        );
+
+      if (
+        Array.isArray(matrixOs) &&
+        matrixOs.length > 1 &&
+        matrixOs.some((v: any) =>
+          typeof v === "string" ? v.toLowerCase().includes("windows") : false,
+        ) &&
+        /(test|build)/.test(lowerName) &&
+        !/aggregate/.test(lowerName)
+      ) {
+        if (job.strategy?.["fail-fast"] !== false) {
+          errors.push(
+            `${wfFile} > ${jobName}: strategy.fail-fast must be false for Windows matrix jobs`,
+          );
+        }
+      }
+    }
+  }
+}
+
+if (warnings.length) {
+  console.warn(warnings.join("\n"));
+}
+if (errors.length) {
+  console.error(errors.join("\n"));
+  process.exit(1);
+}

--- a/tests/ci-guard/windows-cancel-guard/audit.test.ts
+++ b/tests/ci-guard/windows-cancel-guard/audit.test.ts
@@ -1,0 +1,193 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { spawnSync } from "child_process";
+
+const script = path.resolve(
+  __dirname,
+  "../../../scripts/ci-guard/windows-cancel-guard/audit.ts",
+);
+const tsNode = [
+  "-y",
+  "ts-node",
+  "--transpile-only",
+  "--compiler-options",
+  JSON.stringify({ module: "commonjs", moduleResolution: "node" }),
+  script,
+];
+
+function run(cwd: string) {
+  return spawnSync("npx", tsNode, { cwd, encoding: "utf8" });
+}
+
+function writeFile(dir: string, file: string, content: string) {
+  const full = path.join(dir, file);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content);
+}
+
+describe("windows cancel guard", () => {
+  test("t1 Windows job with full bootstrap → pass", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "t1-"));
+    writeFile(tmp, "pnpm-lock.yaml", "");
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `name: t1\njobs:\n  build:\n    runs-on: windows-latest\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n          cache: pnpm\n          cache-dependency-path: pnpm-lock.yaml\n      - run: corepack enable\n      - uses: pnpm/action-setup@v3\n        with:\n          run_install: false\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).toBe(0);
+  });
+
+  test("t2 Windows job missing corepack → fail", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "t2-"));
+    writeFile(tmp, "pnpm-lock.yaml", "");
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `name: t2\njobs:\n  build:\n    runs-on: windows-latest\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n          cache: pnpm\n          cache-dependency-path: pnpm-lock.yaml\n      - uses: pnpm/action-setup@v3\n        with:\n          run_install: false\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).not.toBe(0);
+    expect(res.stderr + res.stdout).toMatch(/corepack/);
+  });
+
+  test("t3 Windows job missing pnpm fallback → fail", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "t3-"));
+    writeFile(tmp, "pnpm-lock.yaml", "");
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `name: t3\njobs:\n  build:\n    runs-on: windows-latest\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n          cache: pnpm\n          cache-dependency-path: pnpm-lock.yaml\n      - run: corepack enable\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).not.toBe(0);
+    expect(res.stderr + res.stdout).toMatch(/pnpm\/action-setup/);
+  });
+
+  test("t4 Matrix Windows+Linux with fail-fast:false → pass", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "t4-"));
+    writeFile(tmp, "pnpm-lock.yaml", "");
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `name: t4\njobs:\n  build-test:\n    runs-on: \${{ matrix.os }}\n    strategy:\n      fail-fast: false\n      matrix:\n        os: [ubuntu-latest, windows-latest]\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n          cache: pnpm\n          cache-dependency-path: pnpm-lock.yaml\n      - run: corepack enable\n      - uses: pnpm/action-setup@v3\n        with:\n          run_install: false\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).toBe(0);
+  });
+
+  test("t5 Matrix default fail-fast (true) and independent lanes → fail", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "t5-"));
+    writeFile(tmp, "pnpm-lock.yaml", "");
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `name: t5\njobs:\n  build-test:\n    runs-on: \${{ matrix.os }}\n    strategy:\n      matrix:\n        os: [ubuntu-latest, windows-latest]\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n          cache: pnpm\n          cache-dependency-path: pnpm-lock.yaml\n      - run: corepack enable\n      - uses: pnpm/action-setup@v3\n        with:\n          run_install: false\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).not.toBe(0);
+    expect(res.stderr + res.stdout).toMatch(/fail-fast/);
+  });
+
+  test("t6 Summary job missing if: always() → fail", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "t6-"));
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `name: t6\njobs:\n  summary:\n    runs-on: ubuntu-latest\n    steps: []\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).not.toBe(0);
+    expect(res.stderr + res.stdout).toMatch(/always\(\)/);
+  });
+
+  test("t7 Non-Windows jobs ignored for fail-fast rule → pass", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "t7-"));
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `name: t7\njobs:\n  test:\n    runs-on: \${{ matrix.os }}\n    strategy:\n      matrix:\n        os: [ubuntu-latest, macos-latest]\n    steps: []\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).toBe(0);
+  });
+
+  test("t8 Windows job using bash instead of pwsh for corepack (warn) → pass", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "t8-"));
+    writeFile(tmp, "pnpm-lock.yaml", "");
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `name: t8\njobs:\n  build:\n    runs-on: windows-latest\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n          cache: pnpm\n          cache-dependency-path: pnpm-lock.yaml\n      - run: corepack enable\n        shell: bash\n      - uses: pnpm/action-setup@v3\n        with:\n          run_install: false\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).toBe(0);
+    expect(res.stderr + res.stdout).toMatch(/pwsh/);
+  });
+
+  test("t9 cache-dependency-path includes pnpm-lock.yaml → pass", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "t9-"));
+    writeFile(tmp, "pnpm-lock.yaml", "");
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `name: t9\njobs:\n  build:\n    runs-on: windows-latest\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n          cache: pnpm\n          cache-dependency-path: pnpm-lock.yaml\n      - run: corepack enable\n      - uses: pnpm/action-setup@v3\n        with:\n          run_install: false\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).toBe(0);
+  });
+
+  test("t9b cache-dependency-path missing → warn", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "t9b-"));
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `name: t9b\njobs:\n  build:\n    runs-on: windows-latest\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n          cache: pnpm\n      - run: corepack enable\n      - uses: pnpm/action-setup@v3\n        with:\n          run_install: false\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).toBe(0);
+    expect(res.stderr + res.stdout).toMatch(/cache-dependency-path/);
+  });
+
+  test("t10 Job-level cancellation probe step present → pass", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "t10-"));
+    writeFile(tmp, "pnpm-lock.yaml", "");
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `name: t10\njobs:\n  build:\n    runs-on: windows-latest\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n          cache: pnpm\n          cache-dependency-path: pnpm-lock.yaml\n      - run: corepack enable\n      - run: echo probe\n      - uses: pnpm/action-setup@v3\n        with:\n          run_install: false\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).toBe(0);
+  });
+
+  test("t11 macOS ARM job unaffected by Windows rules → pass", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "t11-"));
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `name: t11\njobs:\n  mac:\n    runs-on: macos-14\n    steps: []\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).toBe(0);
+  });
+
+  test("t12 Aggregated output lists file+job pointers and remediation", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "t12-"));
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `name: t12a\njobs:\n  build:\n    runs-on: windows-latest\n    steps: []\n`,
+    );
+    writeFile(
+      tmp,
+      ".github/workflows/b.yml",
+      `name: t12b\njobs:\n  build:\n    runs-on: windows-latest\n    steps: []\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).not.toBe(0);
+    expect(res.stderr + res.stdout).toMatch(/a.yml/);
+    expect(res.stderr + res.stdout).toMatch(/b.yml/);
+  });
+});


### PR DESCRIPTION
## Summary
- add audit for Windows workflows ensuring Node 20 pnpm bootstrap, corepack, pnpm/action-setup fallback, fail-fast rules and summary guards
- test windows cancel guard across bootstrap, matrix, cache, shell, and diagnostic scenarios
- wire up guard workflow to run audit and tests

## Testing
- `npm run validate-env` *(fails: Invalid package.json)*
- `SKIP_PW_DEPS=1 npm run setup` *(fails: Invalid package.json)*
- `npm run format` *(fails: Invalid package.json)*
- `SKIP_ROOT_DEPS_CHECK=1 node scripts/run-jest.js tests/ci-guard/windows-cancel-guard/audit.test.ts` *(fails: Invalid package.json)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Invalid package.json)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b449a894832da6c368d13a2d0c03