### PR TITLE
fix(ci): stop re‑requiring core/github in github‑script + add guard

### DIFF
--- a/.github/workflows/full-lane-sentry.yml
+++ b/.github/workflows/full-lane-sentry.yml
@@ -9,37 +9,39 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      actions: read
     steps:
       - uses: actions/github-script@v7
         id: fetch
         with:
           script: |
-            const core = require('@actions/core');
-            const github = require('@actions/github');
-            // Read the current run jobs/timings via the REST API and assert that
-            // the following checks exist and are NOT in "skipped" or "cancelled" and have at least 1 step:
-            const required = [
-              'CI Full Lane / backend',
-              'CI Full Lane / frontend',
-              'CI Full Lane / e2e',
-              'CI Full Lane / docs'
-            ];
-            const {owner, repo} = github.context.repo;
-            const runId = github.context.runId;
-            const octo = github.getOctokit(process.env.GITHUB_TOKEN || process.env.GITHUB_PAT || process.env.GITHUB_WORKSPACE_TOKEN);
-            // Try to list jobs for this run:
-            const jobs = await octo.rest.actions.listJobsForWorkflowRun({owner, repo, run_id: runId});
-            const missing = [];
-            const bad = [];
-            for (const name of required) {
-              const job = jobs.data.jobs.find(j => j.name.includes(name));
-              if (!job) { missing.push(name); continue; }
-              if (['queued','in_progress'].includes(job.status)) continue; // still running
-              if (['skipped','cancelled'].includes(job.conclusion)) bad.push(`${name} concluded=${job.conclusion}`);
-              if (!job.steps || job.steps.length===0) bad.push(`${name} had zero steps`);
-            }
-            if (missing.length || bad.length) {
-              core.setFailed(`Lane Sentry: Problems found.\nMissing: ${missing.join(', ') || '(none)'}\nBad: ${bad.join('; ') || '(none)'}`);
-            } else {
-              core.notice('Lane Sentry OK: all Full Lane jobs present with steps.');
+            try {
+              // Read the current run jobs/timings via the REST API and assert that
+              // the following checks exist and are NOT in "skipped" or "cancelled" and have at least 1 step:
+              const required = [
+                'CI Full Lane / backend',
+                'CI Full Lane / frontend',
+                'CI Full Lane / e2e',
+                'CI Full Lane / docs'
+              ];
+              const {owner, repo} = context.repo;
+              const runId = context.runId;
+              // Try to list jobs for this run:
+              const jobs = await github.rest.actions.listJobsForWorkflowRun({owner, repo, run_id: runId});
+              const missing = [];
+              const bad = [];
+              for (const name of required) {
+                const job = jobs.data.jobs.find(j => j.name.includes(name));
+                if (!job) { missing.push(name); continue; }
+                if (['queued','in_progress'].includes(job.status)) continue; // still running
+                if (['skipped','cancelled'].includes(job.conclusion)) bad.push(`${name} concluded=${job.conclusion}`);
+                if (!job.steps || job.steps.length===0) bad.push(`${name} had zero steps`);
+              }
+              if (missing.length || bad.length) {
+                core.setFailed(`Lane Sentry: Problems found.\nMissing: ${missing.join(', ') || '(none)'}\nBad: ${bad.join('; ') || '(none)'}`);
+              } else {
+                core.notice('Lane Sentry OK: all Full Lane jobs present with steps.');
+              }
+            } catch (error) {
+              core.setFailed(error.message);
             }

--- a/.github/workflows/guard-github-script-requires.yml
+++ b/.github/workflows/guard-github-script-requires.yml
@@ -1,0 +1,13 @@
+name: "Guard: github-script requires"
+on:
+  pull_request:
+    paths: [".github/workflows/**/*.yml", "scripts/ci-guards/**"]
+permissions:
+  contents: read
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run guard
+        run: node scripts/ci-guards/forbid-github-script-requires.js

--- a/scripts/ci-guards/forbid-github-script-requires.js
+++ b/scripts/ci-guards/forbid-github-script-requires.js
@@ -1,0 +1,83 @@
+const fs = require("fs");
+const path = require("path");
+
+function walk(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  let files = [];
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files = files.concat(walk(full));
+    } else if (full.endsWith(".yml") || full.endsWith(".yaml")) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+function checkScript(script, file) {
+  const lines = script.split(/\r?\n/);
+  for (const line of lines) {
+    if (
+      /require\(['"]@actions\/core['"]\)/.test(line) ||
+      /require\(['"]@actions\/github['"]\)/.test(line)
+    ) {
+      console.error(`${file}: forbidden require detected -> ${line.trim()}`);
+      return false;
+    }
+    if (
+      /^\s*const\s+core\s*=/.test(line) ||
+      /^\s*const\s+github\s*=/.test(line)
+    ) {
+      console.error(
+        `${file}: forbidden redeclaration detected -> ${line.trim()}`,
+      );
+      return false;
+    }
+  }
+  return true;
+}
+
+function checkFile(file) {
+  const content = fs.readFileSync(file, "utf8");
+  const lines = content.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    if (/uses:\s*actions\/github-script@/.test(lines[i])) {
+      let j = i + 1;
+      while (j < lines.length && !/script:/.test(lines[j])) j++;
+      if (j >= lines.length) continue;
+      const scriptLine = lines[j];
+      const indent = (scriptLine.match(/^(\s*)/) || [""])[1].length;
+      const indicator = scriptLine.match(/script:\s*(\|[+\-]?|>[+\-]?)/);
+      let script = "";
+      if (indicator) {
+        j++;
+        while (
+          j < lines.length &&
+          lines[j].startsWith(" ".repeat(indent + 2))
+        ) {
+          script += lines[j].slice(indent + 2) + "\n";
+          j++;
+        }
+      } else {
+        script = scriptLine.split(/script:\s*/)[1];
+      }
+      if (!checkScript(script, file)) return false;
+      i = j - 1;
+    }
+  }
+  return true;
+}
+
+function main() {
+  const root = path.join(process.cwd(), ".github", "workflows");
+  let ok = true;
+  if (fs.existsSync(root)) {
+    for (const file of walk(root)) {
+      if (!checkFile(file)) ok = false;
+    }
+  }
+  if (!ok) process.exit(1);
+}
+
+main();

--- a/tests/ci-guards/github-script-guard.smoke.q19rs7d8f6k2p0lm.test.js
+++ b/tests/ci-guards/github-script-guard.smoke.q19rs7d8f6k2p0lm.test.js
@@ -1,0 +1,37 @@
+const { spawnSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const assert = require("assert");
+
+test("fails on forbidden requires", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "guard-bad-"));
+  const wfDir = path.join(tmp, ".github", "workflows");
+  fs.mkdirSync(wfDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(wfDir, "bad.yml"),
+    `name: bad\njobs:\n  t:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/github-script@v7\n        with:\n          script: |\n            const core = require('@actions/core')\n`,
+  );
+  const res = spawnSync(
+    "node",
+    [path.resolve("scripts/ci-guards/forbid-github-script-requires.js")],
+    { cwd: tmp },
+  );
+  assert.notStrictEqual(res.status, 0);
+});
+
+test("passes on injected globals", () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "guard-good-"));
+  const wfDir = path.join(tmp, ".github", "workflows");
+  fs.mkdirSync(wfDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(wfDir, "good.yml"),
+    `name: good\njobs:\n  t:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/github-script@v7\n        with:\n          script: |\n            core.notice('ok')\n`,
+  );
+  const res = spawnSync(
+    "node",
+    [path.resolve("scripts/ci-guards/forbid-github-script-requires.js")],
+    { cwd: tmp },
+  );
+  assert.strictEqual(res.status, 0, res.stderr.toString());
+});


### PR DESCRIPTION
## Summary
- avoid re-declaring `core`/`github` in Full Lane Sentry workflow and use injected context with error handling
- add guard script & workflow to block requiring `@actions/core`/`@actions/github` in `github-script`
- test guard logic against good/bad workflow snippets

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm test --prefix backend`
- `node scripts/run-jest.js tests/ci-guards/github-script-guard.smoke.q19rs7d8f6k2p0lm.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68aa0a32823c832da9719e448e16a5c8