### PR TITLE
feat: handle queued model generation

### DIFF
--- a/js/modelGenerator.js
+++ b/js/modelGenerator.js
@@ -1,11 +1,11 @@
-import React, { useState } from "https://esm.sh/react@18";
-import { createRoot } from "https://esm.sh/react-dom@18/client";
+import React, { useState } from "react";
+import { createRoot } from "react-dom/client";
 import useGenerateModel from "./useGenerateModel.js";
 import ModelViewer from "./ModelViewer.js";
 
-function GeneratorApp() {
+export function GeneratorApp() {
   const [prompt, setPrompt] = useState("");
-  const { generate, loading, modelUrl, error } = useGenerateModel();
+  const { generate, loading, modelUrl } = useGenerateModel();
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -34,23 +34,26 @@ function GeneratorApp() {
           type: "submit",
           className: "px-4 py-2 bg-blue-600 text-white rounded",
           disabled: loading,
+          "data-testid": "generate-btn",
         },
         loading ? "Generating..." : "Generate 3D",
       ),
     ),
     loading &&
-      React.createElement("div", {
-        className:
-          "animate-spin h-8 w-8 border-4 border-blue-500 border-t-transparent rounded-full",
-      }),
-    error && React.createElement("p", { className: "text-red-500" }, error),
+      React.createElement(
+        "div",
+        { "data-testid": "queue-state" },
+        React.createElement("div", {
+          className:
+            "animate-spin h-8 w-8 border-4 border-blue-500 border-t-transparent rounded-full",
+        }),
+      ),
     modelUrl &&
       React.createElement(
-        "p",
-        { id: "gen-success", className: "text-green-500" },
-        "Model generated!",
+        "div",
+        { "data-testid": "viewer" },
+        React.createElement(ModelViewer, { url: modelUrl }),
       ),
-    modelUrl && React.createElement(ModelViewer, { url: modelUrl }),
   );
 }
 

--- a/js/toast.js
+++ b/js/toast.js
@@ -1,0 +1,9 @@
+export default function toast(message) {
+  const el = document.createElement("div");
+  el.textContent = message;
+  el.className = "fixed top-4 right-4 bg-red-600 text-white px-4 py-2 rounded";
+  document.body.appendChild(el);
+  setTimeout(() => {
+    el.remove();
+  }, 3000);
+}

--- a/js/useGenerateModel.js
+++ b/js/useGenerateModel.js
@@ -1,13 +1,11 @@
-import React, { useState } from "https://esm.sh/react@18";
+import React, { useState } from "react";
+import toast from "./toast.js";
 
 export default function useGenerateModel() {
   const [loading, setLoading] = useState(false);
   const [modelUrl, setModelUrl] = useState(null);
-  const [error, setError] = useState(null);
-
   const generate = async (prompt) => {
     setLoading(true);
-    setError(null);
     setModelUrl(null);
     try {
       const res = await fetch("/api/generate", {
@@ -17,13 +15,29 @@ export default function useGenerateModel() {
       });
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || "Request failed");
-      setModelUrl(data.glb_url);
+
+      if (data.url) {
+        setModelUrl(data.url);
+      } else {
+        let state = "running";
+        let status;
+        while (state === "running") {
+          const resStatus = await fetch(`/api/status/${data.jobId}`);
+          status = await resStatus.json();
+          state = status.state;
+        }
+        if (state === "succeeded" && status.url) {
+          setModelUrl(status.url);
+        } else {
+          throw new Error("failed");
+        }
+      }
     } catch (err) {
-      setError(err.message || "Error generating model");
+      toast("Model generation failed. Please try again.");
     } finally {
       setLoading(false);
     }
   };
 
-  return { generate, loading, modelUrl, error };
+  return { generate, loading, modelUrl };
 }

--- a/tests/frontend/generate-queue.b9f4c2d8a7e5f1g0.spec.js
+++ b/tests/frontend/generate-queue.b9f4c2d8a7e5f1g0.spec.js
@@ -1,0 +1,79 @@
+/** @jest-environment jsdom */
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { GeneratorApp } from "../../js/modelGenerator.js";
+import toast from "../../js/toast.js";
+
+jest.mock("../../js/toast.js", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+jest.mock("../../js/ModelViewer.js", () => {
+  const React = require("react");
+  return {
+    __esModule: true,
+    default: () => React.createElement("div"),
+  };
+});
+
+describe("generate queue", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test("success path", async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ jobId: "j_1" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ state: "running" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ state: "succeeded", url: "/m.glb" }),
+      });
+    global.fetch = fetchMock;
+
+    render(<GeneratorApp />);
+    fireEvent.change(screen.getByPlaceholderText("Enter prompt"), {
+      target: { value: "a" },
+    });
+    fireEvent.click(screen.getByTestId("generate-btn"));
+
+    expect(screen.getByTestId("generate-btn")).toBeDisabled();
+    expect(screen.getByTestId("queue-state")).toBeInTheDocument();
+
+    await screen.findByTestId("viewer");
+  });
+
+  test("failure path", async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ jobId: "j_1" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ state: "failed" }),
+      });
+    global.fetch = fetchMock;
+
+    render(<GeneratorApp />);
+    fireEvent.change(screen.getByPlaceholderText("Enter prompt"), {
+      target: { value: "a" },
+    });
+    fireEvent.click(screen.getByTestId("generate-btn"));
+
+    await waitFor(() => {
+      expect(toast).toHaveBeenCalledWith(
+        "Model generation failed. Please try again.",
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add generate button and queue state test ids
- poll job status until model succeeds and toast on failure
- cover queued model generation with tests

## Testing
- `npm run format -- js/modelGenerator.js js/useGenerateModel.js js/toast.js tests/frontend/generate-queue.*.spec.js`
- `node scripts/run-jest.js tests/frontend/generate-queue.*.spec.js`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68aed1fc9538832d9e86f729976d8b55