### PR TITLE
ci: guard corepack pnpm on windows

### DIFF
--- a/.github/workflows/guard-corepack-pnpm-windows.yml
+++ b/.github/workflows/guard-corepack-pnpm-windows.yml
@@ -1,0 +1,20 @@
+name: guard corepack pnpm windows
+on: [pull_request, push]
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: corepack enable
+      - run: npm ci
+      - run: npx ts-node --transpile-only scripts/ci-guard/corepack-pnpm-windows/audit.ts
+      - run: node scripts/run-jest.js tests/ci-guard/corepack-pnpm-windows/audit.test.ts
+      - run: node scripts/ci/print-suite-summary.js > corepack-pnpm-windows-summary.txt
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: corepack-pnpm-windows-summary
+          path: corepack-pnpm-windows-summary.txt

--- a/scripts/ci-guard/corepack-pnpm-windows/audit.ts
+++ b/scripts/ci-guard/corepack-pnpm-windows/audit.ts
@@ -1,0 +1,198 @@
+import fs from "fs";
+import path from "path";
+import yaml from "yaml";
+
+interface Step {
+  name?: string;
+  uses?: string;
+  run?: string;
+  with?: Record<string, any>;
+  shell?: string;
+  ["working-directory"]?: string;
+}
+
+interface Job {
+  [key: string]: any;
+  steps?: Step[];
+  defaults?: { run?: { ["working-directory"]?: string } };
+}
+
+function findFiles(root: string, filename: string): string[] {
+  const out: string[] = [];
+  function walk(dir: string) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (entry.name === "node_modules" || entry.name.startsWith(".git"))
+        continue;
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (entry.isFile() && entry.name === filename) {
+        out.push(path.relative(root, full).replace(/\\/g, "/"));
+      }
+    }
+  }
+  if (fs.existsSync(root)) walk(root);
+  return out;
+}
+
+function hasWindows(value: any): boolean {
+  if (typeof value === "string") return /windows/i.test(value);
+  if (Array.isArray(value)) return value.some(hasWindows);
+  return false;
+}
+
+const repoRoot = process.cwd();
+const workflowsDir = path.join(repoRoot, ".github", "workflows");
+const lockFiles = findFiles(repoRoot, "pnpm-lock.yaml");
+const packageJsons = findFiles(repoRoot, "package.json");
+const pnpmPackages = new Map<string, string>();
+for (const rel of packageJsons) {
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, rel), "utf8"));
+    const pm = pkg.packageManager;
+    if (typeof pm === "string" && pm.startsWith("pnpm@")) {
+      const dir = path.posix.dirname(rel) || ".";
+      pnpmPackages.set(dir, pm.slice("pnpm@".length));
+    }
+  } catch {}
+}
+
+const errors: string[] = [];
+const wfFiles = fs.existsSync(workflowsDir)
+  ? fs
+      .readdirSync(workflowsDir)
+      .filter((f) => f.endsWith(".yml") || f.endsWith(".yaml"))
+  : [];
+
+for (const wfFile of wfFiles) {
+  const wfPath = path.join(workflowsDir, wfFile);
+  let wf: any;
+  try {
+    wf = yaml.parse(fs.readFileSync(wfPath, "utf8"));
+  } catch (e: any) {
+    errors.push(`${wfFile}: failed to parse - ${e.message}`);
+    continue;
+  }
+  const wfDefaultDir = wf?.defaults?.run?.["working-directory"];
+  const jobs: Record<string, Job> = wf.jobs || {};
+  for (const [jobName, job] of Object.entries(jobs)) {
+    let isWindows = false;
+    if (hasWindows(job["runs-on"])) isWindows = true;
+    const matrixOs = job.strategy?.matrix?.os;
+    if (hasWindows(matrixOs)) isWindows = true;
+    if (!isWindows) continue;
+
+    const steps: Step[] = job.steps || [];
+    const jobDefaultDir = job.defaults?.run?.["working-directory"];
+    let setupIndex = -1;
+    let cachePaths: string[] = [];
+    let corepackIndex = -1;
+    let prepareIndex = -1;
+    let prepareVersion: string | undefined;
+    let actionSetupIndex = -1;
+    let actionSetupVersion: string | undefined;
+    let verifyIndex = -1;
+    let hasNpmCache = false;
+
+    steps.forEach((step, idx) => {
+      if (step.uses && /actions\/setup-node@v4/.test(step.uses)) {
+        const cache = step.with?.cache;
+        if (
+          cache === "pnpm" &&
+          (step.with?.["node-version"] === 20 ||
+            step.with?.["node-version"] === "20")
+        ) {
+          setupIndex = idx;
+          const dep = step.with?.["cache-dependency-path"];
+          if (typeof dep === "string") {
+            cachePaths = dep
+              .split(/\n|,/)
+              .map((s: string) => s.trim())
+              .filter(Boolean);
+          }
+        }
+        if (cache === "npm") hasNpmCache = true;
+      }
+      if (
+        typeof step.run === "string" &&
+        step.run.includes("corepack enable")
+      ) {
+        corepackIndex = idx;
+      }
+      if (
+        typeof step.run === "string" &&
+        step.run.includes("corepack prepare")
+      ) {
+        prepareIndex = idx;
+        const m = step.run.match(/corepack prepare pnpm@([^\s]+)/);
+        if (m) prepareVersion = m[1];
+      }
+      if (step.uses && step.uses.startsWith("pnpm/action-setup")) {
+        actionSetupIndex = idx;
+        const v = step.with?.version;
+        if (typeof v === "string") actionSetupVersion = v;
+      }
+      if (
+        typeof step.run === "string" &&
+        /\bpnpm\b/.test(step.run) &&
+        /(?:--version|-v)\b/.test(step.run)
+      ) {
+        verifyIndex = idx;
+      }
+    });
+
+    const lastSetupIdx = Math.max(prepareIndex, actionSetupIndex);
+
+    steps.forEach((step, idx) => {
+      const run = step.run;
+      if (typeof run !== "string") return;
+      if (!/\bpnpm\b/.test(run)) return;
+      if (/corepack prepare/.test(run)) return;
+      if (/(?:--version|-v)\b/.test(run)) return;
+      const prefix = `${wfFile} > ${jobName} > step ${idx + 1}`;
+      if (setupIndex < 0 || idx <= setupIndex) {
+        errors.push(
+          `${prefix}: missing actions/setup-node@v4 (node 20 with cache pnpm) before pnpm`,
+        );
+      } else {
+        if (
+          cachePaths.length !== lockFiles.length ||
+          lockFiles.some((lf) => !cachePaths.includes(lf))
+        ) {
+          errors.push(
+            `${wfFile} > ${jobName}: cache-dependency-path must include all pnpm-lock.yaml files`,
+          );
+        }
+      }
+      if (corepackIndex < 0 || idx <= corepackIndex) {
+        errors.push(`${prefix}: missing corepack enable before pnpm`);
+      }
+      if (lastSetupIdx < 0 || idx <= lastSetupIdx) {
+        errors.push(
+          `${prefix}: missing corepack prepare or pnpm/action-setup before pnpm`,
+        );
+      }
+      if (verifyIndex < 0 || idx <= verifyIndex) {
+        errors.push(`${prefix}: missing pnpm --version before pnpm`);
+      }
+      if (hasNpmCache) {
+        errors.push(`${prefix}: cache: npm present in job using pnpm`);
+      }
+      const stepDir =
+        step["working-directory"] || jobDefaultDir || wfDefaultDir || ".";
+      const normDir = path.posix.normalize(stepDir);
+      const pkgVersion = pnpmPackages.get(normDir) || pnpmPackages.get(".");
+      const pinned = prepareVersion || actionSetupVersion;
+      if (pkgVersion && pinned && pkgVersion !== pinned) {
+        errors.push(
+          `${wfFile} > ${jobName}: pnpm version ${pinned} conflicts with package.json ${pkgVersion}`,
+        );
+      }
+    });
+  }
+}
+
+if (errors.length) {
+  console.error(errors.join("\n"));
+  process.exit(1);
+}

