### PR TITLE
fix: use validated env in ad copy generator

### DIFF
--- a/backend/utils/generateAdCopy.js
+++ b/backend/utils/generateAdCopy.js
@@ -1,12 +1,13 @@
 const axios = require("axios");
 const templates = require("../ad_templates.json");
+const { getEnv } = require("./getEnv");
 
 function pickTemplate() {
   return templates[Math.floor(Math.random() * templates.length)].template;
 }
 
 async function generateAdCopy(subreddit, context = "") {
-  const apiUrl = process.env.LLM_API_URL;
+  const apiUrl = getEnv("LLM_API_URL", { default: "" });
   if (apiUrl) {
     try {
       const { data } = await axios.post(apiUrl, {


### PR DESCRIPTION
## Summary
- use shared getEnv helper to read optional LLM_API_URL
- remove direct process.env usage in ad copy utility

## Testing
- `npm run format` (via npx prettier backend/utils/generateAdCopy.js)
- `npm test` *(fails: setup installs deps but Jest exits before tests run)*
- `npm run ci` *(fails: process.exit in missing DB vars)*
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68af75513be8832d94f640d209e88ca2