### PR TITLE
feat: add db job queue worker

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -12,6 +12,7 @@
     "start": "node src/server.js",
     "start:api": "node src/server.js",
     "start:worker": "node -r dotenv/config queue/printWorker.js",
+    "start:job-queue": "node -r dotenv/config queue/jobQueue.js",
     "dev": "node src/server.js",
     "dev:worker": "NODE_ENV=development node -r dotenv/config queue/printWorker.js",
     "init-db": "node scripts/init-db.js",

--- a/backend/queue/jobQueue.js
+++ b/backend/queue/jobQueue.js
@@ -1,3 +1,4 @@
+require("dotenv").config();
 const db = require("../db");
 
 async function getNextPendingJob() {
@@ -34,3 +35,7 @@ module.exports = {
   getNextPendingJob,
   updateJobStatus,
 };
+
+if (require.main === module) {
+  startProcessing();
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 services:
   api:
     build: ./
@@ -10,7 +10,13 @@ services:
     depends_on:
       - db
     env_file: .env
-    command: ["npm","run","start:worker"]
+    command: ["npm", "run", "start:worker"]
+  db-worker:
+    build: ./
+    depends_on:
+      - db
+    env_file: .env
+    command: ["npm", "run", "start:job-queue"]
   db:
     image: postgres:15
     environment:


### PR DESCRIPTION
## Summary
- enable job queue worker to self-start and load env config
- expose job queue worker through new start script
- run job queue worker in docker-compose via new service

## Testing
- `npm run format` (errors ignored)
- `npm test` (fails: 404 from API endpoints)
- `SKIP_PW_DEPS=1 npm run ci` (fails: lock file out of sync)
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68aeeffccab0832d9041d5db03aa1650