### PR TITLE
ci: add corepack pnpm path guard

### DIFF
--- a/.github/workflows/guard-corepack-pnpm-path.yml
+++ b/.github/workflows/guard-corepack-pnpm-path.yml
@@ -1,0 +1,14 @@
+name: guard corepack pnpm path
+on: [pull_request, push]
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: corepack enable
+      - run: npm ci
+      - run: npx ts-node --transpile-only scripts/ci-guard/corepack-pnpm-path/audit.ts
+      - run: node scripts/run-jest.js tests/ci-guard/corepack-pnpm-path/audit.test.ts

--- a/scripts/ci-guard/corepack-pnpm-path/audit.ts
+++ b/scripts/ci-guard/corepack-pnpm-path/audit.ts
@@ -1,0 +1,147 @@
+import fs from "fs";
+import path from "path";
+import yaml from "yaml";
+
+interface Step {
+  name?: string;
+  uses?: string;
+  run?: string;
+  with?: Record<string, any>;
+  ["working-directory"]?: string;
+}
+
+interface Job {
+  steps?: Step[];
+}
+
+function findFiles(root: string, filename: string): string[] {
+  const out: string[] = [];
+  function walk(dir: string) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (entry.name === "node_modules" || entry.name.startsWith(".git"))
+        continue;
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (entry.isFile() && entry.name === filename) {
+        out.push(path.relative(root, full).replace(/\\/g, "/"));
+      }
+    }
+  }
+  if (fs.existsSync(root)) walk(root);
+  return out;
+}
+
+const repoRoot = process.cwd();
+const workflowsDir = path.join(repoRoot, ".github", "workflows");
+const packageJsons = findFiles(repoRoot, "package.json");
+const versionSet = new Set<string>();
+for (const rel of packageJsons) {
+  const pkgPath = path.join(repoRoot, rel);
+  try {
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+    if (
+      typeof pkg.packageManager === "string" &&
+      pkg.packageManager.startsWith("pnpm@")
+    ) {
+      const v = pkg.packageManager.slice(5);
+      versionSet.add(v);
+    }
+  } catch {
+    // ignore
+  }
+}
+
+const errors: string[] = [];
+const wfFiles = fs.existsSync(workflowsDir)
+  ? fs
+      .readdirSync(workflowsDir)
+      .filter((f) => f.endsWith(".yml") || f.endsWith(".yaml"))
+  : [];
+
+for (const wfFile of wfFiles) {
+  const wfPath = path.join(workflowsDir, wfFile);
+  let wf: any;
+  try {
+    wf = yaml.parse(fs.readFileSync(wfPath, "utf8"));
+  } catch (e: any) {
+    errors.push(`${wfFile}: failed to parse - ${e.message}`);
+    continue;
+  }
+  const jobs: Record<string, Job> = wf.jobs || {};
+  for (const [jobName, job] of Object.entries(jobs)) {
+    const steps = job.steps || [];
+    let setupIdx = -1;
+    let setupVersionOk = false;
+    let corepackIdx = -1;
+    let fallbackIdx = -1;
+    let fallbackVersion: string | undefined;
+    let hasNpmCache = false;
+
+    steps.forEach((step, idx) => {
+      if (step.uses && /actions\/setup-node@v4/.test(step.uses)) {
+        setupIdx = idx;
+        const nv = step.with?.["node-version"];
+        setupVersionOk = nv === 20 || nv === "20";
+        if (step.with?.cache === "npm") hasNpmCache = true;
+      }
+      if (typeof step.run === "string" && step.run.includes("corepack enable")) {
+        corepackIdx = idx;
+      }
+      if (typeof step.run === "string" && step.run.includes("corepack prepare")) {
+        fallbackIdx = idx;
+        const m = step.run.match(/corepack prepare\s+pnpm@([\w.-]+)/);
+        if (m) fallbackVersion = m[1];
+      }
+      if (step.uses && step.uses.startsWith("pnpm/action-setup")) {
+        fallbackIdx = idx;
+        const v = step.with?.version;
+        if (typeof v === "string") fallbackVersion = v;
+      }
+      if (step.with?.cache === "npm") hasNpmCache = true;
+    });
+
+    steps.forEach((step, idx) => {
+      if (typeof step.run !== "string" || !/\bpnpm\b/.test(step.run)) return;
+      const prefix = `${wfFile} > ${jobName} > step ${idx + 1}`;
+      if (setupIdx < 0 || idx <= setupIdx) {
+        errors.push(`${prefix}: missing actions/setup-node@v4 before pnpm`);
+      } else if (!setupVersionOk) {
+        errors.push(`${prefix}: actions/setup-node must use node-version 20`);
+      }
+      if (corepackIdx < 0 || idx <= corepackIdx || corepackIdx <= setupIdx) {
+        errors.push(`${prefix}: missing corepack enable before pnpm`);
+      }
+      if (
+        fallbackIdx < 0 ||
+        idx <= fallbackIdx ||
+        fallbackIdx <= corepackIdx
+      ) {
+        errors.push(
+          `${prefix}: missing corepack prepare or pnpm/action-setup before pnpm`,
+        );
+      }
+      if (hasNpmCache) {
+        errors.push(`${wfFile} > ${jobName}: cache: npm present in job using pnpm`);
+      }
+      if (fallbackVersion && versionSet.size > 0 && !versionSet.has(fallbackVersion)) {
+        const pinned = Array.from(versionSet).join(", ");
+        errors.push(
+          `${wfFile} > ${jobName} > step ${fallbackIdx + 1}: pnpm version ${fallbackVersion} conflicts with packageManager pnpm@${pinned}`,
+        );
+      }
+    });
+  }
+}
+
+if (versionSet.size > 1) {
+  errors.push(
+    `conflicting packageManager pnpm versions: ${Array.from(versionSet).join(", ")}`,
+  );
+}
+
+if (errors.length) {
+  console.error(errors.join("\n"));
+  process.exit(1);
+}
+

