### PR TITLE
feat: introduce backend logger and error middleware

### DIFF
--- a/backend/config.js
+++ b/backend/config.js
@@ -8,6 +8,7 @@
  */
 const { getEnv } = require("./src/lib/getEnv");
 const { applyMockEnv, mockSecrets } = require("./src/lib/mockEnv");
+const logger = require("./src/logger.js");
 
 const isProduction = process.env.NODE_ENV === "production";
 if (!isProduction) {
@@ -23,11 +24,11 @@ const optionalGlb = [
 
 const missing = required.filter((key) => !getEnv(key));
 if (missing.length) {
-  console.warn(`Missing required env vars: ${missing.join(", ")}`);
+  logger.warn(`Missing required env vars: ${missing.join(", ")}`);
 }
 const missingGlb = optionalGlb.filter((key) => !getEnv(key));
 if (missingGlb.length) {
-  console.warn(`Missing optional GLB env vars: ${missingGlb.join(", ")}`);
+  logger.warn(`Missing optional GLB env vars: ${missingGlb.join(", ")}`);
 }
 
 const stripeKey = getEnv("STRIPE_SECRET_KEY", {

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -1,6 +1,6 @@
 const express = require("express");
-const { capture } = require("./lib/logger");
-const logger = require("../../src/logger.js");
+const logger = require("./logger.js");
+const errorHandler = require("./middleware/errorHandler.js");
 
 const app = express();
 module.exports = app;
@@ -13,7 +13,7 @@ try {
     app.use(r.default || r);
   })();
 } catch (err) {
-  console.error("Failed to load stripe webhook router", err);
+  logger.error("Failed to load stripe webhook router", err);
 }
 
 app.use(express.json());
@@ -24,7 +24,7 @@ try {
     app.use(r.default || r);
   })();
 } catch (err) {
-  console.error("Failed to load health router", err);
+  logger.error("Failed to load health router", err);
 }
 
 try {
@@ -33,7 +33,7 @@ try {
     app.use(r.default || r);
   })();
 } catch (err) {
-  console.error("Failed to load items router", err);
+  logger.error("Failed to load items router", err);
 }
 
 try {
@@ -42,7 +42,7 @@ try {
     app.use(r.default || r);
   })();
 } catch (err) {
-  console.error("Failed to load checkout router", err);
+  logger.error("Failed to load checkout router", err);
 }
 
 try {
@@ -51,7 +51,7 @@ try {
     app.use("/api/models", r.default || r);
   })();
 } catch (err) {
-  console.error("Failed to load models router", err);
+  logger.error("Failed to load models router", err);
 }
 
 try {
@@ -60,7 +60,7 @@ try {
     app.use("/api", r.default || r);
   })();
 } catch (err) {
-  console.error("Failed to load generate router", err);
+  logger.error("Failed to load generate router", err);
 }
 
 try {
@@ -69,7 +69,7 @@ try {
     app.use(r.default || r);
   })();
 } catch (err) {
-  console.error("Failed to load analytics router", err);
+  logger.error("Failed to load analytics router", err);
 }
 
 try {
@@ -78,7 +78,7 @@ try {
     app.use("/api", r.default || r);
   })();
 } catch (err) {
-  console.error("Failed to load referral router", err);
+  logger.error("Failed to load referral router", err);
 }
 
 try {
@@ -87,7 +87,7 @@ try {
     app.use("/api", r.default || r);
   })();
 } catch (err) {
-  console.error("Failed to load rewards router", err);
+  logger.error("Failed to load rewards router", err);
 }
 
 try {
@@ -96,7 +96,7 @@ try {
     app.use("/api", r.default || r);
   })();
 } catch (err) {
-  console.error("Failed to load subscription router", err);
+  logger.error("Failed to load subscription router", err);
 }
 
 try {
@@ -105,7 +105,7 @@ try {
     app.use("/api", r.default || r);
   })();
 } catch (err) {
-  console.error("Failed to load credits router", err);
+  logger.error("Failed to load credits router", err);
 }
 
 try {
@@ -114,7 +114,7 @@ try {
     app.use("/api", r.default || r);
   })();
 } catch (err) {
-  console.error("Failed to load payments router", err);
+  logger.error("Failed to load payments router", err);
 }
 
 try {
@@ -123,16 +123,7 @@ try {
     app.use("/api", r.default || r);
   })();
 } catch (err) {
-  console.error("Failed to load worker router", err);
+  logger.error("Failed to load worker router", err);
 }
 
