### PR TITLE
ci: add smoke artifact audit

### DIFF
--- a/.github/workflows/guard-smoke-artifact.yml
+++ b/.github/workflows/guard-smoke-artifact.yml
@@ -1,0 +1,24 @@
+name: smoke artifact guard
+
+on: [pull_request, push]
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - name: audit
+        id: audit
+        run: npx -y tsx scripts/ci-guard/smoke-artifact/audit.ts
+        continue-on-error: true
+      - uses: actions/upload-artifact@v4
+        with:
+          name: smoke-artifact-summary
+          path: smoke-artifact-summary.json
+      - run: node scripts/run-jest.js tests/ci-guard/smoke-artifact/audit.test.ts
+      - name: fail if audit failed
+        run: node -e "const s=require('./smoke-artifact-summary.json'); if(!s.ok) process.exit(1)"

--- a/scripts/ci-guard/smoke-artifact/audit.ts
+++ b/scripts/ci-guard/smoke-artifact/audit.ts
@@ -1,0 +1,205 @@
+#!/usr/bin/env node
+// @ts-check
+import fs from "fs";
+import path from "path";
+import yaml from "yaml";
+import toml from "toml";
+
+function readWrangler(summary: any) {
+  try {
+    const wranglerPath = path.join(process.cwd(), "wrangler.toml");
+    const content = fs.readFileSync(wranglerPath, "utf8");
+    const cfg = toml.parse(content);
+    const build = (cfg as any).build || {};
+    const pages = (cfg as any).pages || {};
+    const wSummary = { ok: true, errors: [] as string[] };
+    if (!build.command) {
+      wSummary.ok = false;
+      wSummary.errors.push("missing [build].command");
+    }
+    if (!pages.build_output_dir) {
+      wSummary.ok = false;
+      wSummary.errors.push("missing [pages].build_output_dir");
+    }
+    summary.wrangler = wSummary;
+    if (!wSummary.ok) summary.ok = false;
+  } catch (e) {
+    summary.wrangler = { ok: false, errors: ["missing wrangler.toml"] };
+    summary.ok = false;
+  }
+}
+
+function stepRefsDist(step: any): boolean {
+  if (!step) return false;
+  if (typeof step.run === "string" && step.run.includes("frontend/dist"))
+    return true;
+  if (
+    step.with &&
+    typeof step.with.path === "string" &&
+    step.with.path.includes("frontend/dist")
+  )
+    return true;
+  return false;
+}
+
+function auditFiles(files: string[]) {
+  const summary: any = {
+    ok: true,
+    files: {},
+    wrangler: { ok: true, errors: [] as string[] },
+  };
+  readWrangler(summary);
+  for (const file of files) {
+    const content = fs.readFileSync(file, "utf8");
+    const doc = yaml.parse(content) || {};
+    const jobs = doc.jobs || {};
+    const fileSummary: any = { ok: true, jobs: {} };
+    for (const [jobName, job] of Object.entries<any>(jobs)) {
+      const steps: any[] = Array.isArray(job.steps) ? job.steps : [];
+      const jobSummary: any = { ok: true, errors: [] as string[] };
+      const stepTexts = steps.map((s) => JSON.stringify(s));
+      const referencesDist = stepTexts.some(
+        (t) => t && t.includes("frontend/dist"),
+      );
+      if (!referencesDist) {
+        fileSummary.jobs[jobName] = jobSummary;
+        continue;
+      }
+      const firstDistIdx = steps.findIndex(stepRefsDist);
+      const downloadIdx = steps.findIndex(
+        (s) =>
+          typeof s.uses === "string" &&
+          s.uses.includes("actions/download-artifact") &&
+          s.with &&
+          typeof s.with.name === "string" &&
+          /^frontend-dist/.test(String(s.with.name)) &&
+          s.with.path &&
+          String(s.with.path).includes("frontend/dist"),
+      );
+      const buildIdx = steps.findIndex(
+        (s) =>
+          typeof s.run === "string" &&
+          /pnpm\s+(?:-C\s+frontend\s+)?(?:run\s+)?build/.test(s.run),
+      );
+      if (buildIdx === -1) {
+        if (downloadIdx === -1 || downloadIdx > firstDistIdx) {
+          jobSummary.ok = false;
+          jobSummary.errors.push(
+            "missing build or artifact download before use",
+          );
+        }
+        fileSummary.jobs[jobName] = jobSummary;
+        if (!jobSummary.ok) fileSummary.ok = summary.ok = false;
+        continue;
+      }
+      const buildStep = steps[buildIdx];
+      if (
+        !(
+          buildStep["working-directory"] === "frontend" ||
+          /-C\s+frontend/.test(buildStep.run || "")
+        )
+      ) {
+        jobSummary.ok = false;
+        jobSummary.errors.push(
+          `step ${buildIdx + 1}: build must run in frontend directory`,
+        );
+      }
+      if (/\bnpm\b/.test(buildStep.run || "")) {
+        jobSummary.ok = false;
+        jobSummary.errors.push(`step ${buildIdx + 1}: build must use pnpm`);
+      }
+      const nodeStep = steps
+        .slice(0, buildIdx)
+        .find(
+          (s) =>
+            typeof s.uses === "string" &&
+            s.uses.startsWith("actions/setup-node") &&
+            s.with,
+        );
+      if (!nodeStep) {
+        jobSummary.ok = false;
+        jobSummary.errors.push("missing Node 20 setup");
+      } else {
+        const nodeVersion = String(nodeStep.with["node-version"] || "");
+        if (!(nodeVersion.includes("20") || nodeVersion.includes("${{"))) {
+          jobSummary.ok = false;
+          jobSummary.errors.push("missing Node 20 setup");
+        }
+        if (nodeStep.with && nodeStep.with.cache !== "pnpm") {
+          jobSummary.ok = false;
+          jobSummary.errors.push("setup-node cache must be pnpm");
+        }
+      }
+      const corepackIdx = steps.findIndex(
+        (s) => typeof s.run === "string" && s.run.trim() === "corepack enable",
+      );
+      if (corepackIdx === -1 || corepackIdx > buildIdx) {
+        jobSummary.ok = false;
+        jobSummary.errors.push("missing corepack enable before build");
+      }
+      const pnpmSetupIdx = steps.findIndex(
+        (s) =>
+          typeof s.uses === "string" && s.uses.startsWith("pnpm/action-setup"),
+      );
+      if (pnpmSetupIdx === -1 || pnpmSetupIdx > buildIdx) {
+        jobSummary.ok = false;
+        jobSummary.errors.push("missing pnpm/action-setup before build");
+      }
+      const verifyIdx = steps.findIndex(
+        (s) =>
+          typeof s.run === "string" &&
+          s.run.includes("frontend/dist/index.html") &&
+          /test\s+-f/.test(s.run),
+      );
+      if (verifyIdx === -1 || verifyIdx < buildIdx) {
+        jobSummary.ok = false;
+        jobSummary.errors.push("missing verify step");
+      }
+      const uploadIdx = steps.findIndex(
+        (s, i) =>
+          i > buildIdx &&
+          typeof s.uses === "string" &&
+          s.uses.includes("actions/upload-artifact") &&
+          s.with &&
+          typeof s.with.name === "string" &&
+          /^frontend-dist/.test(String(s.with.name)) &&
+          s.with.path &&
+          String(s.with.path).includes("frontend/dist"),
+      );
+      if (uploadIdx === -1) {
+        jobSummary.ok = false;
+        jobSummary.errors.push("missing artifact upload after build");
+      }
+      if (!jobSummary.ok) fileSummary.ok = summary.ok = false;
+      fileSummary.jobs[jobName] = jobSummary;
+    }
+    summary.files[file] = fileSummary;
+  }
+  return summary;
+}
+
+function main() {
+  const repoRoot = process.cwd();
+  const args = process.argv.slice(2);
+  let files: string[];
+  if (args.length) {
+    files = args;
+  } else {
+    const wfDir = path.join(repoRoot, ".github", "workflows");
+    files = fs
+      .readdirSync(wfDir)
+      .filter((f) => f.endsWith(".yml"))
+      .map((f) => path.join(wfDir, f));
+  }
+  const summary = auditFiles(files);
+  const out = path.join(repoRoot, "smoke-artifact-summary.json");
+  fs.writeFileSync(out, JSON.stringify(summary, null, 2));
+  console.log(JSON.stringify(summary, null, 2));
+  if (!summary.ok) process.exit(1);
+}
+
+if (require.main === module) {
+  main();
+}
+
+export { auditFiles };

