### PR TITLE
fix: validate Stripe webhook secret

### DIFF
--- a/backend/src/routes/stripeWebhook.ts
+++ b/backend/src/routes/stripeWebhook.ts
@@ -2,15 +2,24 @@ import express from "express";
 import Stripe from "stripe";
 import logger from "../logger.js";
 import { upsertOrderPaid, markPaymentProcessed, linkModelToJob } from "../db";
-import { getEnv, isTest } from "../env";
+import { getEnv as getBackendEnv, isTest } from "../env";
+import { getEnv } from "../../utils/getEnv.js";
 
-const { STRIPE_SECRET_KEY } = getEnv();
+const { STRIPE_SECRET_KEY } = getBackendEnv();
 const realStripe = new Stripe(STRIPE_SECRET_KEY, {
   apiVersion: "2025-06-30.basil",
 });
 const stripe = isTest()
   ? require("../../tests/utils/stripeMock").stripe
   : realStripe;
+
+let stripeWebhookSecret: string;
+try {
+  stripeWebhookSecret = getEnv("STRIPE_WEBHOOK_SECRET", { required: true })!;
+} catch (err) {
+  logger.error((err as Error).message);
+  process.exit(1);
+}
 
 const router = express.Router();
 
@@ -24,7 +33,7 @@ router.post(
       event = stripe.webhooks.constructEvent(
         req.body,
         sig,
-        process.env.STRIPE_WEBHOOK_SECRET || "",
+        stripeWebhookSecret,
       );
     } catch {
       res.status(400).json({ error: "invalid_signature" });


### PR DESCRIPTION
## Summary
- ensure Stripe webhook secret is loaded via `getEnv` and exit on missing configuration

## Testing
- `npx prettier backend/src/routes/stripeWebhook.ts -w`
- `npm test` *(fails: process.exit called with "1" in items.ts)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: process.exit called with "1" in items.ts)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68af6348f0fc832d9063c07ac63fff89