--- a/tests/ci-guard/corepack-pnpm-windows/audit.test.ts
+++ b/tests/ci-guard/corepack-pnpm-windows/audit.test.ts
@@ -1,0 +1,246 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { spawnSync } from "child_process";
+
+const script = path.resolve(
+  __dirname,
+  "../../../scripts/ci-guard/corepack-pnpm-windows/audit.ts",
+);
+const tsNode = [
+  "-y",
+  "ts-node",
+  "--transpile-only",
+  "--compiler-options",
+  JSON.stringify({ module: "commonjs", moduleResolution: "node" }),
+  script,
+];
+
+function run(cwd: string) {
+  return spawnSync("npx", tsNode, { cwd, encoding: "utf8" });
+}
+
+function writeFile(dir: string, file: string, content: string) {
+  const full = path.join(dir, file);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content);
+}
+
+describe("corepack pnpm windows audit", () => {
+  test("t1 windows job with full bootstrap passes", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "t1-"));
+    writeFile(
+      tmp,
+      "package.json",
+      JSON.stringify({ packageManager: "pnpm@10.11.0" }),
+    );
+    writeFile(tmp, "pnpm-lock.yaml", "");
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `name: t1\njobs:\n  build:\n    runs-on: windows-latest\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n          cache: pnpm\n          cache-dependency-path: pnpm-lock.yaml\n      - run: corepack enable\n        shell: pwsh\n      - run: corepack prepare pnpm@10.11.0 --activate\n      - run: pnpm --version\n        shell: pwsh\n      - run: pnpm install\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).toBe(0);
+  });
+
+  test("t2 missing corepack enable fails", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "t2-"));
+    writeFile(
+      tmp,
+      "package.json",
+      JSON.stringify({ packageManager: "pnpm@10.11.0" }),
+    );
+    writeFile(tmp, "pnpm-lock.yaml", "");
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `name: t2\njobs:\n  build:\n    runs-on: windows-latest\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n          cache: pnpm\n          cache-dependency-path: pnpm-lock.yaml\n      - run: corepack prepare pnpm@10.11.0 --activate\n      - run: pnpm --version\n      - run: pnpm install\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).not.toBe(0);
+    expect(res.stderr + res.stdout).toMatch(/corepack enable/);
+  });
+
+  test("t3 missing prepare and fallback fails", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "t3-"));
+    writeFile(
+      tmp,
+      "package.json",
+      JSON.stringify({ packageManager: "pnpm@10.11.0" }),
+    );
+    writeFile(tmp, "pnpm-lock.yaml", "");
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `name: t3\njobs:\n  build:\n    runs-on: windows-latest\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n          cache: pnpm\n          cache-dependency-path: pnpm-lock.yaml\n      - run: corepack enable\n      - run: pnpm --version\n      - run: pnpm install\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).not.toBe(0);
+    expect(res.stderr + res.stdout).toMatch(/corepack prepare/);
+  });
+
+  test("t4 pnpm used before verify fails", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "t4-"));
+    writeFile(
+      tmp,
+      "package.json",
+      JSON.stringify({ packageManager: "pnpm@10.11.0" }),
+    );
+    writeFile(tmp, "pnpm-lock.yaml", "");
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `name: t4\njobs:\n  build:\n    runs-on: windows-latest\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n          cache: pnpm\n          cache-dependency-path: pnpm-lock.yaml\n      - run: corepack enable\n      - run: corepack prepare pnpm@10.11.0 --activate\n      - run: pnpm install\n      - run: pnpm --version\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).not.toBe(0);
+    expect(res.stderr + res.stdout).toMatch(/pnpm --version/);
+  });
+
+  test("t5 cache npm present fails", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "t5-"));
+    writeFile(
+      tmp,
+      "package.json",
+      JSON.stringify({ packageManager: "pnpm@10.11.0" }),
+    );
+    writeFile(tmp, "pnpm-lock.yaml", "");
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `name: t5\njobs:\n  build:\n    runs-on: windows-latest\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n          cache: npm\n      - run: corepack enable\n      - run: corepack prepare pnpm@10.11.0 --activate\n      - run: pnpm --version\n      - run: pnpm install\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).not.toBe(0);
+    expect(res.stderr + res.stdout).toMatch(/cache: npm/);
+  });
+
+  test("t6 packageManager pin mismatch fails", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "t6-"));
+    writeFile(
+      tmp,
+      "package.json",
+      JSON.stringify({ packageManager: "pnpm@10.11.0" }),
+    );
+    writeFile(tmp, "pnpm-lock.yaml", "");
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `name: t6\njobs:\n  build:\n    runs-on: windows-latest\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n          cache: pnpm\n          cache-dependency-path: pnpm-lock.yaml\n      - run: corepack enable\n      - run: corepack prepare pnpm@9.9.0 --activate\n      - run: pnpm --version\n      - run: pnpm install\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).not.toBe(0);
+    expect(res.stderr + res.stdout).toMatch(/pnpm version 9.9.0/);
+  });
+
+  test("t7 non-windows jobs unaffected", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "t7-"));
+    writeFile(
+      tmp,
+      "package.json",
+      JSON.stringify({ packageManager: "pnpm@10.11.0" }),
+    );
+    writeFile(tmp, "pnpm-lock.yaml", "");
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `name: t7\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - run: pnpm install\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).toBe(0);
+  });
+
+  test("t8 multiple lockfiles allowed", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "t8-"));
+    writeFile(
+      tmp,
+      "package.json",
+      JSON.stringify({ packageManager: "pnpm@10.11.0" }),
+    );
+    writeFile(tmp, "pnpm-lock.yaml", "");
+    writeFile(tmp, "frontend/pnpm-lock.yaml", "");
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `name: t8\njobs:\n  build:\n    runs-on: windows-latest\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n          cache: pnpm\n          cache-dependency-path: |\n            pnpm-lock.yaml\n            frontend/pnpm-lock.yaml\n      - run: corepack enable\n      - run: corepack prepare pnpm@10.11.0 --activate\n      - run: pnpm --version\n      - run: pnpm install\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).toBe(0);
+  });
+
+  test("t9 matrix windows + ubuntu passes", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "t9-"));
+    writeFile(
+      tmp,
+      "package.json",
+      JSON.stringify({ packageManager: "pnpm@10.11.0" }),
+    );
+    writeFile(tmp, "pnpm-lock.yaml", "");
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `name: t9\njobs:\n  build:\n    runs-on: ${"${{ matrix.os }}"}\n    strategy:\n      fail-fast: false\n      matrix:\n        os: [ubuntu-latest, windows-latest]\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n          cache: pnpm\n          cache-dependency-path: pnpm-lock.yaml\n      - run: corepack enable\n        if: startsWith(runner.os, 'Windows')\n        shell: pwsh\n      - run: corepack prepare pnpm@10.11.0 --activate\n        if: startsWith(runner.os, 'Windows')\n      - run: pnpm --version\n        if: startsWith(runner.os, 'Windows')\n        shell: pwsh\n      - run: pnpm install\n        if: startsWith(runner.os, 'Windows')\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).toBe(0);
+  });
+
+  test("t10 verify shell bash and action-setup fallback passes", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "t10-"));
+    writeFile(
+      tmp,
+      "package.json",
+      JSON.stringify({ packageManager: "pnpm@10.11.0" }),
+    );
+    writeFile(tmp, "pnpm-lock.yaml", "");
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `name: t10\njobs:\n  build:\n    runs-on: windows-latest\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n          cache: pnpm\n          cache-dependency-path: pnpm-lock.yaml\n      - run: corepack enable\n        shell: bash\n      - uses: pnpm/action-setup@v4\n        with:\n          version: 10.11.0\n          run_install: false\n      - run: pnpm --version\n        shell: bash\n      - run: pnpm install\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).toBe(0);
+  });
+
+  test("t11 job name arbitrary passes", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "t11-"));
+    writeFile(
+      tmp,
+      "package.json",
+      JSON.stringify({ packageManager: "pnpm@10.11.0" }),
+    );
+    writeFile(tmp, "pnpm-lock.yaml", "");
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `name: t11\njobs:\n  weird-name:\n    runs-on: windows-latest\n    steps:\n      - uses: actions/setup-node@v4\n        with:\n          node-version: 20\n          cache: pnpm\n          cache-dependency-path: pnpm-lock.yaml\n      - run: corepack enable\n      - run: corepack prepare pnpm@10.11.0 --activate\n      - run: pnpm --version\n      - run: pnpm install\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).toBe(0);
+  });
+
+  test("t12 aggregated report lists file and job", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "t12-"));
+    writeFile(
+      tmp,
+      "package.json",
+      JSON.stringify({ packageManager: "pnpm@10.11.0" }),
+    );
+    writeFile(tmp, "pnpm-lock.yaml", "");
+    writeFile(
+      tmp,
+      ".github/workflows/a.yml",
+      `name: t12a\njobs:\n  foo:\n    runs-on: windows-latest\n    steps:\n      - run: pnpm install\n`,
+    );
+    writeFile(
+      tmp,
+      ".github/workflows/b.yml",
+      `name: t12b\njobs:\n  bar:\n    runs-on: windows-latest\n    steps:\n      - run: pnpm install\n`,
+    );
+    const res = run(tmp);
+    expect(res.status).not.toBe(0);
+    expect(res.stderr + res.stdout).toMatch(/a.yml > foo > step 1/);
+    expect(res.stderr + res.stdout).toMatch(/b.yml > bar > step 1/);
+  });
+});


### PR DESCRIPTION
## Summary
- enforce pnpm corepack bootstrap on Windows workflows
- add tests for Windows pnpm guard
- wire guard workflow into CI

## Testing
- `npm run format` *(fails: Nested mappings are not allowed in compact mappings)*
- `node scripts/run-jest.js tests/ci-guard/corepack-pnpm-windows/audit.test.ts`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Error occurred when checking code style in 11 files)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b801ab5c832db0e367a85bd88645