### PR TITLE
EC2 SSM + Runner bootstrap (collision-safe kp4mz8e1s3uf)

### DIFF
--- a/.github/workflows/runner-host-ssm-smoketest.kp4mz8e1s3uf.yml
+++ b/.github/workflows/runner-host-ssm-smoketest.kp4mz8e1s3uf.yml
@@ -1,0 +1,16 @@
+name: SSM/Runner Host Smoke Check
+on:
+  workflow_dispatch:
+permissions:
+  contents: read
+  id-token: write
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate documentation presence
+        run: |
+          test -f docs/ssm-runner-readme.kp4mz8e1s3uf.md
+          test -f scripts/ssm/verify-ssm.kp4mz8e1s3uf.sh
+          test -f scripts/runner/bootstrap-runner.kp4mz8e1s3uf.sh

--- a/docs/ssm-runner-readme.kp4mz8e1s3uf.md
+++ b/docs/ssm-runner-readme.kp4mz8e1s3uf.md
@@ -1,0 +1,29 @@
+# EC2 SSM + GitHub Runner Bootstrap
+
+"Managed instances" are EC2 hosts registered with AWS Systems Manager (SSM). They can be patched, accessed with Session Manager, and used to host GitHub self-hosted runners.
+
+## Prepare the instance
+1. Attach an IAM instance profile that includes the **AmazonSSMManagedInstanceCore** policy.
+2. On the EC2 host, verify SSM connectivity:
+
+```bash
+curl -O https://raw.githubusercontent.com/print3git/MVP-website/main/scripts/ssm/verify-ssm.kp4mz8e1s3uf.sh && bash verify-ssm.kp4mz8e1s3uf.sh
+```
+
+## Bootstrap a GitHub runner
+Provide `GH_REPO` and a GitHub PAT via env vars or SSM Parameter Store.
+
+```bash
+GH_REPO=owner/repo GH_PAT=ghp_yourtoken \
+  curl -O https://raw.githubusercontent.com/print3git/MVP-website/main/scripts/runner/bootstrap-runner.kp4mz8e1s3uf.sh && bash bootstrap-runner.kp4mz8e1s3uf.sh
+```
+
+`RUNNER_LABELS` and `RUNNER_VERSION` may be set before running the script. To fetch the PAT from Parameter Store, set `GH_PAT_SSM_PARAM` instead of `GH_PAT`.
+
+## Troubleshooting
+
+| Problem | Fix |
+| --- | --- |
+| Not in **Managed instances** | Check IAM instance profile, `systemctl status amazon-ssm-agent`, and `journalctl -u amazon-ssm-agent`. |
+| Runner not appearing in GitHub | Confirm PAT/SSM parameter and inspect `journalctl -u github-runner`. |
+| Private subnet | Use SSM Session Manager; SSH access (port 22) is not required. |

