### PR TITLE
ci: add no-frozen-lockfile to pnpm installs

### DIFF
--- a/.github/workflows/ci-full-lane.yml
+++ b/.github/workflows/ci-full-lane.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Ensure pnpm
         uses: ./.github/actions/ensure-pnpm
       - name: pnpm install
-        run: pnpm install --ignore-scripts
+        run: pnpm install --no-frozen-lockfile --ignore-scripts
       - name: Check lockfile
         id: lock
         run: |

--- a/.github/workflows/ci-pnpm-smoke.yml
+++ b/.github/workflows/ci-pnpm-smoke.yml
@@ -12,4 +12,4 @@ jobs:
       - uses: pnpm/action-setup@v4
         with: { version: 10.11.0 }
       - run: pnpm --version
-      - run: pnpm install --ignore-scripts
+      - run: pnpm install --no-frozen-lockfile --ignore-scripts


### PR DESCRIPTION
## Summary
- add `--no-frozen-lockfile` flag to pnpm install steps that skip lifecycle scripts to avoid lockfile mismatch errors

## Testing
- `npx prettier -w .github/workflows/ci-pnpm-smoke.yml .github/workflows/ci-full-lane.yml`
- `npm test` *(fails: Dependencies missing. Installing root dependencies...)*

------
https://chatgpt.com/codex/tasks/task_e_68aa35c87d1c832d8c1b4504ee2bf542