### PR TITLE
ci(runners): SSM-managed GitHub runner (no SSH), auto-bootstrap & health

### DIFF
--- a/.github/workflows/runner-ssm-bootstrap.yml
+++ b/.github/workflows/runner-ssm-bootstrap.yml
@@ -1,0 +1,58 @@
+name: runner-ssm-bootstrap
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * *'
+
+jobs:
+  bootstrap:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.1
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4.0.2
+        with:
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-to-assume: ${{ secrets.AWS_RUNNER_ROLE }}
+      - name: Get runner token
+        id: token
+        uses: actions/github-script@v7.0.1
+        with:
+          script: |
+            const res = await github.rest.actions.createRegistrationTokenForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+            core.setOutput('token', res.data.token);
+      - name: Install runner via SSM
+        run: |
+          aws ssm send-command \
+            --document-name AWS-RunShellScript \
+            --instance-ids "${{ secrets.RUNNER_INSTANCE_ID }}" \
+            --comment "bootstrap github runner" \
+            --parameters commands="/usr/local/bin/install.sh $TOKEN"
+        env:
+          TOKEN: ${{ steps.token.outputs.token }}
+      - name: Health check
+        run: |
+          aws ssm describe-instance-information --filters "Key=InstanceIds,Values=${{ secrets.RUNNER_INSTANCE_ID }}"
+          curl -s -H "Authorization: token $GITHUB_TOKEN" \
+            "https://api.github.com/repos/${{ github.repository }}/actions/runners" | jq '.'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+      - name: Recreate service if offline
+        run: |
+          online=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+            "https://api.github.com/repos/${{ github.repository }}/actions/runners" | jq -r '.runners[] | select(.labels[].name=="mvp-gh-runner") | .status')
+          if [ "$online" != "online" ]; then
+            aws ssm send-command \
+              --document-name AWS-RunShellScript \
+              --instance-ids "${{ secrets.RUNNER_INSTANCE_ID }}" \
+              --comment "restart github runner" \
+              --parameters commands="/usr/local/bin/install.sh $TOKEN"
+          fi
+        env:
+          TOKEN: ${{ steps.token.outputs.token }}
+          GITHUB_TOKEN: ${{ github.token }}
+

--- a/.github/workflows/runner-ssm-health.yml
+++ b/.github/workflows/runner-ssm-health.yml
@@ -1,0 +1,39 @@
+name: runner-ssm-health
+
+on:
+  schedule:
+    - cron: '30 6 * * *'
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    outputs:
+      online: ${{ steps.check.outputs.online }}
+    steps:
+      - id: check
+        uses: actions/github-script@v7.0.1
+        with:
+          script: |
+            const res = await github.rest.actions.listSelfHostedRunnersForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+            const online = res.data.runners.filter(r =>
+              r.labels.some(l => l.name === 'mvp-gh-runner') && r.status === 'online'
+            ).length;
+            core.setOutput('online', online);
+      - name: Open issue if runner missing
+        if: steps.check.outputs.online == '0'
+        uses: peter-evans/create-issue@v4.2.0
+        with:
+          title: Self-hosted runner offline
+          body: Runner with label `mvp-gh-runner` is offline.
+          labels: infrastructure
+  canary:
+    needs: check
+    if: needs.check.outputs.online != '0'
+    runs-on: [self-hosted, linux, x64, mvp-gh-runner]
+    steps:
+      - run: echo "runner online"
+

