### PR TITLE
feat(ci): canary, capacity and failover health checks

### DIFF
--- a/.github/ci/canary/README.md
+++ b/.github/ci/canary/README.md
@@ -1,0 +1,17 @@
+# CI Canary
+
+These utilities monitor CI runner health.
+
+## SLA
+
+- **Target:** self-hosted queue latency under 10s
+- **Hard limit:** self-hosted queue latency under 60s
+- GitHub-hosted metrics are recorded for comparison.
+
+## Dashboards
+
+The `ci-canary.yml` workflow stores per-run metrics in `history.ndjson` and exposes per-run JSON artifacts. A summary with gauges is written to the workflow summary for quick inspection.
+
+## SLA breach handling
+
+If the self-hosted queue latency exceeds 60s or the job fails to start, a pinned issue titled **CI Canary: SLA breach** is created or updated with the last 10 datapoints.

--- a/.github/workflows/ci-canary.yml
+++ b/.github/workflows/ci-canary.yml
@@ -1,37 +1,154 @@
 name: CI Canary
 
 on:
-  workflow_dispatch:
   schedule:
-    - cron: "*/10 * * * *"
+    - cron: '*/10 * * * *'
+  workflow_dispatch:
 
 jobs:
-  probe_runner:
-    uses: ./.github/workflows/_runner-probe.yml
-
-  canary:
-    needs: [probe_runner]
-    runs-on: ${{ fromJSON(steps.resolve.outputs.value) }}
+  canary_meta:
+    runs-on: ubuntu-22.04
+    outputs:
+      queued_ms: ${{ steps.meta.outputs.queued_ms }}
+      run_id: ${{ steps.meta.outputs.run_id }}
+      attempt: ${{ steps.meta.outputs.attempt }}
+      branch: ${{ steps.meta.outputs.branch }}
     steps:
-      - name: Resolve runner choice
-        id: resolve
-        uses: ./.github/actions/resolve-runs-on
+      - name: Record metadata
+        id: meta
+        uses: actions/github-script@v7.0.1
         with:
-          online: ${{ needs.probe_runner.outputs.online }}
-      - name: Print runner info
+          script: |
+            const run = await github.rest.actions.getWorkflowRun({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.runId
+            });
+            core.setOutput('queued_ms', Date.parse(run.data.created_at));
+            core.setOutput('run_id', run.data.id);
+            core.setOutput('attempt', process.env.GITHUB_RUN_ATTEMPT);
+            core.setOutput('branch', process.env.GITHUB_REF_NAME);
+
+  canary_selfhosted:
+    needs: canary_meta
+    runs-on: [self-hosted, linux, x64, mvp-gh-runner]
+    steps:
+      - name: Compute latency
+        id: timings
         run: |
-          echo "Runner name: ${{ runner.name }}"
-          echo "Runner OS: ${{ runner.os }}"
-      - name: Disk usage
-        run: df -h
-      - name: Memory usage
-        run: free -m
-      - name: Node version
-        run: node -v || true
-      - name: Save canary
-        run: echo "${{ runner.name }}:${{ runner.os }}" > canary.txt
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
+          start_ms=$(date +%s%3N)
+          queue_ms=$((start_ms - ${{ needs.canary_meta.outputs.queued_ms }}))
+          sleep 1
+          end_ms=$(date +%s%3N)
+          runtime_ms=$((end_ms - start_ms))
+          echo "queue_ms=$queue_ms" >> "$GITHUB_OUTPUT"
+          echo "start_ms=$runtime_ms" >> "$GITHUB_OUTPUT"
+          echo "runner=$RUNNER_NAME" >> "$GITHUB_OUTPUT"
+          echo "labels=$RUNNER_LABELS" >> "$GITHUB_OUTPUT"
+      - name: Write artifact
+        run: |
+          mkdir -p ci/canary
+          jq -n \
+            --arg q "${{ steps.timings.outputs.queue_ms }}" \
+            --arg s "${{ steps.timings.outputs.start_ms }}" \
+            --arg r "${{ steps.timings.outputs.runner }}" \
+            --arg l "${{ steps.timings.outputs.labels }}" \
+            '{queue_ms: ($q|tonumber), start_ms: ($s|tonumber), runner: $r, labels: $l}' \
+            > ci/canary/selfhosted.json
+      - uses: actions/upload-artifact@v4.3.1
         with:
