### PR TITLE
feat: add deterministic model hook for 3D tests

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -19,6 +19,7 @@
       src="https://cdn.jsdelivr.net/npm/@google/model-viewer@1.12.0/dist/model-viewer.min.js"
     ></script>
     <script src="js/modelViewerTouchFix.js"></script>
+    <script src="js/model-ready-hook.js"></script>
     <script
       nomodule
       src="https://cdn.jsdelivr.net/npm/@google/model-viewer@1.12.0/dist/model-viewer-legacy.js"

--- a/competitions.html
+++ b/competitions.html
@@ -29,6 +29,7 @@
       src="https://cdn.jsdelivr.net/npm/@google/model-viewer@1.12.0/dist/model-viewer.min.js"
     ></script>
     <script src="js/modelViewerTouchFix.js"></script>
+    <script src="js/model-ready-hook.js"></script>
     <script
       nomodule
       src="https://cdn.jsdelivr.net/npm/@google/model-viewer@1.12.0/dist/model-viewer-legacy.js"
@@ -114,14 +115,27 @@
       <section
         class="bg-[#2A2A2E] p-4 rounded-xl flex items-center space-x-4 border border-white/10"
       >
-        <model-viewer
-          src="https://modelviewer.dev/shared-assets/models/Astronaut.glb"
-          alt="Contest winner"
-          environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
-          camera-controls
-          auto-rotate
-          class="w-24 h-24 rounded-full"
-        ></model-viewer>
+        <div data-testid="primary-model">
+          <model-viewer
+            src="models/bag.glb"
+            alt="Contest winner"
+            environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
+            camera-controls
+            auto-rotate
+            class="w-24 h-24 rounded-full"
+            data-testid="model-viewer"
+            role="img"
+            aria-label="3D model preview"
+          ></model-viewer>
+        </div>
+        <script>
+          document
+            .querySelector('[data-testid="model-viewer"]')
+            ?.addEventListener('load', () => window.markModelLoaded('competitions'));
+          document
+            .querySelector('#model-modal model-viewer')
+            ?.addEventListener('load', () => window.markModelLoaded('competitions'));
+        </script>
         <div>
           <p>
             <a href="signup.html" class="font-bold text-[#30D5C8]">Sign Up</a>

--- a/index.html
+++ b/index.html
@@ -328,10 +328,12 @@
           />
 
           <!-- 3-D Astronaut (always visible) -->
-          <div
-            id="viewer"
-            style="width: 100%; height: 100%; display: block"
-          ></div>
+          <div data-testid="primary-model">
+            <div
+              id="viewer"
+              style="width: 100%; height: 100%; display: block"
+            ></div>
+          </div>
 
           <!-- loader -->
           <div
@@ -577,9 +579,10 @@
       <p>🛡 Money-Back Guarantee</p>
       <p>🚚 Free UK Shipping</p>
     </div>
+    <script src="js/model-ready-hook.js"></script>
     <script type="module">
       import { loadModel } from "./src/js/loadModel.js";
-      loadModel("models/bag.glb", "viewer");
+      loadModel("models/bag.glb", "viewer", "index");
     </script>
     <!-- ▸▸▸ SCRIPTS ------------------------------------------------------ -->
     <script src="js/modelViewerTouchFix.js" defer></script>

--- a/js/model-ready-hook.js
+++ b/js/model-ready-hook.js
@@ -1,0 +1,9 @@
+(function () {
+  if (window.__modelReadyHookInstalled) return;
+  window.__modelReadyHookInstalled = true;
+  window.__modelsLoaded = window.__modelsLoaded || {};
+  window.markModelLoaded = function (key = "default") {
+    window.__modelsLoaded[key] = Date.now();
+    window.dispatchEvent(new CustomEvent("model-loaded", { detail: { key } }));
+  };
+})();

--- a/library.html
+++ b/library.html
@@ -28,6 +28,7 @@
       src="https://cdn.jsdelivr.net/npm/@google/model-viewer@1.12.0/dist/model-viewer.min.js"
     ></script>
     <script src="js/modelViewerTouchFix.js"></script>
+    <script src="js/model-ready-hook.js"></script>
   </head>
   <body class="bg-[#1A1A1D] text-white font-sans flex flex-col min-h-screen">
     <header class="relative flex items-center justify-between py-4 px-6">
@@ -131,16 +132,26 @@
           </svg>
           <span class="sr-only">Close</span>
         </button>
-        <model-viewer
-          src="about:blank"
-          alt="3D model preview"
-          environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
-          camera-controls
-          auto-rotate
-          class="w-full h-96 bg-[#2A2A2E] rounded-xl"
-        ></model-viewer>
+        <div data-testid="primary-model">
+          <model-viewer
+            src="about:blank"
+            alt="3D model preview"
+            environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
+            camera-controls
+            auto-rotate
+            class="w-full h-96 bg-[#2A2A2E] rounded-xl"
+            data-testid="model-viewer"
+            role="img"
+            aria-label="3D model preview"
+          ></model-viewer>
+        </div>
       </div>
     </div>
+    <script>
+      document
+        .querySelector('[data-testid="model-viewer"]')
+        ?.addEventListener('load', () => window.markModelLoaded('library'));
+    </script>
     <script type="module" src="js/library.js"></script>
     <script type="module" src="js/basket.js"></script>
     <script type="module">

