### PR TITLE
feat: add payment intent creation route

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -108,6 +108,15 @@ try {
   console.error("Failed to load credits router", err);
 }
 
+try {
+  (() => {
+    const r = require("./routes/payments");
+    app.use("/api", r.default || r);
+  })();
+} catch (err) {
+  console.error("Failed to load payments router", err);
+}
+
 app.use((err, req, res, _next) => {
   const context = { method: req.method, url: req.originalUrl, body: req.body };
   try {

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -110,6 +110,15 @@ try {
   console.error("Failed to load credits router", err);
 }
 
+try {
+  (() => {
+    const r = require("./routes/payments");
+    app.use("/api", r.default || r);
+  })();
+} catch (err) {
+  console.error("Failed to load payments router", err);
+}
+
 app.use((err: Error, req: Request, res: Response, _next: NextFunction) => {
   const context = { method: req.method, url: req.originalUrl, body: req.body };
   try {

--- a/backend/src/routes/payments.js
+++ b/backend/src/routes/payments.js
@@ -1,0 +1,54 @@
+const { Router } = require("express");
+const Stripe = require("stripe");
+
+const PRICE_MAP = {
+  print_multi: 3999,
+  print_single: 2999,
+};
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
+  apiVersion: "2025-06-30.basil",
+});
+
+const router = Router();
+
+router.post("/checkout/create", async (req, res) => {
+  try {
+    const { items, currency = "usd", customer_email, metadata } = req.body;
+    if (!Array.isArray(items) || items.length === 0) {
+      return res.status(400).json({ error: "bad_request" });
+    }
+
+    let amount = 0;
+    let qtyTotal = 0;
+    for (const item of items) {
+      if (typeof item.price !== "string" || typeof item.quantity !== "number") {
+        return res.status(400).json({ error: "bad_request" });
+      }
+      const unit = PRICE_MAP[item.price];
+      if (!unit || item.quantity < 1 || item.quantity > 99) {
+        return res.status(400).json({ error: "bad_request" });
+      }
+      amount += unit * item.quantity;
+      qtyTotal += item.quantity;
+    }
+
+    try {
+      const intent = await stripe.paymentIntents.create({
+        amount,
+        currency,
+        automatic_payment_methods: { enabled: true },
+        metadata: { ...metadata, qtyTotal, source: "custom_checkout" },
+        receipt_email: customer_email,
+      });
+      res.json({ clientSecret: intent.client_secret });
+    } catch (err) {
+      res.status(502).json({ error: "stripe_error" });
+    }
+  } catch (err) {
+    res.status(500).json({ error: "internal_error" });
+  }
+});
+
+module.exports = router;
+module.exports.default = router;

--- a/backend/src/routes/payments.ts
+++ b/backend/src/routes/payments.ts
@@ -1,0 +1,68 @@
+import { Router, type Request, type Response } from "express";
+import Stripe from "stripe";
+
+interface Item {
+  price: string;
+  quantity: number;
+}
+
+interface CheckoutBody {
+  items?: Item[];
+  currency?: string;
+  customer_email?: string;
+  metadata?: Record<string, any>;
+}
+
+const PRICE_MAP: Record<string, number> = {
+  print_multi: 3999,
+  print_single: 2999,
+};
+
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {
+  apiVersion: "2025-06-30.basil",
+});
+
+const router = Router();
+
+router.post(
+  "/checkout/create",
+  async (req: Request<{}, any, CheckoutBody>, res: Response) => {
+    try {
+      const { items, currency = "usd", customer_email, metadata } = req.body;
+      if (!Array.isArray(items) || items.length === 0) {
+        return res.status(400).json({ error: "bad_request" });
+      }
+
+      let amount = 0;
+      let qtyTotal = 0;
+      for (const item of items) {
+        if (typeof item.price !== "string" || typeof item.quantity !== "number") {
+          return res.status(400).json({ error: "bad_request" });
+        }
+        const unit = PRICE_MAP[item.price];
+        if (!unit || item.quantity < 1 || item.quantity > 99) {
+          return res.status(400).json({ error: "bad_request" });
+        }
+        amount += unit * item.quantity;
+        qtyTotal += item.quantity;
+      }
+
+      try {
+        const intent = await stripe.paymentIntents.create({
+          amount,
+          currency,
+          automatic_payment_methods: { enabled: true },
+          metadata: { ...metadata, qtyTotal, source: "custom_checkout" },
+          receipt_email: customer_email,
+        });
+        res.json({ clientSecret: intent.client_secret });
+      } catch (err) {
+        res.status(502).json({ error: "stripe_error" });
+      }
+    } catch (err) {
+      res.status(500).json({ error: "internal_error" });
+    }
+  },
+);
+
+export default router;

--- a/backend/tests/stripe.paymentIntent.create.spec.ts
+++ b/backend/tests/stripe.paymentIntent.create.spec.ts
@@ -1,0 +1,41 @@
+process.env.STRIPE_SECRET_KEY = "sk_test";
+
+jest.mock("../db", () => ({ query: jest.fn() }));
+const db = require("../db");
+
+jest.mock("stripe");
+const Stripe = require("stripe");
+const stripeMock = {
+  paymentIntents: {
+    create: jest.fn().mockResolvedValue({ client_secret: "pi_secret_123" }),
+  },
+};
+Stripe.mockImplementation(() => stripeMock);
+
+const request = require("supertest");
+const app = require("../src/app");
+
+describe("POST /api/checkout/create", () => {
+  test("creates payment intent and returns client secret", async () => {
+    const res = await request(app)
+      .post("/api/checkout/create")
+      .send({
+        items: [
+          { price: "print_multi", quantity: 1 },
+          { price: "print_single", quantity: 2 },
+        ],
+        currency: "usd",
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.clientSecret).toBe("pi_secret_123");
+    expect(stripeMock.paymentIntents.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        amount: 3999 + 2 * 2999,
+        currency: "usd",
+        automatic_payment_methods: { enabled: true },
+      }),
+    );
+    expect(db.query).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add payments router for custom checkout that creates Stripe payment intents
- mount payments API in app bootstrap
- test payment intent creation and stripe call

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend -- tests/stripe.paymentIntent.create.spec.ts`
- `PORT=3001 STRIPE_SECRET_KEY=sk_test_123 STRIPE_PUBLISHABLE_KEY=pk_test_123 npm start --prefix backend & sleep 5; curl -s -o /dev/null -w "%{http_code}\n" http://localhost:3001/healthz; kill %1`


------
https://chatgpt.com/codex/tasks/task_e_68ae1bae04bc832d899a8e55267889b2