### PR TITLE
feat: implement sale credits routes and webhook

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -117,6 +117,15 @@ try {
   console.error("Failed to load legacy router", err);
 }
 
+try {
+  (() => {
+    const r = require("./routes/credits");
+    app.use("/api", r.default || r);
+  })();
+} catch (err) {
+  console.error("Failed to load credits router", err);
+}
+
 app.use((err, req, res, _next) => {
   const context = { method: req.method, url: req.originalUrl, body: req.body };
   try {

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -115,6 +115,15 @@ try {
   console.error("Failed to load legacy router", err);
 }
 
+try {
+  (() => {
+    const r = require("./routes/credits");
+    app.use("/api", r.default || r);
+  })();
+} catch (err) {
+  console.error("Failed to load credits router", err);
+}
+
 app.use((err: Error, req: Request, res: Response, _next: NextFunction) => {
   const context = { method: req.method, url: req.originalUrl, body: req.body };
   try {

--- a/backend/src/routes/credits.js
+++ b/backend/src/routes/credits.js
@@ -1,0 +1,25 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const express_1 = require("express");
+const auth_1 = require("../lib/auth");
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const db = require("../../db.js");
+const router = (0, express_1.Router)();
+router.get("/credits", auth_1.authRequired, async (req, res) => {
+  try {
+    const credit = await db.getSaleCredit(req.user.id);
+    res.json({ credit });
+  } catch {
+    res.status(500).json({ error: "Failed to fetch credit" });
+  }
+});
+router.post("/credits/redeem", auth_1.authRequired, async (req, res) => {
+  try {
+    const amount = Number(req.body.amount_cents) || 0;
+    const credit = await db.adjustSaleCredit(req.user.id, -amount);
+    res.json({ credit });
+  } catch {
+    res.status(500).json({ error: "Failed to redeem credit" });
+  }
+});
+exports.default = router;

--- a/backend/src/routes/credits.ts
+++ b/backend/src/routes/credits.ts
@@ -1,0 +1,34 @@
+import { Router, type Request, type Response } from "express";
+import { authRequired } from "../lib/auth";
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const db = require("../../db.js");
+
+const router = Router();
+
+router.get("/credits", authRequired, async (req: Request, res: Response) => {
+  try {
+    const credit = await db.getSaleCredit((req as any).user.id);
+    res.json({ credit });
+  } catch {
+    res.status(500).json({ error: "Failed to fetch credit" });
+  }
+});
+
+router.post(
+  "/credits/redeem",
+  authRequired,
+  async (req: Request, res: Response) => {
+    try {
+      const amount = Number(req.body.amount_cents) || 0;
+      const credit = await db.adjustSaleCredit(
+        (req as any).user.id,
+        -amount,
+      );
+      res.json({ credit });
+    } catch {
+      res.status(500).json({ error: "Failed to redeem credit" });
+    }
+  },
+);
+
+export default router;

--- a/backend/src/routes/stripeWebhook.js
+++ b/backend/src/routes/stripeWebhook.js
@@ -9,6 +9,7 @@ const express_1 = __importDefault(require("express"));
 const stripe_1 = __importDefault(require("stripe"));
 const checkout_1 = require("./checkout");
 const mail_1 = require("../../mail");
+const db = require("../../db.js");
 const secretKey =
   process.env.NODE_ENV === "production"
     ? process.env.STRIPE_LIVE_KEY || process.env.STRIPE_SECRET_KEY
@@ -16,37 +17,48 @@ const secretKey =
 if (!secretKey) {
   throw new Error("Stripe key not configured");
 }
-const stripe = new stripe_1.default(secretKey, { apiVersion: "2025-06-30.basil" });
+const stripe = new stripe_1.default(secretKey, {
+  apiVersion: "2025-06-30.basil",
+});
 const router = express_1.default.Router();
+const handler = async (req, res, next) => {
+  try {
+    const sig = req.headers["stripe-signature"];
+    const event = stripe.webhooks.constructEvent(
+      req.body,
+      sig,
+      process.env.STRIPE_WEBHOOK_SECRET || "",
+    );
+    if (event.type === "checkout.session.completed") {
+      const session = event.data.object;
+      const order = checkout_1.orders.get(session.id);
+      if (order && !order.paid) {
+        order.paid = true;
+        const link = process.env.CLOUDFRONT_MODEL_DOMAIN
+          ? `https://${process.env.CLOUDFRONT_MODEL_DOMAIN}/${order.slug}.glb`
+          : order.slug;
+        await (0, mail_1.sendMail)(order.email, "Your model is ready", link);
+      }
+      if (session.metadata && session.metadata.jobId) {
+        await db.adjustSaleCredit("seller", 500);
+      }
+    }
+    res.sendStatus(200);
+  } catch (err) {
+    if (err && err.message && err.message.includes("Webhook Error")) {
+      return res.sendStatus(400);
+    }
+    next(err);
+  }
+};
 router.post(
   "/stripe/webhook",
   express_1.default.raw({ type: "application/json" }),
-  async (req, res, next) => {
-    try {
-      const sig = req.headers["stripe-signature"];
-      const event = stripe.webhooks.constructEvent(
-        req.body,
-        sig,
-        process.env.STRIPE_WEBHOOK_SECRET || "",
-      );
-      if (event.type === "checkout.session.completed") {
-        const session = event.data.object;
-        const order = checkout_1.orders.get(session.id);
-        if (order && !order.paid) {
-          order.paid = true;
-          const link = process.env.CLOUDFRONT_MODEL_DOMAIN
-            ? `https://${process.env.CLOUDFRONT_MODEL_DOMAIN}/${order.slug}.glb`
-            : order.slug;
-          await (0, mail_1.sendMail)(order.email, "Your model is ready", link);
-        }
-      }
-      res.sendStatus(200);
-    } catch (err) {
-      if (err && err.message && err.message.includes("Webhook Error")) {
-        return res.sendStatus(400);
-      }
-      next(err);
-    }
-  },
+  handler,
+);
+router.post(
+  "/api/webhook/stripe",
+  express_1.default.raw({ type: "application/json" }),
+  handler,
 );
 exports.default = router;

--- a/backend/src/routes/stripeWebhook.ts
+++ b/backend/src/routes/stripeWebhook.ts
@@ -6,6 +6,8 @@ import express, {
 import Stripe from "stripe";
 import { orders } from "./checkout";
 import { sendMail } from "../../mail.js";
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const db = require("../../db.js");
 
 const secretKey =
   process.env["NODE_ENV"] === "production"
@@ -18,43 +20,45 @@ const stripe = new Stripe(secretKey, { apiVersion: "2025-06-30.basil" });
 
 const router = express.Router();
 
-router.post(
-  "/stripe/webhook",
-  express.raw({ type: "application/json" }),
-  async (
-    req: Request,
-    res: Response,
-    next: NextFunction,
-  ): Promise<void> => {
-    try {
-      const sig = req.headers["stripe-signature"] as string;
-      const event = stripe.webhooks.constructEvent(
-        req.body,
-        sig,
-        process.env["STRIPE_WEBHOOK_SECRET"] || "",
-      );
-      if (event.type === "checkout.session.completed") {
-        const session = event.data.object as Stripe.Checkout.Session;
-        const order = orders.get(session.id);
-        if (order && !order.paid) {
-          order.paid = true;
-          const domain = process.env["CLOUDFRONT_MODEL_DOMAIN"];
-          const link = domain
-            ? `https://${domain}/${order.slug}.glb`
-            : order.slug;
-          await sendMail(order.email, "Your model is ready", link);
-        }
+const handler = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    const sig = req.headers["stripe-signature"] as string;
+    const event = stripe.webhooks.constructEvent(
+      req.body,
+      sig,
+      process.env["STRIPE_WEBHOOK_SECRET"] || "",
+    );
+    if (event.type === "checkout.session.completed") {
+      const session = event.data.object as Stripe.Checkout.Session;
+      const order = orders.get(session.id);
+      if (order && !order.paid) {
+        order.paid = true;
+        const domain = process.env["CLOUDFRONT_MODEL_DOMAIN"];
+        const link = domain
+          ? `https://${domain}/${order.slug}.glb`
+          : order.slug;
+        await sendMail(order.email, "Your model is ready", link);
       }
-      res.sendStatus(200);
-      return;
-    } catch (err) {
-      if (err instanceof Error && err.message.includes("Webhook Error")) {
-        res.sendStatus(400);
-        return;
+      if (session.metadata?.jobId) {
+        await db.adjustSaleCredit("seller", 500);
       }
-      next(err);
     }
-  },
-);
+    res.sendStatus(200);
+    return;
+  } catch (err) {
+    if (err instanceof Error && err.message.includes("Webhook Error")) {
+      res.sendStatus(400);
+      return;
+    }
+    next(err);
+  }
+};
+
+router.post("/stripe/webhook", express.raw({ type: "application/json" }), handler);
+router.post("/api/webhook/stripe", express.raw({ type: "application/json" }), handler);
 
 export default router;

--- a/backend/src/routes/subscription.js
+++ b/backend/src/routes/subscription.js
@@ -1,6 +1,6 @@
 const { Router } = require("express");
 const Stripe = require("stripe");
-const db = require("../../db");
+const db = require("../../db.js");
 const config = require("../../config");
 const { authRequired, authOptional } = require("../lib/auth");
 const { logError } = require("../lib/logError");

--- a/backend/src/routes/subscription.ts
+++ b/backend/src/routes/subscription.ts
@@ -1,6 +1,7 @@
 import { Router, type NextFunction, type Request, type Response } from "express";
 import Stripe from "stripe";
-import db from "../../db";
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const db = require("../../db.js");
 import config from "../../config";
 import { authRequired, authOptional } from "../lib/auth";
 import { logError } from "../lib/logError";


### PR DESCRIPTION
## Summary
- expose `/api/credits` and `/api/credits/redeem` for reading and spending sale credits
- extend Stripe webhook to grant sale credits and support `/api/webhook/stripe`
- mount the new credits router in the Express app

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend -- tests/saleCredits.test.js`
- `npm test --prefix backend` *(fails: many routes return 404)*
- `PORT=3001 STRIPE_SECRET_KEY=sk_test_123 STRIPE_PUBLISHABLE_KEY=pk_test_123 npm start --prefix backend >/tmp/server.log & SERVER_PID=$!; sleep 5; STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:3001/healthz); echo $STATUS; kill $SERVER_PID`

------
https://chatgpt.com/codex/tasks/task_e_68addad5f9e0832d95d34309aba0fdd8