### PR TITLE
feat: add github oidc role for runners

### DIFF
--- a/infra/aws-runners/terraform/main.tf
+++ b/infra/aws-runners/terraform/main.tf
@@ -13,22 +13,35 @@ resource "aws_iam_openid_connect_provider" "github" {
 }
 
 resource "aws_iam_role" "github" {
-  name = "github-oidc-role"
+  name               = "github-oidc-role"
+  assume_role_policy = templatefile(
+    "${path.module}/../../selfhosted-runner/iam/oidc-trust-policy.json",
+    {
+      oidc_provider_arn = aws_iam_openid_connect_provider.github.arn,
+      github_org        = var.github_org,
+      github_repo       = var.github_repo
+    }
+  )
+}
 
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17",
-    Statement = [{
-      Effect = "Allow",
-      Principal = {
-        Federated = aws_iam_openid_connect_provider.github.arn
-      },
-      Action = "sts:AssumeRoleWithWebIdentity",
-      Condition = {
-        StringEquals = { "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com" },
-        StringLike   = { "token.actions.githubusercontent.com:sub" = "repo:${var.github_org}/${var.github_repo}:*" }
-      }
-    }]
-  })
+resource "aws_iam_role_policy_attachment" "github_ec2" {
+  role       = aws_iam_role.github.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2FullAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "github_ssm" {
+  role       = aws_iam_role.github.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMFullAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "github_cloudwatch" {
+  role       = aws_iam_role.github.name
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchFullAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "github_s3" {
+  role       = aws_iam_role.github.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonS3FullAccess"
 }
 
 resource "aws_security_group" "runner" {

--- a/infra/aws-runners/terraform/outputs.tf
+++ b/infra/aws-runners/terraform/outputs.tf
@@ -2,3 +2,8 @@ output "runner_labels" {
   description = "Labels applied to the EC2 runners"
   value       = local.runner_labels
 }
+
+output "github_role_arn" {
+  description = "IAM role ARN for GitHub Actions"
+  value       = aws_iam_role.github.arn
+}

--- a/infra/selfhosted-runner/iam/oidc-trust-policy.json
+++ b/infra/selfhosted-runner/iam/oidc-trust-policy.json
@@ -4,13 +4,15 @@
     {
       "Effect": "Allow",
       "Principal": {
-        "Federated": "arn:aws:iam::<AWS_ACCOUNT_ID>:oidc-provider/token.actions.githubusercontent.com"
+        "Federated": "${oidc_provider_arn}"
       },
       "Action": "sts:AssumeRoleWithWebIdentity",
       "Condition": {
         "StringEquals": {
-          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
-          "token.actions.githubusercontent.com:sub": "repo:ORG_NAME/REPO_NAME:ref:refs/heads/BRANCH_NAME"
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+        },
+        "StringLike": {
+          "token.actions.githubusercontent.com:sub": "repo:${github_org}/${github_repo}:*"
         }
       }
     }


### PR DESCRIPTION
## Summary
- template OIDC trust policy for GitHub Actions
- create GitHub OIDC role with EC2/SSM/CloudWatch/S3 access and output its ARN

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` *(fails: SyntaxError: Unterminated string constant)*
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Nested mappings are not allowed in compact mappings)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a8dcdc6eb4832d8ae65ad2d1043130