### PR TITLE
pkgjson-repair: add validator tests and workflow

### DIFF
--- a/.github/workflows/guard-pkgjson-tests.yml
+++ b/.github/workflows/guard-pkgjson-tests.yml
@@ -1,0 +1,14 @@
+name: guard-pkgjson-tests
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: corepack enable
+      - run: pnpm install --no-frozen-lockfile
+      - run: pnpm test tests/ci-guard/pkgjson-repair/validate.test.ts

--- a/scripts/ci-guard/pkgjson-repair/validate.ts
+++ b/scripts/ci-guard/pkgjson-repair/validate.ts
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
-const fs = require('node:fs');
-const path = require('node:path');
+const fs = require("node:fs");
+const path = require("node:path");
 
 function parseJsonWithErrors(filePath) {
-  const src = fs.readFileSync(filePath, 'utf8');
+  let src = fs.readFileSync(filePath, "utf8");
+  if (src.charCodeAt(0) === 0xfeff) src = src.slice(1);
   try {
     return { data: JSON.parse(src), src };
   } catch (err) {
@@ -26,18 +27,21 @@ function collectWorkflowScripts(dir) {
   for (const file of fs.readdirSync(dir)) {
     const full = path.join(dir, file);
     if (fs.statSync(full).isFile()) {
-      const txt = fs.readFileSync(full, 'utf8');
+      const txt = fs.readFileSync(full, "utf8");
       let m;
       while ((m = runRe.exec(txt))) {
         const name = m[1];
-        if (!name.startsWith('-')) scripts.add(name);
+        if (!name.startsWith("-")) scripts.add(name);
       }
     }
   }
   return scripts;
 }
 
-function validate(pkgPath, workflowsDir = path.resolve(process.cwd(), '.github', 'workflows')) {
+function validate(
+  pkgPath,
+  workflowsDir = path.resolve(process.cwd(), ".github", "workflows"),
+) {
   const errors = [];
   const warnings = [];
   let pkg;
@@ -49,29 +53,42 @@ function validate(pkgPath, workflowsDir = path.resolve(process.cwd(), '.github',
     return { errors, warnings };
   }
 
-  if (typeof pkg.name !== 'string') errors.push('package.json missing required string field "name"');
-  if (typeof pkg.private !== 'boolean') errors.push('package.json missing required boolean field "private"');
-  if (!pkg.scripts || typeof pkg.scripts !== 'object') errors.push('package.json missing required object field "scripts"');
+  if (typeof pkg.name !== "string")
+    errors.push('package.json missing required string field "name"');
+  if (typeof pkg.private !== "boolean")
+    errors.push('package.json missing required boolean field "private"');
+  if (!pkg.scripts || typeof pkg.scripts !== "object")
+    errors.push('package.json missing required object field "scripts"');
 
-  if (pkg.version && typeof pkg.version !== 'string') errors.push('package.json optional field "version" must be string');
-  if (pkg.packageManager && typeof pkg.packageManager !== 'string') errors.push('package.json optional field "packageManager" must be string');
-  if (pkg.workspaces && !Array.isArray(pkg.workspaces)) errors.push('package.json optional field "workspaces" must be array of strings');
+  if (pkg.version && typeof pkg.version !== "string")
+    errors.push('package.json optional field "version" must be string');
+  if (pkg.packageManager && typeof pkg.packageManager !== "string")
+    errors.push('package.json optional field "packageManager" must be string');
+  if (pkg.workspaces && !Array.isArray(pkg.workspaces))
+    errors.push(
+      'package.json optional field "workspaces" must be array of strings',
+    );
 
   const referenced = collectWorkflowScripts(workflowsDir);
-  const missing = Array.from(referenced).filter((s) => !pkg.scripts || !(s in pkg.scripts));
-  if (missing.length) warnings.push(`Missing scripts referenced in workflows: ${missing.join(', ')}`);
+  const missing = Array.from(referenced).filter(
+    (s) => !pkg.scripts || !(s in pkg.scripts),
+  );
+  if (missing.length)
+    warnings.push(
+      `Missing scripts referenced in workflows: ${missing.join(", ")}`,
+    );
 
   return { errors, warnings };
 }
 
 if (require.main === module) {
-  const pkgPath = path.resolve(process.cwd(), 'package.json');
+  const pkgPath = path.resolve(process.cwd(), "package.json");
   const res = validate(pkgPath);
   if (res.errors.length) {
     for (const e of res.errors) console.error(e);
     process.exit(1);
   }
-  for (const w of res.warnings) console.warn('WARN:', w);
+  for (const w of res.warnings) console.warn("WARN:", w);
 }
 
 module.exports = { validate };

--- a/tests/ci-guard/pkgjson-repair/fixtures/bad-types.json
+++ b/tests/ci-guard/pkgjson-repair/fixtures/bad-types.json
@@ -1,0 +1,6 @@
+{
+  "name": 123,
+  "private": "yes",
+  "scripts": {},
+  "workspaces": {}
+}

--- a/tests/ci-guard/pkgjson-repair/fixtures/bom.json
+++ b/tests/ci-guard/pkgjson-repair/fixtures/bom.json
@@ -1,0 +1,5 @@
+﻿{
+  "name": "demo",
+  "private": true,
+  "scripts": {}
+}

--- a/tests/ci-guard/pkgjson-repair/fixtures/crlf.json
+++ b/tests/ci-guard/pkgjson-repair/fixtures/crlf.json
@@ -1,0 +1,5 @@
+{
+  "name": "demo",
+  "private": true,
+  "scripts": {}
+}

--- a/tests/ci-guard/pkgjson-repair/fixtures/extra-keys.json
+++ b/tests/ci-guard/pkgjson-repair/fixtures/extra-keys.json
@@ -1,0 +1,6 @@
+{
+  "name": "demo",
+  "private": true,
+  "scripts": {},
+  "unexpected": 1
+}

--- a/tests/ci-guard/pkgjson-repair/fixtures/package-manager.json
+++ b/tests/ci-guard/pkgjson-repair/fixtures/package-manager.json
@@ -1,0 +1,6 @@
+{
+  "name": "demo",
+  "private": true,
+  "scripts": {},
+  "packageManager": "pnpm@1.2.3"
+}

--- a/tests/ci-guard/pkgjson-repair/fixtures/trailing-comma.json
+++ b/tests/ci-guard/pkgjson-repair/fixtures/trailing-comma.json
@@ -1,0 +1,7 @@
+{
+  "name": "demo",
+  "private": true,
+  "scripts": {
+    "build": "echo ok",
+  }
+}

--- a/tests/ci-guard/pkgjson-repair/fixtures/truncated.json
+++ b/tests/ci-guard/pkgjson-repair/fixtures/truncated.json
@@ -1,0 +1,5 @@
+{
+  "name": "demo",
+  "private": true,
+  "scripts": {
+    "build": "echo

--- a/tests/ci-guard/pkgjson-repair/fixtures/valid.json
+++ b/tests/ci-guard/pkgjson-repair/fixtures/valid.json
@@ -1,0 +1,7 @@
+{
+  "name": "demo",
+  "private": true,
+  "scripts": {
+    "build": "echo ok"
+  }
+}

--- a/tests/ci-guard/pkgjson-repair/validate.test.ts
+++ b/tests/ci-guard/pkgjson-repair/validate.test.ts
@@ -1,41 +1,104 @@
-const fs = require('node:fs');
-const os = require('node:os');
-const path = require('node:path');
-const { spawnSync } = require('node:child_process');
-const test = require('node:test');
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
 
-const script = path.resolve(__dirname, '../../../scripts/ci-guard/pkgjson-repair/validate.ts');
+const script = path.resolve(
+  __dirname,
+  "../../../scripts/ci-guard/pkgjson-repair/validate.ts",
+);
+const fixtures = path.resolve(__dirname, "fixtures");
 
-function run(cwd) {
-  return spawnSync('node', [script], { cwd, encoding: 'utf8' });
+function runFixture(name, extraSetup, content) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pkg-"));
+  if (content) {
+    fs.writeFileSync(path.join(dir, "package.json"), content);
+  } else {
+    const src = fs.readFileSync(path.join(fixtures, name));
+    fs.writeFileSync(path.join(dir, "package.json"), src);
+  }
+  if (extraSetup) extraSetup(dir);
+  return spawnSync("node", [script], { cwd: dir, encoding: "utf8" });
 }
 
-test('valid package.json passes', () => {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pkg-'));
-  const pkg = { name: 'demo', private: true, scripts: { build: 'echo ok' }, workspaces: ['a'] };
-  fs.mkdirSync(path.join(dir, '.github', 'workflows'), { recursive: true });
-  fs.writeFileSync(path.join(dir, '.github', 'workflows', 'w.yml'), 'run: npm run build');
-  fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify(pkg));
-  const res = run(dir);
-  if (res.status !== 0) throw new Error(res.stdout + res.stderr);
-});
+describe("pkgjson validator", () => {
+  test("t1 valid minimal package.json", () => {
+    const res = runFixture("valid.json");
+    expect(res.status).toBe(0);
+  });
 
-test('invalid json reports location', () => {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pkg-'));
-  fs.writeFileSync(path.join(dir, 'package.json'), '{ "name": "x"');
-  const res = run(dir);
-  if (res.status === 0) throw new Error('expected failure');
-});
+  test("t2 trailing comma in scripts reports location", () => {
+    const res = runFixture("trailing-comma.json");
+    expect(res.status).toBe(1);
+    expect(res.stderr || res.stdout).toMatch(/JSON parse error at \d+:\d+/);
+  });
 
-test('missing scripts trigger warning', () => {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pkg-'));
-  const pkg = { name: 'demo', private: true, scripts: {} };
-  fs.mkdirSync(path.join(dir, '.github', 'workflows'), { recursive: true });
-  fs.writeFileSync(path.join(dir, '.github', 'workflows', 'w.yml'), 'run: npm run missing');
-  fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify(pkg));
-  const res = run(dir);
-  if (res.status !== 0) throw new Error(res.stdout + res.stderr);
-  if (!/Missing scripts/.test(res.stdout) && !/Missing scripts/.test(res.stderr)) {
-    throw new Error('expected warning');
-  }
+  test("t3 truncated file yields parse error", () => {
+    const res = runFixture("truncated.json");
+    expect(res.status).toBe(1);
+    expect(res.stderr + res.stdout).toMatch(/JSON parse error/);
+  });
+
+  test("t4 name not a string fails schema", () => {
+    const res = runFixture("bad-types.json");
+    expect(res.status).toBe(1);
+    expect(res.stderr + res.stdout).toMatch(
+      /missing required string field "name"/,
+    );
+  });
+
+  test("t5 private not boolean fails schema", () => {
+    const res = runFixture("bad-types.json");
+    expect(res.status).toBe(1);
+    expect(res.stderr + res.stdout).toMatch(
+      /missing required boolean field "private"/,
+    );
+  });
+
+  test("t6 workspaces wrong type fails schema", () => {
+    const res = runFixture("bad-types.json");
+    expect(res.status).toBe(1);
+    expect(res.stderr + res.stdout).toMatch(
+      /optional field "workspaces" must be array of strings/,
+    );
+  });
+
+  test("t7 packageManager with pnpm version passes", () => {
+    const res = runFixture("package-manager.json");
+    expect(res.status).toBe(0);
+  });
+
+  test("t8 missing script referenced in workflows warns", () => {
+    const res = runFixture("valid.json", (dir) => {
+      const wfDir = path.join(dir, ".github", "workflows");
+      fs.mkdirSync(wfDir, { recursive: true });
+      fs.writeFileSync(path.join(wfDir, "w.yml"), "run: pnpm run format:check");
+    });
+    expect(res.status).toBe(0);
+    expect(res.stderr + res.stdout).toMatch(
+      /Missing scripts referenced in workflows: format:check/,
+    );
+  });
+
+  test("t9 file with BOM parses", () => {
+    const res = runFixture("bom.json");
+    expect(res.status).toBe(0);
+  });
+
+  test("t10 CRLF line endings parse", () => {
+    const res = runFixture("crlf.json");
+    expect(res.status).toBe(0);
+  });
+
+  test("t11 extra unknown keys allowed", () => {
+    const res = runFixture("extra-keys.json");
+    expect(res.status).toBe(0);
+  });
+
+  test("t12 corrupt UTF-8 yields readable error", () => {
+    const invalid = Buffer.from('{ "name": "x" }\xc3\x28', "binary");
+    const res = runFixture(null, null, invalid);
+    expect(res.status).toBe(1);
+    expect(res.stderr + res.stdout).toMatch(/Unexpected/);
+  });
 });


### PR DESCRIPTION
## Summary
- cover package.json validator with schema, syntax and workflow warnings
- strip BOM before JSON parsing
- run validator in new guard-pkgjson-tests CI job

## Testing
- `npm run format` *(fails: Nested mappings are not allowed in compact mappings)*
- `npm test tests/ci-guard/pkgjson-repair/validate.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a8ce39b680832d93920cabedea4bab