### PR TITLE
test: add ec2 connect diagnose parser tests

### DIFF
--- a/.github/workflows/guard-ec2-diagnose-tests.yml
+++ b/.github/workflows/guard-ec2-diagnose-tests.yml
@@ -1,0 +1,16 @@
+name: ec2 connect diagnose tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: node scripts/run-jest.js tests/ci-guard/ec2-connect-diagnose/diagnose.test.ts

--- a/scripts/ci-guard/ec2-connect-diagnose/diagnose.ts
+++ b/scripts/ci-guard/ec2-connect-diagnose/diagnose.ts
@@ -1,0 +1,123 @@
+export interface SecurityGroup {
+  id: string;
+  inbound: number[];
+}
+
+export interface Nacl {
+  id: string;
+  deniesEphemeral: boolean;
+  entry?: string;
+}
+
+export interface RouteTable {
+  id: string;
+  hasInternet: boolean;
+}
+
+export interface Ssm {
+  online: boolean;
+  logs?: string;
+}
+
+export interface OsInfo {
+  distro: string;
+  hasEicPackage: boolean;
+}
+
+export interface DiskInfo {
+  full: boolean;
+  df: string;
+}
+
+export interface DiagnoseInput {
+  statusChecks: boolean;
+  publicIp?: string | null;
+  eicEndpoint?: boolean;
+  securityGroup: SecurityGroup;
+  nacl: Nacl;
+  routeTable: RouteTable;
+  ssm: Ssm;
+  os: OsInfo;
+  disk: DiskInfo;
+  region?: string;
+}
+
+export interface DiagnoseOutput {
+  exitCode: number;
+  report: string;
+}
+
+export function diagnose(data: DiagnoseInput): DiagnoseOutput {
+  const issues: string[] = [];
+  const remedies: string[] = [];
+
+  if (!data.publicIp && !data.eicEndpoint) {
+    issues.push("browser Connect will fail; use SSM");
+  }
+
+  if (!data.securityGroup.inbound.includes(22)) {
+    issues.push(`security group ${data.securityGroup.id} missing inbound 22`);
+    remedies.push(
+      `aws ec2 authorize-security-group-ingress --group-id ${data.securityGroup.id} --protocol tcp --port 22 --cidr 0.0.0.0/0`,
+    );
+  }
+
+  if (data.nacl.deniesEphemeral) {
+    const entry = data.nacl.entry ? ` entry ${data.nacl.entry}` : "";
+    issues.push(`network ACL ${data.nacl.id} denies ephemeral${entry}`);
+    remedies.push(
+      `update NACL ${data.nacl.id} to allow ephemeral ports 1024-65535`,
+    );
+  }
+
+  if (!data.routeTable.hasInternet) {
+    issues.push(`route table ${data.routeTable.id} missing IGW/NAT`);
+    remedies.push(
+      `attach an Internet Gateway or NAT Gateway to route table ${data.routeTable.id}`,
+    );
+  }
+
+  if (
+    data.ssm.online &&
+    data.ssm.logs &&
+    /sshd\s+stopped/i.test(data.ssm.logs)
+  ) {
+    issues.push("sshd service stopped");
+    remedies.push("restart sshd via `sudo systemctl restart ssh`");
+  }
+
+  if (!data.ssm.online) {
+    issues.push("SSM agent offline");
+    remedies.push("attach instance profile with AmazonSSMManagedInstanceCore");
+  }
+
+  if (data.os.distro.toLowerCase() === "ubuntu" && !data.os.hasEicPackage) {
+    issues.push("ec2-instance-connect package missing");
+    remedies.push(
+      "install with `sudo apt-get install -y ec2-instance-connect`",
+    );
+  }
+
+  if (data.disk.full) {
+    issues.push("disk 100% full");
+    remedies.push("free up disk space");
+  }
+
+  const lines: string[] = [
+    "# EC2 Connect Diagnose Report",
+    "## Decision Tree",
+    ...issues.map((i) => `- ${i}`),
+    "## Remediation",
+    ...remedies.map((r) => `- ${r}`),
+  ];
+
+  if (data.disk.full) {
+    lines.push("### Disk Usage");
+    lines.push("```\n" + data.disk.df + "\n```");
+  }
+
+  return {
+    exitCode: issues.length > 0 ? 1 : 0,
+    report: lines.join("\n") + "\n",
+  };
+}

