### PR TITLE
fix: harden generate route validation

### DIFF
--- a/backend/src/lib/uploadS3.ts
+++ b/backend/src/lib/uploadS3.ts
@@ -57,6 +57,14 @@ export interface UploadResult {
   key: string;
 }
 
+function sanitizeKey(name: string): string {
+  const base = name.split(/[\\/]/).pop() || "model";
+  let cleaned = base.replace(/\.glb$/i, "");
+  cleaned = cleaned.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+  if (cleaned.length > 80) cleaned = cleaned.slice(0, 80);
+  return `${cleaned}.glb`;
+}
+
 /**
  * Upload raw data to S3 and return its public URL and object key.
  * In test environments or when credentials are missing, returns a
@@ -71,7 +79,7 @@ export async function uploadS3(
   const domain = getEnv("CLOUDFRONT_DOMAIN", {
     defaultValue: "cdn.example.com",
   });
-  const key = safeJoin("models", `${Date.now()}-${filename}`);
+  const key = safeJoin("models", sanitizeKey(`${Date.now()}-${filename}`));
 
   if (
     process.env.NODE_ENV === "test" ||

--- a/backend/src/routes/generate.ts
+++ b/backend/src/routes/generate.ts
@@ -1,4 +1,4 @@
-import { Router } from "express";
+import { Router, type Request } from "express";
 import multer from "multer";
 import * as db from "../../db.js";
 import { userIdFromAuth } from "../lib/auth";
@@ -6,37 +6,90 @@ import { generateModel } from "../lib/generateModel";
 import { preserveColors } from "../lib/preserveColors";
 import { uploadS3 } from "../lib/uploadS3";
 import { logError } from "../lib/logError";
+import logger from "../logger.js";
 
 const upload = multer();
 const router = Router();
 
+const MAX_IMAGE_SIZE = 6 * 1024 * 1024; // ~6MB
+const FALLBACK_JOB_ID = "00000000-0000-0000-0000-000000000000";
+
+interface ValidationResult {
+  prompt?: string;
+  image?: string;
+  source: "prompt" | "image";
+}
+
+function throwValidation(code: string, status = 400): never {
+  const err = new Error(code) as { status?: number; code?: string };
+  err.status = status;
+  err.code = code;
+  throw err;
+}
+
+function validateInput(req: Request): ValidationResult {
+  if (req.is("application/json")) {
+    const raw = typeof req.body?.prompt === "string" ? req.body.prompt.trim() : "";
+    if (!raw) throwValidation("missing_or_ambiguous_input");
+    if (raw.length < 1 || raw.length > 400) throwValidation("invalid_prompt");
+    return { prompt: raw, source: "prompt" };
+  }
+  if (req.is("multipart/form-data")) {
+    const length = Number(req.headers["content-length"] || 0);
+    if (!Number.isNaN(length) && length > MAX_IMAGE_SIZE) {
+      throwValidation("payload_too_large", 413);
+    }
+    if (!req.file) throwValidation("missing_or_ambiguous_input");
+    const raw = typeof req.body?.prompt === "string" ? req.body.prompt.trim() : undefined;
+    if (raw && (raw.length < 1 || raw.length > 400)) throwValidation("invalid_prompt");
+    // If both prompt and image are provided, prefer image as the source and pass prompt metadata.
+    return { prompt: raw, image: req.file.buffer.toString("base64"), source: "image" };
+  }
+  throwValidation("unsupported_media_type", 415);
+}
+
 router.post("/generate", upload.single("image"), async (req, res) => {
-  const prompt =
-    typeof req.body?.prompt === "string" ? req.body.prompt : undefined;
-  const image = req.file ? req.file.buffer.toString("base64") : undefined;
-  if (!prompt && !image) {
-    res.status(400).json({ error: "bad_request" });
+  const userId = userIdFromAuth(req) || null;
+  const start = Date.now();
+  let jobId: string | undefined;
+  let s3Key: string | undefined;
+  let parsed: ValidationResult;
+
+  try {
+    parsed = validateInput(req);
+  } catch (err) {
+    const code = (err as any).code;
+    const status = (err as any).status || 400;
+    logger.error("generate_failed", { stage: "validation", userId, code });
+    logError(err);
+    if (code === "unsupported_media_type") {
+      res.status(415).json({ error: "unsupported_media_type" });
+    } else if (code === "payload_too_large") {
+      res.status(413).json({ error: "payload_too_large" });
+    } else {
+      res.status(400).json({ error: "bad_request", reason: code });
+    }
     return;
   }
 
-  const userId = userIdFromAuth(req);
-  let jobId: string | undefined;
-  const start = Date.now();
+  const { prompt, image, source } = parsed;
 
   try {
     if (typeof (db as any).createJob === "function") {
       const job = await (db as any).createJob({
         user_id: userId,
         prompt,
-        source: image ? "image" : "prompt",
+        source,
         created_at: new Date(start).toISOString(),
       });
       jobId = job?.id || job?.job_id || job?.jobId;
     }
 
-    const model = await generateModel({ prompt, image });
-    const colored = await preserveColors(model);
-    const { url, key } = await uploadS3(colored);
+    let model = await generateModel({ prompt, image });
+    model = await preserveColors(model);
+    const uploadResult = await uploadS3(model);
+    const { url, key } = uploadResult;
+    s3Key = key;
 
     if (jobId && typeof (db as any).linkModelToJob === "function") {
       await (db as any).linkModelToJob(jobId, key);
@@ -44,8 +97,9 @@ router.post("/generate", upload.single("image"), async (req, res) => {
     if (typeof (db as any).insertGenerationLog === "function") {
       await (db as any).insertGenerationLog({
         jobId,
-        prompt,
-        source: image ? "image" : "prompt",
+        userId,
+        prompt: prompt ?? "image",
+        source,
         startTime: new Date(start).toISOString(),
         finishTime: new Date().toISOString(),
         s3Key: key,
@@ -53,14 +107,28 @@ router.post("/generate", upload.single("image"), async (req, res) => {
       });
     }
 
+    logger.info("generate_success", { jobId, userId, source, s3Key: key });
     res.json({ jobId, url });
   } catch (err) {
+    const stage = s3Key ? "upload" : "generation";
+    const code = stage === "upload" ? "upload_failed" : "model_error";
+    logger.error("generate_failed", { stage, userId, code: (err as any).code });
     logError(err);
-    if (process.env.CI_REQUIRE_EXTERNAL) {
-      res.status(500).json({ error: "Generation failed" });
+    if (process.env.CI_REQUIRE_EXTERNAL === "true") {
+      res.status(502).json({ error: code });
       return;
     }
-    res.json({ jobId, url: "/fallback.glb" });
+    if (typeof (db as any).insertGenerationLog === "function") {
+      await (db as any).insertGenerationLog({
+        jobId,
+        userId,
+        prompt: prompt ?? "image",
+        source,
+        startTime: new Date(start).toISOString(),
+        finishTime: new Date().toISOString(),
+      });
+    }
+    res.json({ jobId: jobId || FALLBACK_JOB_ID, url: "/fallback.glb" });
   }
 });
 

--- a/backend/tests/generate.smoke.test.ts
+++ b/backend/tests/generate.smoke.test.ts
@@ -1,0 +1,51 @@
+const request = require("supertest");
+
+process.env.STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY || "sk";
+process.env.STRIPE_WEBHOOK_SECRET = process.env.STRIPE_WEBHOOK_SECRET || "wh";
+process.env.DB_URL = process.env.DB_URL || "postgres://user:pass@localhost/db";
+
+jest.mock("../db", () => ({
+  createJob: jest.fn().mockResolvedValue({ id: "job-1" }),
+  linkModelToJob: jest.fn(),
+  insertGenerationLog: jest.fn(),
+}));
+
+jest.mock("../src/lib/generateModel", () => ({
+  generateModel: jest.fn().mockResolvedValue(Buffer.from("model")),
+}));
+
+jest.mock("../src/lib/preserveColors", () => ({
+  preserveColors: jest.fn().mockResolvedValue(Buffer.from("model")),
+}));
+
+jest.mock("../src/lib/uploadS3", () => ({
+  uploadS3: jest.fn().mockResolvedValue({ url: "/test.glb", key: "test.glb" }),
+}));
+
+const app = require("../server");
+
+describe("POST /api/generate", () => {
+  test("400 for missing input", async () => {
+    const res = await request(app)
+      .post("/api/generate")
+      .set("Content-Type", "application/json");
+    expect(res.status).toBe(400);
+  });
+
+  test("200 for JSON prompt", async () => {
+    const res = await request(app)
+      .post("/api/generate")
+      .send({ prompt: "hi" })
+      .set("Content-Type", "application/json");
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty("url", "/test.glb");
+  });
+
+  test("200 for multipart image", async () => {
+    const res = await request(app)
+      .post("/api/generate")
+      .attach("image", Buffer.from("123"), { filename: "test.png" });
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty("url", "/test.glb");
+  });
+});


### PR DESCRIPTION
## Summary
- validate and log `/api/generate` requests with clear error codes
- sanitize S3 upload keys
- add smoke test coverage for prompt and image generation

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend -- backend/tests/generate.smoke.test.ts`
- `SKIP_PW_DEPS=1 npm run smoke`
- `PORT=3001 STRIPE_SECRET_KEY=sk_test_123 STRIPE_PUBLISHABLE_KEY=pk_test_123 npm start --prefix backend & sleep 5; curl -s -o /dev/null -w "%{http_code}\n" http://localhost:3001/healthz; kill %1`


------
https://chatgpt.com/codex/tasks/task_e_68ae05e88f80832da0ec788bd43ee67f