### PR TITLE
feat: log stripe checkout session

### DIFF
--- a/backend/src/routes/stripeCheckout.ts
+++ b/backend/src/routes/stripeCheckout.ts
@@ -1,6 +1,8 @@
 import { Router, type Request, type Response } from "express";
 import Stripe from "stripe";
 import { getEnv, isTest } from "../env";
+import logger from "../logger.js";
+import { capture } from "../lib/logger";
 
 const router = Router();
 
@@ -32,8 +34,11 @@ router.post(
         cancel_url: process.env.FRONTEND_CANCEL_URL as string,
       });
 
+      logger.info("stripe_checkout_session_created", { sessionId: session.id });
       res.json({ id: session.id });
     } catch (err) {
+      logger.error("stripe_checkout_session_failed");
+      capture(err);
       res.status(500).json({ error: "Failed to create session" });
     }
   },


### PR DESCRIPTION
## Summary
- log stripe checkout session creation with structured metadata
- capture errors when stripe checkout session creation fails

## Testing
- `npm run format`
- `npm test` *(fails: process.exit called with "1")*
- `npm run ci` *(fails: process.exit called with "1")*
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68af63507134832da8e7bf182547fcad