### PR TITLE
feat: route generation through queue

### DIFF
--- a/backend/src/queue/generation.ts
+++ b/backend/src/queue/generation.ts
@@ -1,10 +1,20 @@
 import { EventEmitter } from "events";
 import { randomUUID } from "crypto";
+import * as db from "../db.js";
+import { generateModel } from "../lib/generateModel";
+import { preserveColors } from "../lib/preserveColors";
+import { uploadS3 } from "../lib/uploadS3";
+import { logError } from "../lib/logError";
+import logger from "../logger.js";
 
-export interface GenerationJob {
-  userId: string;
+export interface GenerationPayload {
   prompt?: string;
-  imagePath?: string;
+  image?: string;
+  source: "prompt" | "image";
+}
+
+interface GenerationJob extends GenerationPayload {
+  userId: string;
 }
 
 export interface GenerationJobStatus {
@@ -23,6 +33,8 @@ interface InternalJob extends GenerationJob {
   error?: string;
   startedAt?: string;
   finishedAt?: string;
+  s3Key?: string;
+  dbJobId?: string;
 }
 
 const queue: InternalJob[] = [];
@@ -38,17 +50,77 @@ function processNext() {
     job.state = "running";
     job.startedAt = new Date().toISOString();
 
-    setImmediate(() => {
+    setImmediate(async () => {
+      let s3Key: string | undefined;
       try {
-        job.url = "/placeholder.glb";
+        if (typeof (db as any).createJob === "function") {
+          const created = await (db as any).createJob({
+            user_id: job.userId,
+            prompt: job.prompt,
+            source: job.source,
+            created_at: job.startedAt,
+          });
+          job.dbJobId = created?.id || created?.job_id || created?.jobId;
+        }
+
+        let model = await generateModel({
+          prompt: job.prompt,
+          image: job.image,
+        });
+        model = await preserveColors(model);
+        const uploadResult = await uploadS3(model);
+        job.url = uploadResult.url;
+        s3Key = uploadResult.key;
+        job.s3Key = s3Key;
+
+        if (job.dbJobId && typeof (db as any).linkModelToJob === "function") {
+          await (db as any).linkModelToJob(job.dbJobId, s3Key);
+        }
+        if (typeof (db as any).insertGenerationLog === "function") {
+          await (db as any).insertGenerationLog({
+            jobId: job.dbJobId,
+            userId: job.userId,
+            prompt: job.prompt ?? "image",
+            source: job.source,
+            startTime: job.startedAt,
+            finishTime: new Date().toISOString(),
+            s3Key,
+            url: job.url,
+          });
+        }
+
         job.state = "succeeded";
         job.finishedAt = new Date().toISOString();
-        emitter.emit(`complete:${job.id}`, { ...job });
+        emitter.emit(`complete:${job.id}`, {
+          jobId: job.id,
+          url: job.url,
+          s3Key,
+        });
+        logger.info("generate_success", {
+          jobId: job.id,
+          userId: job.userId,
+          source: job.source,
+          s3Key,
+        });
       } catch (err) {
-        job.error = (err as Error).message;
+        const stage = s3Key ? "upload" : "generation";
+        const code = stage === "upload" ? "upload_failed" : "model_error";
+        job.error = code;
         job.state = "failed";
         job.finishedAt = new Date().toISOString();
-        emitter.emit(`fail:${job.id}`, { ...job });
+        if (typeof (db as any).insertGenerationLog === "function") {
+          await (db as any).insertGenerationLog({
+            jobId: job.dbJobId,
+            userId: job.userId,
+            prompt: job.prompt ?? "image",
+            source: job.source,
+            startTime: job.startedAt,
+            finishTime: job.finishedAt,
+          });
+        }
+        logger.error("generate_failed", { stage, userId: job.userId, code });
+        logError(err);
+        emitter.emit(`fail:${job.id}`, { jobId: job.id, error: code });
       } finally {
         inFlight.delete(job.userId);
         processNext();
@@ -59,23 +131,29 @@ function processNext() {
   }
 }
 
-export async function enqueue(job: GenerationJob): Promise<{ id: string }> {
+export async function enqueue(
+  userId: string,
+  payload: GenerationPayload,
+): Promise<{ jobId: string }> {
   const id = randomUUID();
-  const record: InternalJob = { ...job, id, state: "queued" };
+  const record: InternalJob = { userId, ...payload, id, state: "queued" };
   queue.push(record);
   jobs.set(id, record);
   processNext();
-  return { id };
+  return { jobId: id };
 }
 
 export function onComplete(
   id: string,
-  cb: (status: GenerationJobStatus) => void,
-) {
+  cb: (result: { jobId: string; url: string; s3Key?: string }) => void,
+): void {
   emitter.once(`complete:${id}`, cb);
 }
 
-export function onFail(id: string, cb: (status: GenerationJobStatus) => void) {
+export function onFail(
+  id: string,
+  cb: (result: { jobId: string; error: string }) => void,
+): void {
   emitter.once(`fail:${id}`, cb);
 }
 

--- a/backend/src/routes/generate.ts
+++ b/backend/src/routes/generate.ts
@@ -1,12 +1,9 @@
 import { Router, type Request } from "express";
 import multer from "multer";
-import * as db from "../db.js";
 import { userIdFromAuth } from "../lib/auth";
-import { generateModel } from "../lib/generateModel";
-import { preserveColors } from "../lib/preserveColors";
-import { uploadS3 } from "../lib/uploadS3";
 import { logError } from "../lib/logError";
 import logger from "../logger.js";
+import { enqueue, onComplete, onFail } from "../queue/generation";
 
 const upload = multer();
 const router = Router();
@@ -29,7 +26,8 @@ function throwValidation(code: string, status = 400): never {
 
 function validateInput(req: Request): ValidationResult {
   if (req.is("application/json")) {
-    const raw = typeof req.body?.prompt === "string" ? req.body.prompt.trim() : "";
+    const raw =
+      typeof req.body?.prompt === "string" ? req.body.prompt.trim() : "";
     if (!raw) throwValidation("missing_or_ambiguous_input");
     if (raw.length < 1 || raw.length > 400) throwValidation("invalid_prompt");
     return { prompt: raw, source: "prompt" };
@@ -40,19 +38,22 @@ function validateInput(req: Request): ValidationResult {
       throwValidation("payload_too_large", 413);
     }
     if (!req.file) throwValidation("missing_or_ambiguous_input");
-    const raw = typeof req.body?.prompt === "string" ? req.body.prompt.trim() : undefined;
-    if (raw && (raw.length < 1 || raw.length > 400)) throwValidation("invalid_prompt");
-    // If both prompt and image are provided, prefer image as the source and pass prompt metadata.
-    return { prompt: raw, image: req.file.buffer.toString("base64"), source: "image" };
+    const raw =
+      typeof req.body?.prompt === "string" ? req.body.prompt.trim() : undefined;
+    if (raw && (raw.length < 1 || raw.length > 400))
+      throwValidation("invalid_prompt");
+    return {
+      prompt: raw,
+      image: req.file.buffer.toString("base64"),
+      source: "image",
+    };
   }
   throwValidation("unsupported_media_type", 415);
 }
 
 router.post("/generate", upload.single("image"), async (req, res) => {
-  const userId = userIdFromAuth(req) || null;
-  const start = Date.now();
+  const userId = userIdFromAuth(req) || "";
   let jobId: string | undefined;
-  let s3Key: string | undefined;
   let parsed: ValidationResult;
 
   try {
@@ -75,58 +76,41 @@ router.post("/generate", upload.single("image"), async (req, res) => {
   const { prompt, image, source } = parsed;
 
   try {
-    if (typeof (db as any).createJob === "function") {
-      const job = await (db as any).createJob({
-        user_id: userId,
-        prompt,
-        source,
-        created_at: new Date(start).toISOString(),
-      });
-      jobId = job?.id || job?.job_id || job?.jobId;
-    }
-
-    let model = await generateModel({ prompt, image });
-    model = await preserveColors(model);
-    const uploadResult = await uploadS3(model);
-    const { url, key } = uploadResult;
-    s3Key = key;
-
-    if (jobId && typeof (db as any).linkModelToJob === "function") {
-      await (db as any).linkModelToJob(jobId, key);
-    }
-    if (typeof (db as any).insertGenerationLog === "function") {
-      await (db as any).insertGenerationLog({
-        jobId,
-        userId,
-        prompt: prompt ?? "image",
-        source,
-        startTime: new Date(start).toISOString(),
-        finishTime: new Date().toISOString(),
-        s3Key: key,
-        url,
-      });
-    }
-
-    logger.info("generate_success", { jobId, userId, source, s3Key: key });
-    res.json({ jobId, url });
+    const queued = await enqueue(userId, { prompt, image, source });
+    jobId = queued.jobId;
+    const result = await new Promise<{ url: string; s3Key?: string }>(
+      (resolve, reject) => {
+        const timer = setTimeout(() => {
+          const err = new Error("timeout");
+          (err as any).code = "timeout";
+          reject(err);
+        }, 30_000);
+        onComplete(jobId!, (r) => {
+          clearTimeout(timer);
+          resolve(r);
+        });
+        onFail(jobId!, (r) => {
+          clearTimeout(timer);
+          const err = new Error(r.error);
+          (err as any).code = r.error;
+          reject(err);
+        });
+      },
+    );
+    logger.info("generate_success", {
+      jobId,
+      userId,
+      source,
+      s3Key: result.s3Key,
+    });
+    res.json({ jobId, url: result.url });
   } catch (err) {
-    const stage = s3Key ? "upload" : "generation";
-    const code = stage === "upload" ? "upload_failed" : "model_error";
-    logger.error("generate_failed", { stage, userId, code: (err as any).code });
+    const code = (err as any).code || "model_error";
+    logger.error("generate_failed", { stage: "queue", userId, code });
     logError(err);
     if (process.env.CI_REQUIRE_EXTERNAL === "true") {
       res.status(502).json({ error: code });
       return;
-    }
-    if (typeof (db as any).insertGenerationLog === "function") {
-      await (db as any).insertGenerationLog({
-        jobId,
-        userId,
-        prompt: prompt ?? "image",
-        source,
-        startTime: new Date(start).toISOString(),
-        finishTime: new Date().toISOString(),
-      });
     }
     res.json({ jobId: jobId || FALLBACK_JOB_ID, url: "/fallback.glb" });
   }

--- a/backend/tests/queue.generate.integration.spec.ts
+++ b/backend/tests/queue.generate.integration.spec.ts
@@ -1,0 +1,79 @@
+import request from "supertest";
+import jwt from "jsonwebtoken";
+
+jest.mock("../src/lib/generateModel", () => ({
+  generateModel: jest
+    .fn()
+    .mockImplementationOnce(
+      () =>
+        new Promise<Buffer>((resolve) =>
+          setTimeout(() => resolve(Buffer.from("a")), 80),
+        ),
+    )
+    .mockImplementationOnce(
+      () =>
+        new Promise<Buffer>((resolve) =>
+          setTimeout(() => resolve(Buffer.from("b")), 10),
+        ),
+    ),
+}));
+
+jest.mock("../src/lib/preserveColors", () => ({
+  preserveColors: jest.fn(async (b: Buffer) => b),
+}));
+
+jest.mock("../src/lib/uploadS3", () => ({
+  uploadS3: jest.fn().mockResolvedValue({
+    url: "https://mock.url/model.glb",
+    key: "k",
+  }),
+}));
+
+jest.mock("../src/db.js", () => ({
+  createJob: jest.fn(),
+  linkModelToJob: jest.fn(),
+  insertGenerationLog: jest.fn(),
+}));
+
+const app = require("../src/app");
+const queue = require("../src/queue/generation");
+const db = require("../db");
+(db as any).query = jest.fn();
+const { generateModel } = require("../src/lib/generateModel");
+const { uploadS3 } = require("../src/lib/uploadS3");
+
+describe("generate route queue integration", () => {
+  test("serializes per-user and updates status", async () => {
+    const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
+    const order: string[] = [];
+
+    const req1 = request(app)
+      .post("/api/generate")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ prompt: "one" })
+      .then((res) => {
+        order.push("first");
+        return res;
+      });
+    const req2 = request(app)
+      .post("/api/generate")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ prompt: "two" })
+      .then((res) => {
+        order.push("second");
+        return res;
+      });
+
+    const [res1, res2] = await Promise.all([req1, req2]);
+
+    expect(order).toEqual(["first", "second"]);
+    expect(res1.status).toBe(200);
+    expect(res2.status).toBe(200);
+    expect(generateModel).toHaveBeenCalledTimes(2);
+    expect(uploadS3).toHaveBeenCalledTimes(2);
+    expect((db as any).query).not.toHaveBeenCalled();
+
+    const status2 = await request(app).get(`/api/status/${res2.body.jobId}`);
+    expect(status2.body.state).toBe("succeeded");
+  }, 30000);
+});


### PR DESCRIPTION
## Summary
- funnel /api/generate requests through in-process queue
- extend generation worker to run pipeline and emit job results
- add integration test exercising queue serialization and status updates

## Testing
- `npm test --prefix backend -- backend/tests/queue.generate.integration.spec.ts`
- `PORT=3001 STRIPE_SECRET_KEY=sk_test_123 STRIPE_PUBLISHABLE_KEY=pk_test_123 npm start --prefix backend & sleep 5; curl -s -o /dev/null -w "%{http_code}\n" http://localhost:3001/healthz; kill %1`


------
https://chatgpt.com/codex/tasks/task_e_68ae42988598832d8c2e40a0b7e7ae9e