### PR TITLE
test: add Prettier format guard

### DIFF
--- a/.github/workflows/guard-format-tests.yml
+++ b/.github/workflows/guard-format-tests.yml
@@ -1,0 +1,16 @@
+name: prettier scan-format tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  scan-format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: node scripts/run-jest.js tests/ci-guard/prettier-fix/scan-format.test.ts

--- a/scripts/ci-guard/prettier-fix/scan-format.ts
+++ b/scripts/ci-guard/prettier-fix/scan-format.ts
@@ -1,0 +1,81 @@
+import fs from "fs";
+import path from "path";
+import prettier from "prettier";
+
+interface Mismatch {
+  file: string;
+  line: number;
+}
+
+async function* walk(dir: string): AsyncGenerator<string> {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "node_modules" || entry.name === ".git") continue;
+      yield* walk(full);
+    } else {
+      yield full;
+    }
+  }
+}
+
+function firstDiffLine(a: string, b: string): number {
+  const len = Math.min(a.length, b.length);
+  let line = 1;
+  for (let i = 0; i < len; i++) {
+    if (a[i] !== b[i]) break;
+    if (a[i] === "\n") line++;
+  }
+  return line;
+}
+
+export async function scan(root: string, max = 20): Promise<Mismatch[]> {
+  const mismatches: Mismatch[] = [];
+  const ignorePath = path.join(root, ".prettierignore");
+  for await (const file of walk(root)) {
+    const info = await prettier.getFileInfo(file, { ignorePath });
+    if (info.ignored || !info.inferredParser) continue;
+    const raw = fs.readFileSync(file, "utf8").replace(/\r\n/g, "\n");
+    const opts =
+      (await prettier.resolveConfig(file, { editorconfig: true })) || {};
+    const formatted = await prettier.format(raw, { ...opts, filepath: file });
+    if (formatted !== raw) {
+      mismatches.push({
+        file: path.relative(root, file),
+        line: firstDiffLine(raw, formatted),
+      });
+    }
+  }
+  if (mismatches.length) {
+    console.error(`Found ${mismatches.length} files with formatting issues:`);
+    for (const m of mismatches.slice(0, max)) {
+      console.error(`${m.file}\t${m.line}`);
+    }
+    if (mismatches.length > max) {
+      console.error(`...and ${mismatches.length - max} more`);
+    }
+  } else {
+    console.log("All files formatted");
+  }
+  return mismatches;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  let dir = process.cwd();
+  let max = 20;
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--max" && args[i + 1]) {
+      max = Number(args[++i]);
+    } else {
+      dir = path.resolve(arg);
+    }
+  }
+  const mismatches = await scan(dir, max);
+  process.exit(mismatches.length ? 1 : 0);
+}
+
+if (require.main === module) {
+  main();
+}

