### PR TITLE
fix: remove demo prompt input from index

### DIFF
--- a/index.html
+++ b/index.html
@@ -311,7 +311,6 @@
       class="flex-1 flex flex-col items-center justify-start gap-4 px-4 lg:px-16"
       style="margin-top: -4rem"
     >
-      <div id="gen-app" class="my-4 w-full max-w-md"></div>
       <!-- 3-D preview ---------------------------------------------------- -->
       <div class="relative flex justify-center w-full max-w-lg">
         <section
@@ -679,7 +678,6 @@
     </div>
     <script></script>
     <script type="module" src="js/printclub.js"></script>
-    <script type="module" src="js/modelGenerator.js"></script>
     <script type="module" src="js/rewardBadge.js"></script>
     <script type="module" src="js/basket.js" defer></script>
     <div


### PR DESCRIPTION
## Summary
- remove unused `gen-app` container from index page
- drop `modelGenerator.js` script from page

## Testing
- `npm run validate-env` *(fails: Invalid package.json: Expected ',' or '}' after property value)*
- `curl -I https://registry.npmjs.org | head -n 5`
- `curl -I https://cdn.playwright.dev | head -n 5`
- `SKIP_PW_DEPS=1 npm run setup` *(fails: Invalid package.json: Expected ',' or '}' after property value)*
- `cd backend && npm run format` *(fails: Error parsing /workspace/MVP-website/package.json)*
- `npm test` *(fails: Error parsing /workspace/MVP-website/package.json)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Invalid package.json: Expected ',' or '}' after property value)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Invalid package.json: Expected ',' or '}' after property value)*

------
https://chatgpt.com/codex/tasks/task_e_68ab1d9a457c832d873d8d3c85f7b479