### PR TITLE
ci(windows): guarantee pnpm on PATH via Corepack + fallback, then verify

### DIFF
--- a/.github/workflows/guard-corepack-pnpm-windows.yml
+++ b/.github/workflows/guard-corepack-pnpm-windows.yml
@@ -1,0 +1,14 @@
+name: guard corepack pnpm windows
+on: [pull_request, push]
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: corepack enable
+      - run: npm ci
+      - run: npx ts-node --transpile-only scripts/ci-guard/corepack-pnpm-windows/audit.ts
+      - run: node scripts/run-jest.js tests/ci-guard/corepack-pnpm-windows/audit.test.ts

--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -31,6 +31,47 @@ jobs:
         with:
           run_install: false
 # <<< END MANAGED BLOCK: ci-guard:windows-cancel-guard
+# >>> BEGIN MANAGED BLOCK: ci-guard:corepack-pnpm-windows
+      - name: Setup Node (Windows)
+        if: startsWith(runner.os, 'Windows')
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: |
+            pnpm-lock.yaml
+            frontend/pnpm-lock.yaml
+            backend/pnpm-lock.yaml
+
+      - name: Enable Corepack (Windows)
+        if: startsWith(runner.os, 'Windows')
+        shell: pwsh
+        run: corepack enable
+
+      - name: Prepare pnpm via Corepack (Windows)
+        if: startsWith(runner.os, 'Windows')
+        shell: pwsh
+        run: |
+          $pm = ""
+          try { $pm = (Get-Content package.json | ConvertFrom-Json).packageManager } catch {}
+          if ($pm -and $pm -match "^pnpm@") {
+            $ver = $pm.Split("@")[1]
+            corepack prepare "pnpm@$ver" --activate
+          } else {
+            corepack prepare pnpm@10 --activate
+          }
+
+      - name: Fallback: pnpm/action-setup (Windows)
+        if: startsWith(runner.os, 'Windows')
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Verify pnpm (Windows)
+        if: startsWith(runner.os, 'Windows')
+        shell: pwsh
+        run: pnpm -v
+# <<< END MANAGED BLOCK: ci-guard:corepack-pnpm-windows
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/scripts/ci-guard/corepack-pnpm-windows/audit.ts
+++ b/scripts/ci-guard/corepack-pnpm-windows/audit.ts
@@ -1,0 +1,36 @@
+import fs from "fs";
+import path from "path";
+
+const repoRoot = process.cwd();
+const workflowsDir = path.join(repoRoot, ".github", "workflows");
+const wfFiles = fs.existsSync(workflowsDir)
+  ? fs
+      .readdirSync(workflowsDir)
+      .filter((f) => f.endsWith(".yml") || f.endsWith(".yaml"))
+  : [];
+
+const required = [
+  "name: Setup Node (Windows)",
+  "name: Enable Corepack (Windows)",
+  "name: Prepare pnpm via Corepack (Windows)",
+  "name: Fallback: pnpm/action-setup (Windows)",
+  "name: Verify pnpm (Windows)",
+];
+
+const errors: string[] = [];
+
+for (const wfFile of wfFiles) {
+  if (wfFile.startsWith("guard-")) continue;
+  const wfPath = path.join(workflowsDir, wfFile);
+  const raw = fs.readFileSync(wfPath, "utf8");
+  if (!/windows/i.test(raw)) continue;
+  const missing = required.some((r) => !raw.includes(r));
+  if (missing) {
+    errors.push(`${wfFile}: missing Corepack pnpm bootstrap block`);
+  }
+}
+
+if (errors.length) {
+  console.error(errors.join("\n"));
+  process.exit(1);
+}

--- a/tests/ci-guard/corepack-pnpm-windows/audit.test.ts
+++ b/tests/ci-guard/corepack-pnpm-windows/audit.test.ts
@@ -1,0 +1,52 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { spawnSync } from "child_process";
+
+const script = path.resolve(
+  __dirname,
+  "../../../scripts/ci-guard/corepack-pnpm-windows/audit.ts",
+);
+const tsNode = [
+  "-y",
+  "ts-node",
+  "--transpile-only",
+  "--compiler-options",
+  JSON.stringify({ module: "commonjs", moduleResolution: "node" }),
+  script,
+];
+
+function run(cwd: string) {
+  return spawnSync("npx", tsNode, { cwd, encoding: "utf8" });
+}
+
+function writeFile(dir: string, file: string, content: string) {
+  const full = path.join(dir, file);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content);
+}
+
+describe("corepack pnpm windows guard", () => {
+  test("windows job with block passes", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "corepack-pass-"));
+    writeFile(tmp, "pnpm-lock.yaml", "");
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      String.raw`name: t\njobs:\n  build:\n    runs-on: \${{ matrix.os }}\n    strategy:\n      fail-fast: false\n      matrix:\n        os: [ubuntu-latest, windows-latest]\n    steps:\n      - uses: actions/checkout@v4\n# >>> BEGIN MANAGED BLOCK: ci-guard:corepack-pnpm-windows\n      - name: Setup Node (Windows)\n        if: startsWith(runner.os, 'Windows')\n        uses: actions/setup-node@v4\n        with:\n          node-version: 20\n          cache: pnpm\n          cache-dependency-path: |\n            pnpm-lock.yaml\n            frontend/pnpm-lock.yaml\n            backend/pnpm-lock.yaml\n\n      - name: Enable Corepack (Windows)\n        if: startsWith(runner.os, 'Windows')\n        shell: pwsh\n        run: corepack enable\n\n      - name: Prepare pnpm via Corepack (Windows)\n        if: startsWith(runner.os, 'Windows')\n        shell: pwsh\n        run: |\n          $pm = ""\n          try { $pm = (Get-Content package.json | ConvertFrom-Json).packageManager } catch {}\n          if ($pm -and $pm -match "^pnpm@") {\n            $ver = $pm.Split("@")[1]\n            corepack prepare "pnpm@$ver" --activate\n          } else {\n            corepack prepare pnpm@10 --activate\n          }\n\n      - name: Fallback: pnpm/action-setup (Windows)\n        if: startsWith(runner.os, 'Windows')\n        uses: pnpm/action-setup@v4\n        with:\n          run_install: false\n\n      - name: Verify pnpm (Windows)\n        if: startsWith(runner.os, 'Windows')\n        shell: pwsh\n        run: pnpm -v\n# <<< END MANAGED BLOCK: ci-guard:corepack-pnpm-windows\n      - run: echo ok\n`);
+    const res = run(tmp);
+    expect(res.status).toBe(0);
+  });
+
+  test("missing block fails", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "corepack-fail-"));
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `name: t\njobs:\n  build:\n    runs-on: windows-latest\n    steps:\n      - run: echo hi\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).not.toBe(0);
+    expect(res.stderr + res.stdout).toMatch(/missing Corepack pnpm bootstrap block/);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure Corepack-provisioned pnpm is available on Windows jobs
- add guard workflow and tests for Corepack/pnpm Windows bootstrap block

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` (backend)
- `node scripts/run-jest.js tests/ci-guard/corepack-pnpm-windows/audit.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a8b7fc5c8c832db5ee22da9f5dd38e