### PR TITLE
feat: log route events and capture errors

### DIFF
--- a/backend/src/routes/credits.ts
+++ b/backend/src/routes/credits.ts
@@ -1,5 +1,7 @@
 import { Router, type Request, type Response } from "express";
 import { authRequired } from "../lib/auth";
+import logger from "../logger.js";
+import { capture } from "../lib/logger";
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const db = require("../../db.js");
 
@@ -8,8 +10,11 @@ const router = Router();
 router.get("/credits", authRequired, async (req: Request, res: Response) => {
   try {
     const credit = await db.getSaleCredit((req as any).user.id);
+    logger.info("credit_fetched", { userId: (req as any).user.id, credit });
     res.json({ credit });
-  } catch {
+  } catch (err) {
+    logger.error("credit_fetch_failed", { userId: (req as any).user.id });
+    capture(err);
     res.status(500).json({ error: "Failed to fetch credit" });
   }
 });
@@ -20,12 +25,19 @@ router.post(
   async (req: Request, res: Response) => {
     try {
       const amount = Number(req.body.amount_cents) || 0;
-      const credit = await db.adjustSaleCredit(
-        (req as any).user.id,
-        -amount,
-      );
+      const credit = await db.adjustSaleCredit((req as any).user.id, -amount);
+      logger.info("credit_redeemed", {
+        userId: (req as any).user.id,
+        amount,
+        credit,
+      });
       res.json({ credit });
-    } catch {
+    } catch (err) {
+      logger.error("credit_redeem_failed", {
+        userId: (req as any).user.id,
+        amount: Number(req.body.amount_cents) || 0,
+      });
+      capture(err);
       res.status(500).json({ error: "Failed to redeem credit" });
     }
   },

--- a/backend/src/routes/models.ts
+++ b/backend/src/routes/models.ts
@@ -3,6 +3,8 @@ import { Pool } from "pg";
 import validate from "../../middleware/validate.js";
 import { z } from "zod";
 import { getEnv } from "../env";
+import logger from "../logger.js";
+import { capture } from "../lib/logger";
 
 const router = Router();
 
@@ -29,8 +31,12 @@ router.post("/", validate(createModelSchema), async (req, res) => {
       "INSERT INTO models (prompt, s3_key, cloudfront_url) VALUES ($1, $2, $3) RETURNING id, prompt, s3_key, cloudfront_url",
       [prompt, s3_key, cloudfront_url],
     );
-    res.status(201).json(result.rows[0]);
-  } catch (_err) {
+    const model = result.rows[0];
+    logger.info("model_created", { id: model.id });
+    res.status(201).json(model);
+  } catch (err) {
+    logger.error("model_create_failed", err as Error);
+    capture(err);
     res.status(500).json({ error: "Internal Server Error" });
   }
 });
@@ -40,8 +46,11 @@ router.get("/", async (_req, res) => {
     const result = await pool.query(
       "SELECT id, prompt, s3_key, cloudfront_url FROM models ORDER BY id ASC",
     );
+    logger.info("models_listed", { count: result.rows.length });
     res.json(result.rows);
-  } catch (_err) {
+  } catch (err) {
+    logger.error("models_list_failed", err as Error);
+    capture(err);
     res.status(500).json({ error: "Internal Server Error" });
   }
 });
@@ -53,11 +62,16 @@ router.get("/:id", async (req, res) => {
       [req.params.id],
     );
     if (result.rows.length === 0) {
+      logger.warn("model_not_found", { id: req.params.id });
       res.status(404).json({ error: "Not Found" });
       return;
     }
-    res.json(result.rows[0]);
-  } catch (_err) {
+    const model = result.rows[0];
+    logger.info("model_retrieved", { id: model.id });
+    res.json(model);
+  } catch (err) {
+    logger.error("model_get_failed", { id: req.params.id });
+    capture(err);
     res.status(500).json({ error: "Internal Server Error" });
   }
 });

--- a/backend/src/routes/stripe/webhook.ts
+++ b/backend/src/routes/stripe/webhook.ts
@@ -4,6 +4,7 @@ import db from "../../db.js";
 import { enqueuePrint } from "../../queue/printQueue.js";
 import { enqueuePrint as enqueueDbPrint } from "../../queue/dbPrintQueue.js";
 import logger from "../../logger.js";
+import { capture } from "../../lib/logger";
 import { isTest } from "../../env.js";
 
 const router = Router();
@@ -21,7 +22,9 @@ router.post(
     const sig = req.headers["stripe-signature"] as string | undefined;
     const secret = process.env.STRIPE_WEBHOOK_SECRET;
     if (!sig || !secret) {
-      logger.warn("Stripe webhook missing signature or secret");
+      const err = new Error("stripe_webhook_missing_signature_or_secret");
+      logger.warn("stripe_webhook_missing_signature_or_secret");
+      capture(err);
       res.status(400).json({ error: "invalid_signature" });
       return;
     }
@@ -34,24 +37,43 @@ router.post(
     try {
       event = stripe.webhooks.constructEvent(rawBody, sig, secret);
     } catch (err) {
-      logger.warn("Stripe webhook signature verification failed", err as Error);
+      logger.warn("stripe_webhook_signature_verification_failed", err as Error);
+      capture(err);
       res.status(400).json({ error: "invalid_signature" });
       return;
     }
 
+    logger.info("stripe_webhook_received", { type: event.type });
+
     if (event.type === "checkout.session.completed") {
       const session = event.data.object as Stripe.Checkout.Session;
-      await db.query("UPDATE orders SET status=$1 WHERE session_id=$2", [
-        "paid",
-        session.id,
-      ]);
-      const jobId = session.metadata?.["jobId"];
-      if (jobId) {
-        await enqueueDbPrint(jobId, session.id, {}, null, null);
-        enqueuePrint(jobId);
+      try {
+        await db.query("UPDATE orders SET status=$1 WHERE session_id=$2", [
+          "paid",
+          session.id,
+        ]);
+        logger.info("order_paid", { sessionId: session.id });
+        const jobId = session.metadata?.["jobId"];
+        if (jobId) {
+          await enqueueDbPrint(jobId, session.id, {}, null, null);
+          enqueuePrint(jobId);
+          logger.info("print_enqueued", { jobId, sessionId: session.id });
+        } else {
+          logger.warn("stripe_webhook_missing_job_id", {
+            sessionId: session.id,
+          });
+        }
+      } catch (err) {
+        logger.error("stripe_webhook_processing_failed", {
+          sessionId: session.id,
+        });
+        capture(err);
+        res.status(500).json({ error: "processing_failed" });
+        return;
       }
     }
 
+    logger.info("stripe_webhook_processed", { type: event.type });
     res.status(200).json({ received: true });
   },
 );


### PR DESCRIPTION
## Summary
- log model creation, listing, and retrieval outcomes
- track credit fetch and redemption with error capture
- expand Stripe webhook logging and capture failures

## Testing
- `npm run format`
- `npm test` *(fails: process.exit called with "1" in src/routes/items.ts:15)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: process.exit called with "1" in src/routes/items.ts:15)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68af5a3db3e0832d932c502c30540a0e