### PR TITLE
fix: render glb models with smoke test

### DIFF
--- a/assets/models/boombox.glb
+++ b/assets/models/boombox.glb
@@ -1,0 +1,1 @@
+../../models/bag.glb

--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@
     <!-- Preload default model assets -->
     <link
       rel="preload"
-      href="models/bag.glb"
+      href="/assets/models/boombox.glb"
       as="fetch"
       type="model/gltf-binary"
       fetchpriority="high"
@@ -85,15 +85,7 @@
     />
 
     <!-- Google <model-viewer> -->
-    <script
-      type="module"
-      src="https://cdn.jsdelivr.net/npm/@google/model-viewer@1.12.0/dist/model-viewer.min.js"
-    ></script>
-    <script
-      nomodule
-      src="https://cdn.jsdelivr.net/npm/@google/model-viewer@1.12.0/dist/model-viewer-legacy.js"
-      defer
-    ></script>
+    <script src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js"></script>
 
     <style>
       html,
@@ -329,10 +321,15 @@
 
           <!-- 3-D Astronaut (always visible) -->
           <div data-testid="primary-model">
-            <div
-              id="viewer"
+            <model-viewer
+              data-testid="model-viewer"
+              src="/assets/models/boombox.glb"
+              camera-controls
+              ar
+              role="img"
+              aria-label="3D model preview"
               style="width: 100%; height: 100%; display: block"
-            ></div>
+            ></model-viewer>
           </div>
 
           <!-- loader -->
@@ -579,10 +576,12 @@
       <p>🛡 Money-Back Guarantee</p>
       <p>🚚 Free UK Shipping</p>
     </div>
-    <script src="js/model-ready-hook.js"></script>
+    <script src="js/model-ready-hook.js" type="module"></script>
     <script type="module">
-      import { loadModel } from "./src/js/loadModel.js";
-      loadModel("models/bag.glb", "viewer", "index");
+      const key = location.pathname.includes("payment") ? "payment" : "index";
+      const mv = document.querySelector("[data-testid=\"model-viewer\"]");
+      mv.addEventListener("load", () => window.markModelLoaded(key));
+      mv.addEventListener("error", () => console.error("Model failed to load"));
     </script>
     <!-- ▸▸▸ SCRIPTS ------------------------------------------------------ -->
     <script src="js/modelViewerTouchFix.js" defer></script>

--- a/payment.html
+++ b/payment.html
@@ -15,7 +15,7 @@
     <!-- Preload 3D assets -->
     <link
       rel="preload"
-      href="models/bag.glb"
+      href="/assets/models/boombox.glb"
       as="fetch"
       fetchpriority="high"
     />
@@ -37,15 +37,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" referrerpolicy="no-referrer">
 
     <!-- model-viewer -->
-    <script
-      type="module"
-      src="https://cdn.jsdelivr.net/npm/@google/model-viewer@1.12.0/dist/model-viewer.min.js"
-    ></script>
-    <script
-      nomodule
-      src="https://cdn.jsdelivr.net/npm/@google/model-viewer@1.12.0/dist/model-viewer-legacy.js"
-      defer
-    ></script>
+    <script src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js"></script>
     <style>
       /* Add rainbow shimmer effect used on the index submit arrow */
       #multi-color-button {
@@ -236,10 +228,15 @@
             alt="Preview image"
           />
         <div data-testid="primary-model">
-          <div
-            id="viewer"
+          <model-viewer
+            data-testid="model-viewer"
+            src="/assets/models/boombox.glb"
+            camera-controls
+            ar
+            role="img"
+            aria-label="3D model preview"
             style="width: 100%; height: 100%; display: block"
-          ></div>
+          ></model-viewer>
         </div>
         <p class="absolute top-2 left-2 text-red-300 text-xs">
           Only <span id="slot-count" style="visibility: hidden"></span> print slots remaining
@@ -734,10 +731,12 @@
     </div>
 
     <!-- Init scripts -->
-    <script src="js/model-ready-hook.js"></script>
+    <script src="js/model-ready-hook.js" type="module"></script>
     <script type="module">
-      import { loadModel } from "./src/js/loadModel.js";
-      loadModel("models/bag.glb", "viewer", "payment");
+      const key = location.pathname.includes("payment") ? "payment" : "index";
+      const mv = document.querySelector("[data-testid=\"model-viewer\"]");
+      mv.addEventListener("load", () => window.markModelLoaded(key));
+      mv.addEventListener("error", () => console.error("Model failed to load"));
     </script>
     <script src="js/modelViewerTouchFix.js" defer></script>
     <script type="module" src="js/wizard.js" defer></script>

--- a/tests/e2e/model-smoke.spec.ts
+++ b/tests/e2e/model-smoke.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from "@playwright/test";
+const pages = [
+  { key: "index", url: "/index.html" },
+  { key: "payment", url: "/payment.html" },
+];
+test.describe("GLB smoke", () => {
+  for (const p of pages) {
+    test(`${p.url} loads model`, async ({ page }) => {
+      await page.goto(p.url, { waitUntil: "domcontentloaded" });
+      await page.waitForFunction(
+        (k) => !!(window as any).__modelsLoaded?.[k],
+        p.key,
+        { timeout: 15000 },
+      );
+      const primary = page.locator('[data-testid="primary-model"]');
+      await expect(primary).toBeVisible();
+      const target = primary
+        .locator('[data-testid="model-viewer"], #model-canvas, canvas')
+        .first();
+      await expect(target).toBeVisible();
+      const role = await target.getAttribute("role");
+      const label = await target.getAttribute("aria-label");
+      expect(role === "img" || !!label).toBeTruthy();
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- load `/assets/models/boombox.glb` with `<model-viewer>` on index and payment pages
- expose model load hook and add basic Playwright smoke test

## Testing
- `npm run format >/tmp/backend-format.log && tail -n 20 /tmp/backend-format.log`
- `npm test >/tmp/backend-test.log && tail -n 20 /tmp/backend-test.log`
- `SKIP_PW_DEPS=1 npm run ci >/tmp/ci.log && tail -n 20 /tmp/ci.log`
- `SKIP_PW_DEPS=1 npm run smoke >/tmp/smoke.log && tail -n 20 /tmp/smoke.log`


------
https://chatgpt.com/codex/tasks/task_e_68ab6db62c0c832dbe0b5428fa711b53