### PR TITLE
fix: verify spec files in Jest runner

### DIFF
--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -46,7 +46,7 @@ function verifyFiles(args) {
       checking = true;
       continue;
     }
-    if (checking || /\.test\.(js|ts)$/.test(arg)) {
+    if (checking || /\.(test|spec)\.(js|ts)$/.test(arg)) {
       const file = path.resolve(repoRoot, arg);
       if (!fs.existsSync(file)) {
         console.error(`Test file not found: ${arg}`);


### PR DESCRIPTION
## Summary
- include `.spec` patterns when checking explicit Jest test paths

## Testing
- `npm run format`
- `npm test backend/tests/stripe/webhook.valid-signature.spec.ts` *(fails: Missing STRIPE_SECRET_KEY, FRONTEND_SUCCESS_URL, or FRONTEND_CANCEL_URL)*
- `npm run ci` *(fails: Missing DB_ENDPOINT or DB_PASSWORD)*

------
https://chatgpt.com/codex/tasks/task_e_68b2df0ece40832daf8909e0d4dc8199