### PR TITLE
feat: log health and status routes

### DIFF
--- a/backend/src/routes/health.ts
+++ b/backend/src/routes/health.ts
@@ -1,10 +1,19 @@
 import { Router } from "express";
 import pkg from "../../package.json";
+import logger from "../logger.js";
+import { capture } from "../lib/logger";
 
 const router = Router();
 
 router.get("/healthz", (_req, res) => {
-  res.json({ ok: true, version: pkg.version });
+  logger.info("health_check");
+  try {
+    res.json({ ok: true, version: pkg.version });
+  } catch (err) {
+    logger.error("health_check_failed", err as Error);
+    capture(err);
+    res.status(500).json({ error: "unexpected_error" });
+  }
 });
 
 export default router;

--- a/backend/src/routes/status.ts
+++ b/backend/src/routes/status.ts
@@ -1,60 +1,74 @@
 import { Router } from "express";
 import { emitter, getStatus } from "../queue/generation";
+import logger from "../logger.js";
+import { capture } from "../lib/logger";
 
 const router = Router();
 
 router.get("/status/:id", (req, res) => {
-  if (
-    process.env.NODE_ENV === "test" &&
-    req.headers["x-test-shim"] === "1"
-  ) {
-    return res.json({
-      id: "job1",
-      state: "succeeded",
-      url: "/models/test.glb",
-    });
+  const id = req.params.id;
+  logger.info("status_check", { id });
+  try {
+    if (process.env.NODE_ENV === "test" && req.headers["x-test-shim"] === "1") {
+      return res.json({
+        id: "job1",
+        state: "succeeded",
+        url: "/models/test.glb",
+      });
+    }
+    const status = getStatus(id);
+    if (!status) {
+      res.status(404).json({ error: "not_found" });
+      return;
+    }
+    res.json({ id, ...status });
+  } catch (err) {
+    logger.error("status_check_failed", { id });
+    capture(err);
+    res.status(500).json({ error: "unexpected_error" });
   }
-  const status = getStatus(req.params.id);
-  if (!status) {
-    res.status(404).json({ error: "not_found" });
-    return;
-  }
-  res.json({ id: req.params.id, ...status });
 });
 
 router.get("/progress/:id", (req, res) => {
   const id = req.params.id;
-  const init = getStatus(id);
-  if (!init) {
-    res.status(404).json({ error: "not_found" });
-    return;
-  }
-  res.set({
-    "Content-Type": "text/event-stream",
-    "Cache-Control": "no-cache",
-    Connection: "keep-alive",
-  });
-  res.flushHeaders?.();
-
-  const send = (data: any) => {
-    res.write(`data: ${JSON.stringify(data)}\n\n`);
-  };
-
-  const handler = (status: any) => {
-    send(status);
-    if (status.state === "succeeded" || status.state === "failed") {
-      emitter.removeListener(`progress:${id}`, handler);
-      res.end();
+  logger.info("progress_check", { id });
+  try {
+    const init = getStatus(id);
+    if (!init) {
+      res.status(404).json({ error: "not_found" });
+      return;
     }
-  };
+    res.set({
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    });
+    res.flushHeaders?.();
 
-  send(init);
-  if (init.state === "succeeded" || init.state === "failed") {
-    res.end();
-    return;
+    const send = (data: any) => {
+      res.write(`data: ${JSON.stringify(data)}\n\n`);
+    };
+
+    const handler = (status: any) => {
+      send(status);
+      if (status.state === "succeeded" || status.state === "failed") {
+        emitter.removeListener(`progress:${id}`, handler);
+        res.end();
+      }
+    };
+
+    send(init);
+    if (init.state === "succeeded" || init.state === "failed") {
+      res.end();
+      return;
+    }
+    emitter.on(`progress:${id}`, handler);
+    req.on("close", () => emitter.removeListener(`progress:${id}`, handler));
+  } catch (err) {
+    logger.error("progress_check_failed", { id });
+    capture(err);
+    res.status(500).end();
   }
-  emitter.on(`progress:${id}`, handler);
-  req.on("close", () => emitter.removeListener(`progress:${id}`, handler));
 });
 
 export default router;

--- a/backend/src/routes/worker.ts
+++ b/backend/src/routes/worker.ts
@@ -1,11 +1,19 @@
 import { Router } from "express";
 import { isReady } from "../../queue/printWorker";
+import logger from "../logger.js";
+import { capture } from "../lib/logger";
 
 const router = Router();
 
 router.get("/worker/health", (_req, res) => {
-  res.json({ ok: true, ready: isReady() });
+  logger.info("worker_health_check");
+  try {
+    res.json({ ok: true, ready: isReady() });
+  } catch (err) {
+    logger.error("worker_health_check_failed", err as Error);
+    capture(err);
+    res.status(500).json({ error: "unexpected_error" });
+  }
 });
 
 export default router;
-


### PR DESCRIPTION
## Summary
- log health check requests
- add request logs and error handling for status routes
- record worker health checks with logger

## Testing
- `npm run format`
- `npm test` *(fails: process.exit called with "1")*
- `npm run ci` *(fails: process.exit called with "1")*
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68af636c1948832da4caff89b54d849f