### PR TITLE
fix: install pnpm before node caching

### DIFF
--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -14,6 +14,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 # >>> BEGIN MANAGED BLOCK: ci-guard:windows-cancel-guard
+      - name: Ensure pnpm (Windows)
+        if: startsWith(runner.os, 'Windows')
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.11.0
+          run_install: false
       - name: Setup Node (Windows)
         if: startsWith(runner.os, 'Windows')
         uses: actions/setup-node@v4
@@ -25,14 +31,14 @@ jobs:
         if: startsWith(runner.os, 'Windows')
         shell: pwsh
         run: corepack enable
-      - name: Ensure pnpm (Windows fallback)
+# <<< END MANAGED BLOCK: ci-guard:windows-cancel-guard
+# >>> BEGIN MANAGED BLOCK: ci-guard:corepack-pnpm-windows
+      - name: Setup pnpm (Windows)
         if: startsWith(runner.os, 'Windows')
         uses: pnpm/action-setup@v4
         with:
           version: 10.11.0
           run_install: false
-# <<< END MANAGED BLOCK: ci-guard:windows-cancel-guard
-# >>> BEGIN MANAGED BLOCK: ci-guard:corepack-pnpm-windows
       - name: Setup Node (Windows)
         if: startsWith(runner.os, 'Windows')
         uses: actions/setup-node@v4
@@ -61,13 +67,6 @@ jobs:
           } else {
             corepack prepare pnpm@10 --activate
           }
-
-      - name: "Fallback: pnpm/action-setup (Windows)"
-        if: startsWith(runner.os, 'Windows')
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10.11.0
-          run_install: false
 
       - name: Verify pnpm (Windows)
         if: startsWith(runner.os, 'Windows')


### PR DESCRIPTION
## Summary
- ensure pnpm is installed before using Node cache on Windows runners

## Testing
- `npm run format --prefix backend` *(fails: SyntaxError: Unterminated string constant)*
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing frontend build artifact: frontend/dist/index.html)*

------
https://chatgpt.com/codex/tasks/task_e_68aa2a8643a8832dbfd9ad6b1b3d8793