### PR TITLE
test: add preemptive models route tests

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -40,6 +40,7 @@
       "devDependencies": {
         "@babel/core": "^7.28.0",
         "@babel/preset-env": "^7.28.0",
+        "@babel/preset-react": "^7.27.1",
         "@babel/preset-typescript": "^7.27.1",
         "@eslint/js": "^9.30.1",
         "@types/express": "^5.0.3",
@@ -2434,6 +2435,75 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-transform-react-display-name": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.28.0.tgz",
+      "integrity": "sha512-D6Eujc2zMxKjfa4Zxl4GHMsmhKKZ9VpcqIchJLvwTxad9zWIYulwYItBovpDOoNLISpcZSXoDJ5gaGbQUDqViA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.27.1.tgz",
+      "integrity": "sha512-2KH4LWGSrJIkVf5tSiBFYuXDAoWRq2MMwgivCf+93dd0GQi8RXLjKA/0EvRnVV5G0hrHczsquXuD01L8s6dmBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.1",
+        "@babel/helper-module-imports": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-development": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.27.1.tgz",
+      "integrity": "sha512-ykDdF5yI4f1WrAolLqeF3hmYU12j9ntLQl/AOG1HAS21jxyg1Q0/J/tpREuYLfatGdGmXp/3yS0ZA76kOlVq9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-transform-react-jsx": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-pure-annotations": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.27.1.tgz",
+      "integrity": "sha512-JfuinvDOsD9FVMTHpzA/pBLisxpv1aSf+OIV8lgH3MuWrks19R27e6a6DipIg4aX1Zm9Wpb04p8wljfKrVSnPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-transform-regenerator": {
       "version": "7.28.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.28.1.tgz",
@@ -2749,6 +2819,27 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/@babel/preset-react": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.27.1.tgz",
+      "integrity": "sha512-oJHWh2gLhU9dW9HHr42q0cI0/iHHXTLGe39qvpAZZzagHy0MzYLCnCVV0symeRvzmjHyVU7mw2K06E6u/JwbhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/plugin-transform-react-display-name": "^7.27.1",
+        "@babel/plugin-transform-react-jsx": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-development": "^7.27.1",
+        "@babel/plugin-transform-react-pure-annotations": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/preset-typescript": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -78,6 +78,7 @@
   "devDependencies": {
     "@babel/core": "^7.28.0",
     "@babel/preset-env": "^7.28.0",
+    "@babel/preset-react": "^7.27.1",
     "@babel/preset-typescript": "^7.27.1",
     "@eslint/js": "^9.30.1",
     "@types/express": "^5.0.3",
@@ -95,9 +96,9 @@
     "htmlparser2": "^10.0.0",
     "jest": "^30.0.4",
     "jest-environment-jsdom": "^30.0.4",
+    "jest-junit": "^16.0.0",
     "jest-localstorage-mock": "^2.4.26",
     "jest-retries": "^1.0.1",
-    "jest-junit": "^16.0.0",
     "jsdom": "^26.1.0",
     "lighthouse": "^12.7.1",
     "nock": "^13.3.3",
@@ -105,9 +106,9 @@
     "pg-mem": "^3.0.5",
     "prettier": "^3.6.2",
     "supertest": "^7.1.2",
+    "ts-jest": "^29.2.5",
     "tslib": "^2.8.1",
-    "yaml": "^2.3.4",
-    "ts-jest": "^29.2.5"
+    "yaml": "^2.3.4"
   },
   "engines": {
     "node": "20.x"

--- a/backend/tests/routes/models.preemptive.spec.ts
+++ b/backend/tests/routes/models.preemptive.spec.ts
@@ -1,0 +1,140 @@
+process.env.STRIPE_SECRET_KEY = "test";
+process.env.STRIPE_WEBHOOK_SECRET = "whsec";
+process.env.DB_URL = "postgres://user:pass@localhost/db";
+process.env.CLOUDFRONT_MODEL_DOMAIN = "cdn.example.com";
+process.env.AWS_REGION = "us-east-1";
+process.env.S3_BUCKET = "bucket";
+
+jest.mock("../../db", () => ({
+  query: jest.fn(),
+}));
+const db = require("../../db");
+const request = require("supertest");
+const express = require("express");
+const app = express();
+app.use(express.json());
+
+afterEach(() => {
+  db.query.mockReset();
+});
+
+describe("preemptive /api/models contract", () => {
+  it.skip("POST /api/models with { prompt, s3_key } returns 201 and body includes { cloudfront_url, id }", async () => {
+    const payload = { prompt: "cat", s3_key: "cat.glb" };
+    db.query.mockResolvedValueOnce({ rows: [{ id: 1, ...payload }] });
+    const res = await request(app).post("/api/models").send(payload);
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual(
+      expect.objectContaining({
+        id: 1,
+        cloudfront_url: `https://${process.env.CLOUDFRONT_MODEL_DOMAIN}/${payload.s3_key}`,
+      }),
+    );
+  });
+
+  it.skip("POST /api/models missing prompt returns 400", async () => {
+    const res = await request(app)
+      .post("/api/models")
+      .send({ s3_key: "cat.glb" });
+    expect(res.status).toBe(400);
+  });
+
+  it.skip("POST /api/models missing s3_key returns 400", async () => {
+    const res = await request(app).post("/api/models").send({ prompt: "cat" });
+    expect(res.status).toBe(400);
+  });
+
+  it.skip("POST /api/models empty prompt returns 400", async () => {
+    const res = await request(app)
+      .post("/api/models")
+      .send({ prompt: "", s3_key: "cat.glb" });
+    expect(res.status).toBe(400);
+  });
+
+  it.skip("POST /api/models empty s3_key returns 400", async () => {
+    const res = await request(app)
+      .post("/api/models")
+      .send({ prompt: "cat", s3_key: "" });
+    expect(res.status).toBe(400);
+  });
+
+  it.skip("POST /api/models non-string prompt returns 400", async () => {
+    const res = await request(app)
+      .post("/api/models")
+      .send({ prompt: 123, s3_key: "cat.glb" });
+    expect(res.status).toBe(400);
+  });
+
+  it.skip("POST /api/models non-string s3_key returns 400", async () => {
+    const res = await request(app)
+      .post("/api/models")
+      .send({ prompt: "cat", s3_key: 123 });
+    expect(res.status).toBe(400);
+  });
+
+  it.skip("POST /api/models invalid s3_key format returns 400", async () => {
+    const res = await request(app)
+      .post("/api/models")
+      .send({ prompt: "cat", s3_key: "../cat.glb" });
+    expect(res.status).toBe(400);
+  });
+
+  it.skip("GET /api/models returns array of models with prompt and cloudfront_url", async () => {
+    db.query.mockResolvedValueOnce({
+      rows: [{ id: 1, prompt: "cat", s3_key: "cat.glb" }],
+    });
+    const res = await request(app).get("/api/models");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([
+      {
+        id: 1,
+        prompt: "cat",
+        cloudfront_url: `https://${process.env.CLOUDFRONT_MODEL_DOMAIN}/cat.glb`,
+      },
+    ]);
+  });
+
+  it.skip("GET /api/models returns empty array when no models exist", async () => {
+    db.query.mockResolvedValueOnce({ rows: [] });
+    const res = await request(app).get("/api/models");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+
+  it.skip("GET /api/models/:id returns a single model if it exists", async () => {
+    db.query.mockResolvedValueOnce({
+      rows: [{ id: 1, prompt: "cat", s3_key: "cat.glb" }],
+    });
+    const res = await request(app).get("/api/models/1");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      id: 1,
+      prompt: "cat",
+      cloudfront_url: `https://${process.env.CLOUDFRONT_MODEL_DOMAIN}/cat.glb`,
+    });
+  });
+
+  it.skip("GET /api/models/:id returns 404 when model not found", async () => {
+    db.query.mockResolvedValueOnce({ rows: [] });
+    const res = await request(app).get("/api/models/999");
+    expect(res.status).toBe(404);
+  });
+
+  it.skip("GET /api/models/:id invalid id returns 400", async () => {
+    const res = await request(app).get("/api/models/not-a-number");
+    expect(res.status).toBe(400);
+  });
+
+  it.skip("POST /api/models returns 500 on database error", async () => {
+    const payload = { prompt: "cat", s3_key: "cat.glb" };
+    db.query.mockRejectedValueOnce(new Error("db failure"));
+    const res = await request(app).post("/api/models").send(payload);
+    expect(res.status).toBe(500);
+  });
+
+  it.skip("GET /api/models/:id returns 500 on database error", async () => {
+    db.query.mockRejectedValueOnce(new Error("db failure"));
+    const res = await request(app).get("/api/models/1");
+    expect(res.status).toBe(500);
+  });
+});


### PR DESCRIPTION
## Summary
- add skipped contract tests for upcoming /api/models endpoints covering POST, GET, and error cases
- stub server with Express and mock DB to avoid unrelated dependencies
- include @babel/preset-react in backend dev dependencies for Jest

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `node scripts/run-jest.js backend/tests/routes/models.preemptive.spec.ts --collectCoverage=false`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68aca3d8db18832dbe7a60a66f45862e