--- a/tests/ci-guard/ec2-connect-diagnose/__fixtures__/baseline.json
+++ b/tests/ci-guard/ec2-connect-diagnose/__fixtures__/baseline.json
@@ -1,0 +1,14 @@
+{
+  "statusChecks": true,
+  "publicIp": "1.2.3.4",
+  "eicEndpoint": true,
+  "securityGroup": { "id": "sg-123", "inbound": [22] },
+  "nacl": { "id": "acl-1", "deniesEphemeral": false },
+  "routeTable": { "id": "rtb-1", "hasInternet": true },
+  "ssm": { "online": true, "logs": "" },
+  "os": { "distro": "ubuntu", "hasEicPackage": true },
+  "disk": {
+    "full": false,
+    "df": "Filesystem Size Used Avail Use% Mounted on\n/dev/xvda1 8G 1G 7G 14% /"
+  }
+}

--- a/tests/ci-guard/ec2-connect-diagnose/__fixtures__/disk-full.json
+++ b/tests/ci-guard/ec2-connect-diagnose/__fixtures__/disk-full.json
@@ -1,0 +1,14 @@
+{
+  "statusChecks": true,
+  "publicIp": "1.2.3.4",
+  "eicEndpoint": true,
+  "securityGroup": { "id": "sg-123", "inbound": [22] },
+  "nacl": { "id": "acl-1", "deniesEphemeral": false },
+  "routeTable": { "id": "rtb-1", "hasInternet": true },
+  "ssm": { "online": true, "logs": "" },
+  "os": { "distro": "ubuntu", "hasEicPackage": true },
+  "disk": {
+    "full": true,
+    "df": "Filesystem Size Used Avail Use% Mounted on\n/dev/xvda1 8G 8G 0G 100% /"
+  }
+}

--- a/tests/ci-guard/ec2-connect-diagnose/__fixtures__/missing-eic-package.json
+++ b/tests/ci-guard/ec2-connect-diagnose/__fixtures__/missing-eic-package.json
@@ -1,0 +1,14 @@
+{
+  "statusChecks": true,
+  "publicIp": "1.2.3.4",
+  "eicEndpoint": true,
+  "securityGroup": { "id": "sg-123", "inbound": [22] },
+  "nacl": { "id": "acl-1", "deniesEphemeral": false },
+  "routeTable": { "id": "rtb-1", "hasInternet": true },
+  "ssm": { "online": true, "logs": "" },
+  "os": { "distro": "ubuntu", "hasEicPackage": false },
+  "disk": {
+    "full": false,
+    "df": "Filesystem Size Used Avail Use% Mounted on\n/dev/xvda1 8G 1G 7G 14% /"
+  }
+}

--- a/tests/ci-guard/ec2-connect-diagnose/__fixtures__/nacl-deny-ephemeral.json
+++ b/tests/ci-guard/ec2-connect-diagnose/__fixtures__/nacl-deny-ephemeral.json
@@ -1,0 +1,14 @@
+{
+  "statusChecks": true,
+  "publicIp": "1.2.3.4",
+  "eicEndpoint": true,
+  "securityGroup": { "id": "sg-123", "inbound": [22] },
+  "nacl": { "id": "acl-1", "deniesEphemeral": true, "entry": "100" },
+  "routeTable": { "id": "rtb-1", "hasInternet": true },
+  "ssm": { "online": true, "logs": "" },
+  "os": { "distro": "ubuntu", "hasEicPackage": true },
+  "disk": {
+    "full": false,
+    "df": "Filesystem Size Used Avail Use% Mounted on\n/dev/xvda1 8G 1G 7G 14% /"
+  }
+}

