### PR TITLE
feat: add ssm runner terraform and validation workflow

### DIFF
--- a/.github/workflows/iac-validate.yml
+++ b/.github/workflows/iac-validate.yml
@@ -1,0 +1,23 @@
+name: Terraform validate
+
+on:
+  pull_request:
+    paths:
+      - 'infra/terraform/**'
+      - '.github/workflows/iac-validate.yml'
+
+jobs:
+  terraform:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.7
+      - uses: hashicorp/setup-terraform@v2.0.3
+      - name: Terraform fmt
+        working-directory: infra/terraform/ssm-runner
+        run: terraform fmt -check
+      - name: Terraform init
+        working-directory: infra/terraform/ssm-runner
+        run: terraform init
+      - name: Terraform validate
+        working-directory: infra/terraform/ssm-runner
+        run: terraform validate

--- a/infra/terraform/ssm-runner/.terraform.lock.hcl
+++ b/infra/terraform/ssm-runner/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infra/terraform/ssm-runner/README.md
+++ b/infra/terraform/ssm-runner/README.md
@@ -1,0 +1,31 @@
+# SSM Runner Infrastructure
+
+This module provisions IAM roles for running commands on EC2 instances through AWS Systems Manager (SSM) and for invoking SSM from GitHub Actions.
+
+## Usage
+
+1. Initialize Terraform:
+
+```sh
+terraform init
+```
+
+2. Review the changes:
+
+```sh
+terraform plan \
+  -var "region=us-east-1" \
+  -var "repo_owner=your-org" \
+  -var "repo_name=your-repo"
+```
+
+3. Apply the changes:
+
+```sh
+terraform apply \
+  -var "region=us-east-1" \
+  -var "repo_owner=your-org" \
+  -var "repo_name=your-repo"
+```
+
+The module outputs the ARNs of the created IAM roles and instance profile.

--- a/infra/terraform/ssm-runner/main.tf
+++ b/infra/terraform/ssm-runner/main.tf
@@ -1,0 +1,85 @@
+provider "aws" {
+  region = var.region
+}
+
+data "aws_iam_policy_document" "ec2_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "ec2" {
+  name               = var.ec2_role_name
+  assume_role_policy = data.aws_iam_policy_document.ec2_assume.json
+}
+
+resource "aws_iam_role_policy_attachment" "ssm" {
+  role       = aws_iam_role.ec2.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_role_policy_attachment" "cwlogs" {
+  role       = aws_iam_role.ec2.name
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchLogsFullAccess"
+}
+
+resource "aws_iam_instance_profile" "ec2" {
+  name = "${var.ec2_role_name}-profile"
+  role = aws_iam_role.ec2.name
+}
+
+resource "aws_iam_openid_connect_provider" "github" {
+  url             = "https://token.actions.githubusercontent.com"
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = ["6938fd4d98bab03faadb97b34396831e3780aea1"]
+}
+
+data "aws_iam_policy_document" "github_assume" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.github.arn]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = ["repo:${var.repo_owner}/${var.repo_name}:*"]
+    }
+  }
+}
+
+resource "aws_iam_role" "github" {
+  name               = var.github_role_name
+  assume_role_policy = data.aws_iam_policy_document.github_assume.json
+}
+
+data "aws_iam_policy_document" "github_policy" {
+  statement {
+    actions = [
+      "ssm:SendCommand",
+      "ssm:ListCommands",
+      "ssm:ListCommandInvocations",
+      "ssm:GetCommandInvocation",
+      "ssm:DescribeInstanceInformation"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    actions   = ["ec2:DescribeInstances"]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "github" {
+  name   = "ssm-runner-gha"
+  role   = aws_iam_role.github.id
+  policy = data.aws_iam_policy_document.github_policy.json
+}

--- a/infra/terraform/ssm-runner/outputs.tf
+++ b/infra/terraform/ssm-runner/outputs.tf
@@ -1,0 +1,11 @@
+output "ec2_role_arn" {
+  value = aws_iam_role.ec2.arn
+}
+
+output "instance_profile_arn" {
+  value = aws_iam_instance_profile.ec2.arn
+}
+
+output "github_role_arn" {
+  value = aws_iam_role.github.arn
+}

--- a/infra/terraform/ssm-runner/variables.tf
+++ b/infra/terraform/ssm-runner/variables.tf
@@ -1,0 +1,26 @@
+variable "region" {
+  description = "AWS region"
+  type        = string
+}
+
+variable "repo_owner" {
+  description = "GitHub repository owner"
+  type        = string
+}
+
+variable "repo_name" {
+  description = "GitHub repository name"
+  type        = string
+}
+
+variable "ec2_role_name" {
+  description = "Name for the EC2 role"
+  type        = string
+  default     = "ssm-runner-ec2"
+}
+
+variable "github_role_name" {
+  description = "Name for GitHub Actions role"
+  type        = string
+  default     = "ssm-runner-gha"
+}

--- a/infra/terraform/ssm-runner/versions.tf
+++ b/infra/terraform/ssm-runner/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.4"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Terraform module for SSM runner IAM roles and instance profile
- add workflow to validate Terraform configuration

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`
- `terraform fmt`
- `terraform init`
- `terraform validate`

------
https://chatgpt.com/codex/tasks/task_e_68a8e40bd0dc832d8b5457ff68cdb169