### PR TITLE
fix(pages): remove LFS from test fixtures and add LFS pointer guard

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -31,3 +31,7 @@ upload/* binary
 
 frontend/** -filter=lfs -diff=lfs -merge=lfs
 frontend/public/** -filter=lfs -diff=lfs -merge=lfs
+
+# CI test fixtures must not use Git LFS because Pages doesn't fetch LFS objects
+tests/** -filter=lfs -text
+tests/ci-guard/lfs-prettier-guard/fixtures/** -filter=lfs -text

--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.3.0
+      - run: echo "LFS intentionally disabled for tests"
       - run: corepack enable || true
       - run: (pnpm -v) || npm i -g pnpm@9
       - run: cd frontend && pnpm install --no-frozen-lockfile && pnpm build

--- a/.github/workflows/lfs-prevent-pointers.yml
+++ b/.github/workflows/lfs-prevent-pointers.yml
@@ -1,0 +1,19 @@
+name: lfs-prevent-pointers
+on:
+  push:
+  pull_request:
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.3.0
+      - name: check for LFS pointers in tests
+        run: |
+          set -e
+          matches=$(git ls-files -z | xargs -0 grep -IlZ "version https://git-lfs.github.com/spec" | tr -d '\0' | grep '^tests/' || true)
+          if [ -n "$matches" ]; then
+            echo "LFS pointer files found in tests: $matches"
+            exit 1
+          fi
+          git check-attr filter -- tests | grep -E ": filter: lfs$" && { echo "LFS filter attribute found in tests"; exit 1; }
+      - run: echo "LFS intentionally disabled for tests"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,7 @@ Thank you for helping improve this project! Please follow these steps to keep ou
 3. Execute `npm test` and, if possible, `npm run smoke` before opening the PR.
 4. Open a PR against the `dev` branch and request review.
 5. Do not use Git LFS for files under `frontend/`. Commit real assets or host large files externally (e.g., S3/CDN).
+6. Test fixtures may not use Git LFS; use generated fixtures or commit tiny files. See `.gitattributes` and the `lfs-prevent-pointers` workflow.
 
 ## Tests
 

--- a/scripts/tests/make-fixture.js
+++ b/scripts/tests/make-fixture.js
@@ -1,0 +1,10 @@
+const fs = require('fs');
+const path = require('path');
+
+function writePng(filePath) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  const pngBase64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+cY7kAAAAASUVORK5CYII=';
+  fs.writeFileSync(filePath, Buffer.from(pngBase64, 'base64'));
+}
+
+module.exports = { writePng };

--- a/tests/ci-guard/lfs-prettier-guard/fixtures/raw-image.png
+++ b/tests/ci-guard/lfs-prettier-guard/fixtures/raw-image.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:408c5b78ec79414c058ce8d185b32828c008e3db4323acbe2b4306739c724cb8
-size 11

--- a/tests/ci-guard/lfs-prettier-guard/validate.test.ts
+++ b/tests/ci-guard/lfs-prettier-guard/validate.test.ts
@@ -4,6 +4,7 @@ const path = require("path");
 const {
   validate,
 } = require("../../../scripts/ci-guard/lfs-prettier-guard/validate");
+const { writePng } = require("../../../scripts/tests/make-fixture");
 
 function tmpdir() {
   return fs.mkdtempSync(path.join(os.tmpdir(), "lpg-"));
@@ -25,7 +26,10 @@ describe("lfs-prettier-guard", () => {
 
   test("t2 raw image fails", async () => {
     const dir = tmpdir();
-    copy("raw-image.png", path.join(dir, "img", "bad.png"));
+    const bad = path.join(dir, "img", "bad.png");
+    writePng(bad);
+    const header = fs.readFileSync(bad, "utf8").slice(0, 40);
+    expect(header.startsWith("version https://git-lfs")).toBe(false);
     const res = await validate(dir);
     expect(res.ok).toBe(false);
     expect(res.errors[0]).toMatch(/non-pointer asset/);


### PR DESCRIPTION
## Summary
- stop Git LFS usage under tests and add an explicit guard workflow
- generate raw test image at runtime instead of storing an LFS pointer
- document that test fixtures may not use Git LFS

## Testing
- `node scripts/run-jest.js tests/ci-guard/lfs-prettier-guard/validate.test.ts` *(fails: Missing backend dependencies)*
- `npm run format` *(fails: dependency installation hangs)*

Original error: https://github.com/print3git/MVP-website/actions/runs/0

------
https://chatgpt.com/codex/tasks/task_e_68aa513e1a18832da5ce7decb8009481