### PR TITLE
ci: handle missing test results file in telemetry action

### DIFF
--- a/.github/actions/with-test-telemetry/action.yml
+++ b/.github/actions/with-test-telemetry/action.yml
@@ -46,8 +46,14 @@ runs:
       shell: bash
       run: |
         file='${{ inputs.results-file }}'
-        tests=$(node -pe "require('./$file').numTotalTests || 0")
-        failures=$(node -pe "require('./$file').numFailedTests || 0")
+        if [ -f "$file" ]; then
+          tests=$(node -pe "require('./$file').numTotalTests || 0")
+          failures=$(node -pe "require('./$file').numFailedTests || 0")
+        else
+          echo "Warning: test results file '$file' not found" >&2
+          tests=0
+          failures=0
+        fi
         duration=${{ steps.run.outputs.duration_ms }}
         cat <<JSON > test-telemetry.json
         {


### PR DESCRIPTION
## Summary
- avoid require failures when test results json is missing in with-test-telemetry action by defaulting counts to zero

## Testing
- `npx prettier -w .github/actions/with-test-telemetry/action.yml`
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_68aa2a7082b4832da9f09535c72a7438