### PR TITLE
feat: log checkout parameters

### DIFF
--- a/backend/src/routes/stripe/create-checkout-session.ts
+++ b/backend/src/routes/stripe/create-checkout-session.ts
@@ -2,6 +2,8 @@ import { Router, type Request, type Response } from "express";
 import Stripe from "stripe";
 import db from "../../db"; // imported for tests
 import { isTest } from "../../env";
+import logger from "../../logger.js";
+import { capture } from "../../lib/logger";
 
 interface Item {
   price: string;
@@ -74,6 +76,16 @@ router.post(
       params.shipping_address_collection = { allowed_countries: ["US"] };
     }
 
+    logger.info("create_checkout_session", {
+      items,
+      allowPromotionCodes,
+      metadata,
+      customer_email,
+      requiresShipping,
+      currency,
+      idempotencyKey,
+    });
+
     try {
       const session = await stripe.checkout.sessions.create(
         params,
@@ -81,6 +93,8 @@ router.post(
       );
       res.json({ id: session.id });
     } catch (err) {
+      logger.error("create_checkout_session_failed", err as Error);
+      capture(err);
       res.status(502).json({ error: "stripe_error" });
     }
   },


### PR DESCRIPTION
## Summary
- log key parameters when creating Stripe checkout session
- capture exceptions and log failures in checkout creation

## Testing
- `npm run format` (backend)
- `npm test` (backend) *(fails: process.exit called with missing DB credentials)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: process.exit called with missing DB credentials)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68af63556c28832dbbe28e206b3e6e01