### PR TITLE
ci: add self-hosted runner detection

### DIFF
--- a/.github/workflows/_prepare-runner.yml
+++ b/.github/workflows/_prepare-runner.yml
@@ -1,0 +1,31 @@
+name: _prepare-runner
+
+on:
+  workflow_call:
+    outputs:
+      use_self_hosted:
+        description: Use self-hosted runner if available
+        value: ${{ jobs.detect.outputs.use_self_hosted }}
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      use_self_hosted: ${{ steps.check.outputs.use_self_hosted }}
+    steps:
+      - id: check
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const res = await github.rest.actions.listSelfHostedRunnersForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            });
+            const runners = res.data.runners || [];
+            const online = runners.filter(r => r.status === 'online');
+            const has = online.some(r => r.labels.some(l => l.name === 'mvp-gh-runner'));
+            core.setOutput('use_self_hosted', has ? 'true' : 'false');

--- a/.github/workflows/ci-burst-probe.yml
+++ b/.github/workflows/ci-burst-probe.yml
@@ -8,14 +8,18 @@ on:
         description: "Number of parallel self-hosted attempts"
         default: "4"
 jobs:
+  prepare-runner:
+    uses: ./.github/workflows/_prepare-runner.yml
+
   fanout:
     name: probe-${{ matrix.i }}
+    needs: prepare-runner
+    if: needs.prepare-runner.outputs.use_self_hosted == 'true' && (github.event.inputs.size == '' || fromJSON('['+github.event.inputs.size+']')[0] >= matrix.i)
     strategy:
       fail-fast: false
       matrix:
         i: [1, 2, 3, 4]
-    if: ${{ github.event.inputs.size == '' || fromJSON('['+github.event.inputs.size+']')[0] >= matrix.i }}
-    runs-on: [self-hosted, linux, x64, aws-runner]
+    runs-on: [self-hosted, linux, x64, mvp-gh-runner]
     timeout-minutes: 6
     steps:
       - uses: actions/checkout@v4
@@ -34,8 +38,23 @@ jobs:
       - name: If timed out, mark for fallback
         if: steps.qw.outputs.queue_timeout == 'true'
         run: echo "This attempt will be replaced by fallback."
+
+  fanout-gh:
+    name: probe-${{ matrix.i }}-gh
+    needs: prepare-runner
+    if: needs.prepare-runner.outputs.use_self_hosted != 'true' && (github.event.inputs.size == '' || fromJSON('['+github.event.inputs.size+']')[0] >= matrix.i)
+    strategy:
+      fail-fast: false
+      matrix:
+        i: [1, 2, 3, 4]
+    runs-on: ubuntu-latest
+    timeout-minutes: 6
+    steps:
+      - name: Hosted fallback
+        run: echo "Hosted runner probe ${{ matrix.i }}"
+
   fallback:
-    needs: fanout
+    needs: [fanout, fanout-gh]
     runs-on: ubuntu-latest
     if: always()
     steps:

--- a/.github/workflows/ci-env.yml
+++ b/.github/workflows/ci-env.yml
@@ -11,9 +11,45 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  versions:
+  prepare-runner:
+    uses: ./.github/workflows/_prepare-runner.yml
+
+  versions-self-hosted:
+    needs: prepare-runner
+    if: needs.prepare-runner.outputs.use_self_hosted == 'true'
     timeout-minutes: 15
-    runs-on: [self-hosted, linux, aws]
+    runs-on: [self-hosted, linux, x64, mvp-gh-runner]
+    steps:
+      - name: Heartbeat
+        run: |
+          while true; do date; sleep 120; done &
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - uses: ./.github/actions/install-deps
+      - run: npm ci
+      - run: npm ci --prefix frontend
+      - name: Record tool versions
+        run: |
+          echo "node: $(node -v)" >> versions.txt
+          echo "npm: $(npm -v)" >> versions.txt
+          echo "tsc: $(npx tsc -v)" >> versions.txt
+          echo "vite: $(npx --prefix frontend vite --version)" >> versions.txt
+          echo "eslint: $(npx eslint --version)" >> versions.txt
+          cat versions.txt
+      - uses: actions/upload-artifact@v4.3.4
+        with:
+          name: tool-versions
+          path: versions.txt
+
+  versions-gh:
+    needs: prepare-runner
+    if: needs.prepare-runner.outputs.use_self_hosted != 'true'
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
     steps:
       - name: Heartbeat
         run: |

