### PR TITLE
fix: keep payment guarantee below viewer

### DIFF
--- a/luckybox-payment.html
+++ b/luckybox-payment.html
@@ -272,7 +272,7 @@
               class="h-10 w-10 border-4 border-white border-t-transparent rounded-full animate-spin"
             ></div>
           </div>
-          <div class="mt-4 text-center text-sm text-gray-400 relative h-full">
+          <div class="mt-4 text-center text-sm text-gray-400">
             <p class="mb-1">
               Trusted by <span class="text-white">thousands of makers:</span>
             </p>

--- a/minis-checkout.html
+++ b/minis-checkout.html
@@ -301,7 +301,7 @@
               class="h-10 w-10 border-4 border-white border-t-transparent rounded-full animate-spin"
             ></div>
           </div>
-          <div class="mt-4 text-center text-sm text-gray-400 relative h-full">
+          <div class="mt-4 text-center text-sm text-gray-400">
             <p class="mb-1">
               Trusted by <span class="text-white">thousands of makers:</span>
             </p>

--- a/payment.html
+++ b/payment.html
@@ -278,7 +278,7 @@
               class="h-10 w-10 border-4 border-white border-t-transparent rounded-full animate-spin"
             ></div>
           </div>
-          <div class="mt-4 text-center text-sm text-gray-400 relative h-full">
+          <div class="mt-4 text-center text-sm text-gray-400">
             <p class="mb-1">Trusted by <span class="text-white">thousands of makers:</span></p>
             <p>
               ✅︎ If you don’t love it, we’ll reprint or refund you – no <br />


### PR DESCRIPTION
## Summary
- ensure payment guarantee text sits under model viewer on payment, luckybox, and minis checkout pages

## Testing
- `npx prettier -w payment.html luckybox-payment.html minis-checkout.html`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68ab6d858d10832da047ff634c1d74d7