--- a/tests/ci-guard/smoke-artifact/audit.test.ts
+++ b/tests/ci-guard/smoke-artifact/audit.test.ts
@@ -1,0 +1,199 @@
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import * as path from "path";
+import * as os from "os";
+import { auditFiles } from "../../../scripts/ci-guard/smoke-artifact/audit";
+
+function wf(dir: string, content: string): string {
+  const file = path.join(dir, "flow.yml");
+  writeFileSync(file, content);
+  return file;
+}
+
+function wrangler(dir: string, content: string): void {
+  writeFileSync(path.join(dir, "wrangler.toml"), content);
+}
+
+describe("smoke artifact audit", () => {
+  test("build and upload pass", () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "wf-"));
+    wrangler(
+      dir,
+      '[build]\ncommand = "pnpm -C frontend build"\n[pages]\nbuild_output_dir = "frontend/dist"\n',
+    );
+    const file = wf(
+      dir,
+      `jobs:\n  build:\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n          cache: pnpm\n      - run: corepack enable\n      - uses: pnpm/action-setup@v4\n      - run: pnpm build\n        working-directory: frontend\n      - run: test -f frontend/dist/index.html\n        working-directory: frontend\n      - uses: actions/upload-artifact@v4\n        with:\n          name: frontend-dist\n          path: frontend/dist\n`,
+    );
+    const cwd = process.cwd();
+    process.chdir(dir);
+    const res = auditFiles([file]);
+    process.chdir(cwd);
+    rmSync(dir, { recursive: true, force: true });
+    expect(res.ok).toBe(true);
+  });
+
+  test("-C frontend build and download pass", () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "wf-"));
+    wrangler(
+      dir,
+      '[build]\ncommand = "pnpm -C frontend build"\n[pages]\nbuild_output_dir = "frontend/dist"\n',
+    );
+    const file = wf(
+      dir,
+      [
+        "jobs:",
+        "  build:",
+        "    steps:",
+        "      - uses: actions/setup-node@v4",
+        "        with:",
+        "          node-version: 20",
+        "          cache: pnpm",
+        "      - run: corepack enable",
+        "      - uses: pnpm/action-setup@v4",
+        "      - run: pnpm -C frontend build",
+        "      - run: test -f frontend/dist/index.html",
+        "      - uses: actions/upload-artifact@v4",
+        "        with:",
+        "          name: frontend-dist",
+        "          path: frontend/dist",
+        "  smoke:",
+        "    needs: build",
+        "    steps:",
+        "      - uses: actions/download-artifact@v4",
+        "        with:",
+        "          name: frontend-dist",
+        "          path: frontend/dist",
+        "      - run: ls frontend/dist",
+      ].join("\n"),
+    );
+    const cwd = process.cwd();
+    process.chdir(dir);
+    const res = auditFiles([file]);
+    process.chdir(cwd);
+    rmSync(dir, { recursive: true, force: true });
+    expect(res.ok).toBe(true);
+  });
+
+  test("missing upload fails", () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "wf-"));
+    wrangler(
+      dir,
+      '[build]\ncommand = "pnpm -C frontend build"\n[pages]\nbuild_output_dir = "frontend/dist"\n',
+    );
+    const file = wf(
+      dir,
+      `jobs:\n  build:\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n          cache: pnpm\n      - run: corepack enable\n      - uses: pnpm/action-setup@v4\n      - run: pnpm build\n        working-directory: frontend\n      - run: test -f frontend/dist/index.html\n        working-directory: frontend\n`,
+    );
+    const cwd = process.cwd();
+    process.chdir(dir);
+    const res = auditFiles([file]);
+    process.chdir(cwd);
+    rmSync(dir, { recursive: true, force: true });
+    expect(res.ok).toBe(false);
+  });
+
+  test("missing download fails", () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "wf-"));
+    wrangler(
+      dir,
+      '[build]\ncommand = "pnpm -C frontend build"\n[pages]\nbuild_output_dir = "frontend/dist"\n',
+    );
+    const file = wf(
+      dir,
+      [
+        "jobs:",
+        "  build:",
+        "    steps:",
+        "      - uses: actions/setup-node@v4",
+        "        with:",
+        "          node-version: 20",
+        "          cache: pnpm",
+        "      - run: corepack enable",
+        "      - uses: pnpm/action-setup@v4",
+        "      - run: pnpm build",
+        "        working-directory: frontend",
+        "      - run: test -f frontend/dist/index.html",
+        "        working-directory: frontend",
+        "      - uses: actions/upload-artifact@v4",
+        "        with:",
+        "          name: frontend-dist",
+        "          path: frontend/dist",
+        "  smoke:",
+        "    needs: build",
+        "    steps:",
+        "      - run: ls frontend/dist",
+      ].join("\n"),
+    );
+    const cwd = process.cwd();
+    process.chdir(dir);
+    const res = auditFiles([file]);
+    process.chdir(cwd);
+    rmSync(dir, { recursive: true, force: true });
+    expect(res.ok).toBe(false);
+  });
+
+  test("matrix artifact names pass", () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "wf-"));
+    wrangler(
+      dir,
+      '[build]\ncommand = "pnpm -C frontend build"\n[pages]\nbuild_output_dir = "frontend/dist"\n',
+    );
+    const expr = "${{ matrix.node }}";
+    const file = wf(
+      dir,
+      [
+        "jobs:",
+        "  build:",
+        "    strategy:",
+        "      matrix:",
+        "        node: [18,20]",
+        "        os: [ubuntu-latest, windows-latest]",
+        "    steps:",
+        "      - uses: actions/setup-node@v4",
+        "        with:",
+        `          node-version: ${expr}`,
+        "          cache: pnpm",
+        "      - run: corepack enable",
+        "      - uses: pnpm/action-setup@v4",
+        "      - run: pnpm build",
+        "        working-directory: frontend",
+        "      - run: test -f frontend/dist/index.html",
+        "        working-directory: frontend",
+        "      - uses: actions/upload-artifact@v4",
+        "        with:",
+        `          name: frontend-dist-${expr}-${expr}`,
+        "          path: frontend/dist",
+        "  smoke:",
+        "    needs: build",
+        "    strategy:",
+        "      matrix:",
+        "        node: [18,20]",
+        "        os: [ubuntu-latest, windows-latest]",
+        "    steps:",
+        "      - uses: actions/download-artifact@v4",
+        "        with:",
+        `          name: frontend-dist-${expr}-${expr}`,
+        "          path: frontend/dist",
+        "      - run: ls frontend/dist",
+      ].join("\n"),
+    );
+    const cwd = process.cwd();
+    process.chdir(dir);
+    const res = auditFiles([file]);
+    process.chdir(cwd);
+    rmSync(dir, { recursive: true, force: true });
+    expect(res.ok).toBe(true);
+  });
+
+  test("wrangler missing fields fails", () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "wf-"));
+    wrangler(dir, '[build]\ncommand = "pnpm -C frontend build"\n');
+    const file = wf(dir, `jobs:\n  build:\n    steps: []\n`);
+    const cwd = process.cwd();
+    process.chdir(dir);
+    const res = auditFiles([file]);
+    process.chdir(cwd);
+    rmSync(dir, { recursive: true, force: true });
+    expect(res.ok).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add smoke artifact audit script to verify frontend dist handling and wrangler config
- guard workflow runs audit and tests

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: root eslint exits 0, backend eslint exits 0, etc.)*
- `node scripts/run-jest.js tests/ci-guard/smoke-artifact/audit.test.ts`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: prettier YAML parse errors)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b70b8d64832dafe9e5971b5fb452