### PR TITLE
fix: capture stripe webhook errors

### DIFF
--- a/backend/src/routes/stripeWebhook.ts
+++ b/backend/src/routes/stripeWebhook.ts
@@ -3,6 +3,7 @@ import Stripe from "stripe";
 import logger from "../logger.js";
 import { upsertOrderPaid, markPaymentProcessed, linkModelToJob } from "../db";
 import { getEnv, isTest } from "../env";
+import { capture } from "../lib/logger";
 
 const { STRIPE_SECRET_KEY } = getEnv();
 const realStripe = new Stripe(STRIPE_SECRET_KEY, {
@@ -61,6 +62,7 @@ router.post(
         }
       } catch (err) {
         logger.error("stripe_webhook_error", err);
+        capture(err);
         res.status(500).json({ error: "server_error" });
         return;
       }


### PR DESCRIPTION
## Summary
- import `capture` from logger and report errors to Sentry for Stripe webhooks

## Testing
- `npm --prefix backend run format`
- `npm --prefix backend test` *(fails: Missing DB_ENDPOINT or DB_PASSWORD)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing DB_ENDPOINT or DB_PASSWORD)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68af635c8cd4832d8455d920ef90e8d0