-          name: canary
-          path: canary.txt
+          name: selfhosted
+          path: ci/canary/selfhosted.json
+
+  canary_github:
+    needs: canary_meta
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Compute latency
+        id: timings
+        run: |
+          start_ms=$(date +%s%3N)
+          queue_ms=$((start_ms - ${{ needs.canary_meta.outputs.queued_ms }}))
+          sleep 1
+          end_ms=$(date +%s%3N)
+          runtime_ms=$((end_ms - start_ms))
+          echo "queue_ms=$queue_ms" >> "$GITHUB_OUTPUT"
+          echo "start_ms=$runtime_ms" >> "$GITHUB_OUTPUT"
+          echo "runner=$RUNNER_NAME" >> "$GITHUB_OUTPUT"
+          echo "labels=$RUNNER_LABELS" >> "$GITHUB_OUTPUT"
+      - name: Write artifact
+        run: |
+          mkdir -p ci/canary
+          jq -n \
+            --arg q "${{ steps.timings.outputs.queue_ms }}" \
+            --arg s "${{ steps.timings.outputs.start_ms }}" \
+            --arg r "${{ steps.timings.outputs.runner }}" \
+            --arg l "${{ steps.timings.outputs.labels }}" \
+            '{queue_ms: ($q|tonumber), start_ms: ($s|tonumber), runner: $r, labels: $l}' \
+            > ci/canary/github.json
+      - uses: actions/upload-artifact@v4.3.1
+        with:
+          name: github
+          path: ci/canary/github.json
+
+  compare:
+    needs: [canary_selfhosted, canary_github]
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/download-artifact@v4.1.8
+        with:
+          name: selfhosted
+          path: ci/canary
+      - uses: actions/download-artifact@v4.1.8
+        with:
+          name: github
+          path: ci/canary
+      - uses: actions/download-artifact@v4.1.8
+        with:
+          name: history
+          path: ci/canary
+          if-no-files-found: ignore
+      - name: Compare and record
+        id: cmp
+        run: |
+          node <<'NODE'
+          const fs = require('fs');
+          const dir = 'ci/canary';
+          const self = JSON.parse(fs.readFileSync(`${dir}/selfhosted.json`, 'utf8'));
+          const gh = JSON.parse(fs.readFileSync(`${dir}/github.json`, 'utf8'));
+          const record = {ts: Date.now(), self_hosted: self, github: gh};
+          let history=[];
+          try { history = fs.readFileSync(`${dir}/history.ndjson`, 'utf8').trim().split('\n').filter(Boolean).map(JSON.parse); } catch {}
+          history.push(record);
+          history = history.slice(-30);
+          fs.writeFileSync(`${dir}/history.ndjson`, history.map(r=>JSON.stringify(r)).join('\n')+'\n');
+          const values = history.map(r=>r.self_hosted.queue_ms).sort((a,b)=>a-b);
+          const p50 = values[Math.floor(values.length*0.5)] || 0;
+          const p95 = values[Math.floor(values.length*0.95)] || 0;
+          const summary = `Self-hosted queue: ${self.queue_ms}ms\nGitHub queue: ${gh.queue_ms}ms\nP50: ${p50}ms  P95: ${p95}ms`;
+          fs.writeFileSync(process.env.GITHUB_STEP_SUMMARY, summary);
+          const breach = self.queue_ms > 60000 || !self.start_ms;
+          fs.writeFileSync('last10.json', JSON.stringify(history.slice(-10), null, 2));
+          fs.writeFileSync(process.env.GITHUB_OUTPUT, `breach=${breach}\n`);
+          NODE
+      - uses: actions/upload-artifact@v4.3.1
+        with:
+          name: history
+          path: ci/canary/history.ndjson
+      - name: Report breach
+        if: steps.cmp.outputs.breach == 'true'
+        uses: actions/github-script@v7.0.1
+        with:
+          script: |
+            const issueTitle = 'CI Canary: SLA breach';
+            const last10 = require('./last10.json');
+            const body = last10.map(r => `- ${new Date(r.ts).toISOString()} self-hosted ${r.self_hosted.queue_ms}ms`).join('\n');
+            const {data: issues} = await github.rest.issues.listForRepo({owner: context.repo.owner, repo: context.repo.repo, state:'open', per_page:100});
+            let issue = issues.find(i => i.title === issueTitle);
+            if (!issue) {
+              issue = (await github.rest.issues.create({owner: context.repo.owner, repo: context.repo.repo, title: issueTitle, body})).data;
+              try { await github.rest.issues.pin({owner: context.repo.owner, repo: context.repo.repo, issue_number: issue.number}); } catch {}
+            } else {
+              await github.rest.issues.update({owner: context.repo.owner, repo: context.repo.repo, issue_number: issue.number, body});
+              try { await github.rest.issues.pin({owner: context.repo.owner, repo: context.repo.repo, issue_number: issue.number}); } catch {}
+            }

