### PR TITLE
fix: load glb models on main pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -328,16 +328,10 @@
           />
 
           <!-- 3-D Astronaut (always visible) -->
-          <model-viewer
+          <div
             id="viewer"
-            src="models/bag.glb"
-            alt="3D model preview"
-            environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
-            camera-controls
-            auto-rotate
-            crossOrigin="anonymous"
             style="width: 100%; height: 100%; display: block"
-          ></model-viewer>
+          ></div>
 
           <!-- loader -->
           <div
@@ -583,6 +577,10 @@
       <p>🛡 Money-Back Guarantee</p>
       <p>🚚 Free UK Shipping</p>
     </div>
+    <script type="module">
+      import { loadModel } from "./src/js/loadModel.js";
+      loadModel("models/bag.glb", "viewer");
+    </script>
     <!-- ▸▸▸ SCRIPTS ------------------------------------------------------ -->
     <script src="js/modelViewerTouchFix.js" defer></script>
     <script type="module" src="js/wizard.js" defer></script>

--- a/payment.html
+++ b/payment.html
@@ -235,14 +235,10 @@
             style="display: none"
             alt="Preview image"
           />
-        <model-viewer src="https://modelviewer.dev/shared-assets/models/Astronaut.glb" crossOrigin="anonymous"
+        <div
           id="viewer"
-          alt="3D astronaut"
-          environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
-          camera-controls
-          auto-rotate
           style="width: 100%; height: 100%; display: block"
-        ></model-viewer>
+        ></div>
         <p class="absolute top-2 left-2 text-red-300 text-xs">
           Only <span id="slot-count" style="visibility: hidden"></span> print slots remaining
         </p>
@@ -736,6 +732,10 @@
     </div>
 
     <!-- Init scripts -->
+    <script type="module">
+      import { loadModel } from "./src/js/loadModel.js";
+      loadModel("models/bag.glb", "viewer");
+    </script>
     <script src="js/modelViewerTouchFix.js" defer></script>
     <script type="module" src="js/wizard.js" defer></script>
     <script type="module" src="js/payment.js" defer></script>

--- a/src/js/loadModel.js
+++ b/src/js/loadModel.js
@@ -1,0 +1,51 @@
+import * as THREE from "https://cdn.jsdelivr.net/npm/three@0.152.2/build/three.module.js";
+import { GLTFLoader } from "https://cdn.jsdelivr.net/npm/three@0.152.2/examples/jsm/loaders/GLTFLoader.js";
+
+/**
+ * Load a GLB model into a container element.
+ * @param {string} url path to the .glb file
+ * @param {string} containerId id of the element to host the canvas
+ */
+export async function loadModel(url, containerId) {
+  const container = document.getElementById(containerId);
+  if (!container) {
+    throw new Error(`Container #${containerId} not found`);
+  }
+
+  const width = container.clientWidth || 300;
+  const height = container.clientHeight || 300;
+
+  const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+  renderer.setSize(width, height);
+  container.appendChild(renderer.domElement);
+
+  const scene = new THREE.Scene();
+  const camera = new THREE.PerspectiveCamera(45, width / height, 0.1, 1000);
+  camera.position.z = 2;
+
+  const light = new THREE.DirectionalLight(0xffffff, 1);
+  light.position.set(1, 1, 1);
+  scene.add(light);
+
+  const loader = new GLTFLoader();
+  await new Promise((resolve, reject) => {
+    loader.load(
+      url,
+      (gltf) => {
+        scene.add(gltf.scene);
+        resolve();
+      },
+      undefined,
+      reject,
+    );
+  });
+
+  function animate() {
+    requestAnimationFrame(animate);
+    renderer.render(scene, camera);
+  }
+  animate();
+
+  // expose for tests
+  window.__viewer = { scene, renderer };
+}

--- a/tests/e2e/model-loading.spec.x5h3k9s2d7f4l8a1.ts
+++ b/tests/e2e/model-loading.spec.x5h3k9s2d7f4l8a1.ts
@@ -1,0 +1,26 @@
+import { test, expect } from "@playwright/test";
+
+async function checkModel(page, path: string) {
+  await page.goto(path);
+  const canvas = page.locator("#viewer canvas");
+  await expect(canvas).toBeVisible();
+  await page.waitForFunction(() => {
+    // @ts-ignore
+    return window.__viewer?.scene.children.some((c: any) => c.isMesh);
+  });
+  const hasContext = await page.evaluate(() => {
+    const c = document.querySelector(
+      "#viewer canvas",
+    ) as HTMLCanvasElement | null;
+    return !!c && c.getContext("webgl") !== null;
+  });
+  expect(hasContext).toBe(true);
+}
+
+test("index page loads model", async ({ page }) => {
+  await checkModel(page, "/index.html");
+});
+
+test("payment page loads model", async ({ page }) => {
+  await checkModel(page, "/payment.html");
+});


### PR DESCRIPTION
## Summary
- ensure index.html and payment.html initialize shared Three.js loader
- add reusable `loadModel` helper for rendering .glb files
- introduce Playwright test guarding against model load regressions

## Testing
- `npx --yes prettier@3.5.3 -w index.html payment.html src/js/loadModel.js tests/e2e/model-loading.spec.x5h3k9s2d7f4l8a1.ts`
- `npx --yes playwright@1.53.1 test tests/e2e/model-loading.spec.x5h3k9s2d7f4l8a1.ts --config=playwright.config.js` *(fails: Cannot find module '@playwright/test')*


------
https://chatgpt.com/codex/tasks/task_e_68ab21eb2644832da3c87629e49fd454