### PR TITLE
feat: modularize generate route

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -57,7 +57,7 @@ try {
 try {
   (() => {
     const r = require("./routes/generate");
-    app.use(r.default || r);
+    app.use("/api", r.default || r);
   })();
 } catch (err) {
   console.error("Failed to load generate router", err);

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -59,7 +59,7 @@ try {
 try {
   (() => {
     const r = require("./routes/generate");
-    app.use(r.default || r);
+    app.use("/api", r.default || r);
   })();
 } catch (err) {
   console.error("Failed to load generate router", err);

--- a/backend/src/routes/generate.js
+++ b/backend/src/routes/generate.js
@@ -2,32 +2,42 @@ const { Router } = require("express");
 const multer = require("multer");
 const db = require("../../db.js");
 const { generateModel } = require("../pipeline/generateModel.js");
+const { preserveColors } = require("../lib/preserveColors.js");
+const s3 = require("../lib/uploadS3.js");
 const { logError } = require("../lib/logError.js");
 
 const upload = multer();
 const router = Router();
 
-router.post("/api/generate", upload.single("image"), async (req, res) => {
+router.post("/generate", upload.single("image"), async (req, res) => {
   const prompt = req.body?.prompt;
   const image = req.file ? req.file.buffer.toString("base64") : undefined;
   if (!prompt && !image) {
     res.status(400).json({ error: "prompt or image required" });
     return;
   }
+  let jobId;
   try {
-    const glb_url = await generateModel({ prompt, image });
-    await db.query("INSERT INTO jobs(prompt) VALUES($1)", [prompt || ""]);
+    const job = await db.query(
+      "INSERT INTO jobs(prompt) VALUES($1) RETURNING id",
+      [prompt || ""],
+    );
+    jobId = job.rows?.[0]?.id;
+    const glb = await generateModel({ prompt, image });
+    const colored = await preserveColors(glb);
+    const uploadFn = s3.uploadS3 || s3.uploadFile;
+    const url = await uploadFn(colored);
     if (typeof db.insertGenerationLog === "function") {
-      await db.insertGenerationLog();
+      await db.insertGenerationLog(jobId, url);
     }
-    res.json({ glb_url });
+    res.json({ jobId, url });
   } catch (err) {
     logError(err);
     if (process.env.CI_REQUIRE_EXTERNAL) {
       res.status(500).json({ error: "Generation failed" });
       return;
     }
-    res.json({ glb_url: "/fallback.glb" });
+    res.json({ jobId, url: "/fallback.glb" });
   }
 });
 

--- a/backend/src/routes/generate.ts
+++ b/backend/src/routes/generate.ts
@@ -2,32 +2,42 @@ import { Router } from "express";
 import multer from "multer";
 import * as db from "../../db.js";
 import { generateModel } from "../pipeline/generateModel";
+import { preserveColors } from "../lib/preserveColors";
+import * as s3 from "../lib/uploadS3";
 import { logError } from "../lib/logError";
 
 const upload = multer();
 const router = Router();
 
-router.post("/api/generate", upload.single("image"), async (req, res) => {
+router.post("/generate", upload.single("image"), async (req, res) => {
   const prompt = req.body?.prompt as string | undefined;
   const image = req.file ? req.file.buffer.toString("base64") : undefined;
   if (!prompt && !image) {
     res.status(400).json({ error: "prompt or image required" });
     return;
   }
+  let jobId: string | undefined;
   try {
-    const glb_url = await generateModel({ prompt, image });
-    await db.query("INSERT INTO jobs(prompt) VALUES($1)", [prompt || ""]);
+    const job = await db.query(
+      "INSERT INTO jobs(prompt) VALUES($1) RETURNING id",
+      [prompt || ""],
+    );
+    jobId = job.rows?.[0]?.id;
+    const glb = await generateModel({ prompt, image });
+    const colored = await preserveColors(glb);
+    const uploadFn = (s3 as any).uploadS3 || (s3 as any).uploadFile;
+    const url = await uploadFn(colored);
     if (typeof (db as any).insertGenerationLog === "function") {
-      await (db as any).insertGenerationLog();
+      await (db as any).insertGenerationLog(jobId, url);
     }
-    res.json({ glb_url });
+    res.json({ jobId, url });
   } catch (err) {
     logError(err);
     if (process.env.CI_REQUIRE_EXTERNAL) {
       res.status(500).json({ error: "Generation failed" });
       return;
     }
-    res.json({ glb_url: "/fallback.glb" });
+    res.json({ jobId, url: "/fallback.glb" });
   }
 });
 


### PR DESCRIPTION
## Summary
- add dedicated generate router with job logging and S3 upload pipeline
- mount generate router under `/api` in Express app

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend -- --coverage=false backend/tests/generate.test.js`
- `PORT=3001 npm start --prefix backend & sleep 5; curl -s -o /dev/null -w "%{http_code}" http://localhost:3001/healthz`

## Notes
- Dev server script still contains a stub `/api/generate` handler.


------
https://chatgpt.com/codex/tasks/task_e_68adf6adc614832d884ea4b323c27dda