### PR TITLE
test: add lint guard tests and workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,20 @@
+name: Lint
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+      - run: npm ci
+      - run: npm run lint
+      - run: |
+          if [ -d backend ]; then
+            npm run lint --prefix backend
+          fi

--- a/tests/lint/config-resolves.spec.ts
+++ b/tests/lint/config-resolves.spec.ts
@@ -1,0 +1,56 @@
+import path from "node:path";
+import { existsSync } from "node:fs";
+
+describe("eslint config resolves", () => {
+  const rootConfigPath = path.resolve(__dirname, "../../eslint.config.js");
+
+  it("loads root config and checks tsconfig references", () => {
+    const load = () => require(rootConfigPath);
+    expect(load).not.toThrow();
+    const config = load();
+    config
+      .filter((c: any) => c?.languageOptions?.parserOptions?.project)
+      .forEach((c: any) => {
+        const projects = Array.isArray(c.languageOptions.parserOptions.project)
+          ? c.languageOptions.parserOptions.project
+          : [c.languageOptions.parserOptions.project];
+        const tsconfigRootDir =
+          c.languageOptions.parserOptions.tsconfigRootDir ||
+          path.dirname(rootConfigPath);
+        projects.forEach((p: string) => {
+          const tsconfigPath = path.resolve(tsconfigRootDir, p);
+          expect(existsSync(tsconfigPath)).toBe(true);
+        });
+      });
+  });
+
+  const backendConfigPath = path.resolve(
+    __dirname,
+    "../../backend/eslint.config.js",
+  );
+  if (existsSync(backendConfigPath)) {
+    it("loads backend config and checks tsconfig references", () => {
+      const load = () => require(backendConfigPath);
+      expect(load).not.toThrow();
+      const config = load();
+      config
+        .filter((c: any) => c?.languageOptions?.parserOptions?.project)
+        .forEach((c: any) => {
+          const projects = Array.isArray(
+            c.languageOptions.parserOptions.project,
+          )
+            ? c.languageOptions.parserOptions.project
+            : [c.languageOptions.parserOptions.project];
+          const tsconfigRootDir =
+            c.languageOptions.parserOptions.tsconfigRootDir ||
+            path.dirname(backendConfigPath);
+          projects.forEach((p: string) => {
+            const tsconfigPath = path.resolve(tsconfigRootDir, p);
+            expect(existsSync(tsconfigPath)).toBe(true);
+          });
+        });
+    });
+  } else {
+    it.skip("backend eslint config not found", () => {});
+  }
+});

--- a/tests/lint/ignores.spec.ts
+++ b/tests/lint/ignores.spec.ts
@@ -1,0 +1,37 @@
+import { readFileSync, existsSync } from "node:fs";
+import path from "node:path";
+
+function checkIgnore(file: string) {
+  const contents = readFileSync(file, "utf8");
+  const patterns = [
+    "node_modules",
+    "dist",
+    "build",
+    "coverage",
+    ".next",
+    "**/generated",
+  ];
+  patterns.forEach((p) => {
+    expect(contents).toContain(p);
+  });
+}
+
+describe(".eslintignore coverage", () => {
+  const rootIgnore = path.resolve(__dirname, "../../.eslintignore");
+  if (existsSync(rootIgnore)) {
+    it("root ignore file contains standard patterns", () => {
+      checkIgnore(rootIgnore);
+    });
+  } else {
+    it.skip("root .eslintignore missing", () => {});
+  }
+
+  const backendIgnore = path.resolve(__dirname, "../../backend/.eslintignore");
+  if (existsSync(backendIgnore)) {
+    it("backend ignore file contains standard patterns", () => {
+      checkIgnore(backendIgnore);
+    });
+  } else {
+    it.skip("backend .eslintignore missing", () => {});
+  }
+});

--- a/tests/lint/run-backend.spec.ts
+++ b/tests/lint/run-backend.spec.ts
@@ -1,0 +1,26 @@
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+describe("npm run lint in backend", () => {
+  const backendDir = path.resolve(__dirname, "../../backend");
+  if (!existsSync(backendDir)) {
+    it.skip("backend directory missing", () => {});
+    return;
+  }
+
+  it("completes successfully", () => {
+    const result = spawnSync(
+      "npm",
+      ["run", "lint", "--prefix", "backend", "--silent"],
+      {
+        encoding: "utf8",
+        timeout: 120000,
+        maxBuffer: 10 * 1024 * 1024,
+      },
+    );
+    const output = `${result.stdout}${result.stderr}`;
+    expect(result.status).toBe(0);
+    expect(output).toMatch(/eslint|\d+\s*(?:problem|error|warning|file)/i);
+  });
+});

--- a/tests/lint/run-root.spec.ts
+++ b/tests/lint/run-root.spec.ts
@@ -1,0 +1,14 @@
+import { spawnSync } from "node:child_process";
+
+describe("npm run lint at root", () => {
+  it("completes successfully", () => {
+    const result = spawnSync("npm", ["run", "lint", "--silent"], {
+      encoding: "utf8",
+      timeout: 120000,
+      maxBuffer: 10 * 1024 * 1024,
+    });
+    const output = `${result.stdout}${result.stderr}`;
+    expect(result.status).toBe(0);
+    expect(output).toMatch(/eslint|\d+\s*(?:problem|error|warning|file)/i);
+  });
+});

--- a/tests/lint/warning-threshold.spec.ts
+++ b/tests/lint/warning-threshold.spec.ts
@@ -1,0 +1,41 @@
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+function runEslint(cwd: string) {
+  return spawnSync("npx", ["eslint", ".", "--format", "json"], {
+    cwd,
+    encoding: "utf8",
+    timeout: 120000,
+    maxBuffer: 10 * 1024 * 1024,
+  });
+}
+
+describe("eslint warning threshold", () => {
+  it("root warnings stay under limit", () => {
+    const result = runEslint(path.resolve(__dirname, "../.."));
+    expect(result.status).toBe(0);
+    const reports = JSON.parse(result.stdout || "[]");
+    const totalWarnings = reports.reduce(
+      (sum: number, r: any) => sum + (r.warningCount || 0),
+      0,
+    );
+    expect(totalWarnings).toBeLessThanOrEqual(25);
+  });
+
+  const backendDir = path.resolve(__dirname, "../../backend");
+  if (existsSync(backendDir)) {
+    it("backend warnings stay under limit", () => {
+      const result = runEslint(backendDir);
+      expect(result.status).toBe(0);
+      const reports = JSON.parse(result.stdout || "[]");
+      const totalWarnings = reports.reduce(
+        (sum: number, r: any) => sum + (r.warningCount || 0),
+        0,
+      );
+      expect(totalWarnings).toBeLessThanOrEqual(25);
+    });
+  } else {
+    it.skip("backend directory missing", () => {});
+  }
+});


### PR DESCRIPTION
## Summary
- add tests to verify eslint configs load and lint scripts succeed
- add CI workflow to run lint on pushes and PRs

## Testing
- `npm run format`
- `npm run format --prefix backend`
- `npm test`
- `npm test --prefix backend`
- `npm run ci` (fails: Missing script "ci")
- `npm run smoke` (fails: Missing script "smoke")

------
https://chatgpt.com/codex/tasks/task_e_68ab12f79b70832d94f889888c238254