### PR TITLE
feat(ci): external tool dependency guard (10+ tests) to prevent rg/yq/jq breakages

### DIFF
--- a/.github/workflows/ci-external-tools-guard.yml
+++ b/.github/workflows/ci-external-tools-guard.yml
@@ -1,0 +1,28 @@
+name: "CI: external tool dependency guard"
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**/*.yml"
+      - ".github/actions/**"
+      - "scripts/ci-guards/**"
+      - "tests/ci-guards/**"
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci || npm i
+      - run: node scripts/ci-guards/check-external-tools.js
+      - run: npm test -- --reporters=default
+      - uses: actions/upload-artifact@v4
+        with:
+          name: external-tools-report
+          path: ci/guards/external-tools-report.json

--- a/docs/ci/external-tools-guard.md
+++ b/docs/ci/external-tools-guard.md
@@ -1,0 +1,30 @@
+# External Tool Dependency Guard
+
+This guard scans GitHub Actions workflows and composite actions for usages of tools
+that may not be available in all environments. If a tool is used without being
+installed in the same job, the guard reports an error or warning.
+
+## Rules
+
+- Tools such as `rg`, `yq`, `jq`, `xmlstarlet`, `lsb_release`, and `envsubst`
+  must be installed or replaced with a Node/bash fallback before they are used.
+- Platform specific tools like `gsed`, `gawk`, and `netstat` trigger warnings
+  when used without an install step.
+- The check also warns when relying on default tools like `jq` on `ubuntu-latest`
+  without installing them explicitly.
+
+## Baseline tools
+
+`jq` is available on `ubuntu-latest` runners. Using it without installation
+produces a warning rather than an error.
+
+## Satisfying the guard
+
+Add an explicit install step in the job before the tool is used:
+
+```yaml
+- run: sudo apt-get update && sudo apt-get install -y ripgrep
+- run: rg "pattern"
+```
+
+or replace the tool with a script that does not require extra binaries.

--- a/scripts/ci-guards/check-external-tools.js
+++ b/scripts/ci-guards/check-external-tools.js
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+let yaml;
+try {
+  yaml = require('yaml');
+} catch {
+  console.error('yaml module is required');
+  process.exit(1);
+}
+
+const TOOL_PATTERNS = [
+  { name: 'rg', regex: /\brg\b/ },
+  { name: 'yq', regex: /\byq\b/ },
+  { name: 'jq', regex: /\bjq\b/ },
+  { name: 'enhanced-grep', regex: /\benhanced-grep\b/ },
+  { name: 'netstat', regex: /\bnetstat\b/ },
+  { name: 'lsb_release', regex: /\blsb_release\b/ },
+  { name: 'xmlstarlet', regex: /\bxmlstarlet\b/ },
+  { name: 'envsubst', regex: /\benvsubst\b/ },
+  { name: 'gsed', regex: /\bgsed\b/ },
+  { name: 'gawk', regex: /\bgawk\b/ },
+  { name: 'wget', regex: /\bwget\b/ },
+  { name: 'zip', regex: /\bzip\b/ },
+  { name: 'unzip', regex: /\bunzip\b/ },
+];
+
+const WARN_TOOLS = new Set(['gsed','gawk','netstat','wget']);
+const INSTALL_NAMES = {
+  rg: ['ripgrep', 'rg'],
+  yq: ['yq'],
+  jq: ['jq'],
+  'enhanced-grep': ['enhanced-grep'],
+  netstat: ['netstat'],
+  lsb_release: ['lsb-release', 'lsb_release'],
+  xmlstarlet: ['xmlstarlet'],
+  envsubst: ['envsubst', 'gettext-base'],
+  gsed: ['gsed', 'gnu-sed'],
+  gawk: ['gawk'],
+  wget: ['wget'],
+  zip: ['zip'],
+  unzip: ['unzip'],
+};
+
+function listYamlFiles(start, filter) {
+  const out = [];
+  if (!fs.existsSync(start)) return out;
+  const entries = fs.readdirSync(start, { withFileTypes: true });
+  for (const e of entries) {
+    if (e.name === 'node_modules' || e.name === '.git') continue;
+    const full = path.join(start, e.name);
+    if (e.isDirectory()) out.push(...listYamlFiles(full, filter));
+    else if (filter(full)) out.push(full);
+  }
+  return out;
+}
+
+function stripComments(run) {
+  return run
+    .split('\n')
+    .map((l) => l.replace(/#.*$/, ''))
+    .join('\n');
+}
+
+function isInstalled(script, tool) {
+  const names = INSTALL_NAMES[tool] || [tool];
+  const patterns = names.map(
+    (n) =>
+      new RegExp(
+        `(?:apt(-get)?|aptitude|yum|dnf|brew|choco|pip|npm|apk)\\s+[\\w-]*?install[^\n]*\\b${n}\\b`
+      )
+  );
+  return patterns.some((rx) => rx.test(script));
+}
+
+function baselineWarn(os, tool) {
+  if (!os) return false;
+  const text = Array.isArray(os) ? os.join(' ') : String(os);
+  if (/ubuntu/i.test(text) && tool === 'jq') return true;
+  return false;
+}
+
+function analyzeSteps(steps, os, file, jobName) {
+  const installed = new Set();
+  const results = [];
+  if (!Array.isArray(steps)) return results;
+  steps.forEach((step, idx) => {
+    const run = typeof step.run === 'string' ? stripComments(step.run) : '';
+    for (const t of TOOL_PATTERNS) {
+      if (run && isInstalled(run, t.name)) installed.add(t.name);
+    }
+    for (const t of TOOL_PATTERNS) {
+      if (run && t.regex.test(run)) {
+        const hasInstall = installed.has(t.name);
+        let status = 'error';
+        if (hasInstall) status = 'ok';
+        else if (WARN_TOOLS.has(t.name) || baselineWarn(os, t.name)) status = 'warn';
+        const stepName = step.name || `step${idx + 1}`;
+        results.push({
+          file,
+          job: jobName,
+          step: stepName,
+          tool: t.name,
+          status,
+        });
+      }
+    }
+  });
+  return results;
+}
+
+function analyzeWorkflow(file) {
+  const doc = yaml.parse(fs.readFileSync(file, 'utf8')) || {};
+  const jobs = doc.jobs || {};
+  const results = [];
+  for (const [jobName, job] of Object.entries(jobs)) {
+    const os = job['runs-on'];
+    results.push(...analyzeSteps(job.steps || [], os, path.relative(process.cwd(), file), jobName));
+  }
+  return results;
+}
+
+function analyzeAction(file) {
+  const doc = yaml.parse(fs.readFileSync(file, 'utf8')) || {};
+  const runs = doc.runs || {};
+  const steps = runs.steps || [];
+  return analyzeSteps(steps, null, path.relative(process.cwd(), file), path.basename(path.dirname(file)));
+}
+
+function main() {
+  const root = process.cwd();
+  const workflowFiles = listYamlFiles(path.join(root, '.github', 'workflows'), (f) => f.endsWith('.yml'));
+  const actionFiles = listYamlFiles(path.join(root, '.github', 'actions'), (f) => /action\.yml$/.test(f));
+  const all = [];
+  for (const f of workflowFiles) all.push(...analyzeWorkflow(f));
+  for (const f of actionFiles) all.push(...analyzeAction(f));
+
+  const lines = ['| File | Job/Action | Step | Tool | Result |', '| ---- | ---------- | ---- | ---- | ------ |'];
+  let hasError = false;
+  for (const r of all) {
+    const sym = r.status === 'ok' ? '✅' : r.status === 'warn' ? '⚠️' : '❌';
+    if (r.status === 'error') hasError = true;
+    lines.push(`| ${r.file} | ${r.job} | ${r.step} | ${r.tool} | ${sym} |`);
+  }
+  console.log(lines.join('\n'));
+
+  const outPath = path.join(root, 'ci', 'guards');
+  fs.mkdirSync(outPath, { recursive: true });
+  fs.writeFileSync(path.join(outPath, 'external-tools-report.json'), JSON.stringify({ results: all }, null, 2));
+  if (hasError) process.exitCode = 1;
+}
+
+main();

--- a/tests/ci-guards/external-tools.guard.test.f3e1a9c7b8d6e5a4.js
+++ b/tests/ci-guards/external-tools.guard.test.f3e1a9c7b8d6e5a4.js
@@ -1,0 +1,214 @@
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { execFileSync } = require('child_process');
+const test = require('node:test');
+const assert = require('assert');
+
+const script = path.resolve(__dirname, '../../scripts/ci-guards/check-external-tools.js');
+
+function runGuard(opts) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ext-guard-'));
+  if (opts.workflows) {
+    for (const [name, content] of Object.entries(opts.workflows)) {
+      const p = path.join(dir, '.github/workflows', name);
+      fs.mkdirSync(path.dirname(p), { recursive: true });
+      fs.writeFileSync(p, content);
+    }
+  }
+  if (opts.actions) {
+    for (const [name, content] of Object.entries(opts.actions)) {
+      const p = path.join(dir, '.github/actions', name);
+      fs.mkdirSync(path.dirname(p), { recursive: true });
+      fs.writeFileSync(p, content);
+    }
+  }
+  let code = 0;
+  try {
+    execFileSync('node', [script], { cwd: dir, stdio: 'pipe' });
+  } catch (e) {
+    code = e.status || 1;
+  }
+  const reportPath = path.join(dir, 'ci/guards/external-tools-report.json');
+  const report = JSON.parse(fs.readFileSync(reportPath, 'utf8'));
+  return { code, results: report.results };
+}
+
+test('rg without install -> error', () => {
+    const yaml = [
+      'name: t',
+      'jobs:',
+      '  a:',
+      '    runs-on: ubuntu-latest',
+      '    steps:',
+      '      - run: rg foo',
+    ].join('\n');
+    const r = runGuard({ workflows: { 'test.yml': yaml } });
+    assert.equal(r.code, 1);
+    assert.equal(r.results[0].status, 'error');
+});
+
+test('rg with install -> ok', () => {
+    const yaml = [
+      'name: t',
+      'jobs:',
+      '  a:',
+      '    runs-on: ubuntu-latest',
+      '    steps:',
+      '      - run: apt-get install -y ripgrep',
+      '      - run: rg foo',
+    ].join('\n');
+    const r = runGuard({ workflows: { 'test.yml': yaml } });
+    assert.equal(r.code, 0);
+    assert.equal(r.results[0].status, 'ok');
+});
+
+test('jq without install on ubuntu -> warn', () => {
+    const yaml = [
+      'name: t',
+      'jobs:',
+      '  a:',
+      '    runs-on: ubuntu-latest',
+      '    steps:',
+      '      - run: jq .foo file.json',
+    ].join('\n');
+    const r = runGuard({ workflows: { 'test.yml': yaml } });
+    assert.equal(r.code, 0);
+    assert.equal(r.results[0].status, 'warn');
+});
+
+test('jq with install -> ok', () => {
+    const yaml = [
+      'name: t',
+      'jobs:',
+      '  a:',
+      '    runs-on: ubuntu-latest',
+      '    steps:',
+      '      - run: apt-get install -y jq',
+      '      - run: jq .foo file.json',
+    ].join('\n');
+    const r = runGuard({ workflows: { 'test.yml': yaml } });
+    assert.equal(r.code, 0);
+    assert.equal(r.results[1].status, 'ok');
+});
+
+test('yq with pip install -> ok', () => {
+    const yaml = [
+      'name: t',
+      'jobs:',
+      '  a:',
+      '    runs-on: ubuntu-latest',
+      '    steps:',
+      '      - run: pip install yq',
+      '      - run: yq .a b.yml',
+    ].join('\n');
+    const r = runGuard({ workflows: { 'test.yml': yaml } });
+    assert.equal(r.code, 0);
+    assert.equal(r.results[1].status, 'ok');
+});
+
+test('envsubst without install -> error', () => {
+    const yaml = [
+      'name: t',
+      'jobs:',
+      '  a:',
+      '    runs-on: ubuntu-latest',
+      '    steps:',
+      '      - run: envsubst < in > out',
+    ].join('\n');
+    const r = runGuard({ workflows: { 'test.yml': yaml } });
+    assert.equal(r.code, 1);
+    assert.equal(r.results[0].tool, 'envsubst');
+    assert.equal(r.results[0].status, 'error');
+});
+
+test('composite action using yq -> error', () => {
+    const action = [
+      'runs:',
+      '  using: composite',
+      '  steps:',
+      '    - run: yq .a b.yml',
+    ].join('\n');
+    const r = runGuard({ actions: { 'act/action.yml': action } });
+    assert.equal(r.code, 1);
+    assert.equal(r.results[0].tool, 'yq');
+    assert.equal(r.results[0].status, 'error');
+});
+
+test('macos gsed without install -> warn', () => {
+    const yaml = [
+      'name: t',
+      'jobs:',
+      '  a:',
+      '    runs-on: macos-latest',
+      '    steps:',
+      "      - run: gsed -i '' 's/a/b/' file",
+    ].join('\n');
+    const r = runGuard({ workflows: { 'test.yml': yaml } });
+    assert.equal(r.code, 0);
+    assert.equal(r.results[0].status, 'warn');
+});
+
+test('windows wget without install -> warn', () => {
+    const yaml = [
+      'name: t',
+      'jobs:',
+      '  a:',
+      '    runs-on: windows-latest',
+      '    steps:',
+      '      - run: wget http://example.com',
+    ].join('\n');
+    const r = runGuard({ workflows: { 'test.yml': yaml } });
+    assert.equal(r.code, 0);
+    assert.equal(r.results[0].status, 'warn');
+});
+
+test('node fallback script -> pass', () => {
+    const yaml = [
+      'name: t',
+      'jobs:',
+      '  a:',
+      '    runs-on: ubuntu-latest',
+      '    steps:',
+      '      - run: node scripts/ci-tools/scan-workflows.js',
+    ].join('\n');
+    const r = runGuard({ workflows: { 'test.yml': yaml } });
+    assert.equal(r.code, 0);
+    assert.equal(r.results.length, 0);
+});
+
+test('matrix with conditional install -> ok', () => {
+    const yaml = [
+      'name: t',
+      'jobs:',
+      '  a:',
+      '    runs-on: ${{ matrix.os }}',
+      '    strategy:',
+      '      matrix:',
+      '        os: [ubuntu-latest, macos-latest]',
+      '    steps:',
+      '      - run: |',
+      '          if [ "$RUNNER_OS" = "Linux" ]; then sudo apt-get install -y yq; fi',
+      '          if [ "$RUNNER_OS" = "macOS" ]; then brew install yq; fi',
+      '      - run: yq .a b.yml',
+    ].join('\n');
+    const r = runGuard({ workflows: { 'test.yml': yaml } });
+    assert.equal(r.code, 0);
+    assert.equal(r.results[1].status, 'ok');
+});
+
+test('comments ignored', () => {
+  const yaml = [
+    'name: t',
+    'jobs:',
+    '  a:',
+    '    runs-on: ubuntu-latest',
+    '    steps:',
+    '      - run: |',
+    '          # rg command commented',
+    '          echo done',
+  ].join('\n');
+  const r = runGuard({ workflows: { 'test.yml': yaml } });
+  assert.equal(r.code, 0);
+  assert.equal(r.results.length, 0);
+});


### PR DESCRIPTION
## Summary
- add analyzer to scan workflows/composite actions for uninstalled tools like rg, yq, jq
- document external tool guard expectations and baseline tooling
- add workflow and guard tests covering install detection, warnings and errors

## Testing
- `npm run format` *(fails: Nested mappings are not allowed in compact mappings)*
- `node tests/ci-guards/external-tools.guard.test.f3e1a9c7b8d6e5a4.js`


------
https://chatgpt.com/codex/tasks/task_e_68aa0bc667f4832d9a393438092ab138