### PR TITLE
ci: add corepack pnpm windows guard

### DIFF
--- a/.github/workflows/guard-corepack-pnpm-windows.yml
+++ b/.github/workflows/guard-corepack-pnpm-windows.yml
@@ -12,3 +12,8 @@ jobs:
       - run: npm ci
       - run: npx ts-node --transpile-only scripts/ci-guard/corepack-pnpm-windows/audit.ts
       - run: node scripts/run-jest.js tests/ci-guard/corepack-pnpm-windows/audit.test.ts
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: corepack-pnpm-windows-audit
+          path: corepack-pnpm-windows-audit-summary.json

--- a/scripts/ci-guard/corepack-pnpm-windows/audit.ts
+++ b/scripts/ci-guard/corepack-pnpm-windows/audit.ts
@@ -1,36 +1,146 @@
 import fs from "fs";
 import path from "path";
+import yaml from "yaml";
+
+interface Step {
+  name?: string;
+  uses?: string;
+  run?: string;
+  with?: Record<string, any>;
+  shell?: string;
+  [k: string]: any;
+}
+
+interface Job {
+  name?: string;
+  "runs-on"?: any;
+  steps?: Step[];
+  strategy?: { matrix?: Record<string, any> };
+}
+
+function findFiles(root: string, filename: string): string[] {
+  const out: string[] = [];
+  function walk(dir: string) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (entry.name === "node_modules" || entry.name.startsWith(".git")) continue;
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.isFile() && entry.name === filename)
+        out.push(path.relative(root, full).replace(/\\/g, "/"));
+    }
+  }
+  if (fs.existsSync(root)) walk(root);
+  return out;
+}
+
+function jobRunsOnWindows(job: Job): boolean {
+  const ro = job["runs-on"];
+  if (typeof ro === "string") {
+    if (/windows/i.test(ro)) return true;
+    const m = ro.match(/\$\{\{\s*matrix\.([^\s}]+)\s*}}/i);
+    if (m) {
+      const matrix = job.strategy?.matrix?.[m[1]];
+      if (Array.isArray(matrix)) return matrix.some((v) => /windows/i.test(String(v)));
+    }
+    return false;
+  }
+  if (Array.isArray(ro)) return ro.some((r) => /windows/i.test(String(r)));
+  return false;
+}
 
 const repoRoot = process.cwd();
 const workflowsDir = path.join(repoRoot, ".github", "workflows");
-const wfFiles = fs.existsSync(workflowsDir)
-  ? fs
-      .readdirSync(workflowsDir)
-      .filter((f) => f.endsWith(".yml") || f.endsWith(".yaml"))
-  : [];
+const pkgFiles = findFiles(repoRoot, "package.json");
+let pinnedPnpm: string | null = null;
+for (const rel of pkgFiles) {
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(repoRoot, rel), "utf8"));
+    const pm = pkg.packageManager as string | undefined;
+    if (pm && pm.startsWith("pnpm@")) {
+      pinnedPnpm = pm.split("@")[1];
+      break;
+    }
+  } catch {}
+}
 
