### PR TITLE
feat: expose print worker health

### DIFF
--- a/backend/__tests__/worker-health.test.v9k2n4b7x8m5c1p6.ts
+++ b/backend/__tests__/worker-health.test.v9k2n4b7x8m5c1p6.ts
@@ -1,0 +1,23 @@
+import request from "supertest";
+
+jest.mock("../queue/printWorker", () => ({
+  isReady: jest.fn(),
+}));
+
+const { isReady } = require("../queue/printWorker");
+const app = require("../server");
+
+test("reports ready state", async () => {
+  isReady.mockReturnValue(true);
+  const res = await request(app).get("/api/worker/health");
+  expect(res.status).toBe(200);
+  expect(res.body).toEqual({ ok: true, ready: true });
+});
+
+test("reports unready state", async () => {
+  isReady.mockReturnValue(false);
+  const res = await request(app).get("/api/worker/health");
+  expect(res.status).toBe(200);
+  expect(res.body).toEqual({ ok: true, ready: false });
+});
+

--- a/backend/queue/printWorker.js
+++ b/backend/queue/printWorker.js
@@ -15,6 +15,12 @@ const OCTOPRINT_API_KEY = process.env.OCTOPRINT_API_KEY || "";
 const POLL_INTERVAL_MS = 5000;
 const FILAMENT_GRAMS = parseFloat(process.env.FILAMENT_GRAMS_PER_PRINT || "25");
 
+let ready = false;
+
+function isReady() {
+  return ready;
+}
+
 async function getNextPendingJob(client) {
   const { rows } = await client.query(
     `SELECT j.job_id
@@ -123,17 +129,35 @@ async function processNextJob(client) {
   ]);
 }
 
+async function connectWithRetry(client) {
+  const start = Date.now();
+  let delay = 2000;
+  while (true) {
+    try {
+      await client.connect();
+      ready = true;
+      return;
+    } catch (err) {
+      logger.error("DB connection failed", err);
+      await new Promise((r) => setTimeout(r, delay));
+      if (Date.now() - start >= 60000) {
+        delay = 10000;
+      }
+    }
+  }
+}
+
 async function run(interval = POLL_INTERVAL_MS) {
+  logger.info("=== printWorker starting ===");
   const client = new Client({ connectionString: process.env.DB_URL });
-  await client.connect();
+  await connectWithRetry(client);
   setInterval(() => {
     processNextJob(client).catch((err) => logger.error("Worker error", err));
   }, interval);
 }
 
 if (require.main === module) {
-  console.log("printWorker started");
-  run();
+  run().catch((err) => logger.error("Worker failed to start", err));
 }
 
-module.exports = { run, processNextJob };
+module.exports = { run, processNextJob, isReady };

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -117,6 +117,15 @@ try {
   console.error("Failed to load payments router", err);
 }
 
+try {
+  (() => {
+    const r = require("./routes/worker");
+    app.use("/api", r.default || r);
+  })();
+} catch (err) {
+  console.error("Failed to load worker router", err);
+}
+
 app.use((err, req, res, _next) => {
   const context = { method: req.method, url: req.originalUrl, body: req.body };
   try {

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -121,6 +121,15 @@ try {
 
 try {
   (() => {
+    const r = require("./routes/worker");
+    app.use("/api", r.default || r);
+  })();
+} catch (err) {
+  console.error("Failed to load worker router", err);
+}
+
+try {
+  (() => {
     const r = require("./routes/status");
     app.use("/api", r.default || r);
   })();

--- a/backend/src/routes/worker.js
+++ b/backend/src/routes/worker.js
@@ -1,0 +1,9 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const express_1 = require("express");
+const printWorker_1 = require("../../queue/printWorker");
+const router = (0, express_1.Router)();
+router.get("/worker/health", (_req, res) => {
+  res.json({ ok: true, ready: (0, printWorker_1.isReady)() });
+});
+exports.default = router;

--- a/backend/src/routes/worker.ts
+++ b/backend/src/routes/worker.ts
@@ -1,0 +1,11 @@
+import { Router } from "express";
+import { isReady } from "../../queue/printWorker";
+
+const router = Router();
+
+router.get("/worker/health", (_req, res) => {
+  res.json({ ok: true, ready: isReady() });
+});
+
+export default router;
+


### PR DESCRIPTION
## Summary
- add resilient DB connection with readiness tracking to print worker
- provide `/api/worker/health` endpoint
- test worker health endpoint for ready and unready states

## Testing
- `npm run format`
- `npm test` *(fails: Expected 200, Received 404, etc.)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Invalid lockfile packages)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68aee0dcef38832db83bc1a1aa192804