--- a/infra/ssm-runner/iam.json
+++ b/infra/ssm-runner/iam.json
@@ -1,0 +1,19 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::<runner-artifact-bucket>/*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "*"
+    }
+  ]
+}

--- a/scripts/ssm-runner/install.sh
+++ b/scripts/ssm-runner/install.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="${GITHUB_REPOSITORY:-mvpstudio/MVP-website}"
+TOKEN="${1:-${GH_RUNNER_TOKEN:-}}"
+LABEL="mvp-gh-runner"
+RUNNER_DIR=/opt/actions-runner
+SERVICE="actions.runner.${REPO//\//.}.${LABEL}.service"
+
+if [ -z "$TOKEN" ]; then
+  echo "Usage: $0 <token>" >&2
+  exit 1
+fi
+
+cd "$RUNNER_DIR"
+
+cleanup() {
+  if systemctl list-units --full -all | grep -Fq "$SERVICE"; then
+    ./svc.sh uninstall "$SERVICE" || true
+  fi
+  if [ -f .runner ]; then
+    ./config.sh remove --token "$TOKEN" || true
+  fi
+}
+trap cleanup ERR
+
+if systemctl is-active --quiet "$SERVICE"; then
+  systemctl restart "$SERVICE"
+  exit 0
+fi
+
+./config.sh --unattended --replace \
+  --url "https://github.com/${REPO}" \
+  --token "$TOKEN" \
+  --labels "self-hosted,linux,x64,${LABEL}"
+
+./svc.sh install "$SERVICE"
+systemctl enable "$SERVICE"
+systemctl start "$SERVICE"

--- a/scripts/ssm-runner/uninstall.sh
+++ b/scripts/ssm-runner/uninstall.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="${GITHUB_REPOSITORY:-mvpstudio/MVP-website}"
+TOKEN="${1:-${GH_RUNNER_TOKEN:-}}"
+LABEL="mvp-gh-runner"
+RUNNER_DIR=/opt/actions-runner
+SERVICE="actions.runner.${REPO//\//.}.${LABEL}.service"
+
+cd "$RUNNER_DIR"
+
+if systemctl list-units --full -all | grep -Fq "$SERVICE"; then
+  systemctl stop "$SERVICE" || true
+  ./svc.sh uninstall "$SERVICE" || true
+fi
+
+if [ -f .runner ] && [ -n "$TOKEN" ]; then
+  ./config.sh remove --token "$TOKEN" --unattended || true
+fi

--- a/scripts/ssm-runner/user-data.sh
+++ b/scripts/ssm-runner/user-data.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# Basic packages for runner
+apt-get update
+apt-get install -y curl jq tar
+
+# Enable corepack so pnpm/yarn can be used if needed
+if command -v corepack >/dev/null 2>&1; then
+  corepack enable || true
+fi
+
+RUNNER_DIR=/opt/actions-runner
+mkdir -p "$RUNNER_DIR"
+cd "$RUNNER_DIR"
+
+# Download runner if not already present
+if [ ! -f bin/Runner.Listener ]; then
+  RUNNER_VERSION="${RUNNER_VERSION:-2.311.0}"
+  curl -fsSL "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz" -o runner.tgz
+  tar xzf runner.tgz
+  rm runner.tgz
+fi
+
+# Fetch helper scripts from repo main branch
+REPO="${GH_REPOSITORY:-mvpstudio/MVP-website}"
+BASE="https://raw.githubusercontent.com/${REPO}/main/scripts/ssm-runner"
+for f in install.sh uninstall.sh; do
+  curl -fsSL "$BASE/$f" -o "/usr/local/bin/$f"
+  chmod +x "/usr/local/bin/$f"
+  ln -sf "/usr/local/bin/$f" "/usr/local/bin/ssm-runner-${f%.sh}"
+done
+
+# If a token is provided via GH_RUNNER_TOKEN, perform install
+if [ -n "${GH_RUNNER_TOKEN:-}" ]; then
+  /usr/local/bin/install.sh "$GH_RUNNER_TOKEN"
+fi
+


### PR DESCRIPTION
## Summary
- provision IAM policy for SSM-managed runners
- add scripts to install and uninstall GitHub runner via SSM
- bootstrap and health workflows for SSM-managed runner

## Testing
- `npm run format` (`backend/`) [pass]
- `npm test` (`backend/`) *(fails: STRIPE_SECRET_KEY must be a live secret, eslint plugin error)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: YAML syntax errors in existing workflows)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d0f7d2c8832d8a882d24ce34e30e