### PR TITLE
feat: log reward events

### DIFF
--- a/backend/src/routes/rewards.ts
+++ b/backend/src/routes/rewards.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { authRequired, userIdFromAuth } from "../lib/auth";
-import { logError } from "../lib/logError";
+import logger from "../logger.js";
+import { capture } from "../lib/logger";
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const db = require("../../db.js");
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -9,12 +10,14 @@ const { createTimedCode } = require("../../discountCodes.js");
 const router = Router();
 
 router.get("/rewards", authRequired, async (req, res) => {
+  const userId = userIdFromAuth(req);
   try {
-    const userId = userIdFromAuth(req);
     const points = await db.getRewardPoints(userId);
+    logger.info("reward_points_fetched", { userId, points });
     res.json({ points });
   } catch (err) {
-    logError(err);
+    logger.error("reward_points_fetch_failed", { userId });
+    capture(err);
     res.status(500).json({ error: "Failed to fetch rewards" });
   }
 });
@@ -24,13 +27,13 @@ router.post("/rewards/redeem", authRequired, async (req, res) => {
     res.status(400).json({ error: "Invalid reward" });
     return;
   }
+  const userId = userIdFromAuth(req);
   try {
     const opt = await db.getRewardOption(cost);
     if (!opt) {
       res.status(400).json({ error: "Invalid reward" });
       return;
     }
-    const userId = userIdFromAuth(req);
     const current = await db.getRewardPoints(userId);
     if (current < cost) {
       res.status(400).json({ error: "Insufficient points" });
@@ -38,9 +41,11 @@ router.post("/rewards/redeem", authRequired, async (req, res) => {
     }
     await db.adjustRewardPoints(userId, -cost);
     const code = await createTimedCode(opt.amount_cents, 168);
+    logger.info("reward_redeemed", { userId, cost });
     res.json({ code });
   } catch (err) {
-    logError(err);
+    logger.error("reward_redeem_failed", { userId, cost });
+    capture(err);
     res.status(500).json({ error: "Failed to redeem reward" });
   }
 });
@@ -48,9 +53,11 @@ router.post("/rewards/redeem", authRequired, async (req, res) => {
 router.get("/rewards/options", async (_req, res) => {
   try {
     const options = await db.getRewardOptions();
+    logger.info("reward_options_fetched", { count: options.length });
     res.json({ options });
   } catch (err) {
-    logError(err);
+    logger.error("reward_options_fetch_failed");
+    capture(err);
     res.status(500).json({ error: "Failed to fetch reward options" });
   }
 });


### PR DESCRIPTION
## Summary
- log reward retrieval and redemption events
- capture errors with logger

## Testing
- `npm run format` (backend)
- `npm test` *(fails: Missing DB_ENDPOINT or DB_PASSWORD)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing DB_ENDPOINT or DB_PASSWORD)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68af755db880832da89fbea288abf5e0