--- a/scripts/runner/bootstrap-runner.kp4mz8e1s3uf.sh
+++ b/scripts/runner/bootstrap-runner.kp4mz8e1s3uf.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Environment variables:
+#   GH_REPO (e.g. owner/repo) [required]
+#   RUNNER_LABELS (default: "mvp-gh-runner,linux,x64")
+#   RUNNER_VERSION (default: latest)
+#   GH_PAT_SSM_PARAM (optional SSM Parameter for GH PAT)
+#   GH_PAT (fallback PAT if GH_PAT_SSM_PARAM not set)
+
+RUNNER_LABELS=${RUNNER_LABELS:-mvp-gh-runner,linux,x64}
+RUNNER_VERSION=${RUNNER_VERSION:-latest}
+
+sudo dnf install -y curl tar jq >/dev/null
+
+# Resolve runner version
+if [[ "$RUNNER_VERSION" == "latest" ]]; then
+  RUNNER_VERSION=$(curl -sL https://api.github.com/repos/actions/runner/releases/latest | jq -r .tag_name)
+fi
+RUNNER_VERSION_NO_V=${RUNNER_VERSION#v}
+
+fetch_pat() {
+  if [[ -n "${GH_PAT_SSM_PARAM:-}" && $(command -v aws >/dev/null 2>&1; echo $?) -eq 0 ]]; then
+    aws ssm get-parameter --name "$GH_PAT_SSM_PARAM" --with-decryption --query Parameter.Value --output text
+  else
+    echo "${GH_PAT:-}" | sed -e 's/^\s*//' -e 's/\s*$//'
+  fi
+}
+
+PAT=$(fetch_pat)
+if [[ -z "$PAT" ]]; then
+  echo "GH_PAT or GH_PAT_SSM_PARAM must be provided" >&2
+  exit 1
+fi
+
+REG_TOKEN=$(curl -sX POST -H "Authorization: token $PAT" "https://api.github.com/repos/$GH_REPO/actions/runners/registration-token" | jq -r .token)
+
+INSTALL_DIR=/opt/github-runner
+if ! id -u github-runner >/dev/null 2>&1; then
+  sudo useradd --system --create-home --home-dir "$INSTALL_DIR" github-runner
+fi
+sudo mkdir -p "$INSTALL_DIR"
+sudo chown github-runner:github-runner "$INSTALL_DIR"
+cd "$INSTALL_DIR"
+
+if [[ ! -f .runner ]]; then
+  curl -L -o actions-runner.tar.gz "https://github.com/actions/runner/releases/download/$RUNNER_VERSION/actions-runner-linux-x64-$RUNNER_VERSION_NO_V.tar.gz"
+  sudo -u github-runner tar xzf actions-runner.tar.gz
+  sudo -u github-runner ./config.sh --unattended --url "https://github.com/$GH_REPO" --token "$REG_TOKEN" --labels "$RUNNER_LABELS" --name "$(hostname)-$(uuidgen | cut -d- -f1)"
+fi
+
+sudo tee /etc/systemd/system/github-runner.service >/dev/null <<'UNIT'
+[Unit]
+Description=GitHub Actions Runner
+After=network.target
+
+[Service]
+User=github-runner
+WorkingDirectory=/opt/github-runner
+ExecStart=/opt/github-runner/run.sh
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now github-runner
+sudo systemctl status github-runner --no-pager || true
+journalctl -u github-runner -n 50 --no-pager || true

--- a/scripts/runner/github-runner.service.kp4mz8e1s3uf.example
+++ b/scripts/runner/github-runner.service.kp4mz8e1s3uf.example
@@ -1,0 +1,14 @@
+# Example systemd unit for GitHub runner
+[Unit]
+Description=GitHub Actions Runner
+After=network.target
+
+[Service]
+User=github-runner
+WorkingDirectory=/opt/github-runner
+ExecStart=/opt/github-runner/run.sh
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/ssm/verify-ssm.kp4mz8e1s3uf.sh
+++ b/scripts/ssm/verify-ssm.kp4mz8e1s3uf.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Verify EC2 instance registration with AWS Systems Manager
+
+# Acquire IMDSv2 token
+TOKEN=$(curl -sS --retry 3 -X PUT -H "X-aws-ec2-metadata-token-ttl-seconds: 21600" http://169.254.169.254/latest/api/token || true)
+imdsv2() {
+  curl -sS -H "X-aws-ec2-metadata-token: $TOKEN" "$1" 2>/dev/null || true
+}
+
+REGION=$(imdsv2 http://169.254.169.254/latest/meta-data/placement/region)
+INSTANCE_ID=$(imdsv2 http://169.254.169.254/latest/meta-data/instance-id)
+IAM_ROLE=$(imdsv2 http://169.254.169.254/latest/meta-data/iam/security-credentials/)
+
+echo "Region: ${REGION:-unknown}"
+echo "Instance ID: ${INSTANCE_ID:-unknown}"
+echo "IAM role: ${IAM_ROLE:-none}"
+
+# Ensure SSM agent is installed and running
+if ! rpm -q amazon-ssm-agent >/dev/null 2>&1; then
+  sudo dnf install -y amazon-ssm-agent
+fi
+sudo systemctl enable --now amazon-ssm-agent
+
+# Check agent status and logs
+sudo systemctl status amazon-ssm-agent --no-pager || true
+journalctl -u amazon-ssm-agent -n 50 --no-pager || true
+
+# IAM diagnostics
+if [[ -z "$IAM_ROLE" ]]; then
+  echo "No IAM instance profile attached."
+  echo "---"
+  echo "Remediation: Attach an IAM instance profile with policy AmazonSSMManagedInstanceCore."
+  echo "---"
+fi
+
+# Network diagnostics
+SGS=$(imdsv2 http://169.254.169.254/latest/meta-data/security-groups)
+echo "Security groups: ${SGS:-unknown}"
+if awk '$1 == "Iface" {next} $1=="00000000" {found=1} END{exit !found}' /proc/net/route; then
+  echo "Default route present"
+else
+  echo "No default route found"
+fi
+
+# Optional AWS CLI check
+if command -v aws >/dev/null 2>&1 && [[ -n "$REGION" && -n "$INSTANCE_ID" ]]; then
+  aws ssm describe-instance-information --max-results 5 --region "$REGION" | grep "$INSTANCE_ID" || true
+fi
+
+AGENT_ACTIVE=$(systemctl is-active amazon-ssm-agent || true)
+if [[ "$AGENT_ACTIVE" == "active" && -n "$IAM_ROLE" ]]; then
+  echo "PASS: SSM agent active and instance profile detected."
+  exit 0
+else
+  echo "FAIL: SSM agent state=$AGENT_ACTIVE, IAM role=${IAM_ROLE:-none}"
+  echo "Next steps: ensure amazon-ssm-agent is running and an instance profile with AmazonSSMManagedInstanceCore is attached."
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add SSM verification script for EC2 instances
- bootstrap GitHub Actions runner via systemd
- document usage and smoke-test workflow

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` *(fails: cross-env not found)*
- `npm test` *(fails: Node 20 is required)*

## How to use
See [docs/ssm-runner-readme.kp4mz8e1s3uf.md](docs/ssm-runner-readme.kp4mz8e1s3uf.md)

```bash
curl -O https://raw.githubusercontent.com/print3git/MVP-website/main/scripts/ssm/verify-ssm.kp4mz8e1s3uf.sh && bash verify-ssm.kp4mz8e1s3uf.sh

GH_REPO=OWNER/REPO GH_PAT=ghp_yourtoken \
  curl -O https://raw.githubusercontent.com/print3git/MVP-website/main/scripts/runner/bootstrap-runner.kp4mz8e1s3uf.sh && bash bootstrap-runner.kp4mz8e1s3uf.sh
```

## Safety
- new files only; no existing files touched

## Next steps
- attach instance profile to the EC2, run verify-ssm, then bootstrap-runner


------
https://chatgpt.com/codex/tasks/task_e_68a9a4f6beb8832d84691e22d02fe9f8