--- a/tests/ci-guard/corepack-pnpm-path/audit.test.ts
+++ b/tests/ci-guard/corepack-pnpm-path/audit.test.ts
@@ -1,0 +1,219 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { spawnSync } from "child_process";
+
+const script = path.resolve(
+  __dirname,
+  "../../../scripts/ci-guard/corepack-pnpm-path/audit.ts",
+);
+const tsNode = [
+  "-y",
+  "ts-node",
+  "--transpile-only",
+  "--compiler-options",
+  JSON.stringify({ module: "commonjs", moduleResolution: "node" }),
+  script,
+];
+
+function run(cwd: string) {
+  return spawnSync("npx", tsNode, { cwd, encoding: "utf8" });
+}
+
+function writeFile(dir: string, file: string, content: string) {
+  const full = path.join(dir, file);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content);
+}
+
+describe("corepack pnpm path audit", () => {
+  test("t1: Proper bootstrap → pass", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "t1-"));
+    writeFile(
+      tmp,
+      "package.json",
+      JSON.stringify({ packageManager: "pnpm@8.0.0" }),
+    );
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `jobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n      - run: corepack enable\n      - uses: pnpm/action-setup@v3\n        with:\n          version: 8.0.0\n      - run: pnpm install\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).toBe(0);
+  });
+  test("t2: pnpm command without corepack enable → fail", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "t2-"));
+    writeFile(
+      tmp,
+      "package.json",
+      JSON.stringify({ packageManager: "pnpm@8.0.0" }),
+    );
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `jobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n      - run: pnpm install\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).not.toBe(0);
+    expect(res.stderr + res.stdout).toMatch(/corepack enable/);
+  });
+  test("t3: cache:'npm' with pnpm usage → fail", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "t3-"));
+    writeFile(
+      tmp,
+      "package.json",
+      JSON.stringify({ packageManager: "pnpm@8.0.0" }),
+    );
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `jobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n          cache: npm\n      - run: corepack enable\n      - run: pnpm install\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).not.toBe(0);
+    expect(res.stderr + res.stdout).toMatch(/cache: npm/);
+  });
+  test("t4: conflicting pnpm/action-setup version → fail", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "t4-"));
+    writeFile(
+      tmp,
+      "package.json",
+      JSON.stringify({ packageManager: "pnpm@8.0.0" }),
+    );
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `jobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n      - run: corepack enable\n      - uses: pnpm/action-setup@v3\n        with:\n          version: 7.0.0\n      - run: pnpm install\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).not.toBe(0);
+    expect(res.stderr + res.stdout).toMatch(/conflicts with packageManager/);
+  });
+  test("t5: corepack prepare uses packageManager → pass", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "t5-"));
+    writeFile(
+      tmp,
+      "package.json",
+      JSON.stringify({ packageManager: "pnpm@8.0.0" }),
+    );
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `jobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n      - run: corepack enable\n      - run: corepack prepare pnpm@8.0.0 --activate\n      - run: pnpm install\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).toBe(0);
+  });
+  test("t6: macOS ARM workflow with bootstrap → pass", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "t6-"));
+    writeFile(
+      tmp,
+      "package.json",
+      JSON.stringify({ packageManager: "pnpm@8.0.0" }),
+    );
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `jobs:\n  build:\n    runs-on: macos-14\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n      - run: corepack enable\n      - uses: pnpm/action-setup@v3\n        with:\n          version: 8.0.0\n      - run: pnpm install\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).toBe(0);
+  });
+  test("t7: Linux x64 with bootstrap → pass", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "t7-"));
+    writeFile(
+      tmp,
+      "package.json",
+      JSON.stringify({ packageManager: "pnpm@8.0.0" }),
+    );
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `jobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n      - run: corepack enable\n      - uses: pnpm/action-setup@v3\n        with:\n          version: 8.0.0\n      - run: pnpm install\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).toBe(0);
+  });
+  test("t8: multiple workspaces with cache-dependency-path → pass", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "t8-"));
+    writeFile(tmp, "package.json", "{}");
+    writeFile(tmp, "pnpm-lock.yaml", "");
+    writeFile(
+      tmp,
+      "frontend/package.json",
+      JSON.stringify({ packageManager: "pnpm@8.0.0" }),
+    );
+    writeFile(tmp, "frontend/pnpm-lock.yaml", "");
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `jobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n          cache: pnpm\n          cache-dependency-path: |\n            pnpm-lock.yaml\n            frontend/pnpm-lock.yaml\n      - run: corepack enable\n      - uses: pnpm/action-setup@v3\n        with:\n          version: 8.0.0\n      - run: pnpm install\n        working-directory: frontend\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).toBe(0);
+  });
+  test("t9: missing verify step allowed → pass", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "t9-"));
+    writeFile(
+      tmp,
+      "package.json",
+      JSON.stringify({ packageManager: "pnpm@8.0.0" }),
+    );
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `jobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n      - run: corepack enable\n      - uses: pnpm/action-setup@v3\n        with:\n          version: 8.0.0\n      - run: pnpm install\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).toBe(0);
+  });
+  test("t10: npm-only workflow ignored → pass", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "t10-"));
+    writeFile(
+      tmp,
+      "package.json",
+      JSON.stringify({ packageManager: "npm@9.0.0" }),
+    );
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `jobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n          cache: npm\n      - run: npm install\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).toBe(0);
+  });
+  test("t11: packageManager missing but fallback ensures pnpm → pass", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "t11-"));
+    writeFile(tmp, "package.json", "{}");
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `jobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n      - run: corepack enable\n      - uses: pnpm/action-setup@v3\n      - run: pnpm --version\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).toBe(0);
+  });
+  test("t12: aggregated report lists all offenders", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "t12-"));
+    writeFile(
+      tmp,
+      "package.json",
+      JSON.stringify({ packageManager: "pnpm@8.0.0" }),
+    );
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `jobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - run: pnpm install\n`,
+    );
+    writeFile(
+      tmp,
+      ".github/workflows/b.yml",
+      `jobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n      - run: pnpm install\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).not.toBe(0);
+    expect(res.stderr + res.stdout).toMatch(/a.yml/);
+    expect(res.stderr + res.stdout).toMatch(/b.yml/);
+  });
+});


### PR DESCRIPTION
## Summary
- enforce corepack pnpm path usage in workflows
- test guard across bootstrap scenarios
- add CI workflow for corepack pnpm path audit

## Testing
- `npx prettier scripts/ci-guard/corepack-pnpm-path/audit.ts tests/ci-guard/corepack-pnpm-path/audit.test.ts .github/workflows/guard-corepack-pnpm-path.yml -w` *(failed: npm error canceled)*
- `node scripts/run-jest.js tests/ci-guard/corepack-pnpm-path/audit.test.ts` *(failed: SyntaxError: Error parsing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b442307c832db3328da67c80197d