--- a/.github/workflows/ci-fast-lane.yml
+++ b/.github/workflows/ci-fast-lane.yml
@@ -80,62 +80,144 @@ jobs:
             echo ""
             echo "**reason:** ${{ steps.reason.outputs.msg }}"
           } >> "$GITHUB_STEP_SUMMARY"
+  prepare-runner:
+    uses: ./.github/workflows/_prepare-runner.yml
   lint:
+    needs: [changes, prepare-runner]
+    if: needs.changes.result == 'success' && (needs.changes.outputs.lint == 'true' || needs.changes.outputs._any == 'true') && needs.prepare-runner.outputs.use_self_hosted == 'true'
     uses: ./.github/workflows/reusable-test-job.yml
-    needs: changes
-    if: ${{ needs.changes.result == 'success' && (needs.changes.outputs.lint == 'true' || needs.changes.outputs._any == 'true') }}
     with:
       suite: lint
       command: npm run lint
-  typecheck:
+      runner: '["self-hosted","linux","x64","mvp-gh-runner"]'
+
+  lint-gh:
+    needs: [changes, prepare-runner]
+    if: needs.changes.result == 'success' && (needs.changes.outputs.lint == 'true' || needs.changes.outputs._any == 'true') && needs.prepare-runner.outputs.use_self_hosted != 'true'
     uses: ./.github/workflows/reusable-test-job.yml
-    needs: changes
-    if: ${{ needs.changes.result == 'success' && (needs.changes.outputs.typecheck == 'true' || needs.changes.outputs._any == 'true') }}
+    with:
+      suite: lint
+      command: npm run lint
+      runner: '"ubuntu-latest"'
+  typecheck:
+    needs: [changes, prepare-runner]
+    if: needs.changes.result == 'success' && (needs.changes.outputs.typecheck == 'true' || needs.changes.outputs._any == 'true') && needs.prepare-runner.outputs.use_self_hosted == 'true'
+    uses: ./.github/workflows/reusable-test-job.yml
     with:
       suite: typecheck
       command: npm run typecheck
-  unit:
+      runner: '["self-hosted","linux","x64","mvp-gh-runner"]'
+
+  typecheck-gh:
+    needs: [changes, prepare-runner]
+    if: needs.changes.result == 'success' && (needs.changes.outputs.typecheck == 'true' || needs.changes.outputs._any == 'true') && needs.prepare-runner.outputs.use_self_hosted != 'true'
     uses: ./.github/workflows/reusable-test-job.yml
-    needs: changes
-    if: ${{ needs.changes.result == 'success' && (needs.changes.outputs.unit == 'true' || needs.changes.outputs._any == 'true') }}
+    with:
+      suite: typecheck
+      command: npm run typecheck
+      runner: '"ubuntu-latest"'
+  unit:
+    needs: [changes, prepare-runner]
+    if: needs.changes.result == 'success' && (needs.changes.outputs.unit == 'true' || needs.changes.outputs._any == 'true') && needs.prepare-runner.outputs.use_self_hosted == 'true'
+    uses: ./.github/workflows/reusable-test-job.yml
     with:
       suite: unit
       command: JEST_RETRIES=2 npm test -- --config scripts/ci/jest.config.ci.ts
