### PR TITLE
feat: queue generation with status polling

### DIFF
--- a/backend/src/routes/generate.js
+++ b/backend/src/routes/generate.js
@@ -1,61 +1,89 @@
 const { Router } = require("express");
 const multer = require("multer");
-const db = require("../db.js");
 const { userIdFromAuth } = require("../lib/auth.js");
-const { generateModel } = require("../lib/generateModel.js");
-const { preserveColors } = require("../lib/preserveColors.js");
-const { uploadS3 } = require("../lib/uploadS3.js");
 const { logError } = require("../lib/logError.js");
+const logger = require("../logger.js");
+const { enqueue, getStatus } = require("../queue/generation");
+
 const upload = multer();
 const router = Router();
+
+const MAX_IMAGE_SIZE = 6 * 1024 * 1024; // ~6MB
+
+function throwValidation(code, status = 400) {
+  const err = new Error(code);
+  err.status = status;
+  err.code = code;
+  throw err;
+}
+
+function validateInput(req) {
+  if (req.is("application/json")) {
+    const raw =
+      typeof req.body?.prompt === "string" ? req.body.prompt.trim() : "";
+    if (!raw) throwValidation("missing_or_ambiguous_input");
+    if (raw.length < 1 || raw.length > 400) throwValidation("invalid_prompt");
+    return { prompt: raw, source: "prompt" };
+  }
+  if (req.is("multipart/form-data")) {
+    const length = Number(req.headers["content-length"] || 0);
+    if (!Number.isNaN(length) && length > MAX_IMAGE_SIZE) {
+      throwValidation("payload_too_large", 413);
+    }
+    if (!req.file) throwValidation("missing_or_ambiguous_input");
+    const raw =
+      typeof req.body?.prompt === "string" ? req.body.prompt.trim() : undefined;
+    if (raw && (raw.length < 1 || raw.length > 400))
+      throwValidation("invalid_prompt");
+    return {
+      prompt: raw,
+      image: req.file.buffer.toString("base64"),
+      source: "image",
+    };
+  }
+  throwValidation("unsupported_media_type", 415);
+}
+
 router.post("/generate", upload.single("image"), async (req, res) => {
-  const prompt =
-    typeof (req.body && req.body.prompt) === "string"
-      ? req.body.prompt
-      : undefined;
-  const image = req.file ? req.file.buffer.toString("base64") : undefined;
-  if (!prompt && !image) {
-    res.status(400).json({ error: "bad_request" });
+  const userId = userIdFromAuth(req) || "";
+  let parsed;
+  try {
+    parsed = validateInput(req);
+  } catch (err) {
+    const code = err.code;
+    const status = err.status || 400;
+    logger.error("generate_failed", { stage: "validation", userId, code });
+    logError(err);
+    if (code === "unsupported_media_type") {
+      res.status(415).json({ error: "unsupported_media_type" });
+    } else if (code === "payload_too_large") {
+      res.status(413).json({ error: "payload_too_large" });
+    } else {
+      res.status(400).json({ error: "bad_request", reason: code });
+    }
     return;
   }
-  const userId = userIdFromAuth(req);
-  let jobId;
-  const start = Date.now();
+
+  const { prompt, image, source } = parsed;
   try {
-    if (typeof db.createJob === "function") {
-      const job = await db.createJob({
-        user_id: userId,
-        prompt,
-        source: image ? "image" : "prompt",
-        created_at: new Date(start).toISOString(),
-      });
-      jobId = job && (job.id || job.job_id || job.jobId);
-    }
-    const model = await generateModel({ prompt, image });
-    const colored = await preserveColors(model);
-    const { url, key } = await uploadS3(colored);
-    if (jobId && typeof db.linkModelToJob === "function") {
-      await db.linkModelToJob(jobId, key);
-    }
-    if (typeof db.insertGenerationLog === "function") {
-      await db.insertGenerationLog({
-        jobId,
-        prompt,
-        source: image ? "image" : "prompt",
-        startTime: new Date(start).toISOString(),
-        finishTime: new Date().toISOString(),
-        s3Key: key,
-        url,
-      });
-    }
-    res.json({ jobId, url });
+    const queued = await enqueue(userId, { prompt, image, source });
+    logger.info("generate_queued", { jobId: queued.jobId, userId, source });
+    res.json({ jobId: queued.jobId });
   } catch (err) {
+    const code = err.code || "queue_error";
+    logger.error("generate_failed", { stage: "queue", userId, code });
     logError(err);
-    if (process.env.CI_REQUIRE_EXTERNAL) {
-      res.status(500).json({ error: "Generation failed" });
-      return;
-    }
-    res.json({ jobId, url: "/fallback.glb" });
+    res.status(502).json({ error: code });
   }
 });
+
+router.get("/status/:id", (req, res) => {
+  const status = getStatus(req.params.id);
+  if (!status) {
+    res.status(404).json({ error: "not_found" });
+    return;
+  }
+  res.json(status);
+});
+
 module.exports = router;

--- a/backend/src/routes/generate.ts
+++ b/backend/src/routes/generate.ts
@@ -3,13 +3,12 @@ import multer from "multer";
 import { userIdFromAuth } from "../lib/auth";
 import { logError } from "../lib/logError";
 import logger from "../logger.js";
-import { enqueue, onComplete, onFail } from "../queue/generation";
+import { enqueue, getStatus } from "../queue/generation";
 
 const upload = multer();
 const router = Router();
 
 const MAX_IMAGE_SIZE = 6 * 1024 * 1024; // ~6MB
-const FALLBACK_JOB_ID = "00000000-0000-0000-0000-000000000000";
 
 interface ValidationResult {
   prompt?: string;
@@ -78,42 +77,23 @@ router.post("/generate", upload.single("image"), async (req, res) => {
   try {
     const queued = await enqueue(userId, { prompt, image, source });
     jobId = queued.jobId;
-    const result = await new Promise<{ url: string; s3Key?: string }>(
-      (resolve, reject) => {
-        const timer = setTimeout(() => {
-          const err = new Error("timeout");
-          (err as any).code = "timeout";
-          reject(err);
-        }, 30_000);
-        onComplete(jobId!, (r) => {
-          clearTimeout(timer);
-          resolve(r);
-        });
-        onFail(jobId!, (r) => {
-          clearTimeout(timer);
-          const err = new Error(r.error);
-          (err as any).code = r.error;
-          reject(err);
-        });
-      },
-    );
-    logger.info("generate_success", {
-      jobId,
-      userId,
-      source,
-      s3Key: result.s3Key,
-    });
-    res.json({ jobId, url: result.url });
+    logger.info("generate_queued", { jobId, userId, source });
+    res.json({ jobId });
   } catch (err) {
-    const code = (err as any).code || "model_error";
+    const code = (err as any).code || "queue_error";
     logger.error("generate_failed", { stage: "queue", userId, code });
     logError(err);
-    if (process.env.CI_REQUIRE_EXTERNAL === "true") {
-      res.status(502).json({ error: code });
-      return;
-    }
-    res.json({ jobId: jobId || FALLBACK_JOB_ID, url: "/fallback.glb" });
+    res.status(502).json({ error: code });
   }
+});
+
+router.get("/status/:id", (req, res) => {
+  const status = getStatus(req.params.id);
+  if (!status) {
+    res.status(404).json({ error: "not_found" });
+    return;
+  }
+  res.json(status);
 });
 
 export default router;

--- a/js/modelGenerator.js
+++ b/js/modelGenerator.js
@@ -5,7 +5,7 @@ import ModelViewer from "./ModelViewer.js";
 
 export function GeneratorApp() {
   const [prompt, setPrompt] = useState("");
-  const { generate, loading, modelUrl } = useGenerateModel();
+  const { generate, loading, modelUrl, position } = useGenerateModel();
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -47,6 +47,12 @@ export function GeneratorApp() {
           className:
             "animate-spin h-8 w-8 border-4 border-blue-500 border-t-transparent rounded-full",
         }),
+        position !== null &&
+          React.createElement(
+            "p",
+            { className: "mt-2" },
+            `Position: ${position}`,
+          ),
       ),
     modelUrl &&
       React.createElement(

--- a/js/useGenerateModel.js
+++ b/js/useGenerateModel.js
@@ -4,9 +4,11 @@ import toast from "./toast.js";
 export default function useGenerateModel() {
   const [loading, setLoading] = useState(false);
   const [modelUrl, setModelUrl] = useState(null);
+  const [position, setPosition] = useState(null);
   const generate = async (prompt) => {
     setLoading(true);
     setModelUrl(null);
+    setPosition(null);
     try {
       const res = await fetch("/api/generate", {
         method: "POST",
@@ -16,28 +18,29 @@ export default function useGenerateModel() {
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || "Request failed");
 
-      if (data.url) {
-        setModelUrl(data.url);
+      let state = "queued";
+      let status;
+      while (state === "queued" || state === "running") {
+        const resStatus = await fetch(`/api/status/${data.jobId}`);
+        status = await resStatus.json();
+        state = status.state;
+        setPosition(status.position ?? null);
+        if (state === "queued" || state === "running") {
+          await new Promise((r) => setTimeout(r, 1000));
+        }
+      }
+      if (state === "succeeded" && status.url) {
+        setModelUrl(status.url);
       } else {
-        let state = "running";
-        let status;
-        while (state === "running") {
-          const resStatus = await fetch(`/api/status/${data.jobId}`);
-          status = await resStatus.json();
-          state = status.state;
-        }
-        if (state === "succeeded" && status.url) {
-          setModelUrl(status.url);
-        } else {
-          throw new Error("failed");
-        }
+        throw new Error(status.error || "failed");
       }
     } catch (err) {
       toast("Model generation failed. Please try again.");
     } finally {
       setLoading(false);
+      setPosition(null);
     }
   };
 
-  return { generate, loading, modelUrl };
+  return { generate, loading, modelUrl, position };
 }

--- a/tests/frontend/generate-queue.b9f4c2d8a7e5f1g0.spec.js
+++ b/tests/frontend/generate-queue.b9f4c2d8a7e5f1g0.spec.js
@@ -13,7 +13,7 @@ jest.mock("../../js/ModelViewer.js", () => {
   const React = require("react");
   return {
     __esModule: true,
-    default: () => React.createElement("div"),
+    default: ({ url }) => React.createElement("div", { "data-url": url }),
   };
 });
 
@@ -22,7 +22,7 @@ describe("generate queue", () => {
     jest.resetAllMocks();
   });
 
-  test("success path", async () => {
+  test("button disables during generation and re-enables after success", async () => {
     const fetchMock = jest
       .fn()
       .mockResolvedValueOnce({
@@ -31,7 +31,7 @@ describe("generate queue", () => {
       })
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ state: "running" }),
+        json: async () => ({ state: "queued", position: 2 }),
       })
       .mockResolvedValueOnce({
         ok: true,
@@ -43,15 +43,18 @@ describe("generate queue", () => {
     fireEvent.change(screen.getByPlaceholderText("Enter prompt"), {
       target: { value: "a" },
     });
-    fireEvent.click(screen.getByTestId("generate-btn"));
-
-    expect(screen.getByTestId("generate-btn")).toBeDisabled();
-    expect(screen.getByTestId("queue-state")).toBeInTheDocument();
-
-    await screen.findByTestId("viewer");
+    const btn = screen.getByTestId("generate-btn");
+    fireEvent.click(btn);
+    expect(btn).toBeDisabled();
+    await screen.findByText("Position: 2");
+    await screen.findByTestId("viewer", { timeout: 3000 });
+    expect(
+      screen.getByTestId("viewer").querySelector('[data-url="/m.glb"]'),
+    ).toBeInTheDocument();
+    await waitFor(() => expect(btn).not.toBeDisabled());
   });
 
-  test("failure path", async () => {
+  test("failure shows toast and allows retry", async () => {
     const fetchMock = jest
       .fn()
       .mockResolvedValueOnce({
@@ -60,20 +63,32 @@ describe("generate queue", () => {
       })
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ state: "failed" }),
+        json: async () => ({ state: "failed", error: "boom" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ jobId: "j_2" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ state: "succeeded", url: "/ok.glb" }),
       });
     global.fetch = fetchMock;
 
     render(<GeneratorApp />);
-    fireEvent.change(screen.getByPlaceholderText("Enter prompt"), {
-      target: { value: "a" },
-    });
-    fireEvent.click(screen.getByTestId("generate-btn"));
+    const input = screen.getByPlaceholderText("Enter prompt");
+    fireEvent.change(input, { target: { value: "c" } });
+    const btn = screen.getByTestId("generate-btn");
+    fireEvent.click(btn);
 
     await waitFor(() => {
       expect(toast).toHaveBeenCalledWith(
         "Model generation failed. Please try again.",
       );
     });
+    expect(btn).not.toBeDisabled();
+
+    fireEvent.click(btn);
+    await screen.findByTestId("viewer", { timeout: 3000 });
   });
 });


### PR DESCRIPTION
## Summary
- enqueue `/api/generate` jobs and expose `/api/status/:id`
- poll generation status in `useGenerateModel` and show queue position
- add tests for queue UI success and failure

## Testing
- `npx prettier --write backend/src/routes/generate.ts backend/src/routes/generate.js js/useGenerateModel.js js/modelGenerator.js tests/frontend/generate-queue.b9f4c2d8a7e5f1g0.spec.js`
- `node scripts/run-jest.js tests/frontend/generate-queue.b9f4c2d8a7e5f1g0.spec.js`
- `npm run ci` *(fails: lock file's concurrently@9.2.0 does not satisfy concurrently@9.2.1)*
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68aee7e2eabc832d846e9fdafd960e4f