### PR TITLE
fix(ci): remove ripgrep dependency from aws-gap-report + add smoke test

### DIFF
--- a/.github/workflows/aws-gap-report.yml
+++ b/.github/workflows/aws-gap-report.yml
@@ -24,9 +24,9 @@ jobs:
           blockers=0
 
           echo "#### CI Runners" >> "$REPORT"
-          oidc=$(rg -l "id-token" .github/workflows || true)
-          self_hosted=$(rg -n "runs-on: *.*self-hosted" -g "*.yml" .github/workflows || true)
-          ubuntu_latest=$(rg -l "runs-on: ubuntu-latest" .github/workflows || true)
+          oidc=$(node scripts/ci-tools/scan-workflows.js --id-token | jq -r '.[]?')
+          self_hosted=$(node scripts/ci-tools/scan-workflows.js --self-hosted | jq -r '.[]?')
+          ubuntu_latest=$(node scripts/ci-tools/scan-workflows.js --ubuntu-latest | jq -r '.[]?')
           if [ -n "$oidc" ]; then echo "- [x] OIDC role present" >> "$REPORT"; else echo "- [ ] OIDC role present" >> "$REPORT"; blockers=$((blockers+1)); fi
           if [ -n "$self_hosted" ]; then echo "- self-hosted labels present" >> "$REPORT"; echo "\n\`\`\`\n$self_hosted\n\`\`\`" >> "$REPORT"; else echo "- self-hosted labels missing" >> "$REPORT"; fi
           if [ -n "$ubuntu_latest" ]; then echo "- [ ] Workflows use runs-on: ubuntu-latest" >> "$REPORT"; echo "\n\`\`\`\n$ubuntu_latest\n\`\`\`" >> "$REPORT"; blockers=$((blockers+1)); else echo "- [x] No ubuntu-latest workflows" >> "$REPORT"; fi
@@ -35,43 +35,43 @@ jobs:
           echo "#### Images" >> "$REPORT"
           if [ -f frontend/Dockerfile ]; then echo "- [x] frontend Dockerfile" >> "$REPORT"; else echo "- [ ] frontend Dockerfile" >> "$REPORT"; blockers=$((blockers+1)); fi
           if [ -f backend/Dockerfile ]; then echo "- [x] backend Dockerfile" >> "$REPORT"; else echo "- [ ] backend Dockerfile" >> "$REPORT"; blockers=$((blockers+1)); fi
-          ecr=$(rg -i "ecr" -l || true)
+          ecr=$(node scripts/ci-tools/scan-workflows.js --grep ecr | jq -r '.[]?')
           if [ -n "$ecr" ]; then echo "- [x] ECR references present" >> "$REPORT"; else echo "- [ ] ECR references present" >> "$REPORT"; fi
           echo >> "$REPORT"
 
           echo "#### Deploy" >> "$REPORT"
-          deploy=$(rg -i "ecs|eks|fargate" -l || true)
-          alb=$(rg -i "alb|targetgroup|route53|acm" -l || true)
+          deploy=$(node scripts/ci-tools/scan-workflows.js --grep 'ecs|eks|fargate' | jq -r '.[]?')
+          alb=$(node scripts/ci-tools/scan-workflows.js --grep 'alb|targetgroup|route53|acm' | jq -r '.[]?')
           if [ -n "$deploy" ]; then echo "- [x] ECS/EKS/Fargate references" >> "$REPORT"; else echo "- [ ] ECS/EKS/Fargate references" >> "$REPORT"; blockers=$((blockers+1)); fi
           if [ -n "$alb" ]; then echo "- [x] ALB/TargetGroup/Route53/ACM references" >> "$REPORT"; else echo "- [ ] ALB/TargetGroup/Route53/ACM references" >> "$REPORT"; fi
           echo >> "$REPORT"
 
           echo "#### Frontend" >> "$REPORT"
-          s3=$(rg -i "s3" -l || true)
-          cf=$(rg -i "cloudfront" -l || true)
+          s3=$(node scripts/ci-tools/scan-workflows.js --grep s3 | jq -r '.[]?')
+          cf=$(node scripts/ci-tools/scan-workflows.js --grep cloudfront | jq -r '.[]?')
           if [ -n "$s3" ]; then echo "- [x] S3 references" >> "$REPORT"; else echo "- [ ] S3 references" >> "$REPORT"; blockers=$((blockers+1)); fi
           if [ -n "$cf" ]; then echo "- [x] CloudFront references" >> "$REPORT"; else echo "- [ ] CloudFront references" >> "$REPORT"; fi
           echo >> "$REPORT"
 
           echo "#### Secrets" >> "$REPORT"
-          secrets=$(rg -o "secrets\.[A-Z0-9_\-]+" -h .github/workflows | sort -u)
+          secrets=$(node scripts/ci-tools/scan-workflows.js --secrets | jq -r '.[]?')
           if [ -n "$secrets" ]; then echo "Referenced secrets:" >> "$REPORT"; echo "$secrets" | sed 's/^/  - /' >> "$REPORT"; else echo "No secrets referenced" >> "$REPORT"; fi
           echo >> "$REPORT"
 
           echo "#### Datastores" >> "$REPORT"
