### PR TITLE
feat: add progress SSE endpoint

### DIFF
--- a/backend/src/queue/generation.ts
+++ b/backend/src/queue/generation.ts
@@ -42,6 +42,15 @@ const jobs = new Map<string, InternalJob>();
 const inFlight = new Map<string, string>();
 const emitter = new EventEmitter();
 
+function emitStatus(job: InternalJob): void {
+  const status = getStatus(job.id);
+  if (status) emitter.emit(`progress:${job.id}`, status);
+}
+
+function broadcastQueue(): void {
+  for (const j of queue) emitStatus(j);
+}
+
 function processNext() {
   let index = queue.findIndex((j) => !inFlight.has(j.userId));
   while (index !== -1) {
@@ -49,6 +58,8 @@ function processNext() {
     inFlight.set(job.userId, job.id);
     job.state = "running";
     job.startedAt = new Date().toISOString();
+    emitStatus(job);
+    broadcastQueue();
 
     setImmediate(async () => {
       let s3Key: string | undefined;
@@ -122,7 +133,9 @@ function processNext() {
         logError(err);
         emitter.emit(`fail:${job.id}`, { jobId: job.id, error: code });
       } finally {
+        emitStatus(job);
         inFlight.delete(job.userId);
+        broadcastQueue();
         processNext();
       }
     });
@@ -139,6 +152,7 @@ export async function enqueue(
   const record: InternalJob = { userId, ...payload, id, state: "queued" };
   queue.push(record);
   jobs.set(id, record);
+  emitStatus(record);
   processNext();
   return { jobId: id };
 }

--- a/backend/src/routes/generate.ts
+++ b/backend/src/routes/generate.ts
@@ -3,7 +3,7 @@ import multer from "multer";
 import { userIdFromAuth } from "../lib/auth";
 import { logError } from "../lib/logError";
 import logger from "../logger.js";
-import { enqueue, getStatus } from "../queue/generation";
+import { enqueue } from "../queue/generation";
 
 const upload = multer();
 const router = Router();
@@ -85,15 +85,6 @@ router.post("/generate", upload.single("image"), async (req, res) => {
     logError(err);
     res.status(502).json({ error: code });
   }
-});
-
-router.get("/status/:id", (req, res) => {
-  const status = getStatus(req.params.id);
-  if (!status) {
-    res.status(404).json({ error: "not_found" });
-    return;
-  }
-  res.json(status);
 });
 
 export default router;

--- a/backend/src/routes/status.ts
+++ b/backend/src/routes/status.ts
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import { getStatus } from "../queue/generation";
+import { emitter, getStatus } from "../queue/generation";
 
 const router = Router();
 
@@ -10,6 +10,41 @@ router.get("/status/:id", (req, res) => {
     return;
   }
   res.json({ id: req.params.id, ...status });
+});
+
+router.get("/progress/:id", (req, res) => {
+  const id = req.params.id;
+  const init = getStatus(id);
+  if (!init) {
+    res.status(404).json({ error: "not_found" });
+    return;
+  }
+  res.set({
+    "Content-Type": "text/event-stream",
+    "Cache-Control": "no-cache",
+    Connection: "keep-alive",
+  });
+  res.flushHeaders?.();
+
+  const send = (data: any) => {
+    res.write(`data: ${JSON.stringify(data)}\n\n`);
+  };
+
+  const handler = (status: any) => {
+    send(status);
+    if (status.state === "succeeded" || status.state === "failed") {
+      emitter.removeListener(`progress:${id}`, handler);
+      res.end();
+    }
+  };
+
+  send(init);
+  if (init.state === "succeeded" || init.state === "failed") {
+    res.end();
+    return;
+  }
+  emitter.on(`progress:${id}`, handler);
+  req.on("close", () => emitter.removeListener(`progress:${id}`, handler));
 });
 
 export default router;

--- a/backend/tests/progress.route.f8d1e2c3b4a5d6e7.test.ts
+++ b/backend/tests/progress.route.f8d1e2c3b4a5d6e7.test.ts
@@ -1,0 +1,27 @@
+import request from "supertest";
+import app from "../src/app";
+import { enqueue } from "../src/queue/generation";
+
+jest.mock("../src/lib/generateModel", () => ({
+  generateModel: jest.fn().mockResolvedValue(Buffer.from("a")),
+}));
+jest.mock("../src/lib/preserveColors", () => ({
+  preserveColors: jest.fn(async (b: Buffer) => b),
+}));
+jest.mock("../src/lib/uploadS3", () => ({
+  uploadS3: jest.fn().mockResolvedValue({ url: "/placeholder.glb", key: "k" }),
+}));
+
+jest.useFakeTimers();
+
+describe("progress sse", () => {
+  test("streams final status", async () => {
+    const job = await enqueue("u1", { prompt: "x", source: "prompt" });
+    const resPromise = request(app).get(`/api/progress/${job.jobId}`);
+    await jest.runAllTimersAsync();
+    const res = await resPromise;
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toContain("text/event-stream");
+    expect(res.text).toContain('"state":"succeeded"');
+  });
+});

--- a/backend/tests/queue.status.spec.ts
+++ b/backend/tests/queue.status.spec.ts
@@ -2,35 +2,48 @@ import request from "supertest";
 import app from "../src/app";
 import { enqueue, getStatus } from "../src/queue/generation";
 
+jest.mock("../src/lib/generateModel", () => ({
+  generateModel: jest.fn().mockResolvedValue(Buffer.from("a")),
+}));
+jest.mock("../src/lib/preserveColors", () => ({
+  preserveColors: jest.fn(async (b: Buffer) => b),
+}));
+jest.mock("../src/lib/uploadS3", () => ({
+  uploadS3: jest.fn().mockResolvedValue({ url: "/placeholder.glb", key: "k" }),
+}));
+
 jest.useFakeTimers();
 
 describe("generation queue status", () => {
   test("per-user serialization and status endpoint", async () => {
-    const job1 = await enqueue({ userId: "u1" });
-    const job2 = await enqueue({ userId: "u1" });
-    const job3 = await enqueue({ userId: "u2" });
+    const job1 = await enqueue("u1", { prompt: "a", source: "prompt" });
+    const job2 = await enqueue("u1", { prompt: "b", source: "prompt" });
+    const job3 = await enqueue("u2", { prompt: "c", source: "prompt" });
 
-    expect(getStatus(job1.id)?.state).toBe("running");
-    expect(getStatus(job2.id)).toMatchObject({ state: "queued", position: 1 });
-    expect(getStatus(job3.id)?.state).toBe("running");
-
-    const resQueued = await request(app).get(`/api/status/${job2.id}`);
-    expect(resQueued.body).toMatchObject({
-      id: job2.id,
+    expect(getStatus(job1.jobId)?.state).toBe("running");
+    expect(getStatus(job2.jobId)).toMatchObject({
       state: "queued",
       position: 1,
     });
-    const resRunning = await request(app).get(`/api/status/${job1.id}`);
+    expect(getStatus(job3.jobId)?.state).toBe("running");
+
+    const resQueued = await request(app).get(`/api/status/${job2.jobId}`);
+    expect(resQueued.body).toMatchObject({
+      id: job2.jobId,
+      state: "queued",
+      position: 1,
+    });
+    const resRunning = await request(app).get(`/api/status/${job1.jobId}`);
     expect(resRunning.body.state).toBe("running");
 
     await jest.runAllTimersAsync();
 
-    const done1 = await request(app).get(`/api/status/${job1.id}`);
-    const done2 = await request(app).get(`/api/status/${job2.id}`);
-    const done3 = await request(app).get(`/api/status/${job3.id}`);
+    const done1 = await request(app).get(`/api/status/${job1.jobId}`);
+    const done2 = await request(app).get(`/api/status/${job2.jobId}`);
+    const done3 = await request(app).get(`/api/status/${job3.jobId}`);
 
     expect(done1.body).toMatchObject({
-      id: job1.id,
+      id: job1.jobId,
       state: "succeeded",
       url: "/placeholder.glb",
     });


### PR DESCRIPTION
## Summary
- stream job progress via new `GET /api/progress/:id` SSE endpoint
- emit queue status updates for generation jobs
- add tests for progress stream and queue status

## Testing
- `node scripts/run-jest.js backend/tests/progress.route.f8d1e2c3b4a5d6e7.test.ts`
- `node scripts/run-jest.js backend/tests/queue.status.spec.ts`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: `npm error code EUSAGE` and downstream test failures)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: multiple checkout/stripe tests)*

------
https://chatgpt.com/codex/tasks/task_e_68aefc868968832d905510cde7309027