### PR TITLE
fix: capture item insert errors

### DIFF
--- a/backend/src/routes/items.ts
+++ b/backend/src/routes/items.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import { Pool } from "pg";
 import validate from "../../middleware/validate.js";
 import logger from "../logger.js";
+import { capture } from "../lib/logger";
 import { insertItem, insertItemSchema } from "../lib/items";
 import { getEnv } from "../../utils/getEnv.js";
 
@@ -37,6 +38,7 @@ router.post("/api/items", validate(insertItemSchema), async (req, res) => {
       return;
     }
     logger.error("failed to insert item", err);
+    capture(err);
     res.status(500).json({ error: "Internal Server Error" });
   }
 });


### PR DESCRIPTION
## Summary
- import `capture` into items route
- send errors to `capture` when item insert fails

## Testing
- `npm run format`
- `DB_ENDPOINT=postgres://localhost DB_PASSWORD=pass npm test` (fails: process.exit called)
- `SKIP_PW_DEPS=1 npm run ci` (fails: process.exit called)
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68af6366db40832db4cc293a0747dcf4