### PR TITLE
ci: update runner labels and fix shellcheck warnings

### DIFF
--- a/.github/workflows/aws-runner-health.yml
+++ b/.github/workflows/aws-runner-health.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   health:
     name: AWS runner health
-    runs-on: [self-hosted, linux, aws, mvp-runner]
+    runs-on: [self-hosted, linux, aws, mvp-gh-runner]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5.0.0

--- a/.github/workflows/ci-router.yml
+++ b/.github/workflows/ci-router.yml
@@ -6,11 +6,11 @@ on:
       port:
         required: false
         type: string
-        default: '3000'
+        default: "3000"
       ci_require_external:
         required: false
         type: string
-        default: '0'
+        default: "0"
 
 env:
   PORT: ${{ inputs.port }}
@@ -18,7 +18,7 @@ env:
 
 jobs:
   selfhosted:
-    runs-on: [self-hosted, linux, aws, mvp-runner]
+    runs-on: [self-hosted, linux, aws, mvp-gh-runner]
     continue-on-error: true
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/selfhosted-probe.yml
+++ b/.github/workflows/selfhosted-probe.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   probe-selfhosted:
     name: Probe self-hosted runner
-    runs-on: [self-hosted, linux, aws, mvp-runner]
+    runs-on: [self-hosted, linux, aws, mvp-gh-runner]
     timeout-minutes: 5
     outputs:
       queue_latency: ${{ steps.latency.outputs.queue_latency }}
@@ -37,9 +37,9 @@ jobs:
             const online = runners.filter(
               (r) =>
                 r.status === 'online' &&
-                r.labels.some((l) => l.name === 'mvp-runner')
+                r.labels.some((l) => l.name === 'mvp-gh-runner')
             ).length;
-            core.info(`Online mvp-runner runners: ${online}`);
+            core.info(`Online mvp-gh-runner runners: ${online}`);
             if (online < required) {
               core.setFailed(
                 `Only ${online} self-hosted runners online; need at least ${required}.`

--- a/.github/workflows/update_locks.yml
+++ b/.github/workflows/update_locks.yml
@@ -3,12 +3,11 @@ name: Update Locks
 env:
   HUSKY: 0
 
-
 on:
   push:
     branches: [main]
   schedule:
-    - cron: '*/5 * * * *'
+    - cron: "*/5 * * * *"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -25,9 +24,9 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: true
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: "3.x"
       - name: Install dependencies
         run: pip install requests
       - name: Run update_locks

--- a/docs/ci/self-hosted-aws.md
+++ b/docs/ci/self-hosted-aws.md
@@ -6,6 +6,6 @@ Short playbook:
    - `/github/runner/url`
    - `/github/runner/registration-token`
 2. `cd infra/gh-runner-aws && terraform init && terraform apply`.
-3. Check **Settings → Actions → Runners** for `mvp-runner`.
+3. Check **Settings → Actions → Runners** for `mvp-gh-runner`.
 4. (Optional) toggle `off_hours` to save costs.
 5. Use `.github/actions/js-stack-setup` in jobs that need `pnpm`/`vite`.

--- a/infra/gh-runner-aws/README.md
+++ b/infra/gh-runner-aws/README.md
@@ -20,7 +20,7 @@ This module provisions an ephemeral self-hosted GitHub Actions runner on a singl
 3. **Verify the runner** – it should appear under your repository's self-hosted runners with the labels configured in `runner_labels`.
 4. **Use the labels in workflows**
    ```yaml
-   runs-on: [self-hosted, linux, aws, mvp-runner]
+   runs-on: [self-hosted, linux, aws, mvp-gh-runner]
    ```
 5. **Costs & teardown** – the default `t3.small` incurs hourly charges. Enable `use_spot` or `off_hours` to reduce cost. Destroy the runner when finished:
    ```bash

--- a/infra/gh-runner-aws/variables.tf
+++ b/infra/gh-runner-aws/variables.tf
@@ -15,7 +15,7 @@ variable "repo" {
 
 variable "runner_labels" {
   type        = list(string)
-  default     = ["self-hosted", "linux", "aws", "mvp-runner"]
+  default     = ["self-hosted", "linux", "aws", "mvp-gh-runner"]
   description = "Labels to apply to the GitHub runner"
 }
 

--- a/scripts/diagnose.sh
+++ b/scripts/diagnose.sh
@@ -15,17 +15,19 @@ if [[ -f .env ]]; then
 fi
 
 banner() {
-  echo -e "\n==============================\n$1\n==============================";
+  printf '\n==============================\n%s\n==============================\n' "$1"
 }
 
 timings=()
 time_stage() {
   local name=$1
   shift
-  local start=$(date +%s)
+  local start
+  start=$(date +%s)
   "$@"
   local status=$?
-  local end=$(date +%s)
+  local end
+  end=$(date +%s)
   timings+=("$name:$((end-start))")
   return $status
 }
@@ -41,7 +43,7 @@ SERVER_PID=$!
 trap 'kill $SERVER_PID' EXIT
 
 echo "Waiting for port 3000..."
-for i in {1..30}; do
+for _ in {1..30}; do
   if nc -z localhost 3000; then break; fi
   sleep 1
 done


### PR DESCRIPTION
## Summary
- switch self-hosted workflows to `mvp-gh-runner`
- bump setup-python to v5
- harden diagnostics script against shellcheck

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` *(fails: tests/ci-guard/pkgjson-repair/fixtures/truncated.json: SyntaxError: Unterminated string constant)*
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: YAML syntax errors)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: SyntaxError: Unterminated string constant in truncated.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa05387df8832d8befd2eb4456063f