### PR TITLE
ci: guard against LFS in tests

### DIFF
--- a/.github/workflows/no-lfs-in-tests.yml
+++ b/.github/workflows/no-lfs-in-tests.yml
@@ -1,0 +1,18 @@
+name: No LFS in Tests
+on: [push, pull_request]
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { lfs: false }
+      - name: Fail if any LFS pointer exists under tests/**
+        run: |
+          set -euo pipefail
+          BAD=$(git grep -l "version https://git-lfs.github.com/spec" -- tests || true)
+          if [ -n "$BAD" ]; then
+            echo "❌ LFS pointers found under tests/:"
+            echo "$BAD"
+            exit 1
+          fi
+          echo "✅ No LFS pointers under tests/"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,13 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+BAD=$(git diff --cached --name-only | xargs -I{} sh -c 'grep -q "version https://git-lfs.github.com/spec" "{}" && echo "{}"' || true)
+if [ -n "$BAD" ]; then
+  echo "❌ You are trying to commit LFS pointers under tests/:"
+  echo "$BAD"
+  echo "Please remove LFS from these files (tests should not use LFS)."
+  exit 1
+fi
+echo "✅ pre-commit: no LFS pointers under tests/"
 
 npm audit --audit-level=high
 npm run validate-env

--- a/docs/testing-snapshots-no-lfs.md
+++ b/docs/testing-snapshots-no-lfs.md
@@ -1,0 +1,6 @@
+# Test snapshots and Git LFS
+
+- Cloudflare Pages cannot fetch private LFS blobs during clone.
+- Therefore, **no files under tests/** may be tracked by Git LFS.
+- CI enforces this via `.github/workflows/no-lfs-in-tests.yml`.
+- If you see failures, convert the file to a normal blob and update `.gitattributes` if necessary.


### PR DESCRIPTION
## Summary
- add CI guard preventing Git LFS pointers in tests/
- block committing LFS pointers via husky pre-commit
- document LFS policy for test snapshots

## Testing
- `npm run setup`
- `npx prettier -w .github/workflows/no-lfs-in-tests.yml docs/testing-snapshots-no-lfs.md`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68ab41ef14f8832d8ad42d806e4a25f1