-          rds=$(rg -i "rds" -l || true)
-          elasticache=$(rg -i "elasticache" -l || true)
+          rds=$(node scripts/ci-tools/scan-workflows.js --grep rds | jq -r '.[]?')
+          elasticache=$(node scripts/ci-tools/scan-workflows.js --grep elasticache | jq -r '.[]?')
           if [ -n "$rds" ]; then echo "- [x] RDS references" >> "$REPORT"; else echo "- [ ] RDS references" >> "$REPORT"; fi
           if [ -n "$elasticache" ]; then echo "- [x] ElastiCache references" >> "$REPORT"; else echo "- [ ] ElastiCache references" >> "$REPORT"; fi
           echo >> "$REPORT"
 
           echo "#### Credentials" >> "$REPORT"
-          creds=$(rg -n "AKIA[0-9A-Z]{16}" || true)
+          creds=$(node scripts/ci-tools/scan-workflows.js --awskeys | jq -r '.[]?')
           if [ -n "$creds" ]; then echo "- [ ] Hardcoded AWS credentials found" >> "$REPORT"; echo "\n\`\`\`\n$creds\n\`\`\`" >> "$REPORT"; blockers=$((blockers+1)); else echo "- [x] No hardcoded AWS credentials" >> "$REPORT"; fi
           echo >> "$REPORT"
 
           echo "#### Post-deploy smoke tests" >> "$REPORT"
-          smoke=$(rg -l "post-deploy" .github/workflows || true)
+          smoke=$(node scripts/ci-tools/scan-workflows.js --postdeploy | jq -r '.[]?')
           if [ -n "$smoke" ]; then echo "- [x] Post-deploy smoke tests present" >> "$REPORT"; else echo "- [ ] Post-deploy smoke tests present" >> "$REPORT"; blockers=$((blockers+1)); fi
           echo >> "$REPORT"
 

--- a/.github/workflows/ci-tools-smoke.yml
+++ b/.github/workflows/ci-tools-smoke.yml
@@ -1,0 +1,20 @@
+name: ci-tools smoke
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/aws-gap-report.yml"
+      - "scripts/ci-tools/**"
+      - "tests/ci-tools/**"
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci || npm i
+      - run: node scripts/ci-tools/scan-workflows.js --id-token
+      - run: npm test -- -t scan-workflows

--- a/scripts/ci-tools/scan-workflows.js
+++ b/scripts/ci-tools/scan-workflows.js
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+// scan-workflows.js - replicate rg queries in Node without external deps
+const fs = require("fs");
+const path = require("path");
+
+function walk(dir, fileList = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === ".git" || entry.name === "node_modules") continue;
+    const res = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(res, fileList);
+    else fileList.push(res);
+  }
+  return fileList;
+}
+
+function getWorkflowFiles(cwd) {
+  const dir = path.join(cwd, ".github", "workflows");
+  if (!fs.existsSync(dir)) return [];
+  return walk(dir).filter((f) => f.endsWith(".yml") || f.endsWith(".yaml"));
+}
+
+function readLines(file) {
+  return fs.readFileSync(file, "utf8").split(/\r?\n/);
+}
+
+function findIdToken(cwd) {
+  const files = getWorkflowFiles(cwd);
+  return files
+    .filter((f) => /id-token/i.test(fs.readFileSync(f, "utf8")))
+    .map((f) => path.relative(cwd, f));
+}
+
+function findSelfHostedLabels(cwd) {
+  const files = getWorkflowFiles(cwd);
+  const results = [];
+  for (const f of files) {
+    const lines = readLines(f);
+    lines.forEach((line, idx) => {
+      if (/runs-on:.*self-hosted/.test(line)) {
+        results.push(`${path.relative(cwd, f)}:${idx + 1}:${line.trim()}`);
+      }
+    });
+  }
+  return results;
+}
+
+function findUbuntuLatest(cwd) {
+  const files = getWorkflowFiles(cwd);
+  const results = [];
+  for (const f of files) {
+    const content = fs.readFileSync(f, "utf8");
+    if (/runs-on:\s*ubuntu-latest/.test(content)) {
+      results.push(path.relative(cwd, f));
+    }
+  }
+  return results;
+}
+
+function findText(cwd, pattern) {
+  const regex = new RegExp(pattern, "i");
+  const files = walk(cwd);
+  const matched = new Set();
+  for (const f of files) {
+    try {
+      const content = fs.readFileSync(f, "utf8");
+      if (regex.test(content)) matched.add(path.relative(cwd, f));
+    } catch {
+      /* ignore binary */
+    }
+  }
+  return Array.from(matched).sort();
+}
+
+function listSecretsRefs(cwd) {
+  const files = getWorkflowFiles(cwd);
+  const regex = /secrets\.[A-Z0-9_\-]+/g;
+  const set = new Set();
+  for (const f of files) {
+    const content = fs.readFileSync(f, "utf8");
+    let m;
+    while ((m = regex.exec(content)) !== null) set.add(m[0]);
+  }
+  return Array.from(set).sort();
+}
+
+function findHardcodedAwsKeys(cwd) {
+  const regex = /AKIA[0-9A-Z]{16}/g;
+  const files = walk(cwd);
+  const results = [];
+  for (const f of files) {
+    let lines;
+    try {
+      lines = readLines(f);
+    } catch {
+      continue;
+    }
+    lines.forEach((line, idx) => {
+      if (regex.test(line))
+        results.push(`${path.relative(cwd, f)}:${idx + 1}:${line.trim()}`);
+    });
+  }
+  return results;
+}
+
+function findPostDeployRefs(cwd) {
+  const files = getWorkflowFiles(cwd);
+  const regex = /post-deploy/i;
+  return files
+    .filter((f) => regex.test(fs.readFileSync(f, "utf8")))
+    .map((f) => path.relative(cwd, f));
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const cwd = process.cwd();
+  const flag = args[0];
+  let result = [];
+  switch (flag) {
+    case "--id-token":
+      result = findIdToken(cwd);
+      break;
+    case "--self-hosted":
+      result = findSelfHostedLabels(cwd);
+      break;
+    case "--ubuntu-latest":
+      result = findUbuntuLatest(cwd);
+      break;
+    case "--grep":
+      if (!args[1]) {
+        console.error("missing pattern");
+        process.exit(1);
+      }
+      result = findText(cwd, args[1]);
+      break;
+    case "--secrets":
+      result = listSecretsRefs(cwd);
+      break;
+    case "--awskeys":
+      result = findHardcodedAwsKeys(cwd);
+      break;
+    case "--postdeploy":
+      result = findPostDeployRefs(cwd);
+      break;
+    default:
+      console.error(
+        "usage: node scan-workflows.js [--id-token|--self-hosted|--ubuntu-latest|--grep PATTERN|--secrets|--awskeys|--postdeploy]",
+      );
+      process.exit(1);
+  }
+  console.log(JSON.stringify(result));
+}
+
+main();

