### PR TITLE
fix: correct npm prefix path in run-jest fallback

### DIFF
--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -146,11 +146,10 @@ function runJest(args) {
   if (fs.existsSync(jestBin)) {
     result = spawnSync(jestBin, jestArgs, options);
   } else {
-    result = spawnSync(
-      "npm",
-      ["test", "--prefix", "backend", ...jestArgs],
-      options,
-    );
+    const npmArgs = runFromRoot
+      ? ["test", "--prefix", "backend", ...jestArgs]
+      : ["test", ...jestArgs];
+    result = spawnSync("npm", npmArgs, options);
   }
 
   if (tempConfigPath) {


### PR DESCRIPTION
## Summary
- fix scripts/run-jest.js so npm fallback uses correct backend path

## Testing
- `npm run format` (backend)
- `npm test` (fails: Missing DB_ENDPOINT or DB_PASSWORD)
- `npm run ci` (fails: process.exit called due to missing DB environment)


------
https://chatgpt.com/codex/tasks/task_e_68b2df937124832da7a050803bccbbc2