### PR TITLE
fix: ensure jest args handle leading delimiter

### DIFF
--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -52,6 +52,9 @@ function runJest(args) {
   const jestBin = path.join(backendDir, "node_modules", ".bin", "jest");
 
   let jestArgs = [...args];
+  if (jestArgs[0] === "--") {
+    jestArgs.shift();
+  }
 
   let outputFile;
   const outputIdx = jestArgs.findIndex(


### PR DESCRIPTION
## Summary
- trim initial `--` when forwarding arguments in `run-jest`

## Testing
- `npx prettier -w scripts/run-jest.js`
- `pnpm test backend/tests/api.test.js -- --json --outputFile=test-results.json`


------
https://chatgpt.com/codex/tasks/task_e_68aa5282f41c832d9838e72383bd5ed8