### PR TITLE
test: configure smoke test removal status

### DIFF
--- a/.github/workflows/api-removal-safety.yml
+++ b/.github/workflows/api-removal-safety.yml
@@ -37,6 +37,8 @@ jobs:
           node-version: 20
       - run: npm ci
       - run: npm run smoke
+        env:
+          EXPECT_REMOVED_STATUS: '410'
 
   openapi-check:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "build": "vite build",
     "preview": "vite preview --port 4173",
     "start:backend": "npm start --prefix backend",
-    "ci": "if [ \"$SKIP_PW_DEPS\" = \"1\" ]; then npm ci --ignore-scripts; else npm ci; fi && npm run build --workspaces=false && npm test"
+    "ci": "if [ \"$SKIP_PW_DEPS\" = \"1\" ]; then npm ci --ignore-scripts; else npm ci; fi && npm run build --workspaces=false && npm test",
     "smoke": "npm test -- --maxWorkers=2 --runTestsByPath tests/config/package-scripts.smoke.*.spec.ts tests/smoke/healthcheck.*.spec.ts"
   },
   "babel": {

--- a/tests/api/smoke/basic.n7p3f9d2k6h4q1v5.spec.ts
+++ b/tests/api/smoke/basic.n7p3f9d2k6h4q1v5.spec.ts
@@ -3,6 +3,8 @@ import request from "supertest";
 process.env.NODE_ENV = "test";
 const app = require("../../../backend/server");
 
+const EXPECT = Number(process.env.EXPECT_REMOVED_STATUS || 410);
+
 afterAll(() => {
   global.__servers?.forEach((s: any) => s.close());
 });
@@ -18,11 +20,9 @@ describe("API smoke", () => {
     expect(res.status).toBe(200);
   });
 
-  it("POST /api/generate-model is unavailable", async () => {
-    const res = await request(app)
-      .post("/api/generate-model")
-      .set("Content-Type", "application/json")
-      .send({});
-    expect([400, 410]).toContain(res.status);
+  it("POST /api/generate-model returns expected removal status", async () => {
+    const res = await request(app).post("/api/generate-model").send({});
+    expect([EXPECT]).toContain(res.status);
+    if (EXPECT === 410) expect(res.body && res.body.error).toBe("removed");
   });
 });

--- a/tests/openapi/no-removed-paths.m1n3p5q7r9s2t4u6.spec.ts
+++ b/tests/openapi/no-removed-paths.m1n3p5q7r9s2t4u6.spec.ts
@@ -4,9 +4,11 @@ import YAML from "yaml";
 
 describe("openapi contract", () => {
   test("does not list /api/generate-model", () => {
-    const specPath = path.join(__dirname, "../../docs/openapi.yaml");
+    const jsonPath = path.join(__dirname, "../../docs/openapi.json");
+    const yamlPath = path.join(__dirname, "../../docs/openapi.yaml");
+    const specPath = fs.existsSync(jsonPath) ? jsonPath : yamlPath;
     const raw = fs.readFileSync(specPath, "utf8");
-    const spec = YAML.parse(raw);
+    const spec = specPath.endsWith(".json") ? JSON.parse(raw) : YAML.parse(raw);
     expect(spec.paths["/api/generate-model"]).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- allow smoke test to derive expected status from EXPECT_REMOVED_STATUS
- ensure OpenAPI spec omits removed generate-model path
- pass EXPECT_REMOVED_STATUS=410 during API removal smoke workflow

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` (in backend)
- `node scripts/run-jest.js tests/openapi/no-removed-paths.m1n3p5q7r9s2t4u6.spec.ts`
- `node scripts/run-jest.js tests/api/smoke/basic.n7p3f9d2k6h4q1v5.spec.ts`
- `npm test` (in backend)
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68ab1a52fd50832d849554dad041e6fc