### PR TITLE
ci: add autofix merge policy workflow

### DIFF
--- a/.github/workflows/autofix-merge.yml
+++ b/.github/workflows/autofix-merge.yml
@@ -1,0 +1,28 @@
+on:
+  pull_request:
+    types: [ready_for_review, synchronize, opened, reopened]
+jobs:
+  gate:
+    permissions: { contents: write, pull-requests: write, checks: read }
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const core = require('@actions/core');
+            const github = require('@actions/github');
+            const {owner, repo} = github.context.repo;
+            const pr = github.context.payload.pull_request;
+            if (!pr || !pr.labels?.some(l => l.name==='autofix')) return core.notice('Non-autofix PR; skipping');
+            const octo = github.getOctokit(process.env.GITHUB_TOKEN);
+            const {data: checks} = await octo.rest.checks.listForRef({owner, repo, ref: pr.head.sha});
+            const hasRed = checks.check_runs.some(c => c.conclusion === 'failure');
+            const hasConflict = pr.mergeable_state === 'dirty';
+            if (!hasRed && !hasConflict) {
+              await octo.rest.pulls.merge({owner, repo, pull_number: pr.number, merge_method: 'squash'});
+              core.notice('Merged automatically');
+            } else {
+              await octo.rest.pulls.update({owner, repo, pull_number: pr.number, state: 'closed'});
+              core.setFailed('Closed due to red checks or conflicts');
+            }

--- a/tests/autofix-merge-policy_p7k2m9v4s1d8f3g6.test.js
+++ b/tests/autofix-merge-policy_p7k2m9v4s1d8f3g6.test.js
@@ -1,0 +1,85 @@
+const fs = require("fs");
+const { parse } = require("yaml");
+
+async function run(pr, checkRuns) {
+  const yaml = parse(
+    fs.readFileSync(".github/workflows/autofix-merge.yml", "utf8"),
+  );
+  const script = yaml.jobs.gate.steps[1].with.script;
+  const calls = { merge: [], close: [], notice: [], failed: [] };
+  const core = {
+    notice: (m) => calls.notice.push(m),
+    setFailed: (m) => calls.failed.push(m),
+  };
+  const github = {
+    context: {
+      repo: { owner: "owner", repo: "repo" },
+      payload: { pull_request: pr },
+    },
+    getOctokit: () => ({
+      rest: {
+        checks: {
+          listForRef: async () => ({ data: { check_runs: checkRuns } }),
+        },
+        pulls: {
+          merge: async (args) => calls.merge.push(args),
+          update: async (args) => calls.close.push(args),
+        },
+      },
+    }),
+  };
+  const requireMock = (mod) => {
+    if (mod === "@actions/core") return core;
+    if (mod === "@actions/github") return github;
+    throw new Error("unknown module");
+  };
+  const fn = new Function(
+    "require",
+    "process",
+    `return (async () => {${script}\n})();`,
+  );
+  await fn(requireMock, { env: { GITHUB_TOKEN: "token" } });
+  return calls;
+}
+
+test("merges clean autofix PR", async () => {
+  const pr = {
+    labels: [{ name: "autofix" }],
+    head: { sha: "sha" },
+    mergeable_state: "clean",
+    number: 1,
+  };
+  const checks = [{ conclusion: "success" }];
+  const calls = await run(pr, checks);
+  expect(calls.merge).toHaveLength(1);
+  expect(calls.close).toHaveLength(0);
+  expect(calls.failed).toHaveLength(0);
+});
+
+test("closes PR with failing checks or conflicts", async () => {
+  const pr = {
+    labels: [{ name: "autofix" }],
+    head: { sha: "sha" },
+    mergeable_state: "dirty",
+    number: 1,
+  };
+  const checks = [{ conclusion: "failure" }];
+  const calls = await run(pr, checks);
+  expect(calls.merge).toHaveLength(0);
+  expect(calls.close).toHaveLength(1);
+  expect(calls.failed[0]).toMatch("Closed due to red checks or conflicts");
+});
+
+test("skips non-autofix PR", async () => {
+  const pr = {
+    labels: [{ name: "other" }],
+    head: { sha: "sha" },
+    mergeable_state: "clean",
+    number: 1,
+  };
+  const checks = [];
+  const calls = await run(pr, checks);
+  expect(calls.notice[0]).toMatch("Non-autofix PR");
+  expect(calls.merge).toHaveLength(0);
+  expect(calls.close).toHaveLength(0);
+});


### PR DESCRIPTION
## Summary
- auto-merge autofix PRs when checks are green and conflict-free
- test autofix gate logic for merge, close, and skip scenarios

## Testing
- `npm test --prefix backend`
- `node scripts/run-jest.js tests/autofix-merge-policy_p7k2m9v4s1d8f3g6.test.js`
- `npm run format` *(fails: Nested mappings are not allowed in compact mappings)*
- `npm run format --prefix backend` *(fails: Unterminated string constant)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: interrupted)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68aa13153ce0832d93f5399aaea0410d