### PR TITLE
feat: add centralized env validation

### DIFF
--- a/backend/queue/printWorker.js
+++ b/backend/queue/printWorker.js
@@ -4,9 +4,10 @@ const axios = require("axios");
 const { getPrinterStatus } = require("../printers/octoprint");
 const { selectHub } = require("../utils/routing");
 const logger = require("../../src/logger");
+const { getEnv } = require("../src/env");
 
-const DEFAULT_PRINTER_URL =
-  process.env.PRINTER_API_URL || "http://localhost:5000/print";
+const { PRINTER_API_URL, DB_URL } = getEnv();
+const DEFAULT_PRINTER_URL = PRINTER_API_URL || "http://localhost:5000/print";
 const PRINTER_URLS = (process.env.PRINTER_URLS || DEFAULT_PRINTER_URL)
   .split(",")
   .map((u) => u.trim())
@@ -149,7 +150,7 @@ async function connectWithRetry(client) {
 
 async function run(interval = POLL_INTERVAL_MS) {
   logger.info("=== printWorker starting ===");
-  const client = new Client({ connectionString: process.env.DB_URL });
+  const client = new Client({ connectionString: DB_URL });
   await connectWithRetry(client);
   setInterval(() => {
     processNextJob(client).catch((err) => logger.error("Worker error", err));

--- a/backend/queue/printerTelemetry.js
+++ b/backend/queue/printerTelemetry.js
@@ -2,6 +2,7 @@ require("dotenv").config();
 const { Client } = require("pg");
 const { getPrinterInfo } = require("../printers/octoprint");
 const logger = require("../../src/logger");
+const { getEnv } = require("../src/env");
 
 const OCTOPRINT_API_KEY = process.env.OCTOPRINT_API_KEY || "";
 const POLL_INTERVAL_MS = parseInt(
@@ -73,7 +74,8 @@ async function pollPrinters(client) {
 }
 
 async function run(interval = POLL_INTERVAL_MS) {
-  const client = new Client({ connectionString: process.env.DB_URL });
+  const { DB_URL } = getEnv();
+  const client = new Client({ connectionString: DB_URL });
   await client.connect();
   setInterval(() => {
     pollPrinters(client).catch((err) =>

--- a/backend/src/db.js
+++ b/backend/src/db.js
@@ -1,11 +1,9 @@
 const { Pool } = require("pg");
+const { getEnv } = require("./env");
 
-const dbUrl = process.env.DB_URL;
-if (!dbUrl) {
-  throw new Error("DB_URL is required");
-}
+const { DB_URL, NODE_ENV } = getEnv();
 
-const pool = new Pool({ connectionString: dbUrl });
+const pool = new Pool({ connectionString: DB_URL });
 
 function close() {
   return pool.end();
@@ -24,7 +22,7 @@ async function createJob(input) {
       [id, input.userId, input.url, input.title],
     );
   } catch {
-    if (process.env.NODE_ENV !== "production") {
+    if (NODE_ENV !== "production") {
       jobs.set(id, { id, ...input });
     }
   }
@@ -38,7 +36,7 @@ async function linkModelToJob(jobId, s3Key) {
       s3Key,
     ]);
   } catch {
-    if (process.env.NODE_ENV !== "production") {
+    if (NODE_ENV !== "production") {
       const job = jobs.get(jobId) || { id: jobId };
       job.s3Key = s3Key;
       jobs.set(jobId, job);

--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -1,11 +1,9 @@
 import { Pool } from "pg";
+import { getEnv } from "./env";
 
-const dbUrl = process.env.DB_URL;
-if (!dbUrl) {
-  throw new Error("DB_URL is required");
-}
+const { DB_URL, NODE_ENV } = getEnv();
 
-export const pool = new Pool({ connectionString: dbUrl });
+export const pool = new Pool({ connectionString: DB_URL });
 
 export function close(): Promise<void> {
   return pool.end();
@@ -26,7 +24,7 @@ export async function createJob(input: {
       [id, input.userId, input.url, input.title],
     );
   } catch {
-    if (process.env.NODE_ENV !== "production") {
+    if (NODE_ENV !== "production") {
       jobs.set(id, { id, ...input });
     }
   }
@@ -43,7 +41,7 @@ export async function linkModelToJob(
       s3Key,
     ]);
   } catch {
-    if (process.env.NODE_ENV !== "production") {
+    if (NODE_ENV !== "production") {
       const job = jobs.get(jobId) || { id: jobId };
       job.s3Key = s3Key;
       jobs.set(jobId, job);

--- a/backend/src/env.js
+++ b/backend/src/env.js
@@ -1,19 +1,4 @@
-let cached;
-
-function isProd() {
-  return process.env.NODE_ENV === "production";
-}
-
-function shouldWarn() {
-  return (
-    process.env.NODE_ENV === "development" &&
-    process.env.QUIET_ENV_WARNINGS !== "1"
-  );
-}
-
-function warn(msg) {
-  if (shouldWarn()) console.warn(msg);
-}
+"use strict";
 
 function requireEnv(name) {
   const value = process.env[name];
@@ -23,41 +8,51 @@ function requireEnv(name) {
   return value;
 }
 
-function optionalEnv(name) {
-  const value = process.env[name];
-  if (!value) {
-    if (isProd()) {
-      throw new Error(`${name} is required`);
-    }
-    warn(`${name} is not set`);
-    return undefined;
+function buildEnv() {
+  const NODE_ENV = requireEnv("NODE_ENV");
+  if (!["development", "test", "production"].includes(NODE_ENV)) {
+    throw new Error("NODE_ENV must be development, test, or production");
   }
-  return value;
-}
-
-function getEnv() {
-  if (cached) return cached;
-  const env = {
+  const isProd = NODE_ENV === "production";
+  const shouldWarn =
+    NODE_ENV === "development" && process.env.QUIET_ENV_WARNINGS !== "1";
+  const warn = (msg) => {
+    if (shouldWarn) console.warn(msg);
+  };
+  const optional = (name) => {
+    const value = process.env[name];
+    if (!value) {
+      if (isProd) throw new Error(`${name} is required`);
+      warn(`${name} is not set`);
+      return undefined;
+    }
+    return value;
+  };
+  return Object.freeze({
     DB_URL: requireEnv("DB_URL"),
     STRIPE_SECRET_KEY: requireEnv("STRIPE_SECRET_KEY"),
     STRIPE_PUBLISHABLE_KEY: requireEnv("STRIPE_PUBLISHABLE_KEY"),
-    NODE_ENV: requireEnv("NODE_ENV"),
-    AWS_REGION: optionalEnv("AWS_REGION"),
-    S3_BUCKET: optionalEnv("S3_BUCKET"),
-    CLOUDFRONT_MODEL_DOMAIN: (function () {
+    NODE_ENV,
+    AWS_REGION: optional("AWS_REGION"),
+    S3_BUCKET: optional("S3_BUCKET"),
+    CLOUDFRONT_DOMAIN: (() => {
       const val =
-        process.env.CLOUDFRONT_MODEL_DOMAIN || process.env.CLOUDFRONT_DOMAIN;
+        process.env.CLOUDFRONT_DOMAIN || process.env.CLOUDFRONT_MODEL_DOMAIN;
       if (!val) {
-        if (isProd()) throw new Error("CLOUDFRONT_MODEL_DOMAIN is required");
-        warn("CLOUDFRONT_MODEL_DOMAIN is not set");
+        if (isProd) throw new Error("CLOUDFRONT_DOMAIN is required");
+        warn("CLOUDFRONT_DOMAIN is not set");
         return undefined;
       }
       return val;
     })(),
-    PRINTER_API_URL: optionalEnv("PRINTER_API_URL"),
-  };
-  cached = Object.freeze(env);
-  return cached;
+    PRINTER_API_URL: optional("PRINTER_API_URL"),
+  });
+}
+
+const ENV = buildEnv();
+
+function getEnv() {
+  return ENV;
 }
 
 module.exports = { getEnv };

--- a/backend/src/env.ts
+++ b/backend/src/env.ts
@@ -2,28 +2,11 @@ interface Env {
   DB_URL: string;
   STRIPE_SECRET_KEY: string;
   STRIPE_PUBLISHABLE_KEY: string;
-  NODE_ENV: string;
+  NODE_ENV: 'development' | 'test' | 'production';
   AWS_REGION?: string;
   S3_BUCKET?: string;
-  CLOUDFRONT_MODEL_DOMAIN?: string;
+  CLOUDFRONT_DOMAIN?: string;
   PRINTER_API_URL?: string;
-}
-
-let cached: Readonly<Env> | undefined;
-
-function isProd(): boolean {
-  return process.env.NODE_ENV === 'production';
-}
-
-function shouldWarn(): boolean {
-  return (
-    process.env.NODE_ENV === 'development' &&
-    process.env.QUIET_ENV_WARNINGS !== '1'
-  );
-}
-
-function warn(msg: string): void {
-  if (shouldWarn()) console.warn(msg);
 }
 
 function requireEnv(name: string): string {
@@ -34,42 +17,53 @@ function requireEnv(name: string): string {
   return value;
 }
 
-function optionalEnv(name: string): string | undefined {
-  const value = process.env[name];
-  if (!value) {
-    if (isProd()) {
-      throw new Error(`${name} is required`);
-    }
-    warn(`${name} is not set`);
-    return undefined;
+function buildEnv(): Readonly<Env> {
+  const NODE_ENV = requireEnv('NODE_ENV');
+  if (!['development', 'test', 'production'].includes(NODE_ENV)) {
+    throw new Error('NODE_ENV must be development, test, or production');
   }
-  return value;
-}
-
-export function getEnv(): Readonly<Env> {
-  if (cached) return cached;
+  const isProd = NODE_ENV === 'production';
+  const shouldWarn =
+    NODE_ENV === 'development' && process.env.QUIET_ENV_WARNINGS !== '1';
+  const warn = (msg: string): void => {
+    if (shouldWarn) console.warn(msg);
+  };
+  const optional = (name: string): string | undefined => {
+    const value = process.env[name];
+    if (!value) {
+      if (isProd) throw new Error(`${name} is required`);
+      warn(`${name} is not set`);
+      return undefined;
+    }
+    return value;
+  };
   const env: Env = {
     DB_URL: requireEnv('DB_URL'),
     STRIPE_SECRET_KEY: requireEnv('STRIPE_SECRET_KEY'),
     STRIPE_PUBLISHABLE_KEY: requireEnv('STRIPE_PUBLISHABLE_KEY'),
-    NODE_ENV: requireEnv('NODE_ENV'),
-    AWS_REGION: optionalEnv('AWS_REGION'),
-    S3_BUCKET: optionalEnv('S3_BUCKET'),
-    CLOUDFRONT_MODEL_DOMAIN: (() => {
+    NODE_ENV: NODE_ENV as Env['NODE_ENV'],
+    AWS_REGION: optional('AWS_REGION'),
+    S3_BUCKET: optional('S3_BUCKET'),
+    CLOUDFRONT_DOMAIN: (() => {
       const val =
-        process.env.CLOUDFRONT_MODEL_DOMAIN ||
-        process.env.CLOUDFRONT_DOMAIN;
+        process.env.CLOUDFRONT_DOMAIN || process.env.CLOUDFRONT_MODEL_DOMAIN;
       if (!val) {
-        if (isProd()) throw new Error('CLOUDFRONT_MODEL_DOMAIN is required');
-        warn('CLOUDFRONT_MODEL_DOMAIN is not set');
+        if (isProd) throw new Error('CLOUDFRONT_DOMAIN is required');
+        warn('CLOUDFRONT_DOMAIN is not set');
         return undefined;
       }
       return val;
     })(),
-    PRINTER_API_URL: optionalEnv('PRINTER_API_URL'),
+    PRINTER_API_URL: optional('PRINTER_API_URL'),
   };
-  cached = Object.freeze(env);
-  return cached;
+  return Object.freeze(env);
+}
+
+const ENV = buildEnv();
+
+export function getEnv(): Readonly<Env> {
+  return ENV;
 }
 
 export type { Env };
+

--- a/backend/src/lib/storeGlb.js
+++ b/backend/src/lib/storeGlb.js
@@ -19,7 +19,7 @@ async function storeGlb(data, attempts = 3) {
   const secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
   const key = `models/${Date.now()}-${Math.random().toString(36).slice(2)}.glb`;
 
-  if (env.NODE_ENV !== "production" && !env.CLOUDFRONT_MODEL_DOMAIN) {
+  if (env.NODE_ENV !== "production" && !env.CLOUDFRONT_DOMAIN) {
     return "/models/test.glb";
   }
 

--- a/backend/src/lib/storeGlb.ts
+++ b/backend/src/lib/storeGlb.ts
@@ -20,7 +20,7 @@ export async function storeGlb(
   const secretAccessKey = process.env["AWS_SECRET_ACCESS_KEY"];
   const key = `models/${Date.now()}-${Math.random().toString(36).slice(2)}.glb`;
 
-  if (env.NODE_ENV !== "production" && !env.CLOUDFRONT_MODEL_DOMAIN) {
+  if (env.NODE_ENV !== "production" && !env.CLOUDFRONT_DOMAIN) {
     return "/models/test.glb";
   }
 

--- a/backend/src/lib/uploadS3.js
+++ b/backend/src/lib/uploadS3.js
@@ -31,7 +31,7 @@ async function uploadFile(filePath, contentType) {
   const env = (0, env_1.getEnv)();
   const region = env.AWS_REGION || "us-east-1";
   const bucket = env.S3_BUCKET || "test-bucket";
-  const domain = env.CLOUDFRONT_MODEL_DOMAIN;
+  const domain = env.CLOUDFRONT_DOMAIN;
   const key = safeJoin(
     "images",
     `${Date.now()}-${path_1.default.basename(filePath)}`,
@@ -62,7 +62,7 @@ async function uploadS3(data, filename = "model.glb") {
   const env = (0, env_1.getEnv)();
   const region = env.AWS_REGION || "us-east-1";
   const bucket = env.S3_BUCKET || "test-bucket";
-  const domain = env.CLOUDFRONT_MODEL_DOMAIN;
+  const domain = env.CLOUDFRONT_DOMAIN;
   const key = safeJoin("models", `${Date.now()}-${filename}`);
   if (env.NODE_ENV !== "production" && !domain) {
     return { url: "/models/test.glb", key };

--- a/backend/src/lib/uploadS3.ts
+++ b/backend/src/lib/uploadS3.ts
@@ -28,7 +28,7 @@ export async function uploadFile(
   const env = getEnv();
   const region = env.AWS_REGION || "us-east-1";
   const bucket = env.S3_BUCKET || "test-bucket";
-  const domain = env.CLOUDFRONT_MODEL_DOMAIN;
+  const domain = env.CLOUDFRONT_DOMAIN;
 
   const key = safeJoin("images", `${Date.now()}-${path.basename(filePath)}`);
   if (env.NODE_ENV !== "production" && !domain) {
@@ -79,7 +79,7 @@ export async function uploadS3(
   const env = getEnv();
   const region = env.AWS_REGION || "us-east-1";
   const bucket = env.S3_BUCKET || "test-bucket";
-  const domain = env.CLOUDFRONT_MODEL_DOMAIN;
+  const domain = env.CLOUDFRONT_DOMAIN;
   const key = safeJoin("models", sanitizeKey(`${Date.now()}-${filename}`));
 
   if (env.NODE_ENV !== "production" && !domain) {

--- a/backend/src/routes/checkout.js
+++ b/backend/src/routes/checkout.js
@@ -1,12 +1,13 @@
 "use strict";
 const express = require("express");
 const Stripe = require("stripe");
+const { getEnv } = require("../env");
 
 const router = express.Router();
 
 router.post("/checkout/create", async (req, res) => {
   try {
-    const secretKey = process.env.STRIPE_SECRET_KEY;
+    const { STRIPE_SECRET_KEY: secretKey } = getEnv();
     const successUrl = process.env.FRONTEND_SUCCESS_URL;
     const cancelUrl = process.env.FRONTEND_CANCEL_URL;
     if (!secretKey || !successUrl || !cancelUrl) {

--- a/backend/src/routes/checkout.ts
+++ b/backend/src/routes/checkout.ts
@@ -1,11 +1,12 @@
 import { Router } from "express";
 import Stripe from "stripe";
+import { getEnv } from "../env";
 
 const router = Router();
 
 router.post("/checkout/create", async (req, res) => {
   try {
-    const secretKey = process.env.STRIPE_SECRET_KEY;
+    const { STRIPE_SECRET_KEY: secretKey } = getEnv();
     const successUrl = process.env.FRONTEND_SUCCESS_URL;
     const cancelUrl = process.env.FRONTEND_CANCEL_URL;
 

--- a/backend/src/routes/models.ts
+++ b/backend/src/routes/models.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import { Pool } from "pg";
 import validate from "../../middleware/validate.js";
 import { z } from "zod";
+import { getEnv } from "../env";
 
 const router = Router();
 
@@ -22,7 +23,8 @@ export const createModelSchema = z.object({
 router.post("/", validate(createModelSchema), async (req, res) => {
   try {
     const { prompt, s3_key } = req.body as { prompt: string; s3_key: string };
-    const cloudfront_url = `https://${process.env.CLOUDFRONT_DOMAIN}/${s3_key}`;
+    const { CLOUDFRONT_DOMAIN } = getEnv();
+    const cloudfront_url = `https://${CLOUDFRONT_DOMAIN}/${s3_key}`;
     const result = await pool.query(
       "INSERT INTO models (prompt, s3_key, cloudfront_url) VALUES ($1, $2, $3) RETURNING id, prompt, s3_key, cloudfront_url",
       [prompt, s3_key, cloudfront_url],

--- a/backend/src/routes/payments.js
+++ b/backend/src/routes/payments.js
@@ -1,12 +1,14 @@
 const { Router } = require("express");
 const Stripe = require("stripe");
+const { getEnv } = require("../env");
 
 const PRICE_MAP = {
   print_multi: 3999,
   print_single: 2999,
 };
 
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
+const { STRIPE_SECRET_KEY } = getEnv();
+const stripe = new Stripe(STRIPE_SECRET_KEY, {
   apiVersion: "2025-06-30.basil",
 });
 

--- a/backend/src/routes/payments.ts
+++ b/backend/src/routes/payments.ts
@@ -1,5 +1,6 @@
 import { Router, type Request, type Response } from "express";
 import Stripe from "stripe";
+import { getEnv } from "../env";
 
 interface Item {
   price: string;
@@ -18,7 +19,8 @@ const PRICE_MAP: Record<string, number> = {
   print_single: 2999,
 };
 
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {
+const { STRIPE_SECRET_KEY } = getEnv();
+const stripe = new Stripe(STRIPE_SECRET_KEY, {
   apiVersion: "2025-06-30.basil",
 });
 

--- a/backend/src/routes/stripeCheckout.ts
+++ b/backend/src/routes/stripeCheckout.ts
@@ -1,9 +1,11 @@
 import { Router, type Request, type Response } from "express";
 import Stripe from "stripe";
+import { getEnv } from "../env";
 
 const router = Router();
 
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY as string, {
+const { STRIPE_SECRET_KEY } = getEnv();
+const stripe = new Stripe(STRIPE_SECRET_KEY as string, {
   apiVersion: "2025-06-30.basil",
 });
 

--- a/backend/src/routes/stripeWebhook.js
+++ b/backend/src/routes/stripeWebhook.js
@@ -9,11 +9,9 @@ const express_1 = __importDefault(require("express"));
 const stripe_1 = __importDefault(require("stripe"));
 const logger_js_1 = __importDefault(require("../logger.js"));
 const db_1 = require("../db");
-const secretKey = process.env.STRIPE_SECRET_KEY;
-if (!secretKey) {
-  throw new Error("Stripe key not configured");
-}
-const stripe = new stripe_1.default(secretKey, {
+const env_1 = require("../env");
+const { STRIPE_SECRET_KEY } = (0, env_1.getEnv)();
+const stripe = new stripe_1.default(STRIPE_SECRET_KEY, {
   apiVersion: "2025-06-30.basil",
 });
 const router = express_1.default.Router();

--- a/backend/src/routes/stripeWebhook.ts
+++ b/backend/src/routes/stripeWebhook.ts
@@ -2,12 +2,10 @@ import express from "express";
 import Stripe from "stripe";
 import logger from "../logger.js";
 import { upsertOrderPaid, markPaymentProcessed, linkModelToJob } from "../db";
+import { getEnv } from "../env";
 
-const secretKey = process.env.STRIPE_SECRET_KEY;
-if (!secretKey) {
-  throw new Error("Stripe key not configured");
-}
-const stripe = new Stripe(secretKey, { apiVersion: "2025-06-30.basil" });
+const { STRIPE_SECRET_KEY } = getEnv();
+const stripe = new Stripe(STRIPE_SECRET_KEY, { apiVersion: "2025-06-30.basil" });
 
 const router = express.Router();
 

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -3,6 +3,8 @@ config();
 
 const app =
   require("./app").app || require("./app").default || require("./app");
+const { getEnv } = require("./env");
+getEnv();
 const port = parseInt(process.env.PORT || "3000", 10);
 const PORT = isNaN(port) || port < 1 || port > 65535 ? 3000 : port;
 

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -2,6 +2,10 @@ import { config } from "dotenv";
 config();
 
 import { app } from "./app";
+import { getEnv } from "./env";
+
+// Validate environment at startup
+getEnv();
 
 const port = Number.parseInt(process.env.PORT || "3000", 10);
 const PORT = Number.isNaN(port) || port < 1 || port > 65535 ? 3000 : port;

--- a/backend/tests/env.getEnv.spec.ts
+++ b/backend/tests/env.getEnv.spec.ts
@@ -1,12 +1,9 @@
-import { getEnv } from '../src/env';
-
 describe('getEnv', () => {
   const OLD_ENV = process.env;
 
   beforeEach(() => {
     jest.resetModules();
     process.env = { ...OLD_ENV } as NodeJS.ProcessEnv;
-    delete require.cache[require.resolve('../src/env')];
   });
 
   afterEach(() => {
@@ -14,14 +11,26 @@ describe('getEnv', () => {
     jest.restoreAllMocks();
   });
 
-  test('does not warn in test env', () => {
+  test('allows optional vars in test env without warning', () => {
     process.env.NODE_ENV = 'test';
     process.env.DB_URL = 'postgres://user:pass@localhost/db';
     process.env.STRIPE_SECRET_KEY = 'sk';
     process.env.STRIPE_PUBLISHABLE_KEY = 'pk';
     const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
-    getEnv();
+    const { getEnv } = require('../src/env');
+    expect(() => getEnv()).not.toThrow();
     expect(warn).not.toHaveBeenCalled();
+  });
+
+  test('warns but does not throw when optional vars missing in development', () => {
+    process.env.NODE_ENV = 'development';
+    process.env.DB_URL = 'postgres://user:pass@localhost/db';
+    process.env.STRIPE_SECRET_KEY = 'sk';
+    process.env.STRIPE_PUBLISHABLE_KEY = 'pk';
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const { getEnv } = require('../src/env');
+    expect(() => getEnv()).not.toThrow();
+    expect(warn).toHaveBeenCalled();
   });
 
   test('throws when required vars missing', () => {
@@ -29,6 +38,7 @@ describe('getEnv', () => {
     delete process.env.DB_URL;
     process.env.STRIPE_SECRET_KEY = 'sk';
     process.env.STRIPE_PUBLISHABLE_KEY = 'pk';
-    expect(() => getEnv()).toThrow(/DB_URL/);
+    expect(() => require('../src/env')).toThrow(/DB_URL/);
   });
 });
+


### PR DESCRIPTION
## Summary
- add env module validating required variables and warning on missing optional ones
- switch db, workers, and stripe routes to use typed env getters
- fail fast on missing configuration and test env handling

## Testing
- `npm run format`
- `npm test tests/env.getEnv.spec.ts`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: multiple test assertions)*


------
https://chatgpt.com/codex/tasks/task_e_68af39c53674832d82ba455f80ca01c2