--- a/tests/ci-tools/scan-workflows.smoke.h82sj4k9f6p2q1r7.test.js
+++ b/tests/ci-tools/scan-workflows.smoke.h82sj4k9f6p2q1r7.test.js
@@ -1,0 +1,56 @@
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { execFileSync, spawnSync } = require("child_process");
+
+describe("scan-workflows smoke", () => {
+  const script = path.resolve(
+    __dirname,
+    "../../scripts/ci-tools/scan-workflows.js",
+  );
+
+  test("detects self-hosted, ubuntu-latest, and ecr", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "wf-"));
+    const wfDir = path.join(tmp, ".github", "workflows");
+    fs.mkdirSync(wfDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(wfDir, "self.yml"),
+      `name: a\njobs:\n  t:\n    runs-on: [self-hosted, linux]\n`,
+    );
+    fs.writeFileSync(
+      path.join(wfDir, "ubuntu.yml"),
+      `name: b\njobs:\n  t:\n    runs-on: ubuntu-latest\n`,
+    );
+    fs.writeFileSync(path.join(tmp, "Dockerfile"), "# ecr reference");
+
+    const selfHosted = JSON.parse(
+      execFileSync("node", [script, "--self-hosted"], {
+        cwd: tmp,
+        encoding: "utf8",
+      }),
+    );
+    expect(selfHosted.some((line) => line.includes("self.yml"))).toBe(true);
+
+    const ubuntu = JSON.parse(
+      execFileSync("node", [script, "--ubuntu-latest"], {
+        cwd: tmp,
+        encoding: "utf8",
+      }),
+    );
+    expect(ubuntu).toContain(".github/workflows/ubuntu.yml");
+
+    const ecr = JSON.parse(
+      execFileSync("node", [script, "--grep", "ecr"], {
+        cwd: tmp,
+        encoding: "utf8",
+      }),
+    );
+    expect(ecr).toContain("Dockerfile");
+  });
+
+  test("exits 0 even without rg", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "wf-"));
+    const res = spawnSync("node", [script, "--self-hosted"], { cwd: tmp });
+    expect(res.status).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- replace ripgrep calls in aws-gap-report with portable Node.js helper
- add scan-workflows helper and smoke test
- wire CI smoke workflow for aws-gap-report tools

## Testing
- `npm run format --prefix backend` *(fails: SyntaxError in tests/ci-guard/pkgjson-repair/fixtures/truncated.json)*
- `npm test --prefix backend`
- `npm test -- tests/ci-tools/scan-workflows.smoke.h82sj4k9f6p2q1r7.test.js`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: YAML syntax errors in existing workflows)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*


------
https://chatgpt.com/codex/tasks/task_e_68aa0bc37f28832db8368ac34604e908