+      runner: '["self-hosted","linux","x64","mvp-gh-runner"]'
+
+  unit-gh:
+    needs: [changes, prepare-runner]
+    if: needs.changes.result == 'success' && (needs.changes.outputs.unit == 'true' || needs.changes.outputs._any == 'true') && needs.prepare-runner.outputs.use_self_hosted != 'true'
+    uses: ./.github/workflows/reusable-test-job.yml
+    with:
+      suite: unit
+      command: JEST_RETRIES=2 npm test -- --config scripts/ci/jest.config.ci.ts
+      runner: '"ubuntu-latest"'
   backend:
-    needs: changes
-    if: ${{ needs.changes.result == 'success' && (needs.changes.outputs.backend == 'true' || needs.changes.outputs._any == 'true') }}
+    needs: [changes, prepare-runner]
+    if: needs.changes.result == 'success' && (needs.changes.outputs.backend == 'true' || needs.changes.outputs._any == 'true') && needs.prepare-runner.outputs.use_self_hosted == 'true'
     uses: ./.github/workflows/reusable-test-job.yml
     with:
       suite: backend
       command: npm test -- --backend
+      runner: '["self-hosted","linux","x64","mvp-gh-runner"]'
+
+  backend-gh:
+    needs: [changes, prepare-runner]
+    if: needs.changes.result == 'success' && (needs.changes.outputs.backend == 'true' || needs.changes.outputs._any == 'true') && needs.prepare-runner.outputs.use_self_hosted != 'true'
+    uses: ./.github/workflows/reusable-test-job.yml
+    with:
+      suite: backend
+      command: npm test -- --backend
+      runner: '"ubuntu-latest"'
   frontend:
-    needs: changes
-    if: ${{ needs.changes.result == 'success' && (needs.changes.outputs.frontend == 'true' || needs.changes.outputs._any == 'true') }}
+    needs: [changes, prepare-runner]
+    if: needs.changes.result == 'success' && (needs.changes.outputs.frontend == 'true' || needs.changes.outputs._any == 'true') && needs.prepare-runner.outputs.use_self_hosted == 'true'
     uses: ./.github/workflows/reusable-test-job.yml
     with:
       suite: frontend
       command: npm test -- --frontend
+      runner: '["self-hosted","linux","x64","mvp-gh-runner"]'
+
+  frontend-gh:
+    needs: [changes, prepare-runner]
+    if: needs.changes.result == 'success' && (needs.changes.outputs.frontend == 'true' || needs.changes.outputs._any == 'true') && needs.prepare-runner.outputs.use_self_hosted != 'true'
+    uses: ./.github/workflows/reusable-test-job.yml
+    with:
+      suite: frontend
+      command: npm test -- --frontend
+      runner: '"ubuntu-latest"'
   e2e:
-    needs: changes
-    if: ${{ needs.changes.result == 'success' && (needs.changes.outputs.e2e == 'true' || needs.changes.outputs._any == 'true') }}
+    needs: [changes, prepare-runner]
+    if: needs.changes.result == 'success' && (needs.changes.outputs.e2e == 'true' || needs.changes.outputs._any == 'true') && needs.prepare-runner.outputs.use_self_hosted == 'true'
     uses: ./.github/workflows/reusable-test-job.yml
     with:
       suite: e2e
       command: npm run test:e2e
+      runner: '["self-hosted","linux","x64","mvp-gh-runner"]'
+
+  e2e-gh:
+    needs: [changes, prepare-runner]
+    if: needs.changes.result == 'success' && (needs.changes.outputs.e2e == 'true' || needs.changes.outputs._any == 'true') && needs.prepare-runner.outputs.use_self_hosted != 'true'
+    uses: ./.github/workflows/reusable-test-job.yml
+    with:
+      suite: e2e
+      command: npm run test:e2e
+      runner: '"ubuntu-latest"'
   docs:
-    needs: changes
-    if: ${{ needs.changes.result == 'success' && (needs.changes.outputs.docs == 'true' || needs.changes.outputs._any == 'true') }}
+    needs: [changes, prepare-runner]
+    if: needs.changes.result == 'success' && (needs.changes.outputs.docs == 'true' || needs.changes.outputs._any == 'true') && needs.prepare-runner.outputs.use_self_hosted == 'true'
     uses: ./.github/workflows/reusable-test-job.yml
     with:
       suite: docs
       command: npm test -- --docs
