### PR TITLE
ci: add autofix orchestrator workflow

### DIFF
--- a/.github/workflows/autofix-orchestrate.yml
+++ b/.github/workflows/autofix-orchestrate.yml
@@ -1,0 +1,25 @@
+name: autofix orchestrator
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: "0/30 * * * *"
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      actions: read
+      artifacts: read
+    steps:
+      - uses: actions/checkout@v4.3.0
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version: 20
+      - run: npm ci || npm i
+      - run: node scripts/autofix/harvest.js
+      - run: node scripts/autofix/cluster.js
+      - run: node scripts/autofix/generate-prompts.js
+      - run: node scripts/autofix/codex-driver.js

--- a/docs/autofix/README.md
+++ b/docs/autofix/README.md
@@ -1,0 +1,24 @@
+# Autofix orchestrator
+
+This workflow glues the autofix pipeline together. Every run executes the full loop:
+
+1. **harvest** – collect pending issues or code alerts.
+2. **cluster** – group related findings for batch fixes.
+3. **generate-prompts** – build Codex prompts for each cluster.
+4. **codex-driver** – apply generated patches and open pull requests.
+
+Runs can be triggered manually or on a 30 minute schedule. The workflow keeps rerunning until no work remains.
+
+## Required secrets
+
+Set these secrets in the repository to allow the driver to push fixes:
+
+- `AUTOFIX_GH_TOKEN` – personal access token with `repo` scope for committing branches and opening PRs.
+- `OPENAI_API_KEY` – API key used by Codex to propose fixes.
+- `AUTOFIX_STORAGE` – bucket or database connection string for harvest artifacts.
+
+## Safety rails
+
+- All actions use the least required permissions and run in a fresh checkout.
+- The driver exits without committing when no changes are generated.
+- Run manually to supervise new fixes or rely on the scheduled cadence for continuous maintenance.


### PR DESCRIPTION
## Summary
- orchestrate harvest → cluster → prompt generation → codex in one workflow
- document autofix loop, required secrets and safety rails

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` *(fails: Nested mappings are not allowed in compact mappings)*
- `cd backend && npm run format` *(fails: Unterminated string constant)*
- `cd backend && npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Nested mappings are not allowed in compact mappings)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html)*

------
https://chatgpt.com/codex/tasks/task_e_68aa13193488832d88659279dd86f0b6