### PR TITLE
feat: add items API

### DIFF
--- a/backend/migrations/061_create_items.sql
+++ b/backend/migrations/061_create_items.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS items (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name text NOT NULL UNIQUE,
+  description text,
+  price_cents integer NOT NULL CHECK (price_cents > 0),
+  currency text NOT NULL DEFAULT 'USD',
+  images jsonb NOT NULL DEFAULT '[]',
+  metadata jsonb NOT NULL DEFAULT '{}',
+  created_at timestamptz NOT NULL DEFAULT now()
+);

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -1,5 +1,6 @@
 const express = require("express");
 const modelsRouter = require("./routes/models");
+const itemsRouter = require("./routes/items").default;
 const checkoutRouter = require("./routes/checkout").default;
 const stripeWebhookRouter = require("./routes/stripeWebhook").default;
 const stripeCheckoutRouter = require("./routes/stripeCheckout").default;
@@ -10,6 +11,7 @@ const app = express();
 app.use(stripeWebhookRouter);
 app.use(express.json());
 app.use(modelsRouter);
+app.use(itemsRouter);
 app.use(checkoutRouter);
 app.use(stripeCheckoutRouter);
 

--- a/backend/src/lib/items.js
+++ b/backend/src/lib/items.js
@@ -1,0 +1,35 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.insertItem = exports.insertItemSchema = void 0;
+const zod_1 = require("zod");
+exports.insertItemSchema = zod_1.z.object({
+  name: zod_1.z.string().min(1).max(120),
+  description: zod_1.z.string().max(2000).optional(),
+  priceCents: zod_1.z.number().int().min(1),
+  currency: zod_1.z.string().default("USD"),
+  images: zod_1.z
+    .array(
+      zod_1.z
+        .string()
+        .url()
+        .refine((u) => u.startsWith("http://") || u.startsWith("https://"), "invalid url"),
+    )
+    .default([]),
+  metadata: zod_1.z.record(zod_1.z.any()).default({}),
+});
+async function insertItem(db, payload) {
+  const data = exports.insertItemSchema.parse(payload);
+  const res = await db.query(
+    `INSERT INTO items (name, description, price_cents, currency, images, metadata) VALUES ($1, $2, $3, $4, $5, $6) RETURNING id`,
+    [
+      data.name,
+      data.description ?? null,
+      data.priceCents,
+      data.currency,
+      JSON.stringify(data.images),
+      data.metadata,
+    ],
+  );
+  return { id: res.rows[0].id };
+}
+exports.insertItem = insertItem;

--- a/backend/src/lib/items.ts
+++ b/backend/src/lib/items.ts
@@ -1,0 +1,44 @@
+import type { Pool } from "pg";
+import { z } from "zod";
+
+export const insertItemSchema = z.object({
+  name: z.string().min(1).max(120),
+  description: z.string().max(2000).optional(),
+  priceCents: z.number().int().min(1),
+  currency: z.string().default("USD"),
+  images: z
+    .array(
+      z
+        .string()
+        .url()
+        .refine(
+          (u) => u.startsWith("http://") || u.startsWith("https://"),
+          "invalid url",
+        ),
+    )
+    .default([]),
+  metadata: z.record(z.any()).default({}),
+});
+
+export type InsertItemInput = z.infer<typeof insertItemSchema>;
+
+export async function insertItem(
+  db: Pool,
+  payload: InsertItemInput,
+): Promise<{ id: string }> {
+  const data = insertItemSchema.parse(payload);
+  const res = await db.query(
+    `INSERT INTO items (name, description, price_cents, currency, images, metadata)
+     VALUES ($1, $2, $3, $4, $5, $6)
+     RETURNING id`,
+    [
+      data.name,
+      data.description ?? null,
+      data.priceCents,
+      data.currency,
+      JSON.stringify(data.images),
+      data.metadata,
+    ],
+  );
+  return { id: res.rows[0].id as string };
+}

--- a/backend/src/routes/items.js
+++ b/backend/src/routes/items.js
@@ -1,0 +1,42 @@
+"use strict";
+var __importDefault =
+  (this && this.__importDefault) ||
+  function (mod) {
+    return mod && mod.__esModule ? mod : { default: mod };
+  };
+Object.defineProperty(exports, "__esModule", { value: true });
+const express_1 = require("express");
+const pg_1 = require("pg");
+const validate_js_1 = __importDefault(require("../../middleware/validate.js"));
+const logger_js_1 = __importDefault(require("../../../src/logger.js"));
+const items_1 = require("../lib/items");
+const router = (0, express_1.Router)();
+const pool = new pg_1.Pool({
+  connectionString: process.env.DB_ENDPOINT,
+  user: "postgres",
+  password: process.env.DB_PASSWORD,
+  database: "postgres",
+});
+router.post(
+  "/api/items",
+  (0, validate_js_1.default)(items_1.insertItemSchema),
+  async (req, res) => {
+    try {
+      const { id } = await (0, items_1.insertItem)(pool, req.body);
+      res.status(201).json({ id });
+    } catch (err) {
+      if (
+        err &&
+        typeof err === "object" &&
+        "code" in err &&
+        err.code === "23505"
+      ) {
+        res.status(409).json({ error: "item name already exists" });
+        return;
+      }
+      logger_js_1.default.error("failed to insert item", err);
+      res.status(500).json({ error: "Internal Server Error" });
+    }
+  },
+);
+exports.default = router;

--- a/backend/src/routes/items.ts
+++ b/backend/src/routes/items.ts
@@ -1,0 +1,34 @@
+import { Router } from "express";
+import { Pool } from "pg";
+import validate from "../../middleware/validate.js";
+import logger from "../../../src/logger.js";
+import { insertItem, insertItemSchema } from "../lib/items";
+
+const router = Router();
+
+const pool = new Pool({
+  connectionString: process.env.DB_ENDPOINT,
+  user: "postgres",
+  password: process.env.DB_PASSWORD,
+  database: "postgres",
+});
+
+router.post(
+  "/api/items",
+  validate(insertItemSchema),
+  async (req, res) => {
+    try {
+      const { id } = await insertItem(pool, req.body);
+      res.status(201).json({ id });
+    } catch (err) {
+      if (err && typeof err === "object" && "code" in err && err.code === "23505") {
+        res.status(409).json({ error: "item name already exists" });
+        return;
+      }
+      logger.error("failed to insert item", err);
+      res.status(500).json({ error: "Internal Server Error" });
+    }
+  },
+);
+
+export default router;


### PR DESCRIPTION
## Summary
- add migration for items table
- add data-access helper and POST /api/items endpoint
- wire items route into app

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68ab997ec93c832db0930ab701c8ba43