-const required = [
-  "name: Setup Node (Windows)",
-  "name: Enable Corepack (Windows)",
-  "name: Prepare pnpm via Corepack (Windows)",
-  "name: Fallback: pnpm/action-setup (Windows)",
-  "name: Verify pnpm (Windows)",
-];
+const wfFiles = fs.existsSync(workflowsDir)
+  ? fs.readdirSync(workflowsDir).filter((f) => f.endsWith(".yml") || f.endsWith(".yaml"))
+  : [];
 
 const errors: string[] = [];
 
 for (const wfFile of wfFiles) {
-  if (wfFile.startsWith("guard-")) continue;
   const wfPath = path.join(workflowsDir, wfFile);
-  const raw = fs.readFileSync(wfPath, "utf8");
-  if (!/windows/i.test(raw)) continue;
-  const missing = required.some((r) => !raw.includes(r));
-  if (missing) {
-    errors.push(`${wfFile}: missing Corepack pnpm bootstrap block`);
+  let wf: any;
+  try {
+    wf = yaml.parse(fs.readFileSync(wfPath, "utf8"));
+  } catch (e: any) {
+    errors.push(`${wfFile}: failed to parse - ${e.message}`);
+    continue;
+  }
+  const jobs: Record<string, Job> = wf?.jobs || {};
+  for (const [jobName, job] of Object.entries(jobs)) {
+    if (!jobRunsOnWindows(job)) continue;
+    const steps = job.steps || [];
+    let setupIdx = -1;
+    let corepackIdx = -1;
+    let prepareIdx = -1;
+    let actionSetupIdx = -1;
+    let verifyIdx = -1;
+    let firstUseIdx = -1;
+    let hasNpmCache = false;
+    let pinnedWorkflow: string | null = null;
+    steps.forEach((step, idx) => {
+      if (step.uses && /^actions\/setup-node@v4$/i.test(step.uses)) {
+        const cache = step.with?.cache;
+        if (cache === "npm") hasNpmCache = true;
+        const nv = step.with?.["node-version"];
+        if (cache === "pnpm" && String(nv) === "20") setupIdx = idx;
+      }
+      if (typeof step.run === "string") {
+        if (/corepack enable/i.test(step.run) && (!step.shell || /(pwsh|bash)/i.test(step.shell))) corepackIdx = idx;
+        if (/corepack prepare/i.test(step.run)) {
+          prepareIdx = idx;
+          const m = step.run.match(/corepack prepare\s+pnpm@([^\s]+)\b/i);
+          if (m) pinnedWorkflow = m[1];
+        }
+        if (/pnpm\s+(-v|--version)/i.test(step.run)) verifyIdx = idx;
+        if (/\bpnpm(?!@)\b/.test(step.run)) {
+          if (firstUseIdx === -1) firstUseIdx = idx;
+        }
+      }
+      if (step.uses && step.uses.startsWith("pnpm/action-setup")) {
+        actionSetupIdx = idx;
+        const v = step.with?.version;
+        if (typeof v === "string") pinnedWorkflow = v;
+      }
+    });
+
+    if (firstUseIdx === -1) continue; // no pnpm usage
+
+    const prefix = `${wfFile} > ${jobName}`;
+    if (setupIdx === -1)
+      errors.push(`${prefix}: missing actions/setup-node@v4 with node-version 20 and cache pnpm`);
+    if (corepackIdx === -1)
+      errors.push(`${prefix}: missing corepack enable step`);
+    if (prepareIdx === -1 && actionSetupIdx === -1)
+      errors.push(`${prefix}: missing corepack prepare or pnpm/action-setup step`);
+    if (verifyIdx === -1)
+      errors.push(`${prefix}: missing pnpm verification step`);
+    if (verifyIdx !== -1 && firstUseIdx !== -1 && verifyIdx > firstUseIdx)
+      errors.push(`${prefix} > step ${firstUseIdx + 1}: pnpm used before verification step`);
+    if (hasNpmCache)
+      errors.push(`${prefix}: cache:npm present in pnpm job`);
+    if (pinnedPnpm && pinnedWorkflow && pinnedWorkflow !== pinnedPnpm)
+      errors.push(`${prefix}: workflow pins pnpm@${pinnedWorkflow} but packageManager is pnpm@${pinnedPnpm}`);
   }
 }
+
+const summaryPath = path.join(repoRoot, "corepack-pnpm-windows-audit-summary.json");
+fs.writeFileSync(summaryPath, JSON.stringify({ errors }, null, 2));
 
 if (errors.length) {
   console.error(errors.join("\n"));
   process.exit(1);
 }
+

--- a/tests/ci-guard/corepack-pnpm-windows/audit.test.ts
+++ b/tests/ci-guard/corepack-pnpm-windows/audit.test.ts
@@ -26,27 +26,252 @@ function writeFile(dir: string, file: string, content: string) {
   fs.writeFileSync(full, content);
 }
 
-describe("corepack pnpm windows guard", () => {
-  test("windows job with block passes", () => {
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "corepack-pass-"));
-    writeFile(tmp, "pnpm-lock.yaml", "");
-    writeFile(
-      tmp,
-      ".github/workflows/a.yml",
-      String.raw`name: t\njobs:\n  build:\n    runs-on: \${{ matrix.os }}\n    strategy:\n      fail-fast: false\n      matrix:\n        os: [ubuntu-latest, windows-latest]\n    steps:\n      - uses: actions/checkout@v4\n# >>> BEGIN MANAGED BLOCK: ci-guard:corepack-pnpm-windows\n      - name: Setup Node (Windows)\n        if: startsWith(runner.os, 'Windows')\n        uses: actions/setup-node@v4\n        with:\n          node-version: 20\n          cache: pnpm\n          cache-dependency-path: |\n            pnpm-lock.yaml\n            frontend/pnpm-lock.yaml\n            backend/pnpm-lock.yaml\n\n      - name: Enable Corepack (Windows)\n        if: startsWith(runner.os, 'Windows')\n        shell: pwsh\n        run: corepack enable\n\n      - name: Prepare pnpm via Corepack (Windows)\n        if: startsWith(runner.os, 'Windows')\n        shell: pwsh\n        run: |\n          $pm = ""\n          try { $pm = (Get-Content package.json | ConvertFrom-Json).packageManager } catch {}\n          if ($pm -and $pm -match "^pnpm@") {\n            $ver = $pm.Split("@")[1]\n            corepack prepare "pnpm@$ver" --activate\n          } else {\n            corepack prepare pnpm@10 --activate\n          }\n\n      - name: Fallback: pnpm/action-setup (Windows)\n        if: startsWith(runner.os, 'Windows')\n        uses: pnpm/action-setup@v4\n        with:\n          run_install: false\n\n      - name: Verify pnpm (Windows)\n        if: startsWith(runner.os, 'Windows')\n        shell: pwsh\n        run: pnpm -v\n# <<< END MANAGED BLOCK: ci-guard:corepack-pnpm-windows\n      - run: echo ok\n`);
+function writePkg(dir: string, ver = "10.11.0") {
+  writeFile(dir, "package.json", `{"name":"t","packageManager":"pnpm@${ver}"}`);
+  writeFile(dir, "pnpm-lock.yaml", "");
+}
+
+interface WfOpts {
+  runsOn: string;
+  steps: string[];
+  strategy?: string[];
+  jobName?: string;
+}
+
+function wf({ runsOn, steps, strategy, jobName = "build" }: WfOpts): string {
+  const lines = [
+    "name: t",
+    "jobs:",
+    `  ${jobName}:`,
+    `    runs-on: ${runsOn}`,
+  ];
+  if (strategy) {
+    for (const l of strategy) lines.push(`    ${l}`);
+  }
+  lines.push("    steps:");
+  for (const step of steps) {
+    for (const l of step.split("\n")) lines.push(`      ${l}`);
+  }
+  return lines.join("\n") + "\n";
+}
+
+describe("corepack pnpm windows audit", () => {
+  test("t1 windows job with full bootstrap passes", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "cpw-t1-"));
+    writePkg(tmp);
+    const content = wf({
+      runsOn: "windows-latest",
+      steps: [
+        "- uses: actions/setup-node@v4\n  with:\n    node-version: 20\n    cache: pnpm",
+        "- shell: pwsh\n  run: corepack enable",
+        "- shell: pwsh\n  run: corepack prepare pnpm@10.11.0 --activate",
+        "- shell: pwsh\n  run: pnpm -v",
+        "- run: pnpm install",
+      ],
+    });
+    writeFile(tmp, ".github/workflows/a.yml", content);
     const res = run(tmp);
     expect(res.status).toBe(0);
   });
 
-  test("missing block fails", () => {
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "corepack-fail-"));
-    writeFile(
-      tmp,
-      ".github/workflows/a.yml",
-      `name: t\njobs:\n  build:\n    runs-on: windows-latest\n    steps:\n      - run: echo hi\n`,
-    );
+  test("t2 missing corepack enable fails", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "cpw-t2-"));
+    writePkg(tmp);
+    const content = wf({
+      runsOn: "windows-latest",
+      steps: [
+        "- uses: actions/setup-node@v4\n  with:\n    node-version: 20\n    cache: pnpm",
+        "- run: pnpm -v",
+        "- run: pnpm install",
+      ],
+    });
+    writeFile(tmp, ".github/workflows/a.yml", content);
     const res = run(tmp);
     expect(res.status).not.toBe(0);
-    expect(res.stderr + res.stdout).toMatch(/missing Corepack pnpm bootstrap block/);
+    expect(res.stderr + res.stdout).toMatch(/missing corepack enable/);
+  });
+
+  test("t3 missing prepare and fallback fails", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "cpw-t3-"));
+    writePkg(tmp);
+    const content = wf({
+      runsOn: "windows-latest",
+      steps: [
+        "- uses: actions/setup-node@v4\n  with:\n    node-version: 20\n    cache: pnpm",
+        "- shell: pwsh\n  run: corepack enable",
+        "- shell: pwsh\n  run: pnpm -v",
+        "- run: pnpm install",
+      ],
+    });
+    writeFile(tmp, ".github/workflows/a.yml", content);
+    const res = run(tmp);
+    expect(res.status).not.toBe(0);
+    expect(res.stderr + res.stdout).toMatch(/missing corepack prepare or pnpm\/action-setup/);
+  });
+
+  test("t4 pnpm used before verify fails", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "cpw-t4-"));
+    writePkg(tmp);
+    const content = wf({
+      runsOn: "windows-latest",
+      steps: [
+        "- uses: actions/setup-node@v4\n  with:\n    node-version: 20\n    cache: pnpm",
+        "- shell: pwsh\n  run: corepack enable",
+        "- shell: pwsh\n  run: corepack prepare pnpm@10.11.0 --activate",
+        "- run: pnpm install",
+        "- run: pnpm -v",
+      ],
+    });
+    writeFile(tmp, ".github/workflows/a.yml", content);
+    const res = run(tmp);
+    expect(res.status).not.toBe(0);
+    expect(res.stderr + res.stdout).toMatch(/pnpm used before verification/);
+  });
+
+  test("t5 cache npm fails", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "cpw-t5-"));
+    writePkg(tmp);
+    const content = wf({
+      runsOn: "windows-latest",
+      steps: [
+        "- uses: actions/setup-node@v4\n  with:\n    node-version: 20\n    cache: npm",
+        "- shell: pwsh\n  run: corepack enable",
+        "- shell: pwsh\n  run: corepack prepare pnpm@10.11.0 --activate",
+        "- shell: pwsh\n  run: pnpm -v",
+        "- run: pnpm install",
+      ],
+    });
+    writeFile(tmp, ".github/workflows/a.yml", content);
+    const res = run(tmp);
+    expect(res.status).not.toBe(0);
+    expect(res.stderr + res.stdout).toMatch(/cache:npm/);
+  });
+
+  test("t6 conflicting pinned version fails", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "cpw-t6-"));
+    writePkg(tmp, "10.11.0");
+    const content = wf({
+      runsOn: "windows-latest",
+      steps: [
+        "- uses: actions/setup-node@v4\n  with:\n    node-version: 20\n    cache: pnpm",
+        "- shell: pwsh\n  run: corepack enable",
+        "- shell: pwsh\n  run: corepack prepare pnpm@9 --activate",
+        "- shell: pwsh\n  run: pnpm -v",
+        "- run: pnpm install",
+      ],
+    });
+    writeFile(tmp, ".github/workflows/a.yml", content);
+    const res = run(tmp);
+    expect(res.status).not.toBe(0);
+    expect(res.stderr + res.stdout).toMatch(/workflow pins pnpm@9/);
+  });
+
+  test("t7 non-windows job ignored", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "cpw-t7-"));
+    writePkg(tmp);
+    const content = wf({
+      runsOn: "ubuntu-latest",
+      steps: ["- run: pnpm install"],
+    });
+    writeFile(tmp, ".github/workflows/a.yml", content);
+    const res = run(tmp);
+    expect(res.status).toBe(0);
+  });
+
+  test("t8 multiple lockfiles pass", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "cpw-t8-"));
+    writePkg(tmp);
+    writeFile(tmp, "frontend/pnpm-lock.yaml", "");
+    const content = wf({
+      runsOn: "windows-latest",
+      steps: [
+        "- uses: actions/setup-node@v4\n  with:\n    node-version: 20\n    cache: pnpm\n    cache-dependency-path: |\n      pnpm-lock.yaml\n      frontend/pnpm-lock.yaml",
+        "- shell: pwsh\n  run: corepack enable",
+        "- shell: pwsh\n  run: corepack prepare pnpm@10.11.0 --activate",
+        "- shell: pwsh\n  run: pnpm -v",
+        "- run: pnpm install",
+      ],
+    });
+    writeFile(tmp, ".github/workflows/a.yml", content);
+    const res = run(tmp);
+    expect(res.status).toBe(0);
+  });
+
+  test("t9 matrix with windows validated", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "cpw-t9-"));
+    writePkg(tmp);
+    const content = wf({
+      runsOn: "${{ matrix.os }}",
+      strategy: [
+        "strategy:",
+        "  fail-fast: false",
+        "  matrix:",
+        "    os: [windows-latest, ubuntu-latest]",
+      ],
+      steps: [
+        "- uses: actions/setup-node@v4\n  with:\n    node-version: 20\n    cache: pnpm",
+        "- if: startsWith(runner.os, 'Windows')\n  shell: pwsh\n  run: corepack enable",
+        "- if: startsWith(runner.os, 'Windows')\n  shell: pwsh\n  run: corepack prepare pnpm@10.11.0 --activate",
+        "- if: startsWith(runner.os, 'Windows')\n  shell: pwsh\n  run: pnpm -v",
+        "- if: startsWith(runner.os, 'Windows')\n  run: pnpm install",
+      ],
+    });
+    writeFile(tmp, ".github/workflows/a.yml", content);
+    const res = run(tmp);
+    expect(res.status).toBe(0);
+  });
+
+  test("t10 verify shell bash accepted", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "cpw-t10-"));
+    writePkg(tmp);
+    const content = wf({
+      runsOn: "windows-latest",
+      steps: [
+        "- uses: actions/setup-node@v4\n  with:\n    node-version: 20\n    cache: pnpm",
+        "- shell: pwsh\n  run: corepack enable",
+        "- shell: pwsh\n  run: corepack prepare pnpm@10.11.0 --activate",
+        "- shell: bash\n  run: pnpm -v",
+        "- run: pnpm install",
+      ],
+    });
+    writeFile(tmp, ".github/workflows/a.yml", content);
+    const res = run(tmp);
+    expect(res.status).toBe(0);
+  });
+
+  test("t11 job name irrelevant", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "cpw-t11-"));
+    writePkg(tmp);
+    const content = wf({
+      runsOn: "windows-latest",
+      jobName: "funky-job-name",
+      steps: [
+        "- uses: actions/setup-node@v4\n  with:\n    node-version: 20\n    cache: pnpm",
+        "- shell: pwsh\n  run: corepack enable",
+        "- shell: pwsh\n  run: corepack prepare pnpm@10.11.0 --activate",
+        "- shell: pwsh\n  run: pnpm -v",
+        "- run: pnpm install",
+      ],
+    });
+    writeFile(tmp, ".github/workflows/a.yml", content);
+    const res = run(tmp);
+    expect(res.status).toBe(0);
+  });
+
+  test("t12 aggregated errors reported", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "cpw-t12-"));
+    writePkg(tmp);
+    const content = wf({
+      runsOn: "windows-latest",
+      jobName: "bad",
+      steps: ["- run: pnpm install"],
+    });
+    writeFile(tmp, ".github/workflows/a.yml", content);
+    const res = run(tmp);
+    expect(res.status).not.toBe(0);
+    expect(res.stderr + res.stdout).toMatch(/a.yml > bad/);
+    expect(res.stderr + res.stdout).toMatch(/missing actions\/setup-node@v4/);
+    expect(res.stderr + res.stdout).toMatch(/missing corepack enable/);
   });
 });
+


### PR DESCRIPTION
## Summary
- add auditor for Windows pnpm bootstrap order and conflicts
- enforce Windows pnpm corepack guard in CI
- cover Windows pnpm guard with comprehensive tests

## Testing
- `npm run format --prefix backend`
- `node scripts/run-jest.js tests/ci-guard/corepack-pnpm-windows/audit.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a8ce5d6390832d931da6a2bad23774