### PR TITLE
ci: run self-hosted runner provisioning on ubuntu

### DIFF
--- a/.github/workflows/provision-selfhosted-runner.yml
+++ b/.github/workflows/provision-selfhosted-runner.yml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   provision:
     timeout-minutes: 15
-    runs-on: [self-hosted, linux, aws]
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary
- run provision job on ubuntu-latest

## Testing
- `npm run format`
- `npm test` (backend)
- `npm run ci`
- `npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html)*
- `gh workflow run provision-selfhosted-runner.yml` *(fails: To get started with GitHub CLI, please run: gh auth login)*

------
https://chatgpt.com/codex/tasks/task_e_68a8b9d3b18c832da745829d310df830