### PR TITLE
ci: fix pnpm smoke workflow

### DIFF
--- a/.github/workflows/ci-pnpm-smoke.yml
+++ b/.github/workflows/ci-pnpm-smoke.yml
@@ -12,4 +12,4 @@ jobs:
       - uses: pnpm/action-setup@v4
         with: { version: 10.11.0 }
       - run: pnpm --version
-      - run: pnpm init -y
+      - run: pnpm install --ignore-scripts


### PR DESCRIPTION
## Summary
- replace unsupported `pnpm init -y` command with `pnpm install --ignore-scripts`

## Testing
- `npm run format` (failed: SyntaxError: Unterminated string constant)
- `npm test`
- `npm run ci` (failed: Error occurred when checking code style in 8 files.)
- `npm run smoke` (failed: Missing frontend build artifact: frontend/dist/index.html)


------
https://chatgpt.com/codex/tasks/task_e_68aa2a21edb8832dbc0676fa25002037