### PR TITLE
fix: remove duplicate Cloudflare build config

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,12 +1,6 @@
 name = "print2"
 compatibility_date = "2025-08-22"
 
-[build]
-command = "bash -lc 'corepack enable && pnpm -C frontend install --frozen-lockfile && pnpm -C frontend build'"
-
-[pages]
-build_output_dir = "frontend/dist"
-
 [env.preview]
   name = "print2"
 


### PR DESCRIPTION
## Summary
- remove duplicate [build] and [pages] sections in wrangler config to satisfy Cloudflare

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` *(fails: SyntaxError in tests/ci-guard/pkgjson-repair/fixtures/truncated.json)*
- `npm test` *(fails: process terminated, SIGINT)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: setup ran, then aborted)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact)*

------
https://chatgpt.com/codex/tasks/task_e_68aa2aa930f8832d81fb09dd193f6f74