### PR TITLE
feat: expand payment flow tests

### DIFF
--- a/js/PaymentPanel.js
+++ b/js/PaymentPanel.js
@@ -2,12 +2,20 @@ import React, { useEffect } from "react";
 import usePayment from "./usePayment.js";
 import toast from "./toast.js";
 
-export default function PaymentPanel() {
-  const { cardRef, pay, paying, error, succeeded } = usePayment();
+export default function PaymentPanel({ onSuccess } = {}) {
+  const { cardRef, pay, paying, error, succeeded, status, paymentIntentId } =
+    usePayment();
 
   useEffect(() => {
-    if (succeeded) toast("Payment confirmed");
-  }, [succeeded]);
+    if (succeeded) {
+      toast("Payment confirmed");
+      onSuccess?.({ status, paymentIntentId });
+    }
+  }, [succeeded, status, paymentIntentId, onSuccess]);
+
+  useEffect(() => {
+    if (error) toast(error);
+  }, [error]);
 
   const handlePay = async (e) => {
     e.preventDefault();
@@ -32,15 +40,16 @@ export default function PaymentPanel() {
         { className: "text-red-500", "data-testid": "payment-error" },
         error,
       ),
-    React.createElement(
-      "button",
-      {
-        onClick: handlePay,
-        disabled: paying,
-        className: "px-4 py-2 bg-green-600 text-white rounded",
-        "data-testid": "pay-btn",
-      },
-      paying ? "Paying..." : "Pay £29.99",
-    ),
+    !succeeded &&
+      React.createElement(
+        "button",
+        {
+          onClick: handlePay,
+          disabled: paying,
+          className: "px-4 py-2 bg-green-600 text-white rounded",
+          "data-testid": "pay-btn",
+        },
+        paying ? "Paying..." : "Pay £29.99",
+      ),
   );
 }

--- a/js/modelGenerator.js
+++ b/js/modelGenerator.js
@@ -7,6 +7,7 @@ import PaymentPanel from "./PaymentPanel.js";
 export function GeneratorApp() {
   const [prompt, setPrompt] = useState("");
   const { generate, loading, modelUrl, position } = useGenerateModel();
+  const [purchase, setPurchase] = useState(null);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -64,7 +65,13 @@ export function GeneratorApp() {
           { "data-testid": "viewer" },
           React.createElement(ModelViewer, { url: modelUrl }),
         ),
-        React.createElement(PaymentPanel),
+        purchase &&
+          React.createElement(
+            "p",
+            { className: "text-green-600", "data-testid": "purchase-status" },
+            `Status: ${purchase.status} (${purchase.paymentIntentId})`,
+          ),
+        React.createElement(PaymentPanel, { onSuccess: setPurchase }),
       ),
   );
 }

