### PR TITLE
fix: ensure test results go to repo root

### DIFF
--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -53,6 +53,18 @@ function runJest(args) {
 
   let jestArgs = [...args];
 
+  let outputFile;
+  const outputIdx = jestArgs.findIndex(
+    (a) => a === "--outputFile" || a.startsWith("--outputFile="),
+  );
+  if (outputIdx !== -1) {
+    if (jestArgs[outputIdx] === "--outputFile") {
+      outputFile = jestArgs[outputIdx + 1];
+    } else {
+      outputFile = jestArgs[outputIdx].split("=")[1];
+    }
+  }
+
   const fileArgs = jestArgs.filter((arg) => !arg.startsWith("-"));
   const runFromRoot = fileArgs.some((arg) => {
     const abs = path.resolve(repoRoot, arg);
@@ -65,6 +77,15 @@ function runJest(args) {
       const abs = path.resolve(repoRoot, arg);
       return path.relative(backendDir, abs);
     });
+
+    if (outputFile && !path.isAbsolute(outputFile)) {
+      const resolved = path.join(repoRoot, outputFile);
+      if (jestArgs[outputIdx] === "--outputFile") {
+        jestArgs[outputIdx + 1] = resolved;
+      } else {
+        jestArgs[outputIdx] = `--outputFile=${resolved}`;
+      }
+    }
   }
 
   const env = { ...process.env };


### PR DESCRIPTION
## Summary
- ensure run-jest writes relative `--outputFile` paths to repo root so CI can find test-results.json

## Testing
- `npx prettier --log-level warn --write scripts/run-jest.js`
- `npm run format --prefix backend` *(fails: Dependencies missing. Installing root dependencies...)*
- `npm test -- --json --outputFile=test-results.json` *(fails: ENOENT rename cache file)*

------
https://chatgpt.com/codex/tasks/task_e_68aa35fcacb4832da0c18022ba99fefd