### PR TITLE
feat: add generation queue infrastructure

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -119,6 +119,15 @@ try {
   console.error("Failed to load payments router", err);
 }
 
+try {
+  (() => {
+    const r = require("./routes/status");
+    app.use("/api", r.default || r);
+  })();
+} catch (err) {
+  console.error("Failed to load status router", err);
+}
+
 app.use((err: Error, req: Request, res: Response, _next: NextFunction) => {
   const context = { method: req.method, url: req.originalUrl, body: req.body };
   try {

--- a/backend/src/queue/generation.ts
+++ b/backend/src/queue/generation.ts
@@ -1,0 +1,99 @@
+import { EventEmitter } from "events";
+import { randomUUID } from "crypto";
+
+export interface GenerationJob {
+  userId: string;
+  prompt?: string;
+  imagePath?: string;
+}
+
+export interface GenerationJobStatus {
+  state: "queued" | "running" | "succeeded" | "failed";
+  url?: string;
+  error?: string;
+  startedAt?: string;
+  finishedAt?: string;
+  position?: number;
+}
+
+interface InternalJob extends GenerationJob {
+  id: string;
+  state: GenerationJobStatus["state"];
+  url?: string;
+  error?: string;
+  startedAt?: string;
+  finishedAt?: string;
+}
+
+const queue: InternalJob[] = [];
+const jobs = new Map<string, InternalJob>();
+const inFlight = new Map<string, string>();
+const emitter = new EventEmitter();
+
+function processNext() {
+  let index = queue.findIndex((j) => !inFlight.has(j.userId));
+  while (index !== -1) {
+    const job = queue.splice(index, 1)[0];
+    inFlight.set(job.userId, job.id);
+    job.state = "running";
+    job.startedAt = new Date().toISOString();
+
+    setImmediate(() => {
+      try {
+        job.url = "/placeholder.glb";
+        job.state = "succeeded";
+        job.finishedAt = new Date().toISOString();
+        emitter.emit(`complete:${job.id}`, { ...job });
+      } catch (err) {
+        job.error = (err as Error).message;
+        job.state = "failed";
+        job.finishedAt = new Date().toISOString();
+        emitter.emit(`fail:${job.id}`, { ...job });
+      } finally {
+        inFlight.delete(job.userId);
+        processNext();
+      }
+    });
+
+    index = queue.findIndex((j) => !inFlight.has(j.userId));
+  }
+}
+
+export async function enqueue(job: GenerationJob): Promise<{ id: string }> {
+  const id = randomUUID();
+  const record: InternalJob = { ...job, id, state: "queued" };
+  queue.push(record);
+  jobs.set(id, record);
+  processNext();
+  return { id };
+}
+
+export function onComplete(
+  id: string,
+  cb: (status: GenerationJobStatus) => void,
+) {
+  emitter.once(`complete:${id}`, cb);
+}
+
+export function onFail(id: string, cb: (status: GenerationJobStatus) => void) {
+  emitter.once(`fail:${id}`, cb);
+}
+
+export function getStatus(id: string): GenerationJobStatus | undefined {
+  const job = jobs.get(id);
+  if (!job) return undefined;
+  const status: GenerationJobStatus = {
+    state: job.state,
+    url: job.url,
+    error: job.error,
+    startedAt: job.startedAt,
+    finishedAt: job.finishedAt,
+  };
+  if (job.state === "queued") {
+    const pos = queue.findIndex((j) => j.id === id);
+    if (pos !== -1) status.position = pos + 1;
+  }
+  return status;
+}
+
+export { emitter };

--- a/backend/src/routes/status.ts
+++ b/backend/src/routes/status.ts
@@ -1,0 +1,15 @@
+import { Router } from "express";
+import { getStatus } from "../queue/generation";
+
+const router = Router();
+
+router.get("/status/:id", (req, res) => {
+  const status = getStatus(req.params.id);
+  if (!status) {
+    res.status(404).json({ error: "not_found" });
+    return;
+  }
+  res.json({ id: req.params.id, ...status });
+});
+
+export default router;

--- a/backend/tests/queue.status.spec.ts
+++ b/backend/tests/queue.status.spec.ts
@@ -1,0 +1,42 @@
+import request from "supertest";
+import app from "../src/app";
+import { enqueue, getStatus } from "../src/queue/generation";
+
+jest.useFakeTimers();
+
+describe("generation queue status", () => {
+  test("per-user serialization and status endpoint", async () => {
+    const job1 = await enqueue({ userId: "u1" });
+    const job2 = await enqueue({ userId: "u1" });
+    const job3 = await enqueue({ userId: "u2" });
+
+    expect(getStatus(job1.id)?.state).toBe("running");
+    expect(getStatus(job2.id)).toMatchObject({ state: "queued", position: 1 });
+    expect(getStatus(job3.id)?.state).toBe("running");
+
+    const resQueued = await request(app).get(`/api/status/${job2.id}`);
+    expect(resQueued.body).toMatchObject({
+      id: job2.id,
+      state: "queued",
+      position: 1,
+    });
+    const resRunning = await request(app).get(`/api/status/${job1.id}`);
+    expect(resRunning.body.state).toBe("running");
+
+    await jest.runAllTimersAsync();
+
+    const done1 = await request(app).get(`/api/status/${job1.id}`);
+    const done2 = await request(app).get(`/api/status/${job2.id}`);
+    const done3 = await request(app).get(`/api/status/${job3.id}`);
+
+    expect(done1.body).toMatchObject({
+      id: job1.id,
+      state: "succeeded",
+      url: "/placeholder.glb",
+    });
+    expect(done1.body).toHaveProperty("startedAt");
+    expect(done1.body).toHaveProperty("finishedAt");
+    expect(done2.body.state).toBe("succeeded");
+    expect(done3.body.state).toBe("succeeded");
+  });
+});


### PR DESCRIPTION
## Summary
- add lightweight in-process generation queue with per-user serialization
- expose `/api/status/:id` for checking job state
- cover queue/status behavior with tests

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend -- backend/tests/queue.status.spec.ts`
- `SKIP_PW_DEPS=1 npm run smoke`
- `curl -s -o /tmp/healthz.out -w "%{http_code}" http://localhost:3001/healthz`

------
https://chatgpt.com/codex/tasks/task_e_68ae34c33974832db806bcdbb2753df3