### PR TITLE
fix: run root jest when backend deps missing

### DIFF
--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -142,13 +142,22 @@ function runJest(args) {
     env,
   };
 
+  const rootJestBin = path.join(repoRoot, "node_modules", ".bin", "jest");
   let result;
-  if (fs.existsSync(jestBin)) {
+  if (runFromRoot) {
+    if (!fs.existsSync(rootJestBin)) {
+      console.error(
+        "Missing root Jest binary. Run 'npm install' in the repo root first.",
+      );
+      process.exit(1);
+    }
+    result = spawnSync(rootJestBin, jestArgs, options);
+  } else if (fs.existsSync(jestBin)) {
     result = spawnSync(jestBin, jestArgs, options);
   } else {
     result = spawnSync(
       "npm",
-      ["test", "--prefix", "backend", ...jestArgs],
+      ["test", "--prefix", "backend", "--", ...jestArgs],
       options,
     );
   }


### PR DESCRIPTION
## Summary
- avoid backend prefix when backend dependencies are absent so smoke tests run

## Testing
- `npm test -- --maxWorkers=2 --runTestsByPath tests/config/package-scripts.smoke.e7082164ae33772d.spec.ts tests/smoke/healthcheck.a7a3f7a4a4adf630.spec.ts`
- `SKIP_PW_DEPS=1 npm run smoke`
- `npm test --prefix backend` *(fails: process.exit called due to missing DB_ENDPOINT or DB_PASSWORD)*


------
https://chatgpt.com/codex/tasks/task_e_68b2dee56db4832d94f46f8c87732129