### PR TITLE
test: add smoke test suite

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,16 @@
+name: smoke
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+      - uses: actions/setup-node@v4.4.0
+        with:
+          node-version: 'lts/*'
+      - run: npm ci
+      - run: npm run smoke

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "setup": "bash scripts/setup.sh",
     "build": "vite build",
     "preview": "vite preview --port 4173",
-    "start:backend": "npm start --prefix backend"
+    "start:backend": "npm start --prefix backend",
+    "smoke": "node scripts/run-jest.js --config tests/smoke/jest.config.js tests/smoke"
   },
   "babel": {
     "presets": [

--- a/tests/smoke/api-contract.spec.ts
+++ b/tests/smoke/api-contract.spec.ts
@@ -1,0 +1,23 @@
+const fs = require('fs');
+const path = require('path');
+const yaml = require('yaml');
+
+test('OpenAPI spec loads and has paths', () => {
+  const candidates = [
+    'openapi.yaml',
+    'openapi.yml',
+    'openapi.json',
+    path.join('docs', 'openapi.yaml'),
+    path.join('docs', 'openapi.yml'),
+    path.join('docs', 'openapi.json'),
+  ];
+  const specPath = candidates.find((p) => fs.existsSync(p));
+  if (!specPath) {
+    console.warn('OpenAPI spec not found, skipping');
+    return;
+  }
+  const content = fs.readFileSync(specPath, 'utf8');
+  const spec = specPath.endsWith('.json') ? JSON.parse(content) : yaml.parse(content);
+  expect(spec && spec.paths && Object.keys(spec.paths).length).toBeGreaterThan(0);
+  expect(Object.keys(spec.paths)).not.toContain('/api/generate-model');
+});

--- a/tests/smoke/basic-app.spec.ts
+++ b/tests/smoke/basic-app.spec.ts
@@ -1,0 +1,40 @@
+const { startDevServer } = require('../../scripts/dev-server');
+const fetch = global.fetch;
+
+describe('basic app smoke', () => {
+  let server;
+  beforeAll(() => {
+    server = startDevServer(0);
+  });
+  afterAll(() => {
+    if (server) {
+      server.removeAllListeners && server.removeAllListeners('close');
+      server.close();
+    }
+  });
+
+  test('GET / returns 200', async () => {
+    const port = server.address().port;
+    const res = await fetch(`http://localhost:${port}/`);
+    expect(res.status).toBe(200);
+  });
+
+  test('health or status endpoint', async () => {
+    const port = server.address().port;
+    const paths = ['/health', '/status'];
+    for (const p of paths) {
+      try {
+        const res = await fetch(`http://localhost:${port}${p}`);
+        if (res.status !== 404) {
+          expect(res.status).toBe(200);
+          const text = (await res.text()).toLowerCase();
+          expect(text).toContain('ok');
+          return;
+        }
+      } catch (_e) {
+        // ignore network errors and continue
+      }
+    }
+    console.warn('No /health or /status endpoint found');
+  });
+});

--- a/tests/smoke/cli.spec.ts
+++ b/tests/smoke/cli.spec.ts
@@ -1,0 +1,13 @@
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const cliPath = path.join(process.cwd(), 'bin', 'cli.js');
+
+(hasCli => {
+  const testFn = hasCli ? test : test.skip;
+  testFn('CLI --help exits with code 0', () => {
+    const result = spawnSync('node', [cliPath, '--help'], { stdio: 'pipe' });
+    expect(result.status).toBe(0);
+  });
+})(fs.existsSync(cliPath));

--- a/tests/smoke/dependencies.spec.ts
+++ b/tests/smoke/dependencies.spec.ts
@@ -1,0 +1,7 @@
+const { spawnSync } = require('child_process');
+
+test('npm ls has no missing dependencies', () => {
+  const res = spawnSync('npm', ['ls'], { encoding: 'utf8' });
+  expect(res.status).toBe(0);
+  expect(res.stdout).not.toMatch(/missing/i);
+});

--- a/tests/smoke/jest.config.js
+++ b/tests/smoke/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  testEnvironment: "node",
+  transform: {
+    "^.+\\.ts$": ["babel-jest", { presets: ["@babel/preset-typescript"] }],
+  },
+};


### PR DESCRIPTION
## Summary
- add smoke tests for app, API contract, CLI and dependencies
- run smoke suite in new GitHub Actions workflow

## Testing
- `npm run format --prefix backend`
- `npm run smoke`
- `npm test -- --config tests/smoke/jest.config.js tests/smoke`


------
https://chatgpt.com/codex/tasks/task_e_68ab0cabadf8832da17a5164eca865b3