### PR TITLE
fix: use ES module for model viewer touch fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -584,7 +584,7 @@
       mv.addEventListener("error", () => console.error("Model failed to load"));
     </script>
     <!-- ▸▸▸ SCRIPTS ------------------------------------------------------ -->
-    <script src="js/modelViewerTouchFix.js" defer></script>
+    <script type="module" src="js/modelViewerTouchFix.js"></script>
     <script type="module" src="js/wizard.js" defer></script>
     <script type="module" src="js/index.js" defer></script>
     <script type="module" src="js/subredditLanding.js" defer></script>

--- a/js/modelViewerTouchFix.js
+++ b/js/modelViewerTouchFix.js
@@ -1,4 +1,4 @@
-function applyTouchFix() {
+export function applyTouchFix() {
   function setTouchNone(el) {
     el.style.touchAction = "none";
   }


### PR DESCRIPTION
## Summary
- switch modelViewerTouchFix to an ES module
- load modelViewerTouchFix.js as a module in index.html

## Testing
- `npx prettier -w index.html js/modelViewerTouchFix.js`
- `npm run format`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68ab83530a74832d8ce154b58536ba3d