+      runner: '["self-hosted","linux","x64","mvp-gh-runner"]'
+
+  docs-gh:
+    needs: [changes, prepare-runner]
+    if: needs.changes.result == 'success' && (needs.changes.outputs.docs == 'true' || needs.changes.outputs._any == 'true') && needs.prepare-runner.outputs.use_self_hosted != 'true'
+    uses: ./.github/workflows/reusable-test-job.yml
+    with:
+      suite: docs
+      command: npm test -- --docs
+      runner: '"ubuntu-latest"'
   infra:
-    needs: changes
-    if: ${{ needs.changes.result == 'success' && (needs.changes.outputs.infra == 'true' || needs.changes.outputs._any == 'true') }}
+    needs: [changes, prepare-runner]
+    if: needs.changes.result == 'success' && (needs.changes.outputs.infra == 'true' || needs.changes.outputs._any == 'true') && needs.prepare-runner.outputs.use_self_hosted == 'true'
     uses: ./.github/workflows/reusable-test-job.yml
     with:
       suite: infra
       command: npm test -- --infra
+      runner: '["self-hosted","linux","x64","mvp-gh-runner"]'
+
+  infra-gh:
+    needs: [changes, prepare-runner]
+    if: needs.changes.result == 'success' && (needs.changes.outputs.infra == 'true' || needs.changes.outputs._any == 'true') && needs.prepare-runner.outputs.use_self_hosted != 'true'
+    uses: ./.github/workflows/reusable-test-job.yml
+    with:
+      suite: infra
+      command: npm test -- --infra
+      runner: '"ubuntu-latest"'
   inventory:
     needs: impact
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable-test-job.yml
+++ b/.github/workflows/reusable-test-job.yml
@@ -9,11 +9,15 @@ on:
       command:
         required: true
         type: string
+      runner:
+        required: false
+        type: string
+        default: '"ubuntu-latest"'
 
 jobs:
   test:
     name: ${{ inputs.suite }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runner) }}
     permissions:
       contents: read
     defaults:

--- a/.github/workflows/selfhosted-runner-status.yml
+++ b/.github/workflows/selfhosted-runner-status.yml
@@ -1,0 +1,26 @@
+name: Self-hosted runner status
+
+on:
+  workflow_dispatch:
+
+jobs:
+  diag:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: List runners
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const res = await github.rest.actions.listSelfHostedRunnersForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            });
+            for (const r of res.data.runners) {
+              const labels = r.labels.map(l => l.name).join(', ');
+              const group = r.runner_group_name || r.runner_group_id;
+              core.info(`${r.name}: ${r.status} labels=[${labels}] group=${group}`);
+            }

--- a/tools/runner-diag/README.md
+++ b/tools/runner-diag/README.md
@@ -1,0 +1,9 @@
+# Runner diagnostics
+
+Self-hosted runners that execute CI jobs must register with the label `mvp-gh-runner` in addition to the standard `self-hosted`, `linux`, and `x64` labels.
+
+If a workflow fails to locate a runner with these labels, jobs automatically fall back to `ubuntu-latest` hosted runners.
+
+To rebuild or re-bootstrap an EC2 runner, trigger the existing **runner-ssm-bootstrap** workflow. It connects via AWS Systems Manager (SSM) to install the runner service and re-register it with the required labels.
+
+Use the accompanying `selfhosted-runner-status` workflow to check which runners GitHub currently sees and confirm their labels and runner groups.


### PR DESCRIPTION
## Summary
- add workflow to print self-hosted runner status
- detect `mvp-gh-runner` availability before CI jobs
- document runner labels and rebootstrap instructions

## Testing
- `npm run format` *(fails: SyntaxError in truncated.json)*
- `npm test` *(passes)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: YAML parse errors)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68a9fae4b960832d8694ffdfc1ee2e12