### PR TITLE
fix: guard telemetry duration

### DIFF
--- a/.github/actions/with-test-telemetry/action.yml
+++ b/.github/actions/with-test-telemetry/action.yml
@@ -55,6 +55,9 @@ runs:
           failures=0
         fi
         duration=${{ steps.run.outputs.duration_ms }}
+        if [ -z "$duration" ]; then
+          duration=0
+        fi
         cat <<JSON > test-telemetry.json
         {
           "job": "$GITHUB_JOB",


### PR DESCRIPTION
## Summary
- default telemetry duration to 0 when missing

## Testing
- `npm run format --prefix backend` *(fails: Unterminated string constant)*
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(interrupted: long output)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5269e154832d8dcc3b5dd74278ed