### PR TITLE
fix: allow root tests without backend deps

### DIFF
--- a/backend/tests/runJestCli.test.js
+++ b/backend/tests/runJestCli.test.js
@@ -24,4 +24,11 @@ describe("run-jest CLI", () => {
     const output = result.stdout + result.stderr;
     expect(output).toMatch(/Test file not found/);
   });
+
+  test("runs root tests without backend deps", () => {
+    const result = run([
+      "tests/openapi/no-removed-paths.m1n3p5q7r9s2t4u6.spec.ts",
+    ]);
+    expect(result.status).toBe(0);
+  });
 });

--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -16,15 +16,25 @@ if (!process.env.SKIP_ROOT_DEPS_CHECK) {
   }
 }
 
-try {
-  require.resolve("nodemailer", {
-    paths: [path.join(__dirname, "..", "backend")],
+const cliArgs = process.argv.slice(2);
+const repoRoot = path.resolve(__dirname, "..");
+const backendDir = path.join(repoRoot, "backend");
+const requiresBackendDeps = cliArgs
+  .filter((a) => !a.startsWith("-"))
+  .some((arg) => {
+    const abs = path.resolve(repoRoot, arg);
+    return abs.startsWith(backendDir);
   });
-} catch {
-  console.error(
-    "Missing backend dependencies. Run 'npm run setup' before running tests.",
-  );
-  process.exit(1);
+
+if (requiresBackendDeps) {
+  try {
+    require.resolve("nodemailer", { paths: [backendDir] });
+  } catch {
+    console.error(
+      "Missing backend dependencies. Run 'npm run setup' before running tests.",
+    );
+    process.exit(1);
+  }
 }
 
 function verifyFiles(args) {


### PR DESCRIPTION
## Summary
- skip backend dependency check in run-jest when running root-level tests
- add regression test for running root tests without backend deps

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npx prettier --log-level warn --write scripts/run-jest.js backend/tests/runJestCli.test.js`
- `npm test --prefix backend`
- `node scripts/run-jest.js tests/openapi/no-removed-paths.m1n3p5q7r9s2t4u6.spec.ts`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: <script src="js/modelViewerTouchFix.js"> in "/index.html" can't be bundled without type="module" attribute)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7c7524b4832dae4e767d670235bb