### PR TITLE
fix: position print run info correctly

### DIFF
--- a/index.html
+++ b/index.html
@@ -611,7 +611,7 @@
         const info = document.getElementById("print-run-info");
         const checkout = document.getElementById("checkout-button");
         const error = document.getElementById("gen-error");
-        const logo = document.querySelector('img[alt="print3 cube"]');
+        const logo = document.querySelector('img[alt="print2 cube"]');
         if (!quote || !checkout) return;
 
         // bounding rectangles relative to the viewport


### PR DESCRIPTION
## Summary
- ensure print-run info selector matches the logo alt text so slot notice positions below the 3D viewer

## Testing
- `npm run validate-env` *(fails: Invalid package.json)*
- `SKIP_PW_DEPS=1 npm run setup` *(fails: Invalid package.json)*
- `npm run format` *(fails: Invalid package.json)*
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab1dcae8d0832d81c2abcc192082a3