### PR TITLE
feat: add logging to referral routes

### DIFF
--- a/backend/src/routes/referral.ts
+++ b/backend/src/routes/referral.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { authRequired, userIdFromAuth } from "../lib/auth";
-import { logError } from "../lib/logError";
+import logger from "../logger.js";
+import { capture } from "../lib/logger";
 import { tinyPng } from "../lib/legacy/tinyPng";
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const db = require("../../db.js");
@@ -13,9 +14,11 @@ router.get("/referral-link", authRequired, async (req, res) => {
   try {
     const userId = userIdFromAuth(req);
     const code = await db.getOrCreateReferralLink(userId);
+    logger.info("referral_link_retrieved", { userId });
     res.json({ code });
   } catch (err) {
-    logError(err);
+    logger.error("referral_link_fetch_failed", err);
+    capture(err);
     res.status(500).json({ error: "Failed to fetch referral link" });
   }
 });
@@ -23,19 +26,23 @@ router.get("/referral-link", authRequired, async (req, res) => {
 router.get("/referral-click", async (req, res) => {
   const code = (req.query.code as string) || (req.body && (req.body as any).code);
   if (!code) {
+    logger.warn("referral_click_missing_code");
     res.status(400).json({ error: "Missing code" });
     return;
   }
   try {
     const referrer = await db.getUserIdForReferral(code);
     if (!referrer) {
+      logger.warn("referral_click_invalid_code", { code });
       res.status(404).json({ error: "Invalid code" });
       return;
     }
     await db.insertReferralEvent(referrer, "click");
+    logger.info("referral_click_recorded", { referrer });
     res.json({ ok: true });
   } catch (err) {
-    logError(err);
+    logger.error("referral_click_failed", err);
+    capture(err);
     res.status(500).json({ error: "Failed to record click" });
   }
 });
@@ -43,12 +50,14 @@ router.get("/referral-click", async (req, res) => {
 router.post("/referral-signup", async (req, res) => {
   const { code } = (req.body as any) || {};
   if (!code) {
+    logger.warn("referral_signup_missing_code");
     res.status(400).json({ error: "Missing code" });
     return;
   }
   try {
     const userId = await db.getUserIdForReferral(code);
     if (!userId) {
+      logger.warn("referral_signup_invalid_code", { code });
       res.status(404).json({ error: "Invalid code" });
       return;
     }
@@ -59,16 +68,20 @@ router.post("/referral-signup", async (req, res) => {
     ]);
     await createTimedCode(300, 168);
     const reward = await createTimedCode(300, 168);
+    logger.info("referral_signup_success", { userId });
     res.json({ code: reward });
   } catch (err) {
-    logError(err);
+    logger.error("referral_signup_failed", err);
+    capture(err);
     res.status(500).json({ error: "Failed to process referral" });
   }
 });
 
 router.post("/referral-post", authRequired, async (req, res) => {
   const { url } = (req.body as any) || {};
+  const userId = userIdFromAuth(req);
   if (!url) {
+    logger.warn("referral_post_missing_url", { userId });
     res.status(400).json({ error: "Missing url" });
     return;
   }
@@ -76,13 +89,16 @@ router.post("/referral-post", authRequired, async (req, res) => {
     const { verifyTag } = require("../../social");
     const ok = await verifyTag(url);
     if (!ok) {
+      logger.warn("referral_post_invalid_tag", { url, userId });
       res.status(400).json({ error: "Invalid tag" });
       return;
     }
     const code = await createTimedCode(500, 168);
+    logger.info("referral_post_code_created", { userId });
     res.json({ code });
   } catch (err) {
-    logError(err);
+    logger.error("referral_post_failed", err);
+    capture(err);
     res.status(500).json({ error: "Failed to process post" });
   }
 });
@@ -93,13 +109,16 @@ router.get("/orders/:id/referral-link", authRequired, async (req, res) => {
     const userId = userIdFromAuth(req);
     const { rows } = await db.query("SELECT user_id FROM orders WHERE session_id=$1", [id]);
     if (!rows.length || rows[0].user_id !== userId) {
+      logger.warn("order_referral_link_not_found", { id, userId });
       res.status(404).json({ error: "Order not found" });
       return;
     }
     const code = await db.getOrCreateOrderReferralLink(id);
+    logger.info("order_referral_link_retrieved", { id, userId });
     res.json({ code });
   } catch (err) {
-    logError(err);
+    logger.error("order_referral_link_fetch_failed", err);
+    capture(err);
     res.status(500).json({ error: "Failed to fetch referral link" });
   }
 });
@@ -113,14 +132,17 @@ router.get("/orders/:id/referral-qr", authRequired, async (req, res) => {
       [id],
     );
     if (!rows.length || rows[0].user_id !== userId) {
+      logger.warn("order_referral_qr_not_found", { id, userId });
       res.status(404).json({ error: "Order not found" });
       return;
     }
     await db.getOrCreateOrderReferralLink(id);
     const png = tinyPng();
+    logger.info("order_referral_qr_generated", { id, userId });
     res.type("png").send(png);
   } catch (err) {
-    logError(err);
+    logger.error("order_referral_qr_failed", err);
+    capture(err);
     res.status(500).json({ error: "Failed to generate QR code" });
   }
 });


### PR DESCRIPTION
## Summary
- log key referral route actions
- use logger.error and capture instead of logError

## Testing
- `npm run format`
- `npm test` *(fails: process.exit: Missing DB_ENDPOINT or DB_PASSWORD)*
- `npm run ci` *(fails: process.exit: Missing DB_ENDPOINT or DB_PASSWORD)*
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68af7559edfc832dae4b0d68e251967e