--- a/tests/ci-guard/ec2-connect-diagnose/__fixtures__/no-public-ip.json
+++ b/tests/ci-guard/ec2-connect-diagnose/__fixtures__/no-public-ip.json
@@ -1,0 +1,14 @@
+{
+  "statusChecks": true,
+  "publicIp": null,
+  "eicEndpoint": false,
+  "securityGroup": { "id": "sg-123", "inbound": [22] },
+  "nacl": { "id": "acl-1", "deniesEphemeral": false },
+  "routeTable": { "id": "rtb-1", "hasInternet": true },
+  "ssm": { "online": true, "logs": "" },
+  "os": { "distro": "ubuntu", "hasEicPackage": true },
+  "disk": {
+    "full": false,
+    "df": "Filesystem Size Used Avail Use% Mounted on\n/dev/xvda1 8G 1G 7G 14% /"
+  }
+}

--- a/tests/ci-guard/ec2-connect-diagnose/__fixtures__/rtb-missing-igw.json
+++ b/tests/ci-guard/ec2-connect-diagnose/__fixtures__/rtb-missing-igw.json
@@ -1,0 +1,14 @@
+{
+  "statusChecks": true,
+  "publicIp": "1.2.3.4",
+  "eicEndpoint": true,
+  "securityGroup": { "id": "sg-123", "inbound": [22] },
+  "nacl": { "id": "acl-1", "deniesEphemeral": false },
+  "routeTable": { "id": "rtb-1", "hasInternet": false },
+  "ssm": { "online": true, "logs": "" },
+  "os": { "distro": "ubuntu", "hasEicPackage": true },
+  "disk": {
+    "full": false,
+    "df": "Filesystem Size Used Avail Use% Mounted on\n/dev/xvda1 8G 1G 7G 14% /"
+  }
+}

--- a/tests/ci-guard/ec2-connect-diagnose/__fixtures__/sg-missing-22.json
+++ b/tests/ci-guard/ec2-connect-diagnose/__fixtures__/sg-missing-22.json
@@ -1,0 +1,14 @@
+{
+  "statusChecks": true,
+  "publicIp": "1.2.3.4",
+  "eicEndpoint": true,
+  "securityGroup": { "id": "sg-123", "inbound": [] },
+  "nacl": { "id": "acl-1", "deniesEphemeral": false },
+  "routeTable": { "id": "rtb-1", "hasInternet": true },
+  "ssm": { "online": true, "logs": "" },
+  "os": { "distro": "ubuntu", "hasEicPackage": true },
+  "disk": {
+    "full": false,
+    "df": "Filesystem Size Used Avail Use% Mounted on\n/dev/xvda1 8G 1G 7G 14% /"
+  }
+}

--- a/tests/ci-guard/ec2-connect-diagnose/__fixtures__/ssm-offline.json
+++ b/tests/ci-guard/ec2-connect-diagnose/__fixtures__/ssm-offline.json
@@ -1,0 +1,14 @@
+{
+  "statusChecks": true,
+  "publicIp": "1.2.3.4",
+  "eicEndpoint": true,
+  "securityGroup": { "id": "sg-123", "inbound": [22] },
+  "nacl": { "id": "acl-1", "deniesEphemeral": false },
+  "routeTable": { "id": "rtb-1", "hasInternet": true },
+  "ssm": { "online": false, "logs": "" },
+  "os": { "distro": "ubuntu", "hasEicPackage": true },
+  "disk": {
+    "full": false,
+    "df": "Filesystem Size Used Avail Use% Mounted on\n/dev/xvda1 8G 1G 7G 14% /"
+  }
+}

--- a/tests/ci-guard/ec2-connect-diagnose/__fixtures__/ssm-online-sshd-stopped.json
+++ b/tests/ci-guard/ec2-connect-diagnose/__fixtures__/ssm-online-sshd-stopped.json
@@ -1,0 +1,14 @@
+{
+  "statusChecks": true,
+  "publicIp": "1.2.3.4",
+  "eicEndpoint": true,
+  "securityGroup": { "id": "sg-123", "inbound": [22] },
+  "nacl": { "id": "acl-1", "deniesEphemeral": false },
+  "routeTable": { "id": "rtb-1", "hasInternet": true },
+  "ssm": { "online": true, "logs": "sshd stopped" },
+  "os": { "distro": "ubuntu", "hasEicPackage": true },
+  "disk": {
+    "full": false,
+    "df": "Filesystem Size Used Avail Use% Mounted on\n/dev/xvda1 8G 1G 7G 14% /"
+  }
+}