-app.use((err, req, res, _next) => {
-  const context = { method: req.method, url: req.originalUrl, body: req.body };
-  try {
-    logger.error("Error handling request", context, err);
-  } catch {
-    // ignore logging failures
-  }
-  capture(err);
-  res.status(500).json({ error: "Internal Server Error" });
-});
+app.use(errorHandler);

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,10 +1,6 @@
-import express, {
-  type NextFunction,
-  type Request,
-  type Response,
-} from "express";
-import { capture } from "./lib/logger";
-import logger from "../../src/logger.js";
+import express from "express";
+import logger from "./logger.js";
+import errorHandler from "./middleware/errorHandler";
 
 const app = express();
 export { app };
@@ -15,7 +11,7 @@ try {
     app.use(r.default || r);
   })();
 } catch (err) {
-  console.error("Failed to load stripe webhook router", err);
+  logger.error("Failed to load stripe webhook router", err as Error);
 }
 
 app.use(express.json());
@@ -26,7 +22,7 @@ try {
     app.use(r.default || r);
   })();
 } catch (err) {
-  console.error("Failed to load health router", err);
+  logger.error("Failed to load health router", err as Error);
 }
 
 try {
@@ -35,7 +31,7 @@ try {
     app.use(r.default || r);
   })();
 } catch (err) {
-  console.error("Failed to load items router", err);
+  logger.error("Failed to load items router", err as Error);
 }
 
 try {
@@ -44,7 +40,7 @@ try {
     app.use("/api", r.default || r);
   })();
 } catch (err) {
-  console.error("Failed to load checkout router", err);
+  logger.error("Failed to load checkout router", err as Error);
 }
 
 try {
@@ -53,7 +49,7 @@ try {
     app.use("/api/models", r.default || r);
   })();
 } catch (err) {
-  console.error("Failed to load models router", err);
+  logger.error("Failed to load models router", err as Error);
 }
 
 try {
@@ -62,7 +58,7 @@ try {
     app.use("/api", r.default || r);
   })();
 } catch (err) {
-  console.error("Failed to load generate router", err);
+  logger.error("Failed to load generate router", err as Error);
 }
 
 try {
@@ -71,7 +67,7 @@ try {
     app.use(r.default || r);
   })();
 } catch (err) {
-  console.error("Failed to load analytics router", err);
+  logger.error("Failed to load analytics router", err as Error);
 }
 
 try {
@@ -80,7 +76,7 @@ try {
     app.use("/api", r.default || r);
   })();
 } catch (err) {
-  console.error("Failed to load referral router", err);
+  logger.error("Failed to load referral router", err as Error);
 }
 
 try {
@@ -89,7 +85,7 @@ try {
     app.use("/api", r.default || r);
   })();
 } catch (err) {
-  console.error("Failed to load rewards router", err);
+  logger.error("Failed to load rewards router", err as Error);
 }
 
 try {
@@ -98,7 +94,7 @@ try {
     app.use("/api", r.default || r);
   })();
 } catch (err) {
-  console.error("Failed to load subscription router", err);
+  logger.error("Failed to load subscription router", err as Error);
 }
 
 try {
@@ -107,7 +103,7 @@ try {
     app.use("/api", r.default || r);
   })();
 } catch (err) {
-  console.error("Failed to load credits router", err);
+  logger.error("Failed to load credits router", err as Error);
 }
 
 try {
@@ -116,7 +112,7 @@ try {
     app.use("/api", r.default || r);
   })();
 } catch (err) {
-  console.error("Failed to load payments router", err);
+  logger.error("Failed to load payments router", err as Error);
 }
 
 try {
@@ -125,7 +121,7 @@ try {
     app.use("/api", r.default || r);
   })();
 } catch (err) {
-  console.error("Failed to load worker router", err);
+  logger.error("Failed to load worker router", err as Error);
 }
 
 try {
@@ -134,19 +130,10 @@ try {
     app.use("/api", r.default || r);
   })();
 } catch (err) {
-  console.error("Failed to load status router", err);
+  logger.error("Failed to load status router", err as Error);
 }
 
