### PR TITLE
feat: log checkout session events

### DIFF
--- a/backend/src/routes/checkout.js
+++ b/backend/src/routes/checkout.js
@@ -2,6 +2,8 @@
 const express = require("express");
 const Stripe = require("stripe");
 const { getEnv, isTest } = require("../env");
+const logger = require("../logger.js");
+const { capture } = require("../lib/logger");
 
 const router = express.Router();
 
@@ -26,17 +28,22 @@ router.post("/checkout/create", async (req, res) => {
     } = req.body || {};
     const email = customerEmail ?? customer_email;
     if (!Array.isArray(items) || items.length === 0) {
+      logger.warn("checkout_create_bad_request", { reason: "missing_items" });
       res.status(400).json({ error: "bad_request" });
       return;
     }
     const normalized = [];
     for (const item of items) {
       if (typeof item.price !== "string") {
+        logger.warn("checkout_create_bad_request", { reason: "invalid_item" });
         res.status(400).json({ error: "bad_request" });
         return;
       }
       const qty = item.quantity ?? 1;
       if (typeof qty !== "number" || qty < 1 || qty > 99) {
+        logger.warn("checkout_create_bad_request", {
+          reason: "invalid_quantity",
+        });
         res.status(400).json({ error: "bad_request" });
         return;
       }
@@ -71,11 +78,16 @@ router.post("/checkout/create", async (req, res) => {
         },
         { idempotencyKey: idempotencyKey || undefined },
       );
+      logger.info("checkout_session_created", { sessionId: session.id });
       res.status(200).json({ id: session.id });
     } catch (err) {
+      logger.error("stripe_checkout_session_failed");
+      capture(err);
       res.status(502).json({ error: "stripe_error" });
     }
   } catch (err) {
+    logger.error("checkout_create_failed");
+    capture(err);
     res.status(400).json({ error: "bad_request" });
   }
 });

--- a/backend/src/routes/checkout.ts
+++ b/backend/src/routes/checkout.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import Stripe from "stripe";
 import logger from "../logger.js";
+import { capture } from "../lib/logger";
 import { getEnv } from "../../utils/getEnv.js";
 
 const secretKey = getEnv("STRIPE_SECRET_KEY");
@@ -32,6 +33,7 @@ router.post("/checkout/create", async (req, res) => {
     const email = customerEmail ?? customer_email;
 
     if (!Array.isArray(items) || items.length === 0) {
+      logger.warn("checkout_create_bad_request", { reason: "missing_items" });
       res.status(400).json({ error: "bad_request" });
       return;
     }
@@ -39,11 +41,15 @@ router.post("/checkout/create", async (req, res) => {
     const normalized: { price: string; quantity: number }[] = [];
     for (const item of items) {
       if (typeof item.price !== "string") {
+        logger.warn("checkout_create_bad_request", { reason: "invalid_item" });
         res.status(400).json({ error: "bad_request" });
         return;
       }
       const qty = item.quantity ?? 1;
       if (typeof qty !== "number" || qty < 1 || qty > 99) {
+        logger.warn("checkout_create_bad_request", {
+          reason: "invalid_quantity",
+        });
         res.status(400).json({ error: "bad_request" });
         return;
       }
@@ -83,11 +89,16 @@ router.post("/checkout/create", async (req, res) => {
           idempotencyKey: idempotencyKey || undefined,
         },
       );
+      logger.info("checkout_session_created", { sessionId: session.id });
       res.status(200).json({ id: session.id });
-    } catch {
+    } catch (err) {
+      logger.error("stripe_checkout_session_failed");
+      capture(err);
       res.status(502).json({ error: "stripe_error" });
     }
-  } catch {
+  } catch (err) {
+    logger.error("checkout_create_failed");
+    capture(err);
     res.status(400).json({ error: "bad_request" });
   }
 });


### PR DESCRIPTION
## Summary
- log checkout session creation success and invalid requests
- capture errors and forward to Sentry in checkout handler

## Testing
- `npm run format`
- `npm test` *(fails: Missing DB_ENDPOINT or DB_PASSWORD)*
- `npm run ci` *(fails: process.exit called with "1")*
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68af63618710832db2a5242f3a5f972f