### PR TITLE
refactor: centralize backend env access

### DIFF
--- a/backend/queue/printerTelemetry.js
+++ b/backend/queue/printerTelemetry.js
@@ -2,17 +2,23 @@ require("dotenv").config();
 const { Client } = require("pg");
 const { getPrinterInfo } = require("../printers/octoprint");
 const logger = require("../../src/logger");
-const { getEnv } = require("../src/env");
+const { getEnv: getEnvObject } = require("../src/env");
+const { getEnv } = require("../utils/getEnv");
 
-const OCTOPRINT_API_KEY = process.env.OCTOPRINT_API_KEY || "";
+const OCTOPRINT_API_KEY = getEnv("OCTOPRINT_API_KEY");
 const POLL_INTERVAL_MS = parseInt(
-  process.env.PRINTER_POLL_INTERVAL_MS || "60000",
+  getEnv("PRINTER_POLL_INTERVAL_MS") || "60000",
   10,
 );
-const PRINTER_URLS = (process.env.PRINTER_URLS || "")
+const PRINTER_URLS = (getEnv("PRINTER_URLS") || "")
   .split(",")
   .map((u) => u.trim())
   .filter(Boolean);
+
+if (!OCTOPRINT_API_KEY || PRINTER_URLS.length === 0) {
+  logger.error("Missing OCTOPRINT_API_KEY or PRINTER_URLS");
+  process.exit(1);
+}
 
 const lastStatus = {};
 
@@ -74,7 +80,7 @@ async function pollPrinters(client) {
 }
 
 async function run(interval = POLL_INTERVAL_MS) {
-  const { DB_URL } = getEnv();
+  const { DB_URL } = getEnvObject();
   const client = new Client({ connectionString: DB_URL });
   await client.connect();
   setInterval(() => {

--- a/backend/shipping.js
+++ b/backend/shipping.js
@@ -1,7 +1,14 @@
-const SHIPPING_API_URL = process.env.SHIPPING_API_URL;
-const SHIPPING_API_KEY = process.env.SHIPPING_API_KEY;
-const TRACKING_BASE_URL = process.env.TRACKING_BASE_URL || "";
+const { getEnv } = require("./utils/getEnv");
 const logger = require("../src/logger");
+
+const SHIPPING_API_URL = getEnv("SHIPPING_API_URL");
+const SHIPPING_API_KEY = getEnv("SHIPPING_API_KEY");
+const TRACKING_BASE_URL = getEnv("TRACKING_BASE_URL") || "";
+
+if (!SHIPPING_API_URL || !SHIPPING_API_KEY) {
+  logger.error("Missing SHIPPING_API_URL or SHIPPING_API_KEY");
+  process.exit(1);
+}
 
 async function getShippingEstimate(destination, model) {
   const weight = model.weight || 1;
@@ -46,9 +53,6 @@ function getTrackingUrl(carrier, trackingNumber) {
 }
 
 async function getTrackingStatus(carrier, trackingNumber) {
-  if (!SHIPPING_API_URL || !SHIPPING_API_KEY) {
-    return null;
-  }
   try {
     const res = await fetch(
       `${SHIPPING_API_URL}/track?carrier=${encodeURIComponent(carrier)}&tracking=${encodeURIComponent(trackingNumber)}`,

--- a/backend/src/routes/checkout.ts
+++ b/backend/src/routes/checkout.ts
@@ -1,20 +1,23 @@
 import { Router } from "express";
 import Stripe from "stripe";
-import { getEnv } from "../env";
+import logger from "../logger.js";
+import { getEnv } from "../../utils/getEnv.js";
+
+const secretKey = getEnv("STRIPE_SECRET_KEY");
+const successUrl = getEnv("FRONTEND_SUCCESS_URL");
+const cancelUrl = getEnv("FRONTEND_CANCEL_URL");
+
+if (!secretKey || !successUrl || !cancelUrl) {
+  logger.error(
+    "Missing STRIPE_SECRET_KEY, FRONTEND_SUCCESS_URL, or FRONTEND_CANCEL_URL",
+  );
+  process.exit(1);
+}
 
 const router = Router();
 
 router.post("/checkout/create", async (req, res) => {
   try {
-    const { STRIPE_SECRET_KEY: secretKey } = getEnv();
-    const successUrl = process.env.FRONTEND_SUCCESS_URL;
-    const cancelUrl = process.env.FRONTEND_CANCEL_URL;
-
-    if (!secretKey || !successUrl || !cancelUrl) {
-      res.status(500).json({ error: "server_misconfig" });
-      return;
-    }
-
     const {
       items,
       allowPromotionCodes,

--- a/backend/src/routes/items.ts
+++ b/backend/src/routes/items.ts
@@ -3,13 +3,22 @@ import { Pool } from "pg";
 import validate from "../../middleware/validate.js";
 import logger from "../logger.js";
 import { insertItem, insertItemSchema } from "../lib/items";
+import { getEnv } from "../../utils/getEnv.js";
 
 const router = Router();
 
+const dbEndpoint = getEnv("DB_ENDPOINT");
+const dbPassword = getEnv("DB_PASSWORD");
+
+if (!dbEndpoint || !dbPassword) {
+  logger.error("Missing DB_ENDPOINT or DB_PASSWORD");
+  process.exit(1);
+}
+
 const pool = new Pool({
-  connectionString: process.env.DB_ENDPOINT,
+  connectionString: dbEndpoint,
   user: "postgres",
-  password: process.env.DB_PASSWORD,
+  password: dbPassword,
   database: "postgres",
 });
 

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -4,11 +4,12 @@ config();
 import { app } from "./app";
 import { getEnv } from "./env";
 import logger from "./logger.js";
+import { getEnv as getEnvVar } from "../utils/getEnv.js";
 
 // Validate environment at startup
 getEnv();
 
-const port = Number.parseInt(process.env.PORT || "3000", 10);
+const port = Number.parseInt(getEnvVar("PORT") || "3000", 10);
 const PORT = Number.isNaN(port) || port < 1 || port > 65535 ? 3000 : port;
 
 const server = app.listen(PORT, () => {


### PR DESCRIPTION
## Summary
- use getEnv in checkout and items routes
- validate printer telemetry and shipping env vars at startup
- fetch server port through getEnv

## Testing
- `npx prettier backend/src/routes/checkout.ts backend/src/routes/items.ts backend/queue/printerTelemetry.js backend/shipping.js backend/src/server.ts --write`
- `npm test` *(fails: Expected "/models/test.glb" to be returned)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: many API route tests 404)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68af519b00b4832db4622820038579eb