### PR TITLE
test: expand lfs-prettier guard coverage

### DIFF
--- a/tests/ci-guard/lfs-prettier-guard/fixtures/raw-image.png
+++ b/tests/ci-guard/lfs-prettier-guard/fixtures/raw-image.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:408c5b78ec79414c058ce8d185b32828c008e3db4323acbe2b4306739c724cb8
+size 11

--- a/tests/ci-guard/lfs-prettier-guard/fixtures/single-line-array.json
+++ b/tests/ci-guard/lfs-prettier-guard/fixtures/single-line-array.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["config:base"]
+}

--- a/tests/ci-guard/lfs-prettier-guard/fixtures/valid-pointer.png
+++ b/tests/ci-guard/lfs-prettier-guard/fixtures/valid-pointer.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:36c12958af795e331bf736adc8767dfb95d8f1e6c57d15a9d4a397b6d1f8ed7a
+size 67

--- a/tests/ci-guard/lfs-prettier-guard/validate.test.ts
+++ b/tests/ci-guard/lfs-prettier-guard/validate.test.ts
@@ -94,4 +94,20 @@ describe("lfs-prettier-guard", () => {
     const res = await validate(dir);
     expect(res.ok).toBe(true);
   });
+
+  test("t11 single line array triggers false positive", async () => {
+    const dir = tmpdir();
+    copy("single-line-array.json", path.join(dir, "data.json"));
+    const res = await validate(dir);
+    expect(res.ok).toBe(false);
+    expect(res.errors[0]).toMatch(/prettier: data.json/);
+    expect(res.errors[0]).toMatch(/\+\s+"config:base"/);
+  });
+
+  test("t12 node_modules ignored", async () => {
+    const dir = tmpdir();
+    copy("misformatted.js", path.join(dir, "node_modules", "bad.js"));
+    const res = await validate(dir);
+    expect(res.ok).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- add fixtures for pointer and raw images to lfs-prettier guard tests
- cover single-line array edge case and ignore node_modules

## Testing
- `npx prettier -w tests/ci-guard/lfs-prettier-guard/validate.test.ts tests/ci-guard/lfs-prettier-guard/fixtures/single-line-array.json`
- `node scripts/run-jest.js tests/ci-guard/lfs-prettier-guard/validate.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68aa37696164832db398a2e42ee91458