### PR TITLE
ci: enforce random suffix for test files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,3 +12,10 @@ repos:
     rev: v9.33.0
     hooks:
       - id: eslint
+  - repo: local
+    hooks:
+      - id: test-file-suffix
+        name: ensure new test files have random suffix
+        entry: node scripts/check-test-file-suffix.js
+        language: system
+        files: (?i)(?:^|/)(?:tests?|__tests__|ci-guard)/.*\.(?:test|spec)\.[cm]?[jt]sx?$

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,10 @@ These guidelines apply to all automated agents (e.g. the Codex agent) working on
 19. **Avoid committing binary files** – Codex cannot generate patches for binary changes. Do not modify images, audio, or other binary assets. If adding new ones, update `.gitattributes` so they are treated as binary.
 20. **Pin GitHub Action versions** – use explicit tags instead of broad majors to prevent resolution errors (e.g. `aquasecurity/tfsec-action@v1.0.3`).
 
+## Test file naming
+
+All new test files in `tests/`, `test/`, `__tests__/`, `ci-guard/`, or similar directories **must append a unique 16–20 character random alphanumeric suffix** before the file extension. Example: `audit.test.h3298mx894uz3m03mx1.ts`. Use a different random string for each run and update any imports accordingly. This avoids filename collisions between concurrent Codex runs and CI jobs.
+
 ## Troubleshooting
 
 If `npm run ci` outputs messages like `1 interrupted` or `2 did not run` during the Playwright tests, the browsers were likely not installed. You may also see errors such as `browser.newContext: Test ended`, `page.evaluate: Test ended`, or `Test was interrupted` in `/tmp/ci.log`:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,7 @@ Thank you for helping improve this project! Please follow these steps to keep ou
 ## Tests
 
 - All new code should include appropriate tests.
+- New test files must append a unique 16–20 character random alphanumeric suffix before the file extension (e.g. `feature.test.h3298mx894uz3m03mx1.ts`) to avoid collisions across concurrent runs.
 - CI runs `npm run ci` and `npm test`; please ensure these succeed locally.
 - If Playwright dependencies are already installed you can set `SKIP_PW_DEPS=1` when running setup or CI to skip the lengthy install step.
 - Mock all external HTTP calls in tests. Only `localhost` traffic is permitted; any other network access must be stubbed with tools like [nock](https://github.com/nock/nock).

--- a/scripts/check-test-file-suffix.js
+++ b/scripts/check-test-file-suffix.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+const { execSync } = require("child_process");
+const path = require("path");
+
+function isNewFile(file) {
+  try {
+    execSync(`git cat-file -e HEAD:${file}`, { stdio: "ignore" });
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+const validPattern = /\.(?:test|spec)\.[a-zA-Z0-9]{16,20}\.[cm]?(?:js|ts)x?$/;
+let failed = false;
+
+for (const file of process.argv.slice(2)) {
+  if (!isNewFile(file)) continue;
+  const base = path.basename(file);
+  if (!validPattern.test(base)) {
+    console.error(
+      `❌ ${file} is missing required 16–20 character random suffix before the extension.`,
+    );
+    failed = true;
+  }
+}
+
+if (failed) {
+  console.error(
+    "Rename test files to include a unique random 16–20 character alphanumeric suffix before the extension, e.g. audit.test.h3298mx894uz3m03mx1.ts",
+  );
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- document random suffix requirement for new tests
- add pre-commit hook to check test filenames
- clarify contribution docs

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Nested mappings are not allowed in compact mappings)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a8cf135e74832d8de5cdf98b1063ec