--- a/tests/ci-guard/prettier-fix/scan-format.test.ts
+++ b/tests/ci-guard/prettier-fix/scan-format.test.ts
@@ -1,0 +1,133 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { spawnSync } from "child_process";
+
+const script = path.resolve(
+  __dirname,
+  "../../../scripts/ci-guard/prettier-fix/scan-format.ts",
+);
+const tsNode = [
+  "-y",
+  "ts-node",
+  "--transpile-only",
+  "--compiler-options",
+  JSON.stringify({ module: "commonjs", moduleResolution: "node" }),
+  script,
+];
+
+function run(cwd: string, args: string[] = []) {
+  return spawnSync("npx", [...tsNode, cwd, ...args], { encoding: "utf8" });
+}
+
+function write(dir: string, file: string, content: string | Buffer) {
+  const full = path.join(dir, file);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content);
+}
+
+describe("scan-format", () => {
+  test("t1 formatted file passes", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "fmt-pass-"));
+    write(tmp, "a.js", "const x = 1;\n");
+    const res = run(tmp);
+    expect(res.status).toBe(0);
+  });
+
+  test("t2 extra spaces fail", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "fmt-fail-"));
+    write(tmp, "a.js", "const x =  1;\n");
+    const res = run(tmp);
+    expect(res.status).not.toBe(0);
+    expect(res.stderr).toMatch(/a.js\s+1/);
+  });
+
+  test("t3 mixed tabs and spaces in yaml fail", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "yaml-fail-"));
+    write(tmp, "a.yml", "a:\n\tb: 1\n");
+    const res = run(tmp);
+    expect(res.status).not.toBe(0);
+  });
+
+  test("t4 trailing comma pass", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "comma-pass-"));
+    write(tmp, "a.js", "const o = {\n  a: 1,\n};\n");
+    const res = run(tmp);
+    expect(res.status).toBe(0);
+  });
+
+  test("t5 trailing comma missing fails", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "comma-fail-"));
+    write(tmp, "a.js", "const o = {\n  a: 1\n};\n");
+    const res = run(tmp);
+    expect(res.status).not.toBe(0);
+  });
+
+  test("t6 long line wrapped passes", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "wrap-pass-"));
+    const body = Array(20).fill("  { a: 1 },").join("\n");
+    write(tmp, "a.js", `const arr = [\n${body}\n];\n`);
+    const res = run(tmp);
+    expect(res.status).toBe(0);
+  });
+
+  test("t7 json spacing enforced", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "json-fail-"));
+    write(tmp, "data.json", '{\n    "a": 1\n}\n');
+    const res = run(tmp);
+    expect(res.status).not.toBe(0);
+  });
+
+  test("t8 markdown fenced code block passes", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "md-pass-"));
+    write(tmp, "readme.md", "# T\n\n```\ncode    with   spaces\n```\n");
+    const res = run(tmp);
+    expect(res.status).toBe(0);
+  });
+
+  test("t9 prettierignore honored", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "ignore-pass-"));
+    write(tmp, ".prettierignore", "bad.js\n");
+    write(tmp, "bad.js", "const  x = 1;\n");
+    write(tmp, "good.js", "const x = 1;\n");
+    const res = run(tmp);
+    expect(res.status).toBe(0);
+  });
+
+  test("t10 binary files ignored", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "bin-pass-"));
+    write(tmp, "bin.dat", Buffer.from([0, 1, 2, 3]));
+    const res = run(tmp);
+    expect(res.status).toBe(0);
+  });
+
+  test("t11 windows line endings pass", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "crlf-pass-"));
+    write(tmp, "a.js", "const x = 1;\r\n");
+    const res = run(tmp);
+    expect(res.status).toBe(0);
+  });
+
+  test("t12 editorconfig respected", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "editorconfig-fail-"));
+    write(tmp, ".editorconfig", "[*.js]\nindent_size=4\n");
+    write(tmp, "a.js", "function a() {\n  console.log(1);\n}\n");
+    const res = run(tmp);
+    expect(res.status).not.toBe(0);
+  });
+
+  test("t13 summary reports count and limit", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "summary-fail-"));
+    write(tmp, "a.js", "const x =  1;\n");
+    write(tmp, "b.js", "const x =  1;\n");
+    write(tmp, "c.js", "const x =  1;\n");
+    const res = run(tmp, ["--max", "2"]);
+    expect(res.status).not.toBe(0);
+    expect(res.stderr).toMatch(/Found 3 files/);
+    const lines = res.stderr
+      .trim()
+      .split(/\n/)
+      .filter((l) => /\.js\s+1$/.test(l));
+    expect(lines.length).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- scan repository for Prettier formatting differences using the API and report first offending line
- cover formatting edge cases and ignore rules with comprehensive tests
- run format guard tests in CI

## Testing
- `npm run validate-env`
- `curl -I https://registry.npmjs.org`
- `curl -I https://cdn.playwright.dev`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format --prefix backend`
- `node scripts/run-jest.js tests/ci-guard/prettier-fix/scan-format.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68a8b7040cec832db43c88f4745e7903