### PR TITLE
feat: add autofix policy enforcement

### DIFF
--- a/codex-driver.js
+++ b/codex-driver.js
@@ -1,0 +1,50 @@
+const fs = require("fs");
+const path = require("path");
+const { minimatch } = require("minimatch");
+
+function loadPolicy() {
+  const policyPath = path.join(__dirname, "config", "autofix", "policy.json");
+  return JSON.parse(fs.readFileSync(policyPath, "utf8"));
+}
+
+function enforceAutofixPolicy({
+  changedFiles,
+  openAutofixPRs,
+  testsA = 0,
+  testsB = 0,
+}) {
+  const policy = loadPolicy();
+
+  if (openAutofixPRs >= policy.maxOpenAutofixPRs) {
+    throw new Error("too many open autofix PRs");
+  }
+
+  for (const file of changedFiles) {
+    const forbidden = policy.forbiddenPaths.some((p) =>
+      p.includes("*") || p.includes("?")
+        ? minimatch(file, p, { dot: true })
+        : file.startsWith(p),
+    );
+    if (forbidden) {
+      throw new Error(`changes to ${file} forbidden`);
+    }
+    const allowed = policy.allowedPaths.some((p) =>
+      p.includes("*") || p.includes("?")
+        ? minimatch(file, p, { dot: true })
+        : file.startsWith(p),
+    );
+    if (!allowed) {
+      throw new Error(`changes to ${file} not allowed`);
+    }
+  }
+
+  if (policy.requireTestsForA && testsA === 0) {
+    throw new Error("tests required for A");
+  }
+
+  if (testsB < policy.minTestsForB) {
+    throw new Error(`at least ${policy.minTestsForB} tests required for B`);
+  }
+}
+
+module.exports = { enforceAutofixPolicy, loadPolicy };

--- a/config/autofix/policy.json
+++ b/config/autofix/policy.json
@@ -1,0 +1,7 @@
+{
+  "maxOpenAutofixPRs": 5,
+  "allowedPaths": [".github/workflows", "scripts/ci-*", "tests/ci-*"],
+  "forbiddenPaths": ["src/runtime/**", "secrets/**"],
+  "requireTestsForA": true,
+  "minTestsForB": 10
+}

--- a/tests/policy/policy.q4w9e8r7t6y5u4i3.test.ts
+++ b/tests/policy/policy.q4w9e8r7t6y5u4i3.test.ts
@@ -1,0 +1,39 @@
+const { enforceAutofixPolicy } = require("../../codex-driver");
+
+describe("autofix policy enforcement", () => {
+  const base = {
+    changedFiles: [
+      ".github/workflows/test.yml",
+      "scripts/ci-build.js",
+      "tests/ci-sample.test.js",
+    ],
+    openAutofixPRs: 0,
+    testsA: 1,
+    testsB: 10,
+  };
+
+  test("allows compliant changes", () => {
+    expect(() => enforceAutofixPolicy(base)).not.toThrow();
+  });
+
+  test("blocks excessive open PRs", () => {
+    expect(() => enforceAutofixPolicy({ ...base, openAutofixPRs: 5 })).toThrow(
+      /too many/,
+    );
+  });
+
+  test("blocks forbidden paths", () => {
+    expect(() =>
+      enforceAutofixPolicy({ ...base, changedFiles: ["src/runtime/index.js"] }),
+    ).toThrow(/forbidden/);
+  });
+
+  test("requires tests for A and minimum for B", () => {
+    expect(() => enforceAutofixPolicy({ ...base, testsA: 0 })).toThrow(
+      /tests required/,
+    );
+    expect(() => enforceAutofixPolicy({ ...base, testsB: 5 })).toThrow(
+      /at least/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add config-driven autofix guardrails
- enforce autofix policy before creating PRs
- test policy behavior for allowed and forbidden changes

## Testing
- `npm run format --prefix backend` *(fails: SyntaxError: Unterminated string constant)*
- `npm run format` *(fails: Nested mappings are not allowed in compact mappings)*
- `npm test --prefix backend`
- `node scripts/run-jest.js --runTestsByPath tests/policy/policy.q4w9e8r7t6y5u4i3.test.ts`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_68aa131c4ac8832d9263121920dc2a3b