### PR TITLE
fix: use getEnv for env vars

### DIFF
--- a/backend/src/routes/models.ts
+++ b/backend/src/routes/models.ts
@@ -2,14 +2,26 @@ import { Router } from "express";
 import { Pool } from "pg";
 import validate from "../../middleware/validate.js";
 import { z } from "zod";
-import { getEnv } from "../env";
+import logger from "../logger.js";
+import { getEnv as getEnvVar } from "../../utils/getEnv.js";
+import { getEnv as getEnvConfig } from "../env";
 
 const router = Router();
 
+let dbEndpoint: string;
+let dbPassword: string;
+try {
+  dbEndpoint = getEnvVar("DB_ENDPOINT", { required: true })!;
+  dbPassword = getEnvVar("DB_PASSWORD", { required: true })!;
+} catch (err) {
+  logger.error((err as Error).message);
+  process.exit(1);
+}
+
 const pool = new Pool({
-  connectionString: process.env.DB_ENDPOINT,
+  connectionString: dbEndpoint,
   user: "postgres",
-  password: process.env.DB_PASSWORD,
+  password: dbPassword,
   database: "postgres",
 });
 
@@ -23,7 +35,7 @@ export const createModelSchema = z.object({
 router.post("/", validate(createModelSchema), async (req, res) => {
   try {
     const { prompt, s3_key } = req.body as { prompt: string; s3_key: string };
-    const { CLOUDFRONT_DOMAIN } = getEnv();
+    const { CLOUDFRONT_DOMAIN } = getEnvConfig();
     const cloudfront_url = `https://${CLOUDFRONT_DOMAIN}/${s3_key}`;
     const result = await pool.query(
       "INSERT INTO models (prompt, s3_key, cloudfront_url) VALUES ($1, $2, $3) RETURNING id, prompt, s3_key, cloudfront_url",

--- a/backend/src/routes/stripe/webhook.ts
+++ b/backend/src/routes/stripe/webhook.ts
@@ -5,9 +5,20 @@ import { enqueuePrint } from "../../queue/printQueue.js";
 import { enqueuePrint as enqueueDbPrint } from "../../queue/dbPrintQueue.js";
 import logger from "../../logger.js";
 import { isTest } from "../../env.js";
+import { getEnv as getEnvVar } from "../../../utils/getEnv.js";
 
 const router = Router();
-const realStripe = new Stripe(process.env["STRIPE_KEY"] as string, {
+let stripeKey: string;
+let stripeWebhookSecret: string;
+try {
+  stripeKey = getEnvVar("STRIPE_KEY", { required: true })!;
+  stripeWebhookSecret = getEnvVar("STRIPE_WEBHOOK_SECRET", { required: true })!;
+} catch (err) {
+  logger.error((err as Error).message);
+  process.exit(1);
+}
+
+const realStripe = new Stripe(stripeKey, {
   apiVersion: "2025-06-30.basil",
 });
 const stripe = isTest()
@@ -19,9 +30,8 @@ router.post(
   express.raw({ type: "application/json" }),
   async (req: Request<any, any, Buffer>, res: Response): Promise<void> => {
     const sig = req.headers["stripe-signature"] as string | undefined;
-    const secret = process.env.STRIPE_WEBHOOK_SECRET;
-    if (!sig || !secret) {
-      logger.warn("Stripe webhook missing signature or secret");
+    if (!sig) {
+      logger.warn("Stripe webhook missing signature");
       res.status(400).json({ error: "invalid_signature" });
       return;
     }
@@ -32,7 +42,7 @@ router.post(
 
     let event: Stripe.Event;
     try {
-      event = stripe.webhooks.constructEvent(rawBody, sig, secret);
+      event = stripe.webhooks.constructEvent(rawBody, sig, stripeWebhookSecret);
     } catch (err) {
       logger.warn("Stripe webhook signature verification failed", err as Error);
       res.status(400).json({ error: "invalid_signature" });


### PR DESCRIPTION
## Summary
- use getEnv for database connection settings and exit when missing
- secure Stripe webhook by sourcing keys via getEnv

## Testing
- `npm run format`
- `DB_ENDPOINT=dummy_endpoint DB_PASSWORD=dummy_password npm test` (fails: Missing STRIPE_SECRET_KEY, FRONTEND_SUCCESS_URL, or FRONTEND_CANCEL_URL)
- `SKIP_PW_DEPS=1 npm run ci` (fails: Missing DB_ENDPOINT or DB_PASSWORD)
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68af5a3682c4832dbc1b099bdb39bc38