### PR TITLE
fix(ci): ensure pnpm installed on Windows/macOS/Linux + add smoke test

### DIFF
--- a/.github/workflows/_reusable-node.yml
+++ b/.github/workflows/_reusable-node.yml
@@ -35,6 +35,9 @@ jobs:
           fetch-depth: 1
           sparse-checkout: ${{ inputs.sparse-checkout }}
           sparse-checkout-cone-mode: false
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.11.0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/ci-pnpm-smoke.yml
+++ b/.github/workflows/ci-pnpm-smoke.yml
@@ -1,0 +1,15 @@
+name: "CI: pnpm install smoke"
+
+on: [pull_request]
+
+jobs:
+  check-pnpm:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix: { os: [ubuntu-latest, macos-latest, windows-latest] }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with: { version: 10.11.0 }
+      - run: pnpm --version
+      - run: pnpm init -y

--- a/.github/workflows/ci-sparse-checkout.yml
+++ b/.github/workflows/ci-sparse-checkout.yml
@@ -26,10 +26,14 @@ jobs:
             apps/**
             packages/**
           sparse-checkout-cone-mode: false
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.11.0
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
       - run: corepack enable
       - run: pnpm i --frozen-lockfile
       - run: pnpm -w run build

--- a/.github/workflows/pipeline-smoke.yml
+++ b/.github/workflows/pipeline-smoke.yml
@@ -20,15 +20,16 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.11.0
+          run_install: false
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: pnpm
           cache-dependency-path: frontend/pnpm-lock.yaml
       - run: corepack enable
-      - uses: pnpm/action-setup@v4
-        with:
-          run_install: false
       - run: pnpm install --frozen-lockfile
         working-directory: frontend
       - run: pnpm build

--- a/.github/workflows/pnpm-guard.yml
+++ b/.github/workflows/pnpm-guard.yml
@@ -17,6 +17,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       # >>> BEGIN MANAGED BLOCK: ci-guard:pnpm-monorepo-install
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.11.0
+          run_install: false
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -27,9 +31,6 @@ jobs:
             backend/pnpm-lock.yaml
       - run: corepack enable
         shell: bash
-      - uses: pnpm/action-setup@v4
-        with:
-          run_install: false
       - name: Discover package roots
         id: cg-pkg-roots
         shell: bash

--- a/.github/workflows/pr-path-filters.yml
+++ b/.github/workflows/pr-path-filters.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: [self-hosted, linux, aws]
     steps:
       - uses: actions/checkout@v5.0.0
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.11.0
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/selfhosted-featuretest.yml
+++ b/.github/workflows/selfhosted-featuretest.yml
@@ -10,15 +10,16 @@ jobs:
     runs-on: [self-hosted]
     steps:
       - uses: actions/checkout@v4.1.7
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.11.0
+          run_install: false
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: pnpm
           cache-dependency-path: frontend/pnpm-lock.yaml
       - run: corepack enable
-      - uses: pnpm/action-setup@v4
-        with:
-          run_install: false
       - run: pnpm install --frozen-lockfile
         working-directory: frontend
       - run: pnpm build

--- a/.github/workflows/sync-space.yml
+++ b/.github/workflows/sync-space.yml
@@ -17,15 +17,16 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.11.0
+          run_install: false
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: pnpm
           cache-dependency-path: frontend/pnpm-lock.yaml
       - run: corepack enable
-      - uses: pnpm/action-setup@v4
-        with:
-          run_install: false
       - run: pnpm install --frozen-lockfile
         working-directory: frontend
       - run: pnpm build

--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -29,6 +29,7 @@ jobs:
         if: startsWith(runner.os, 'Windows')
         uses: pnpm/action-setup@v4
         with:
+          version: 10.11.0
           run_install: false
 # <<< END MANAGED BLOCK: ci-guard:windows-cancel-guard
 # >>> BEGIN MANAGED BLOCK: ci-guard:corepack-pnpm-windows
@@ -65,6 +66,7 @@ jobs:
         if: startsWith(runner.os, 'Windows')
         uses: pnpm/action-setup@v4
         with:
+          version: 10.11.0
           run_install: false
 
       - name: Verify pnpm (Windows)
@@ -72,6 +74,9 @@ jobs:
         shell: pwsh
         run: pnpm -v
 # <<< END MANAGED BLOCK: ci-guard:corepack-pnpm-windows
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.11.0
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/test-rerun.yml
+++ b/.github/workflows/test-rerun.yml
@@ -9,6 +9,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.11.0
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/test-timeout.yml
+++ b/.github/workflows/test-timeout.yml
@@ -12,10 +12,14 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.11.0
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
       - uses: ./.github/actions/node-setup
       - name: Install dependencies
         run: |

--- a/.github/workflows/web-matrix.yml
+++ b/.github/workflows/web-matrix.yml
@@ -29,6 +29,9 @@ jobs:
             package.json
             pnpm-lock.yaml
           sparse-checkout-cone: true
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.11.0
       - uses: actions/setup-node@v4
         with:
           node-version: 20


### PR DESCRIPTION
## Summary
- run pnpm/action-setup before Node setup in workflows using pnpm caching
- add ci-pnpm-smoke workflow to verify pnpm on all platforms

## Testing
- `npm run validate-env`
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Nested mappings in YAML files)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68aa0c8ea9c4832d8b6f5a8e127c8f5e