### PR TITLE
ci: add metrics action YAML guard

### DIFF
--- a/.github/workflows/guard-metrics-action-yaml.yml
+++ b/.github/workflows/guard-metrics-action-yaml.yml
@@ -1,20 +1,16 @@
-name: metrics action yaml guard
-
-env:
-  HUSKY: 0
+name: Guard metrics action YAML
 
 on:
-  pull_request:
   push:
-    branches: [main]
+  pull_request:
 
 jobs:
-  validate:
+  guard:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.1
-      - uses: actions/setup-node@v4.4.0
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - run: npx -y @actions/manifest-validation@latest .github/actions/ci-metrics-emit/action.yml
-      - run: npx -y yaml-eslint .github/actions/ci-metrics-emit/action.yml || true
+      - run: npm ci
+      - run: node scripts/ci-guard/metrics-action-yaml/audit.ts

--- a/scripts/ci-guard/metrics-action-yaml/audit.ts
+++ b/scripts/ci-guard/metrics-action-yaml/audit.ts
@@ -8,19 +8,17 @@ function audit(file) {
     throw new Error(`File not found: ${abs}`);
   }
   const raw = fs.readFileSync(abs, "utf8");
-  if (raw.includes("\t")) {
-    throw new Error("Tabs detected");
-  }
-  if (/\r/.test(raw)) {
-    throw new Error("CRLF line endings detected");
-  }
   const lines = raw.split("\n");
   lines.forEach((line, idx) => {
+    if (line.includes("\t")) {
+      throw new Error(`${abs}:${idx + 1} Tabs detected`);
+    }
+    if (line.includes("\r")) {
+      throw new Error(`${abs}:${idx + 1} CRLF line endings detected`);
+    }
     const m = line.match(/^( +)\S/);
-    if (m) {
-      if (m[1].length % 2 !== 0) {
-        throw new Error(`Invalid indentation on line ${idx + 1}`);
-      }
+    if (m && m[1].length % 2 !== 0) {
+      throw new Error(`${abs}:${idx + 1} Invalid indentation`);
     }
   });
   const pre = raw.replace(
@@ -34,9 +32,14 @@ function audit(file) {
       return start + indented + indent + end.trim();
     },
   );
+  const lineCounter = new yaml.LineCounter();
   let doc;
   try {
-    doc = yaml.parseDocument(pre, { prettyErrors: true, uniqueKeys: true });
+    doc = yaml.parseDocument(pre, {
+      prettyErrors: true,
+      uniqueKeys: true,
+      lineCounter,
+    });
   } catch (e) {
     const pos = e.linePos?.[0];
     const loc = pos ? `:${pos.line}:${pos.col}` : "";
@@ -48,40 +51,70 @@ function audit(file) {
     const loc = pos ? `:${pos.line}:${pos.col}` : "";
     throw new Error(`${abs}${loc} ${e.message}`);
   }
-  const data = doc.toJSON();
-  if (!data.name || !data.description) {
-    throw new Error("name/description required");
+  function loc(node) {
+    const pos = node && node.range ? lineCounter.linePos(node.range[0]) : { line: 0, col: 0 };
+    return `${abs}:${pos.line}:${pos.col}`;
   }
-  if (data.runs?.using !== "composite") {
-    throw new Error('runs.using must be "composite"');
+  if (!doc.get("name") || !doc.get("description")) {
+    throw new Error(`${abs}:1 name/description required`);
   }
-  const steps = data.runs?.steps;
-  if (!Array.isArray(steps) || steps.length === 0) {
-    throw new Error("steps must be non-empty array");
+  const runs = doc.get("runs", true);
+  const using = runs?.get("using", true);
+  if (!using || using.toString() !== "composite") {
+    throw new Error(`${loc(using || runs)} runs.using must be "composite"`);
   }
-  for (const [i, step] of steps.entries()) {
+  const stepsNode = runs.get("steps", true);
+  if (!stepsNode || stepsNode.items.length === 0) {
+    throw new Error(`${loc(stepsNode || runs)} steps must be non-empty array`);
+  }
+  let scriptCount = 0;
+  let uploadFound = false;
+  for (const item of stepsNode.items) {
+    const step = item.toJSON();
     const hasUses = Object.prototype.hasOwnProperty.call(step, "uses");
     const hasRun = Object.prototype.hasOwnProperty.call(step, "run");
-    const hasShell = Object.prototype.hasOwnProperty.call(step, "shell");
     if (hasUses && hasRun) {
-      throw new Error(`step ${i} has both uses and run`);
+      throw new Error(`${loc(item)} step has both uses and run`);
     }
     if (hasRun) {
-      if (!hasShell) throw new Error(`step ${i} missing shell`);
+      scriptCount++;
+      const shellNode = item.get("shell", true);
+      if (!shellNode) {
+        throw new Error(`${loc(item)} step missing shell`);
+      }
+      if (shellNode.toString() !== "bash") {
+        throw new Error(`${loc(shellNode)} script step shell must be bash`);
+      }
     } else if (!hasUses) {
-      throw new Error(`step ${i} missing uses or run`);
+      throw new Error(`${loc(item)} step missing uses or run`);
+    }
+    if (hasUses && /^actions\/upload-artifact@/.test(step.uses)) {
+      const pathNode = item.get("with", true)?.get("path", true);
+      if (!pathNode || pathNode.toString() !== "ci/metrics/series.ndjson") {
+        throw new Error(`${loc(pathNode || item)} upload-artifact path must be ci/metrics/series.ndjson`);
+      }
+      uploadFound = true;
     }
   }
-  const timings = data.inputs?.timings;
-  if (!timings || timings.required !== true) {
-    throw new Error("inputs.timings.required must be true");
+  if (scriptCount !== 1) {
+    throw new Error(`${loc(stepsNode)} expected exactly one script step, found ${scriptCount}`);
   }
-  const inventory = data.inputs?.inventory;
-  if (!inventory || inventory.default === undefined) {
-    throw new Error("inputs.inventory.default required");
+  if (!uploadFound) {
+    throw new Error(`${loc(stepsNode)} missing upload-artifact step`);
   }
-  if (typeof inventory.default !== "string") {
-    throw new Error("inputs.inventory.default must be string");
+  const inputs = doc.get("inputs", true);
+  const timings = inputs?.get("timings", true);
+  const timingsReq = timings?.get("required", true);
+  if (!timings || timingsReq?.toJSON() !== true) {
+    throw new Error(`${loc(timingsReq || timings || inputs)} inputs.timings.required must be true`);
+  }
+  const inventory = inputs?.get("inventory", true);
+  const invDef = inventory?.get("default", true);
+  if (!inventory || invDef === undefined) {
+    throw new Error(`${loc(inventory || inputs)} inputs.inventory.default required`);
+  }
+  if (typeof invDef.toJSON() !== "string") {
+    throw new Error(`${loc(invDef)} inputs.inventory.default must be string`);
   }
 }
 

--- a/tests/ci-guard/metrics-action-yaml/audit.test.ts
+++ b/tests/ci-guard/metrics-action-yaml/audit.test.ts
@@ -50,6 +50,7 @@ describe("metrics action audit", () => {
     const file = writeTemp(yaml.stringify(obj));
     const res = runAudit(file);
     expect(res.ok).toBe(false);
+    expect(res.stderr).toMatch(new RegExp(`${file}:\\d+:\\d+`));
     expect(res.stderr).toMatch(/runs\.using/);
   });
 
@@ -59,6 +60,7 @@ describe("metrics action audit", () => {
     const file = writeTemp(yaml.stringify(obj));
     const res = runAudit(file);
     expect(res.ok).toBe(false);
+    expect(res.stderr).toMatch(new RegExp(`${file}:\\d+:\\d+`));
     expect(res.stderr).toMatch(/both uses and run/);
   });
 
@@ -68,6 +70,7 @@ describe("metrics action audit", () => {
     const file = writeTemp(yaml.stringify(obj));
     const res = runAudit(file);
     expect(res.ok).toBe(false);
+    expect(res.stderr).toMatch(new RegExp(`${file}:\\d+:\\d+`));
     expect(res.stderr).toMatch(/missing shell/);
   });
 
@@ -147,5 +150,54 @@ describe("metrics action audit", () => {
     const res = runAudit(missing);
     expect(res.ok).toBe(false);
     expect(res.stderr).toMatch(/File not found/);
+  });
+
+  test("t13 multiple script steps fails", () => {
+    const obj = JSON.parse(JSON.stringify(validObj));
+    obj.runs.steps.push({ run: "echo hi", shell: "bash" });
+    const file = writeTemp(yaml.stringify(obj));
+    const res = runAudit(file);
+    expect(res.ok).toBe(false);
+    expect(res.stderr).toMatch(/exactly one script step/);
+  });
+
+  test("t14 script shell not bash fails", () => {
+    const obj = JSON.parse(JSON.stringify(validObj));
+    obj.runs.steps[0].shell = "sh";
+    const file = writeTemp(yaml.stringify(obj));
+    const res = runAudit(file);
+    expect(res.ok).toBe(false);
+    expect(res.stderr).toMatch(/shell must be bash/);
+  });
+
+  test("t15 missing upload-artifact step fails", () => {
+    const obj = JSON.parse(JSON.stringify(validObj));
+    obj.runs.steps = obj.runs.steps.filter(
+      (s: any) => !(s.uses && s.uses.startsWith("actions/upload-artifact@")),
+    );
+    const file = writeTemp(yaml.stringify(obj));
+    const res = runAudit(file);
+    expect(res.ok).toBe(false);
+    expect(res.stderr).toMatch(/missing upload-artifact step/);
+  });
+
+  test("t16 upload-artifact path wrong fails", () => {
+    const obj = JSON.parse(JSON.stringify(validObj));
+    const up = obj.runs.steps.find(
+      (s: any) => s.uses && s.uses.startsWith("actions/upload-artifact@"),
+    );
+    up.with.path = "ci/metrics/bad.ndjson";
+    const file = writeTemp(yaml.stringify(obj));
+    const res = runAudit(file);
+    expect(res.ok).toBe(false);
+    expect(res.stderr).toMatch(/upload-artifact path/);
+  });
+
+  test("t17 extra top-level key passes", () => {
+    const obj = JSON.parse(JSON.stringify(validObj));
+    obj.branding = { color: "blue", icon: "smile" };
+    const file = writeTemp(yaml.stringify(obj));
+    const res = runAudit(file);
+    expect(res.ok).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- expand metrics action audit to enforce bash script and upload-artifact path
- add extensive tests for metrics action audit
- run audit in guard-metrics-action-yaml workflow on push and PR

## Testing
- `npm run format` (backend)
- `npm test` (backend)
- `node scripts/run-jest.js tests/ci-guard/metrics-action-yaml/audit.test.ts`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Error occurred when checking code style in 11 files)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b6f7def4832da277bd275e088290