--- a/tests/ci-guard/ec2-connect-diagnose/diagnose.test.ts
+++ b/tests/ci-guard/ec2-connect-diagnose/diagnose.test.ts
@@ -1,0 +1,93 @@
+import fs from "fs";
+import path from "path";
+import { diagnose } from "../../../scripts/ci-guard/ec2-connect-diagnose/diagnose";
+
+function load(name: string) {
+  const file = path.join(__dirname, "__fixtures__", name);
+  return JSON.parse(fs.readFileSync(file, "utf8"));
+}
+
+describe("ec2-connect-diagnose", () => {
+  test("instance checks pass -> network checks run", () => {
+    const data = load("sg-missing-22.json");
+    const res = diagnose(data);
+    expect(res.exitCode).toBe(1);
+    expect(res.report).toMatch(/security group sg-123 missing inbound 22/);
+  });
+
+  test("no public IP and no EIC endpoint", () => {
+    const data = load("no-public-ip.json");
+    const res = diagnose(data);
+    expect(res.exitCode).toBe(1);
+    expect(res.report).toMatch(/browser Connect will fail; use SSM/);
+  });
+
+  test("security group missing inbound 22", () => {
+    const data = load("sg-missing-22.json");
+    const res = diagnose(data);
+    expect(res.report).toMatch(/security group sg-123 missing inbound 22/);
+    expect(res.report).toMatch(/authorize-security-group-ingress/);
+  });
+
+  test("NACL denies ephemeral", () => {
+    const data = load("nacl-deny-ephemeral.json");
+    const res = diagnose(data);
+    expect(res.report).toMatch(/network ACL acl-1 denies ephemeral/);
+  });
+
+  test("route table missing IGW/NAT", () => {
+    const data = load("rtb-missing-igw.json");
+    const res = diagnose(data);
+    expect(res.report).toMatch(/route table rtb-1 missing IGW\/NAT/);
+  });
+
+  test("SSM online with sshd stopped", () => {
+    const data = load("ssm-online-sshd-stopped.json");
+    const res = diagnose(data);
+    expect(res.report).toMatch(/sshd service stopped/);
+    expect(res.report).toMatch(/restart sshd/);
+  });
+
+  test("SSM offline", () => {
+    const data = load("ssm-offline.json");
+    const res = diagnose(data);
+    expect(res.report).toMatch(/SSM agent offline/);
+    expect(res.report).toMatch(/AmazonSSMManagedInstanceCore/);
+  });
+
+  test("missing ec2-instance-connect package", () => {
+    const data = load("missing-eic-package.json");
+    const res = diagnose(data);
+    expect(res.report).toMatch(/ec2-instance-connect package missing/);
+    expect(res.report).toMatch(/apt-get install -y ec2-instance-connect/);
+  });
+
+  test("disk 100% full", () => {
+    const data = load("disk-full.json");
+    const res = diagnose(data);
+    expect(res.report).toMatch(/disk 100% full/);
+    expect(res.report).toMatch(/Filesystem/);
+    expect(res.report).toMatch(/free up disk space/);
+  });
+
+  test("markdown contains decision tree and remediation", () => {
+    const data = load("sg-missing-22.json");
+    const res = diagnose(data);
+    expect(res.report).toMatch(/## Decision Tree/);
+    expect(res.report).toMatch(/## Remediation/);
+  });
+
+  test("reports deterministic across regions", () => {
+    const base = load("baseline.json");
+    const us = diagnose({ ...base, region: "us-east-1" }).report;
+    const eu = diagnose({ ...base, region: "eu-west-1" }).report;
+    expect(us).toBe(eu);
+  });
+
+  test("exit code reflects blockers", () => {
+    const good = load("baseline.json");
+    const bad = load("sg-missing-22.json");
+    expect(diagnose(good).exitCode).toBe(0);
+    expect(diagnose(bad).exitCode).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add EC2 Connect diagnose parser with decision tree and remediation markdown
- cover connectivity edge cases via Jest fixtures
- run new tests in dedicated workflow

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: root eslint exits 0 expected 0, received 2)*
- `node scripts/run-jest.js tests/ci-guard/ec2-connect-diagnose/diagnose.test.ts`
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d1074d84832d82074715e099e16b