### PR TITLE
feat(ci): pnpm guard suite (10+ tests) to ensure setup across OSes

### DIFF
--- a/.github/workflows/ci-pnpm-guard.yml
+++ b/.github/workflows/ci-pnpm-guard.yml
@@ -1,0 +1,18 @@
+name: "CI: pnpm guard"
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**/*.yml"
+      - "scripts/ci-guards/**"
+      - "tests/ci-guards/**"
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.3.0
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version: 20
+      - run: npm ci || npm i
+      - run: node scripts/ci-guards/check-pnpm-usage.js
+      - run: npm test -- --reporters=default

--- a/scripts/ci-guards/check-pnpm-usage.js
+++ b/scripts/ci-guards/check-pnpm-usage.js
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+const fs = require("fs");
+const path = require("path");
+const YAML = require("yaml");
+
+function findWorkflows(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const p = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...findWorkflows(p));
+    } else if (entry.isFile() && p.endsWith(".yml")) {
+      files.push(p);
+    }
+  }
+  return files;
+}
+
+function analyzeWorkflow(file, pkgVersion) {
+  const content = fs.readFileSync(file, "utf8");
+  const wf = YAML.parse(content);
+  const jobs = wf.jobs || {};
+  const results = [];
+  for (const [jobName, job] of Object.entries(jobs)) {
+    const steps = job.steps || [];
+    let usesPnpm = false;
+    let hasSetup = false;
+    let versionMismatch = false;
+    for (const step of steps) {
+      if (typeof step.run === "string" && /\bpnpm\b/.test(step.run)) {
+        usesPnpm = true;
+      }
+      if (step.uses && /pnpm\/action-setup@/.test(step.uses)) {
+        hasSetup = true;
+        const stepVersion = step.with && step.with.version;
+        if (stepVersion && pkgVersion && stepVersion !== pkgVersion) {
+          versionMismatch = true;
+        }
+      }
+      if (
+        step.uses &&
+        step.uses.startsWith("actions/setup-node") &&
+        step.with &&
+        step.with.cache === "pnpm"
+      ) {
+        usesPnpm = true;
+      }
+    }
+    if (usesPnpm) {
+      const ok = hasSetup && !versionMismatch;
+      const info = {
+        workflow: file,
+        job: jobName,
+        ok,
+      };
+      if (!hasSetup) info.missingSetup = true;
+      if (versionMismatch) info.versionMismatch = true;
+      results.push(info);
+    }
+  }
+  return results;
+}
+
+async function main() {
+  const root = process.argv[2] ? path.resolve(process.argv[2]) : process.cwd();
+  const pkgPath = path.join(root, "package.json");
+  let pkgVersion = null;
+  if (fs.existsSync(pkgPath)) {
+    try {
+      const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+      if (pkg.packageManager && pkg.packageManager.startsWith("pnpm@")) {
+        pkgVersion = pkg.packageManager.split("@")[1];
+      }
+    } catch {}
+  }
+  const workflowsDir = path.join(root, ".github", "workflows");
+  let files = [];
+  if (fs.existsSync(workflowsDir)) {
+    files = findWorkflows(workflowsDir);
+  }
+  let all = [];
+  for (const file of files) {
+    all = all.concat(analyzeWorkflow(file, pkgVersion));
+  }
+  console.log(JSON.stringify(all, null, 2));
+  console.log("\n| Workflow | Job | Status |");
+  console.log("| --- | --- | --- |");
+  for (const r of all) {
+    const reason = r.missingSetup
+      ? "missing pnpm/action-setup"
+      : r.versionMismatch
+        ? "version mismatch"
+        : "";
+    console.log(
+      `| ${path.relative(root, r.workflow)} | ${r.job} | ${r.ok ? "✅" : "❌ " + reason} |`,
+    );
+  }
+  if (all.some((r) => !r.ok)) {
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}
+
+module.exports = { analyzeWorkflow };

--- a/tests/ci-guards/pnpm-usage.guard.test.ts
+++ b/tests/ci-guards/pnpm-usage.guard.test.ts
@@ -1,0 +1,196 @@
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import { execFileSync } from "child_process";
+
+type Dir = string;
+const script = path.resolve(
+  __dirname,
+  "../../scripts/ci-guards/check-pnpm-usage.js",
+);
+
+function setup(pkgManager = "pnpm@9.0.0"): Dir {
+  const dir = mkdtempSync(path.join(tmpdir(), "pnpm-guard-"));
+  mkdirSync(path.join(dir, ".github", "workflows"), { recursive: true });
+  writeFileSync(
+    path.join(dir, "package.json"),
+    JSON.stringify({ packageManager: pkgManager }, null, 2),
+  );
+  return dir;
+}
+
+function run(dir: Dir) {
+  return execFileSync("node", [script, dir], { encoding: "utf8" });
+}
+
+describe("check-pnpm-usage", () => {
+  test("workflow with pnpm install but no setup fails", () => {
+    const dir = setup();
+    writeFileSync(
+      path.join(dir, ".github/workflows/test.yml"),
+      `jobs:
+  build:
+    steps:
+      - run: pnpm install
+`,
+    );
+    expect(() => run(dir)).toThrow();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("workflow with pnpm/action-setup then install passes", () => {
+    const dir = setup();
+    writeFileSync(
+      path.join(dir, ".github/workflows/test.yml"),
+      `jobs:
+  build:
+    steps:
+      - uses: pnpm/action-setup@v4
+      - run: pnpm install
+`,
+    );
+    run(dir);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("package.json with pnpm but no setup fails", () => {
+    const dir = setup("pnpm@8.0.0");
+    writeFileSync(
+      path.join(dir, ".github/workflows/test.yml"),
+      `jobs:
+  build:
+    steps:
+      - run: pnpm install
+`,
+    );
+    expect(() => run(dir)).toThrow();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("mismatched pnpm version fails", () => {
+    const dir = setup("pnpm@9");
+    writeFileSync(
+      path.join(dir, ".github/workflows/test.yml"),
+      `jobs:
+  build:
+    steps:
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 8
+      - run: pnpm install
+`,
+    );
+    expect(() => run(dir)).toThrow();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("setup on linux but missing on windows job fails", () => {
+    const dir = setup();
+    writeFileSync(
+      path.join(dir, ".github/workflows/test.yml"),
+      `jobs:
+  linux:
+    steps:
+      - uses: pnpm/action-setup@v4
+      - run: pnpm install
+  windows:
+    steps:
+      - run: pnpm install
+`,
+    );
+    expect(() => run(dir)).toThrow();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("matrix with setup passes", () => {
+    const dir = setup();
+    writeFileSync(
+      path.join(dir, ".github/workflows/test.yml"),
+      `jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+      - uses: pnpm/action-setup@v4
+      - run: pnpm install
+`,
+    );
+    run(dir);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("actions/setup-node cache pnpm without setup fails", () => {
+    const dir = setup();
+    writeFileSync(
+      path.join(dir, ".github/workflows/test.yml"),
+      `jobs:
+  build:
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          cache: pnpm
+      - run: pnpm install
+`,
+    );
+    expect(() => run(dir)).toThrow();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("workflow using only npm passes", () => {
+    const dir = setup();
+    writeFileSync(
+      path.join(dir, ".github/workflows/test.yml"),
+      `jobs:
+  build:
+    steps:
+      - run: npm install
+`,
+    );
+    run(dir);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("pnpm --version smoke step passes", () => {
+    const dir = setup();
+    writeFileSync(
+      path.join(dir, ".github/workflows/test.yml"),
+      `jobs:
+  build:
+    steps:
+      - uses: pnpm/action-setup@v4
+      - run: pnpm --version
+`,
+    );
+    run(dir);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("multiple jobs only flag misconfigured ones", () => {
+    const dir = setup();
+    writeFileSync(
+      path.join(dir, ".github/workflows/test.yml"),
+      `jobs:
+  good:
+    steps:
+      - uses: pnpm/action-setup@v4
+      - run: pnpm install
+  bad:
+    steps:
+      - run: pnpm install
+`,
+    );
+    try {
+      run(dir);
+      throw new Error("expected failure");
+    } catch (e: any) {
+      const out = e.stdout.toString();
+      const json = JSON.parse(out.split("\n\n")[0]);
+      const good = json.find((r: any) => r.job === "good");
+      const bad = json.find((r: any) => r.job === "bad");
+      expect(good.ok).toBe(true);
+      expect(bad.ok).toBe(false);
+    }
+    rmSync(dir, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
## Summary
- add `check-pnpm-usage.js` to scan workflows for pnpm usage and ensure `pnpm/action-setup`
- cover pnpm guard scenarios with 10-test suite
- wire up CI workflow to run guard and tests on PRs

## Testing
- `npx prettier -w scripts/ci-guards/check-pnpm-usage.js tests/ci-guards/pnpm-usage.guard.test.ts .github/workflows/ci-pnpm-guard.yml`
- `node scripts/run-jest.js tests/ci-guards/pnpm-usage.guard.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68aa0c90b6f8832dadfc4c1b8dd7b90a