### PR TITLE
ci: add aws label for self-hosted runner

### DIFF
--- a/infra/aws-runners/terraform/main.tf
+++ b/infra/aws-runners/terraform/main.tf
@@ -1,5 +1,5 @@
 locals {
-  runner_labels       = ["self-hosted", "linux", "x64", "ephemeral", "aws-ec2"]
+  runner_labels       = ["self-hosted", "linux", "x64", "ephemeral", "aws", "aws-ec2"]
   runner_label_string = join(",", local.runner_labels)
 }
 


### PR DESCRIPTION
## Summary
- add `aws` label to EC2 runner configuration so workflows targeting `aws` can schedule jobs

## Testing
- `SKIP_PW_DEPS=1 npm run format`
- `SKIP_PW_DEPS=1 npm test` *(aborted: tests were running but process was interrupted)*
- `SKIP_PW_DEPS=1 npm run ci` *(aborted: setup hung installing Playwright)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ce2582ec832dbeb90c9b8dd3e89a