### PR TITLE
ci(pkgjson): repair truncated package.json and add guard

### DIFF
--- a/.github/workflows/guard-pkgjson.yml
+++ b/.github/workflows/guard-pkgjson.yml
@@ -1,0 +1,25 @@
+# >>> BEGIN MANAGED BLOCK: ci-guard:pkgjson-repair
+name: Guard package.json
+on: [push, pull_request]
+jobs:
+  pkgjson:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: corepack enable
+        shell: bash
+      - run: node scripts/ci-guard/pkgjson-repair/validate.ts
+        shell: bash
+      - run: |
+          {
+            echo '```json'
+            head -n 15 package.json
+            echo '...'
+            tail -n 15 package.json
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+        shell: bash
+# <<< END MANAGED BLOCK: ci-guard:pkgjson-repair

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "mvp-website",
   "version": "1.0.0",
+  "private": true,
   "nyc": {
     "reporter": [
       "lcov",

--- a/scripts/ci-guard/pkgjson-repair/validate.ts
+++ b/scripts/ci-guard/pkgjson-repair/validate.ts
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+const fs = require('node:fs');
+const path = require('node:path');
+
+function parseJsonWithErrors(filePath) {
+  const src = fs.readFileSync(filePath, 'utf8');
+  try {
+    return { data: JSON.parse(src), src };
+  } catch (err) {
+    const m = /position (\d+)/.exec(err.message);
+    if (m) {
+      const pos = Number(m[1]);
+      const lines = src.slice(0, pos).split(/\n/);
+      const line = lines.length;
+      const col = lines[lines.length - 1].length + 1;
+      err.message = `JSON parse error at ${line}:${col} - ${err.message}`;
+    }
+    throw err;
+  }
+}
+
+function collectWorkflowScripts(dir) {
+  const scripts = new Set();
+  if (!fs.existsSync(dir)) return scripts;
+  const runRe = /\b(?:npm|pnpm)\s+run\s+([\w:-]+)/g;
+  for (const file of fs.readdirSync(dir)) {
+    const full = path.join(dir, file);
+    if (fs.statSync(full).isFile()) {
+      const txt = fs.readFileSync(full, 'utf8');
+      let m;
+      while ((m = runRe.exec(txt))) {
+        const name = m[1];
+        if (!name.startsWith('-')) scripts.add(name);
+      }
+    }
+  }
+  return scripts;
+}
+
+function validate(pkgPath, workflowsDir = path.resolve(process.cwd(), '.github', 'workflows')) {
+  const errors = [];
+  const warnings = [];
+  let pkg;
+  try {
+    const { data } = parseJsonWithErrors(pkgPath);
+    pkg = data;
+  } catch (err) {
+    errors.push(err.message);
+    return { errors, warnings };
+  }
+
+  if (typeof pkg.name !== 'string') errors.push('package.json missing required string field "name"');
+  if (typeof pkg.private !== 'boolean') errors.push('package.json missing required boolean field "private"');
+  if (!pkg.scripts || typeof pkg.scripts !== 'object') errors.push('package.json missing required object field "scripts"');
+
+  if (pkg.version && typeof pkg.version !== 'string') errors.push('package.json optional field "version" must be string');
+  if (pkg.packageManager && typeof pkg.packageManager !== 'string') errors.push('package.json optional field "packageManager" must be string');
+  if (pkg.workspaces && !Array.isArray(pkg.workspaces)) errors.push('package.json optional field "workspaces" must be array of strings');
+
+  const referenced = collectWorkflowScripts(workflowsDir);
+  const missing = Array.from(referenced).filter((s) => !pkg.scripts || !(s in pkg.scripts));
+  if (missing.length) warnings.push(`Missing scripts referenced in workflows: ${missing.join(', ')}`);
+
+  return { errors, warnings };
+}
+
+if (require.main === module) {
+  const pkgPath = path.resolve(process.cwd(), 'package.json');
+  const res = validate(pkgPath);
+  if (res.errors.length) {
+    for (const e of res.errors) console.error(e);
+    process.exit(1);
+  }
+  for (const w of res.warnings) console.warn('WARN:', w);
+}
+
+module.exports = { validate };

--- a/tests/ci-guard/pkgjson-repair/validate.test.ts
+++ b/tests/ci-guard/pkgjson-repair/validate.test.ts
@@ -1,0 +1,41 @@
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const test = require('node:test');
+
+const script = path.resolve(__dirname, '../../../scripts/ci-guard/pkgjson-repair/validate.ts');
+
+function run(cwd) {
+  return spawnSync('node', [script], { cwd, encoding: 'utf8' });
+}
+
+test('valid package.json passes', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pkg-'));
+  const pkg = { name: 'demo', private: true, scripts: { build: 'echo ok' }, workspaces: ['a'] };
+  fs.mkdirSync(path.join(dir, '.github', 'workflows'), { recursive: true });
+  fs.writeFileSync(path.join(dir, '.github', 'workflows', 'w.yml'), 'run: npm run build');
+  fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify(pkg));
+  const res = run(dir);
+  if (res.status !== 0) throw new Error(res.stdout + res.stderr);
+});
+
+test('invalid json reports location', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pkg-'));
+  fs.writeFileSync(path.join(dir, 'package.json'), '{ "name": "x"');
+  const res = run(dir);
+  if (res.status === 0) throw new Error('expected failure');
+});
+
+test('missing scripts trigger warning', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pkg-'));
+  const pkg = { name: 'demo', private: true, scripts: {} };
+  fs.mkdirSync(path.join(dir, '.github', 'workflows'), { recursive: true });
+  fs.writeFileSync(path.join(dir, '.github', 'workflows', 'w.yml'), 'run: npm run missing');
+  fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify(pkg));
+  const res = run(dir);
+  if (res.status !== 0) throw new Error(res.stdout + res.stderr);
+  if (!/Missing scripts/.test(res.stdout) && !/Missing scripts/.test(res.stderr)) {
+    throw new Error('expected warning');
+  }
+});


### PR DESCRIPTION
## Summary
- restore missing `private` flag in root package.json and add validator guard
- add script and tests ensuring package.json schema validity
- wire up a dedicated workflow to run the guard and snapshot package.json

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend tests/api.test.js`
- `node --test tests/ci-guard/pkgjson-repair/validate.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a8b89cbca4832d804b3919559ac426