### PR TITLE
ci: add cf pages build guard

### DIFF
--- a/.github/workflows/guard-cf-pages-build.yml
+++ b/.github/workflows/guard-cf-pages-build.yml
@@ -1,0 +1,15 @@
+name: cf pages build guard
+
+on: [pull_request, push]
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npx ts-node --transpile-only scripts/ci-guard/cf-pages-build/audit.ts
+      - run: node scripts/run-jest.js tests/ci-guard/cf-pages-build/audit.test.ts

--- a/scripts/ci-guard/cf-pages-build/audit.ts
+++ b/scripts/ci-guard/cf-pages-build/audit.ts
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+// @ts-check
+const fs = require('fs');
+const path = require('path');
+const toml = require('toml');
+const yaml = require('yaml');
+const { spawnSync } = require('child_process');
+
+function findLine(content, search) {
+  const lines = content.split(/\r?\n/);
+  const idx = lines.findIndex((l) => l.includes(search));
+  return idx === -1 ? null : idx + 1;
+}
+
+/**
+ * @param {string} wranglerPath
+ * @param {string[]} workflowFiles
+ */
+function audit(wranglerPath, workflowFiles) {
+  const summary = {
+    ok: true,
+    wrangler: { file: wranglerPath },
+    workflows: {},
+  };
+  const wContent = fs.readFileSync(wranglerPath, 'utf8');
+  const wDoc = toml.parse(wContent);
+  const buildCmd = wDoc.build && wDoc.build.command;
+  const buildCmdLine = findLine(wContent, 'command');
+  summary.wrangler.buildCommand = { ok: !!buildCmd, line: buildCmdLine, command: buildCmd || null, errors: [] };
+  if (!buildCmd) summary.ok = false;
+  const outDir = wDoc.pages && wDoc.pages.build_output_dir;
+  const outDirLine = findLine(wContent, 'build_output_dir');
+  summary.wrangler.buildOutputDir = { ok: !!outDir, line: outDirLine, value: outDir || null, errors: [] };
+  if (!outDir) summary.ok = false; else if (outDir !== 'frontend/dist') {
+    summary.wrangler.buildOutputDir.ok = false;
+    summary.wrangler.buildOutputDir.errors.push('must be frontend/dist');
+    summary.ok = false;
+  }
+  if (buildCmd) {
+    if (!/corepack\s+enable/.test(buildCmd)) {
+      summary.wrangler.buildCommand.ok = false;
+      summary.wrangler.buildCommand.errors.push('missing corepack enable');
+      summary.ok = false;
+    }
+    if (!/pnpm\s+-C\s+frontend\s+install/.test(buildCmd)) {
+      summary.wrangler.buildCommand.ok = false;
+      summary.wrangler.buildCommand.errors.push('missing pnpm -C frontend install');
+      summary.ok = false;
+    }
+    if (!/pnpm\s+-C\s+frontend\s+build/.test(buildCmd)) {
+      summary.wrangler.buildCommand.ok = false;
+      summary.wrangler.buildCommand.errors.push('missing pnpm -C frontend build');
+      summary.ok = false;
+    }
+    const dryRunScript = [
+      'bash() { echo bash "$@"; }',
+      'corepack() { echo corepack "$@"; }',
+      'pnpm() { echo pnpm "$@"; }',
+      buildCmd,
+    ].join('\n');
+    const proc = spawnSync('bash', ['-lc', dryRunScript], { encoding: 'utf8' });
+    const output = (proc.stdout || '') + (proc.stderr || '');
+    summary.wrangler.dryRun = { output };
+    if (!output.includes('corepack') || !output.includes('pnpm -C frontend build')) {
+      summary.wrangler.buildCommand.ok = false;
+      summary.wrangler.buildCommand.errors.push('dry-run missing expected output');
+      summary.ok = false;
+    }
+  }
+  for (const file of workflowFiles) {
+    const wfContent = fs.readFileSync(file, 'utf8');
+    const wfLines = wfContent.split(/\r?\n/);
+    const verifyIdx = wfLines.findIndex((l) => l.includes('test -f frontend/dist/index.html'));
+    const wfSummary = {
+      file,
+      verify: { ok: verifyIdx !== -1, line: verifyIdx === -1 ? null : verifyIdx + 1 },
+    };
+    if (verifyIdx === -1) summary.ok = false;
+    summary.workflows[file] = wfSummary;
+  }
+  return summary;
+}
+
+function main() {
+  const repoRoot = process.cwd();
+  const wranglerPath = path.join(repoRoot, 'wrangler.toml');
+  const wfDir = path.join(repoRoot, '.github', 'workflows');
+  const workflowFiles = fs
+    .readdirSync(wfDir)
+    .filter((f) => f.endsWith('.yml') || f.endsWith('.yaml'))
+    .map((f) => path.join(wfDir, f));
+  const summary = audit(wranglerPath, workflowFiles);
+  fs.writeFileSync('cf-pages-build-audit-summary.json', JSON.stringify(summary, null, 2));
+  console.log(JSON.stringify(summary, null, 2));
+  if (!summary.ok) process.exit(1);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { audit };

--- a/tests/ci-guard/cf-pages-build/audit.test.ts
+++ b/tests/ci-guard/cf-pages-build/audit.test.ts
@@ -1,0 +1,116 @@
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { audit } from '../../../scripts/ci-guard/cf-pages-build/audit';
+
+function tmpFile(name: string, content: string): string {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'cf-'));
+  const file = path.join(dir, name);
+  writeFileSync(file, content);
+  return file;
+}
+
+function goodWrangler(cmd?: string): string {
+  const command =
+    cmd ||
+    'corepack enable && pnpm -C frontend install && pnpm -C frontend build';
+  return tmpFile(
+    'wrangler.toml',
+    `[build]\ncommand = "${command}"\n[pages]\nbuild_output_dir = "frontend/dist"\n`,
+  );
+}
+
+function goodWorkflow(runsOn = 'ubuntu-latest'): string {
+  return tmpFile(
+    'wf.yml',
+    `jobs:\n  build:\n    runs-on: ${runsOn}\n    steps:\n      - run: test -f frontend/dist/index.html\n`,
+  );
+}
+
+describe('cf pages build audit', () => {
+  test('t1 missing build command fails', () => {
+    const w = tmpFile('wrangler.toml', `[pages]\nbuild_output_dir = "frontend/dist"\n`);
+    const wf = goodWorkflow();
+    const res = audit(w, [wf]);
+    expect(res.ok).toBe(false);
+  });
+  test('t2 missing build_output_dir fails', () => {
+    const w = tmpFile(
+      'wrangler.toml',
+      `[build]\ncommand = "corepack enable && pnpm -C frontend install && pnpm -C frontend build"\n`,
+    );
+    const wf = goodWorkflow();
+    const res = audit(w, [wf]);
+    expect(res.ok).toBe(false);
+  });
+  test('t3 command without corepack fails', () => {
+    const w = goodWrangler('pnpm -C frontend install && pnpm -C frontend build');
+    const wf = goodWorkflow();
+    const res = audit(w, [wf]);
+    expect(res.ok).toBe(false);
+  });
+  test('t4 command without install fails', () => {
+    const w = goodWrangler('corepack enable && pnpm -C frontend build');
+    const wf = goodWorkflow();
+    const res = audit(w, [wf]);
+    expect(res.ok).toBe(false);
+  });
+  test('t5 command without build fails', () => {
+    const w = goodWrangler('corepack enable && pnpm -C frontend install');
+    const wf = goodWorkflow();
+    const res = audit(w, [wf]);
+    expect(res.ok).toBe(false);
+  });
+  test('t6 wrong build_output_dir fails', () => {
+    const w = tmpFile(
+      'wrangler.toml',
+      `[build]\ncommand = "corepack enable && pnpm -C frontend install && pnpm -C frontend build"\n[pages]\nbuild_output_dir = "out"\n`,
+    );
+    const wf = goodWorkflow();
+    const res = audit(w, [wf]);
+    expect(res.ok).toBe(false);
+  });
+  test('t7 workflow verify step present passes', () => {
+    const w = goodWrangler();
+    const wf = goodWorkflow();
+    const res = audit(w, [wf]);
+    expect(res.ok).toBe(true);
+  });
+  test('t8 workflow missing verify fails', () => {
+    const w = goodWrangler();
+    const wf = tmpFile('wf.yml', `jobs:\n  build:\n    steps:\n      - run: echo none\n`);
+    const res = audit(w, [wf]);
+    expect(res.ok).toBe(false);
+  });
+  test('t9 macOS runner passes', () => {
+    const w = goodWrangler();
+    const wf = goodWorkflow('macos-latest');
+    const res = audit(w, [wf]);
+    expect(res.ok).toBe(true);
+  });
+  test('t10 bad quoting still passes', () => {
+    const w = goodWrangler(
+      'bash -lc corepack enable && pnpm -C frontend install && pnpm -C frontend build',
+    );
+    const wf = goodWorkflow();
+    const res = audit(w, [wf]);
+    expect(res.ok).toBe(true);
+  });
+  test('t11 extra keys pass', () => {
+    const w = tmpFile(
+      'wrangler.toml',
+      `[extra]\nfoo = "bar"\n[build]\ncommand = "corepack enable && pnpm -C frontend install && pnpm -C frontend build"\n[pages]\nbuild_output_dir = "frontend/dist"\n`,
+    );
+    const wf = goodWorkflow();
+    const res = audit(w, [wf]);
+    expect(res.ok).toBe(true);
+  });
+  test('t12 summary includes line numbers', () => {
+    const w = goodWrangler();
+    const wf = goodWorkflow();
+    const res = audit(w, [wf]);
+    expect(res.wrangler.buildCommand.line).toBeGreaterThan(0);
+    const wfEntry = res.workflows[wf];
+    expect(wfEntry.verify.line).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add audit to ensure cf pages build command and output verification
- cover edge cases with 12 audit tests
- enforce guard via dedicated workflow

## Testing
- `npm run validate-env` *(fails: Invalid package.json)*
- `npm run setup` *(fails: Invalid package.json)*
- `node scripts/ci-guard/cf-pages-build/audit.ts` *(fails: Error parsing package.json)*
- `node scripts/run-jest.js tests/ci-guard/cf-pages-build/audit.test.ts` *(fails: Error parsing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b5878f40832d83ede901d9055faa