### PR TITLE
ci(lfs): migrate tracked images to Git LFS and enforce pointers in CI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -31,3 +31,7 @@ upload/* binary
 
 frontend/** -filter=lfs -diff=lfs -merge=lfs
 frontend/public/** -filter=lfs -diff=lfs -merge=lfs
+# >>> BEGIN MANAGED BLOCK: ci-guard:lfs-migrate-enforce
+img/*.png filter=lfs diff=lfs merge=lfs -text
+img/*.jpg filter=lfs diff=lfs merge=lfs -text
+# <<< END MANAGED BLOCK: ci-guard:lfs-migrate-enforce

--- a/.github/workflows/guard-lfs.yml
+++ b/.github/workflows/guard-lfs.yml
@@ -1,0 +1,23 @@
+name: LFS Guard
+on: [pull_request, push]
+jobs:
+  lfs-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0, lfs: false }
+      - name: Verify LFS pointers
+        shell: bash
+        run: |
+          set -euo pipefail
+          missing=$(git lfs ls-files --errors 2>&1 | sed -n 's/^\\! \\(.*\\)$/\\1/p' || true)
+          if [ -n "$missing" ]; then
+            echo "::error::Files expected to be LFS pointers are not: "
+            echo "$missing"
+            exit 1
+          fi
+          echo "All LFS-tracked files are pointers."
+      - name: Guidance
+        if: failure()
+        run: bash scripts/ci-guard/lfs-migrate-enforce/migrate.sh || true
+        shell: bash

--- a/scripts/ci-guard/lfs-migrate-enforce/migrate.sh
+++ b/scripts/ci-guard/lfs-migrate-enforce/migrate.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+git lfs install
+git lfs migrate import --include="img/.png,img/.jpg" --no-rewrite || true
+git add .gitattributes || true
+echo "If binaries are already committed as regular files, run:"
+echo " git lfs migrate import --include='img/.png,img/.jpg'"

--- a/tests/ci-guard/lfs-migrate-enforce/audit.test.ts
+++ b/tests/ci-guard/lfs-migrate-enforce/audit.test.ts
@@ -1,0 +1,11 @@
+const fs = require("fs");
+const path = require("path");
+
+describe("lfs migrate enforce", () => {
+  test(".gitattributes has managed block", () => {
+    const attrs = fs.readFileSync(path.join(__dirname, "../../../.gitattributes"), "utf8");
+    expect(attrs).toMatch(/BEGIN MANAGED BLOCK: ci-guard:lfs-migrate-enforce/);
+    expect(attrs).toMatch(/img\/\*\.png filter=lfs diff=lfs merge=lfs -text/);
+    expect(attrs).toMatch(/img\/\*\.jpg filter=lfs diff=lfs merge=lfs -text/);
+  });
+});


### PR DESCRIPTION
## Summary
- add explicit LFS rules for images
- include migration helper
- fail CI when LFS-tracked files aren't pointers

## Testing
- `npm run validate-env` *(fails: Invalid package.json)*
- `SKIP_PW_DEPS=1 npm run setup` *(fails: Invalid package.json)*
- `npm run format` in `backend/` *(fails: Error parsing package.json)*
- `npm test` in `backend/` *(fails: Error parsing package.json)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Invalid package.json)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b58f0d7c832d826358192f1e7906