-app.use((err: Error, req: Request, res: Response, _next: NextFunction) => {
-  const context = { method: req.method, url: req.originalUrl, body: req.body };
-  try {
-    logger.error("Error handling request", context, err);
-  } catch {
-    // ignore logging failures
-  }
-  capture(err);
-  res.status(500).json({ error: "Internal Server Error" });
-});
+app.use(errorHandler);
 
 export default app;
 module.exports = app;

--- a/backend/src/env.js
+++ b/backend/src/env.js
@@ -8,6 +8,8 @@ function requireEnv(name) {
   return value;
 }
 
+const logger = require("./logger.js");
+
 function buildEnv() {
   const NODE_ENV = requireEnv("NODE_ENV");
   if (!["development", "test", "production"].includes(NODE_ENV)) {
@@ -17,7 +19,7 @@ function buildEnv() {
   const shouldWarn =
     NODE_ENV === "development" && process.env.QUIET_ENV_WARNINGS !== "1";
   const warn = (msg) => {
-    if (shouldWarn) console.warn(msg);
+    if (shouldWarn) logger.warn(msg);
   };
   const optional = (name) => {
     const value = process.env[name];

--- a/backend/src/env.ts
+++ b/backend/src/env.ts
@@ -1,3 +1,5 @@
+import logger from "./logger.js";
+
 interface Env {
   DB_URL: string;
   STRIPE_SECRET_KEY: string;
@@ -26,7 +28,7 @@ function buildEnv(): Readonly<Env> {
   const shouldWarn =
     NODE_ENV === 'development' && process.env.QUIET_ENV_WARNINGS !== '1';
   const warn = (msg: string): void => {
-    if (shouldWarn) console.warn(msg);
+    if (shouldWarn) logger.warn(msg);
   };
   const optional = (name: string): string | undefined => {
     const value = process.env[name];

--- a/backend/src/logger.ts
+++ b/backend/src/logger.ts
@@ -1,4 +1,4 @@
-const { createLogger, format, transports } = require("winston");
+import { createLogger, format, transports } from "winston";
 
 const { combine, timestamp, json, colorize, printf } = format;
 
@@ -31,10 +31,13 @@ const baseLogger = createLogger({
 });
 
 const logger = {
-  info: (msg, meta) => baseLogger.info(msg, meta),
-  warn: (msg, meta) => baseLogger.warn(msg, meta),
-  error: (msg, meta) => baseLogger.error(msg, meta),
+  info: (msg: string, meta?: Record<string, unknown>) =>
+    baseLogger.info(msg, meta),
+  warn: (msg: string, meta?: Record<string, unknown>) =>
+    baseLogger.warn(msg, meta),
+  error: (msg: string, meta?: Record<string, unknown>) =>
+    baseLogger.error(msg, meta),
   transports: baseLogger.transports,
 };
 
-module.exports = logger;
+export default logger;

--- a/backend/src/middleware/errorHandler.js
+++ b/backend/src/middleware/errorHandler.js
@@ -1,0 +1,20 @@
+const logger = require("../logger.js");
+const { capture } = require("../lib/logger");
+
+function errorHandler(err, req, res, _next) {
+  const context = {
+    method: req.method,
+    url: req.originalUrl,
+    stack: err.stack,
+  };
+  try {
+    logger.error("Error handling request", context);
+  } catch {
+    // ignore logging failures
+  }
+  capture(err);
+  res.status(500).json({ error: "Internal Server Error" });
+}
+
+module.exports = errorHandler;
+module.exports.default = errorHandler;

--- a/backend/src/middleware/errorHandler.ts
+++ b/backend/src/middleware/errorHandler.ts
@@ -1,0 +1,23 @@
+import type { NextFunction, Request, Response } from "express";
+import logger from "../logger.js";
+import { capture } from "../lib/logger";
+
+export default function errorHandler(
+  err: Error,
+  req: Request,
+  res: Response,
+  _next: NextFunction,
+): void {
+  const context = {
+    method: req.method,
+    url: req.originalUrl,
+    stack: err.stack,
+  };
+  try {
+    logger.error("Error handling request", context);
+  } catch {
+    // ignore logging failures
+  }
+  capture(err);
+  res.status(500).json({ error: "Internal Server Error" });
+}

--- a/backend/src/routes/stripe/webhook.ts
+++ b/backend/src/routes/stripe/webhook.ts
@@ -3,6 +3,7 @@ import Stripe from "stripe";
 import db from "../../db.js";
 import { enqueuePrint } from "../../queue/printQueue.js";
 import { enqueuePrint as enqueueDbPrint } from "../../queue/dbPrintQueue.js";
+import logger from "../../logger.js";
 
 const router = Router();
 const stripe = new Stripe(process.env["STRIPE_KEY"] as string, {
@@ -16,7 +17,7 @@ router.post(
     const sig = req.headers["stripe-signature"] as string | undefined;
     const secret = process.env.STRIPE_WEBHOOK_SECRET;
     if (!sig || !secret) {
-      console.warn("Stripe webhook missing signature or secret");
+      logger.warn("Stripe webhook missing signature or secret");
       res.status(400).json({ error: "invalid_signature" });
       return;
     }
@@ -29,7 +30,7 @@ router.post(
     try {
       event = stripe.webhooks.constructEvent(rawBody, sig, secret);
     } catch (err) {
-      console.warn("Stripe webhook signature verification failed", err);
+      logger.warn("Stripe webhook signature verification failed", err as Error);
       res.status(400).json({ error: "invalid_signature" });
       return;
     }

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -4,12 +4,13 @@ config();
 const app =
   require("./app").app || require("./app").default || require("./app");
 const { getEnv } = require("./env");
+const logger = require("./logger.js");
 getEnv();
 const port = parseInt(process.env.PORT || "3000", 10);
 const PORT = isNaN(port) || port < 1 || port > 65535 ? 3000 : port;
 
 const server = app.listen(PORT, () => {
-  console.log(`Server listening on port ${PORT}`);
+  logger.info(`Server listening on port ${PORT}`);
 });
 
 module.exports = server;

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -3,6 +3,7 @@ config();
 
 import { app } from "./app";
 import { getEnv } from "./env";
+import logger from "./logger.js";
 
 // Validate environment at startup
 getEnv();
@@ -11,7 +12,7 @@ const port = Number.parseInt(process.env.PORT || "3000", 10);
 const PORT = Number.isNaN(port) || port < 1 || port > 65535 ? 3000 : port;
 
 const server = app.listen(PORT, () => {
-  console.log(`Server listening on port ${PORT}`);
+  logger.info(`Server listening on port ${PORT}`);
 });
 
 export default server;

--- a/backend/tests/logger.spec.5vh3813hflq2k9cp.ts
+++ b/backend/tests/logger.spec.5vh3813hflq2k9cp.ts
@@ -1,0 +1,40 @@
+import { jest } from "@jest/globals";
+
+describe("logger", () => {
+  test("logs at different levels", () => {
+    const prevEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "development";
+    jest.isolateModules(() => {
+      const logger = require("../src/logger.js");
+      const transport = logger.transports[0];
+      const spy = jest.spyOn(transport, "log");
+      logger.info("info message");
+      logger.warn("warn message");
+      logger.error("error message");
+      expect(spy.mock.calls.map((c: any) => c[0].level)).toEqual([
+        "info",
+        "warn",
+        "error",
+      ]);
+    });
+    process.env.NODE_ENV = prevEnv;
+  });
+
+  test("getEnv warnings use logger", () => {
+    const prev = { ...process.env };
+    process.env.NODE_ENV = "development";
+    delete process.env.QUIET_ENV_WARNINGS;
+    process.env.DB_URL = "postgres://user:pass@localhost/db";
+    process.env.STRIPE_SECRET_KEY = "sk";
+    process.env.STRIPE_PUBLISHABLE_KEY = "pk";
+    jest.isolateModules(() => {
+      const logger = require("../src/logger.js");
+      const warnSpy = jest.spyOn(logger, "warn").mockImplementation(() => {});
+      const { getEnv } = require("../src/env.js");
+      getEnv();
+      expect(warnSpy).toHaveBeenCalled();
+      warnSpy.mockRestore();
+    });
+    Object.assign(process.env, prev);
+  });
+});


### PR DESCRIPTION
## Summary
- add Winston-based logger with environment-aware formatting
- centralize env warnings and server logs through new logger
- capture and report route errors via dedicated middleware

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: POST /api/generate returns glb url expected 200 received 404)*
- `SKIP_PW_DEPS=1 npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_68af47bc8488832dbe5eae57e244a75a