--- a/marketplace.html
+++ b/marketplace.html
@@ -11,6 +11,7 @@
       src="https://cdn.jsdelivr.net/npm/@google/model-viewer@1.12.0/dist/model-viewer.min.js"
     ></script>
     <script src="js/modelViewerTouchFix.js"></script>
+    <script src="js/model-ready-hook.js"></script>
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css"
@@ -139,17 +140,27 @@
             your own .glb file to earn free
             <span class="text-[#30D5C8]">£ credit</span>.
           </p>
-          <model-viewer
-            src="https://modelviewer.dev/shared-assets/models/Astronaut.glb"
-            alt="Shopping bag model"
-            environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
-            camera-controls
-            auto-rotate
-            crossOrigin="anonymous"
-            class="w-full flex-grow bg-[#2A2A2E] rounded-xl mt-4"
-            style="width: 100%; height: 100%; display: block"
-          ></model-viewer>
+          <div data-testid="primary-model">
+            <model-viewer
+              src="models/bag.glb"
+              alt="Shopping bag model"
+              environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
+              camera-controls
+              auto-rotate
+              crossOrigin="anonymous"
+              class="w-full flex-grow bg-[#2A2A2E] rounded-xl mt-4"
+              style="width: 100%; height: 100%; display: block"
+              data-testid="model-viewer"
+              role="img"
+              aria-label="3D model preview"
+            ></model-viewer>
+          </div>
           <input id="glbUpload" type="file" accept=".glb" class="hidden" />
+          <script>
+            document
+              .querySelector('[data-testid="model-viewer"]')
+              ?.addEventListener('load', () => window.markModelLoaded('marketplace'));
+          </script>
         </div>
         <div
           class="bg-[#2A2A2E] p-4 rounded-xl border border-white/10 flex flex-col h-[40vh]"

--- a/payment.html
+++ b/payment.html
@@ -235,10 +235,12 @@
             style="display: none"
             alt="Preview image"
           />
-        <div
-          id="viewer"
-          style="width: 100%; height: 100%; display: block"
-        ></div>
+        <div data-testid="primary-model">
+          <div
+            id="viewer"
+            style="width: 100%; height: 100%; display: block"
+          ></div>
+        </div>
         <p class="absolute top-2 left-2 text-red-300 text-xs">
           Only <span id="slot-count" style="visibility: hidden"></span> print slots remaining
         </p>
@@ -732,9 +734,10 @@
     </div>
 
     <!-- Init scripts -->
+    <script src="js/model-ready-hook.js"></script>
     <script type="module">
       import { loadModel } from "./src/js/loadModel.js";
-      loadModel("models/bag.glb", "viewer");
+      loadModel("models/bag.glb", "viewer", "payment");
     </script>
     <script src="js/modelViewerTouchFix.js" defer></script>
     <script type="module" src="js/wizard.js" defer></script>

--- a/src/js/loadModel.js
+++ b/src/js/loadModel.js
@@ -6,7 +6,7 @@ import { GLTFLoader } from "https://cdn.jsdelivr.net/npm/three@0.152.2/examples/
  * @param {string} url path to the .glb file
  * @param {string} containerId id of the element to host the canvas
  */
-export async function loadModel(url, containerId) {
+export async function loadModel(url, containerId, key = "default") {
   const container = document.getElementById(containerId);
   if (!container) {
     throw new Error(`Container #${containerId} not found`);
@@ -17,6 +17,9 @@ export async function loadModel(url, containerId) {
 
   const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
   renderer.setSize(width, height);
+  renderer.domElement.setAttribute("data-testid", "model-canvas");
+  renderer.domElement.setAttribute("role", "img");
+  renderer.domElement.setAttribute("aria-label", "3D model preview");
   container.appendChild(renderer.domElement);
 
   const scene = new THREE.Scene();
@@ -33,6 +36,7 @@ export async function loadModel(url, containerId) {
       url,
       (gltf) => {
         scene.add(gltf.scene);
+        window.markModelLoaded(key);
         resolve();
       },
       undefined,

--- a/tests/e2e/model-loading.smoke.spec.ts
+++ b/tests/e2e/model-loading.smoke.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from '@playwright/test';
+const pages = [{key:'index', url:'/index.html'}];
+test.describe('3D model smoke', () => {
+  for (const p of pages) {
+    test(`loads model on ${p.url}`, async ({ page }) => {
+      await page.goto(p.url, { waitUntil: 'domcontentloaded' });
+      await page.waitForFunction(() => window.__modelsLoaded && window.__modelsLoaded['index'], null, { timeout: 10000 });
+      const primary = page.locator('[data-testid="primary-model"]');
+      await expect(primary).toBeVisible();
+      const canvas = primary.locator('[data-testid="model-canvas"], model-viewer');
+      await expect(canvas).toBeVisible();
+      // Accessibility hint
+      const role = await canvas.getAttribute('role');
+      const label = await canvas.getAttribute('aria-label');
+      expect(role === 'img' || !!label).toBeTruthy();
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add shared `model-ready-hook` and mark-model calls in pages to stabilize model loading
- tag primary viewer elements with `data-testid` for strict Playwright selectors
- add smoke test verifying model load on index page

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `cd backend && npm run format`
- `cd backend && npm test`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68ab3cdf9d0c832da8e162304731fb19