--- a/.github/workflows/ci-capacity-burst.yml
+++ b/.github/workflows/ci-capacity-burst.yml
@@ -1,0 +1,44 @@
+name: CI Capacity Burst
+
+on:
+  workflow_dispatch:
+
+jobs:
+  burst:
+    runs-on: [self-hosted, linux, x64, mvp-gh-runner]
+    strategy:
+      matrix:
+        idx: [1,2,3,4,5,6]
+    steps:
+      - name: Record start
+        run: |
+          start=$(date +%s)
+          echo $start > start.txt
+          sleep 10
+      - uses: actions/upload-artifact@v4.3.1
+        with:
+          name: start-${{ matrix.idx }}
+          path: start.txt
+
+  report:
+    runs-on: ubuntu-22.04
+    needs: burst
+    steps:
+      - uses: actions/download-artifact@v4.1.8
+        with:
+          pattern: start-*
+          path: starts
+          merge-multiple: true
+      - name: Summarize
+        run: |
+          starts=($(cat starts/start-*))
+          IFS=$'\n' sorted=($(sort -n <<<"${starts[*]}"))
+          earliest=${sorted[0]}
+          latest=${sorted[${#sorted[@]}-1]}
+          duration=$((latest-earliest+10))
+          total=$((6*10))
+          parallel=$(( total / duration ))
+          echo "Effective parallelism: $parallel" >> "$GITHUB_STEP_SUMMARY"
+          if [ $parallel -lt 2 ]; then
+            echo 'Warning: capacity below 2' >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/ci-failover-probe.yml
+++ b/.github/workflows/ci-failover-probe.yml
@@ -1,0 +1,43 @@
+name: CI Failover Probe
+
+on:
+  workflow_dispatch:
+
+jobs:
+  probe_runner:
+    runs-on: ubuntu-22.04
+    outputs:
+      online: ${{ steps.check.outputs.online }}
+    steps:
+      - name: Check runner availability
+        id: check
+        uses: actions/github-script@v7.0.1
+        with:
+          script: |
+            const {data} = await github.rest.actions.listSelfHostedRunnersForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            });
+            const online = data.runners.some(r => r.labels.some(l => l.name === 'mvp-gh-runner') && r.status === 'online');
+            core.setOutput('online', online);
+
+  run_actual:
+    needs: probe_runner
+    runs-on: ${{ needs.probe_runner.outputs.online == 'true' && fromJSON('["self-hosted","linux","x64","mvp-gh-runner"]') || 'ubuntu-22.04' }}
+    steps:
+      - uses: actions/checkout@v4.1.6
+      - run: node -v
+      - run: npm --version
+      - name: Create artifact
+        run: echo "ok" > probe.txt
+      - uses: actions/upload-artifact@v4.3.1
+        with:
+          name: probe
+          path: probe.txt
+      - uses: actions/download-artifact@v4.1.8
+        with:
+          name: probe
+          path: .
+      - run: cat probe.txt
+      - name: Summary
+        run: echo "lane: ${{ needs.probe_runner.outputs.online == 'true' && 'self-hosted' || 'github-hosted' }}" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- monitor self-hosted vs GitHub runner latency with scheduled canary
- probe self-hosted runner availability and fall back to GitHub-hosted
- burst-test self-hosted pool to estimate parallel capacity

## Testing
- `npm run format` *(fails: tests/ci-guard/pkgjson-repair/fixtures/truncated.json: Unterminated string constant)*
- `npm test`
- `npm run ci` *(fails: SyntaxError in multiple workflow YAML files)*
- `npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68aa070c9ddc832db3c50e26f6c312f8