### PR TITLE
fix: avoid root npm cache from setup cleanup

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -85,10 +85,10 @@ fi
 remove_modules() {
   local target="$1"
   for i in {1..3}; do
-    if sudo npx --yes rimraf@5 "$target" >/dev/null 2>&1; then
+    if npx --yes rimraf@5 "$target" >/dev/null 2>&1; then
       break
     fi
-    sudo rm -rf "$target" >/dev/null 2>&1 || true
+    rm -rf "$target" >/dev/null 2>&1 || true
     if [ ! -d "$target" ]; then
       break
     fi


### PR DESCRIPTION
## Summary
- avoid using sudo when removing node_modules in setup to prevent root-owned npm cache

## Testing
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` *(fails: SyntaxError: Unterminated string constant)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa37924fd4832db7c2f0e5636917f0