### PR TITLE
build: use Node 20 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM node:20-alpine
 COPY backend/ /app/backend/
 WORKDIR /app/backend
 RUN npm ci


### PR DESCRIPTION
## Summary
- use Node 20 Alpine base image in Dockerfile

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` *(backend)*
- `npm test` *(backend, fails: Expected 200 Received 404)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: numerous API route assertions)*
- `SKIP_PW_DEPS=1 npm run smoke`
- `docker compose build` *(fails: command not found)*
- `docker compose up -d` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af05a37ddc832dab00a4348cdb5e83