### PR TITLE
Add Playwright model rendering tests and workflow

### DIFF
--- a/.github/workflows/model-tests.yml
+++ b/.github/workflows/model-tests.yml
@@ -1,0 +1,18 @@
+name: Model Tests
+on: [push, pull_request]
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5.0.0
+      - uses: actions/setup-node@v4.4.0
+        with: { node-version: "lts/*" }
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - run: |
+          nohup npm run start &>/tmp/app.log & disown
+          npx wait-on http://localhost:3000
+      - run: npx playwright test tests/e2e/model-loading.hf.spec.ts tests/e2e/model-fallbacks.spec.ts tests/e2e/a11y-model.spec.ts
+    env:
+      CI: "true"
+      MODEL_LOAD_BUDGET_MS: "5000"

--- a/tests/e2e/a11y-model.spec.ts
+++ b/tests/e2e/a11y-model.spec.ts
@@ -1,0 +1,12 @@
+import { test, expect } from "@playwright/test";
+
+test("primary model has a descriptive label", async ({ page }) => {
+  await page.goto("/index.html");
+  const target = page
+    .locator(
+      '[data-testid="primary-model"] [data-testid="model-canvas"], [data-testid="primary-model"] model-viewer',
+    )
+    .first();
+  const label = await target.getAttribute("aria-label");
+  expect(label && label.length >= 3).toBeTruthy();
+});

--- a/tests/e2e/model-fallbacks.spec.ts
+++ b/tests/e2e/model-fallbacks.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from "@playwright/test";
+
+test("missing model shows fallback UI", async ({ page }) => {
+  await page.route(/\.glb($|\?)/, (route) => route.abort()); // simulate 404
+  await page.goto("/index.html");
+  const primary = page.locator('[data-testid="primary-model"]');
+  // App-specific fallback: tweak selector/text if your UI differs
+  await expect(
+    primary.locator(
+      '[data-testid="model-fallback"], text=/model not available/i',
+    ),
+  ).toBeVisible();
+});

--- a/tests/e2e/model-loading.hf.spec.ts
+++ b/tests/e2e/model-loading.hf.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from "@playwright/test";
+
+const pages = [
+  { key: "index", url: "/index.html" },
+  { key: "addons", url: "/addons.html" },
+  { key: "competitions", url: "/competitions.html" },
+  { key: "library", url: "/library.html" },
+  { key: "marketplace", url: "/marketplace.html" },
+  { key: "payment", url: "/payment.html" },
+];
+
+test.describe("3D model high\u2011fidelity checks", () => {
+  for (const p of pages) {
+    test(`${p.url} renders and is accessible`, async ({ page }) => {
+      await page.goto(p.url, { waitUntil: "domcontentloaded" });
+      await page.waitForFunction(
+        (k) => window.__modelsLoaded && window.__modelsLoaded[k],
+        p.key,
+        { timeout: 15000 },
+      );
+
+      const primary = page.locator('[data-testid="primary-model"]');
+      await expect(primary).toBeVisible();
+
+      // Single target inside primary to avoid strict\u2011mode conflicts
+      const target = primary
+        .locator('[data-testid="model-canvas"], model-viewer')
+        .first();
+      // Accessibility (either role=img or aria-label present)
+      const role = await target.getAttribute("role");
+      const label = await target.getAttribute("aria-label");
+      expect(role === "img" || !!label).toBeTruthy();
+
+      // Visual snapshot (keep tight viewport to reduce flake)
+      await page.setViewportSize({ width: 600, height: 400 });
+      const shot = await primary.screenshot();
+      expect(shot).toMatchSnapshot(`${p.key}-model.png`, { threshold: 0.05 });
+    });
+
+    test(`${p.url} loads within budget`, async ({ page }) => {
+      const budgetMs = Number(process.env.MODEL_LOAD_BUDGET_MS || 5000);
+      const start = Date.now();
+      await page.goto(p.url, { waitUntil: "domcontentloaded" });
+      await page.waitForFunction(
+        (k) => window.__modelsLoaded && window.__modelsLoaded[k],
+        p.key,
+        { timeout: 15000 },
+      );
+      const elapsed = Date.now() - start;
+      expect(elapsed).toBeLessThanOrEqual(budgetMs);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add high-fidelity Playwright suite validating model rendering across pages
- cover missing-model fallback and accessibility label checks
- wire up GitHub Actions workflow to run model tests with pinned action versions

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68ab3ce6c7d4832db3c5c710b2f9570a