--- a/js/usePayment.js
+++ b/js/usePayment.js
@@ -11,6 +11,7 @@ export default function usePayment() {
   const [error, setError] = useState(null);
   const [succeeded, setSucceeded] = useState(false);
   const [paymentIntentId, setPaymentIntentId] = useState(null);
+  const [status, setStatus] = useState(null);
 
   useEffect(() => {
     let active = true;
@@ -33,6 +34,9 @@ export default function usePayment() {
     if (!stripeRef.current || !cardElementRef.current) return;
     setPaying(true);
     setError(null);
+    setSucceeded(false);
+    setStatus(null);
+    setPaymentIntentId(null);
     try {
       const res = await fetch("/api/checkout/create", {
         method: "POST",
@@ -58,6 +62,7 @@ export default function usePayment() {
       } else if (result?.paymentIntent?.status === "succeeded") {
         setSucceeded(true);
         setPaymentIntentId(result.paymentIntent.id);
+        setStatus(result.paymentIntent.status);
       } else {
         setError("Payment failed");
       }
@@ -68,5 +73,5 @@ export default function usePayment() {
     }
   };
 
-  return { cardRef, pay, paying, error, succeeded, paymentIntentId };
+  return { cardRef, pay, paying, error, succeeded, paymentIntentId, status };
 }

--- a/tests/frontend/payment-flow.a1b2c3d4e5f6g7h8.spec.js
+++ b/tests/frontend/payment-flow.a1b2c3d4e5f6g7h8.spec.js
@@ -24,6 +24,7 @@ jest.mock("../../js/ModelViewer.js", () => {
   };
 });
 
+const confirmCardPaymentMock = jest.fn();
 jest.mock(
   "@stripe/stripe-js",
   () => ({
@@ -31,9 +32,7 @@ jest.mock(
       elements: () => ({
         create: () => ({ mount: jest.fn(), unmount: jest.fn() }),
       }),
-      confirmCardPayment: jest.fn().mockResolvedValue({
-        paymentIntent: { id: "pi_1", status: "succeeded" },
-      }),
+      confirmCardPayment: confirmCardPaymentMock,
     }),
   }),
   { virtual: true },
@@ -44,10 +43,14 @@ const { GeneratorApp } = require("../../js/modelGenerator.js");
 describe("payment flow", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    confirmCardPaymentMock.mockReset();
+    confirmCardPaymentMock.mockResolvedValue({
+      paymentIntent: { id: "pi_1", status: "succeeded" },
+    });
   });
 
-  test("pay button disables and model remains", async () => {
-    const fetchMock = jest
+  const buildFetch = () =>
+    jest
       .fn()
       .mockResolvedValueOnce({
         ok: true,
@@ -57,16 +60,13 @@ describe("payment flow", () => {
         ok: true,
         json: async () => ({ state: "succeeded", url: "/m.glb" }),
       })
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ clientSecret: "pi_secret_123" }),
-      })
       .mockResolvedValue({
         ok: true,
         json: async () => ({ clientSecret: "pi_secret_123" }),
       });
-    global.fetch = fetchMock;
 
+  test("successful payment shows confirmation", async () => {
+    global.fetch = buildFetch();
     const startHref = window.location.href;
     render(<GeneratorApp />);
     fireEvent.change(screen.getByPlaceholderText("Enter prompt"), {
@@ -80,8 +80,35 @@ describe("payment flow", () => {
     await waitFor(() =>
       expect(toast).toHaveBeenCalledWith("Payment confirmed"),
     );
-    await waitFor(() => expect(payBtn).not.toBeDisabled());
-    expect(window.location.href).toBe(startHref);
+    await waitFor(() =>
+      expect(screen.queryByTestId("pay-btn")).not.toBeInTheDocument(),
+    );
+    expect(screen.getByTestId("purchase-status")).toHaveTextContent(
+      /succeeded/i,
+    );
     expect(screen.getByTestId("model-link")).toBeInTheDocument();
+    expect(window.location.href).toBe(startHref);
+  });
+
+  test("failed payment surfaces error", async () => {
+    global.fetch = buildFetch();
+    confirmCardPaymentMock.mockResolvedValueOnce({
+      error: { message: "Card declined" },
+    });
+    render(<GeneratorApp />);
+    fireEvent.change(screen.getByPlaceholderText("Enter prompt"), {
+      target: { value: "tree" },
+    });
+    fireEvent.click(screen.getByTestId("generate-btn"));
+    await screen.findByTestId("viewer");
+    const payBtn = await screen.findByTestId("pay-btn");
+    fireEvent.click(payBtn);
+    expect(payBtn).toBeDisabled();
+    await waitFor(() => expect(toast).toHaveBeenCalledWith("Card declined"));
+    await waitFor(() => expect(payBtn).not.toBeDisabled());
+    expect(screen.getByTestId("payment-error")).toHaveTextContent(
+      "Card declined",
+    );
+    expect(screen.queryByTestId("purchase-status")).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- disable pay button after success and expose status
- surface Stripe errors and toast outcomes in PaymentPanel
- show purchase confirmation under model viewer and add success/failure tests

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format`
- `npx prettier -w js/usePayment.js js/PaymentPanel.js js/modelGenerator.js tests/frontend/payment-flow.a1b2c3d4e5f6g7h8.spec.js`
- `npm test` *(fails: Expected 200 Received 404)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68af14166310832d93aadddff5461ecb