### PR TITLE
ci: add Playwright deps workflow and sanity test

### DIFF
--- a/.github/workflows/playwright-deps-and-e2e.yml
+++ b/.github/workflows/playwright-deps-and-e2e.yml
@@ -1,0 +1,24 @@
+name: Playwright E2E (with deps)
+on: [push, pull_request]
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+      - name: Install deps
+        run: npm ci
+      - name: Install Playwright browsers + OS dependencies
+        run: |
+          npx playwright install --with-deps chromium
+      - name: Start dev server
+        run: |
+          nohup npm run start &>/tmp/app.log & disown
+          npx wait-on http://localhost:3000
+      - name: Run model-loading tests
+        env:
+          CI: "true"
+        run: |
+          npx playwright test tests/e2e/model-loading.spec.ts

--- a/ops/docker/ci.playwright.Dockerfile
+++ b/ops/docker/ci.playwright.Dockerfile
@@ -1,0 +1,6 @@
+FROM mcr.microsoft.com/playwright:v1.47.0-jammy
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+CMD ["bash","-lc","npx playwright test tests/e2e/model-loading.spec.ts"]

--- a/tests/e2e/_sanity/browser-launch.spec.ts
+++ b/tests/e2e/_sanity/browser-launch.spec.ts
@@ -1,0 +1,10 @@
+import { test, expect, chromium } from "@playwright/test";
+
+test("chromium launches", async () => {
+  const browser = await chromium.launch();
+  const ctx = await browser.newContext();
+  const page = await ctx.newPage();
+  await page.goto("about:blank");
+  await expect(page).toHaveTitle("");
+  await browser.close();
+});


### PR DESCRIPTION
## Summary
- add Playwright workflow that installs browser deps and runs e2e
- provide optional CI Dockerfile for Playwright
- add sanity test ensuring Chromium can launch

## Testing
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`
- `CI=1 npx playwright install --with-deps chromium`
- `npx playwright test e2e/_sanity/browser-launch.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ab32703f4c832d97ee3b906ad70335