### PR TITLE
feat: add stripe payment panel

### DIFF
--- a/js/PaymentPanel.js
+++ b/js/PaymentPanel.js
@@ -1,0 +1,46 @@
+import React, { useEffect } from "react";
+import usePayment from "./usePayment.js";
+import toast from "./toast.js";
+
+export default function PaymentPanel() {
+  const { cardRef, pay, paying, error, succeeded } = usePayment();
+
+  useEffect(() => {
+    if (succeeded) toast("Payment confirmed");
+  }, [succeeded]);
+
+  const handlePay = async (e) => {
+    e.preventDefault();
+    await pay();
+  };
+
+  return React.createElement(
+    "div",
+    { className: "space-y-2", "data-testid": "payment-panel" },
+    React.createElement(
+      "h2",
+      { className: "text-lg font-bold" },
+      "Purchase model",
+    ),
+    React.createElement("div", {
+      ref: cardRef,
+      className: "p-2 bg-white text-black",
+    }),
+    error &&
+      React.createElement(
+        "p",
+        { className: "text-red-500", "data-testid": "payment-error" },
+        error,
+      ),
+    React.createElement(
+      "button",
+      {
+        onClick: handlePay,
+        disabled: paying,
+        className: "px-4 py-2 bg-green-600 text-white rounded",
+        "data-testid": "pay-btn",
+      },
+      paying ? "Paying..." : "Pay £29.99",
+    ),
+  );
+}

--- a/js/modelGenerator.js
+++ b/js/modelGenerator.js
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { createRoot } from "react-dom/client";
 import useGenerateModel from "./useGenerateModel.js";
 import ModelViewer from "./ModelViewer.js";
+import PaymentPanel from "./PaymentPanel.js";
 
 export function GeneratorApp() {
   const [prompt, setPrompt] = useState("");
@@ -56,9 +57,14 @@ export function GeneratorApp() {
       ),
     modelUrl &&
       React.createElement(
-        "div",
-        { "data-testid": "viewer" },
-        React.createElement(ModelViewer, { url: modelUrl }),
+        React.Fragment,
+        null,
+        React.createElement(
+          "div",
+          { "data-testid": "viewer" },
+          React.createElement(ModelViewer, { url: modelUrl }),
+        ),
+        React.createElement(PaymentPanel),
       ),
   );
 }

--- a/js/usePayment.js
+++ b/js/usePayment.js
@@ -1,0 +1,72 @@
+import { useEffect, useRef, useState } from "react";
+import { loadStripe } from "@stripe/stripe-js";
+
+const stripePromise = loadStripe(process.env.STRIPE_PUBLISHABLE_KEY);
+
+export default function usePayment() {
+  const cardRef = useRef(null);
+  const stripeRef = useRef(null);
+  const cardElementRef = useRef(null);
+  const [paying, setPaying] = useState(false);
+  const [error, setError] = useState(null);
+  const [succeeded, setSucceeded] = useState(false);
+  const [paymentIntentId, setPaymentIntentId] = useState(null);
+
+  useEffect(() => {
+    let active = true;
+    stripePromise.then((stripe) => {
+      if (!stripe || !active) return;
+      stripeRef.current = stripe;
+      const elements = stripe.elements();
+      cardElementRef.current = elements.create("card");
+      if (cardRef.current) {
+        cardElementRef.current.mount(cardRef.current);
+      }
+    });
+    return () => {
+      active = false;
+      cardElementRef.current?.unmount();
+    };
+  }, []);
+
+  const pay = async (billingDetails = {}) => {
+    if (!stripeRef.current || !cardElementRef.current) return;
+    setPaying(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/checkout/create", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          items: [{ price: "print_single", quantity: 1 }],
+          currency: "gbp",
+        }),
+      });
+      const data = (await res.json().catch(() => ({}))) || {};
+      if (!res.ok) throw new Error(data.error || "Payment failed");
+      const result = await stripeRef.current.confirmCardPayment(
+        data.clientSecret,
+        {
+          payment_method: {
+            card: cardElementRef.current,
+            billing_details: billingDetails,
+          },
+        },
+      );
+      if (result?.error) {
+        setError(result.error.message || "Payment failed");
+      } else if (result?.paymentIntent?.status === "succeeded") {
+        setSucceeded(true);
+        setPaymentIntentId(result.paymentIntent.id);
+      } else {
+        setError("Payment failed");
+      }
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setPaying(false);
+    }
+  };
+
+  return { cardRef, pay, paying, error, succeeded, paymentIntentId };
+}

--- a/tests/frontend/payment-flow.a1b2c3d4e5f6g7h8.spec.js
+++ b/tests/frontend/payment-flow.a1b2c3d4e5f6g7h8.spec.js
@@ -1,0 +1,87 @@
+/** @jest-environment jsdom */
+import React from "react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import toast from "../../js/toast.js";
+
+process.env.STRIPE_PUBLISHABLE_KEY = "pk_test";
+
+jest.mock("../../js/toast.js", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock("../../js/ModelViewer.js", () => {
+  const React = require("react");
+  return {
+    __esModule: true,
+    default: ({ url }) =>
+      React.createElement(
+        "a",
+        { href: url, "data-testid": "model-link" },
+        "Model",
+      ),
+  };
+});
+
+jest.mock(
+  "@stripe/stripe-js",
+  () => ({
+    loadStripe: jest.fn().mockResolvedValue({
+      elements: () => ({
+        create: () => ({ mount: jest.fn(), unmount: jest.fn() }),
+      }),
+      confirmCardPayment: jest.fn().mockResolvedValue({
+        paymentIntent: { id: "pi_1", status: "succeeded" },
+      }),
+    }),
+  }),
+  { virtual: true },
+);
+
+const { GeneratorApp } = require("../../js/modelGenerator.js");
+
+describe("payment flow", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("pay button disables and model remains", async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ jobId: "j_1" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ state: "succeeded", url: "/m.glb" }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ clientSecret: "pi_secret_123" }),
+      })
+      .mockResolvedValue({
+        ok: true,
+        json: async () => ({ clientSecret: "pi_secret_123" }),
+      });
+    global.fetch = fetchMock;
+
+    const startHref = window.location.href;
+    render(<GeneratorApp />);
+    fireEvent.change(screen.getByPlaceholderText("Enter prompt"), {
+      target: { value: "tree" },
+    });
+    fireEvent.click(screen.getByTestId("generate-btn"));
+    await screen.findByTestId("viewer");
+    const payBtn = await screen.findByTestId("pay-btn");
+    fireEvent.click(payBtn);
+    expect(payBtn).toBeDisabled();
+    await waitFor(() =>
+      expect(toast).toHaveBeenCalledWith("Payment confirmed"),
+    );
+    await waitFor(() => expect(payBtn).not.toBeDisabled());
+    expect(window.location.href).toBe(startHref);
+    expect(screen.getByTestId("model-link")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add `usePayment` hook for Stripe Payment Intent flow
- show `PaymentPanel` after model generation succeeds
- test payment confirmation and model persistence

## Testing
- `npm run format`
- `npm test` *(fails: Expected "/models/test.glb" etc.)*
- `node scripts/run-jest.js tests/frontend/payment-flow.a1b2c3d4e5f6g7h8.spec.js`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: lock file's concurrently@9.2.0 does not satisfy concurrently@9.2.1)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68af0b08654c832d8dda4ce546eab776