### PR TITLE
ci: add wait-on timeouts for GitHub workflows

### DIFF
--- a/.github/workflows/model-e2e.yml
+++ b/.github/workflows/model-e2e.yml
@@ -7,13 +7,13 @@ jobs:
       - uses: actions/checkout@v4.1.7
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
-          cache: 'npm'
+          node-version: "20.x"
+          cache: "npm"
       - run: npm ci
       - run: npx playwright install --with-deps chromium
       - run: |
-          nohup npm run start &>/tmp/app.log & disown
-          npx wait-on http://localhost:3000
+          nohup npm run start > /tmp/app.log 2>&1 &
+          npx wait-on http://localhost:3000 --timeout 180000
       - run: npx playwright test tests/e2e/model-loading.hf.spec.ts tests/e2e/model-visual.spec.ts tests/e2e/model-fallbacks.spec.ts
     env:
       CI: "true"

--- a/.github/workflows/model-tests.yml
+++ b/.github/workflows/model-tests.yml
@@ -8,13 +8,13 @@ jobs:
       - uses: actions/checkout@v5.0.0
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
-          cache: 'npm'
+          node-version: "20.x"
+          cache: "npm"
       - run: npm ci
       - run: npx playwright install --with-deps chromium
       - run: |
-          nohup npm run start &>/tmp/app.log & disown
-          npx wait-on http://localhost:3000
+          nohup npm run start > /tmp/app.log 2>&1 &
+          npx wait-on http://localhost:3000 --timeout 180000
       - run: npx playwright test tests/e2e/model-loading.hf.spec.ts tests/e2e/model-fallbacks.spec.ts tests/e2e/a11y-model.spec.ts
     env:
       CI: "true"
@@ -26,21 +26,21 @@ jobs:
       - uses: actions/checkout@v5.0.0
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
-          cache: 'npm'
+          node-version: "20.x"
+          cache: "npm"
       - run: npm ci
       - run: npx lhci autorun --config=lighthouserc-model.json
 
       - uses: actions/checkout@v5.0.0
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
-          cache: 'npm'
+          node-version: "20.x"
+          cache: "npm"
       - run: npm ci
       - run: npx playwright install --with-deps chromium
       - run: |
-          nohup npm run start &>/tmp/app.log & disown
-          npx wait-on http://localhost:3000
+          nohup npm run start > /tmp/app.log 2>&1 &
+          npx wait-on http://localhost:3000 --timeout 180000
       - run: npx playwright test tests/e2e/model-loading.hf.spec.ts tests/e2e/model-fallbacks.spec.ts tests/e2e/a11y-model.spec.ts
     env:
       CI: "true"

--- a/.github/workflows/playwright-deps-and-e2e.yml
+++ b/.github/workflows/playwright-deps-and-e2e.yml
@@ -7,8 +7,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
-          cache: 'npm'
+          node-version: "20.x"
+          cache: "npm"
       - name: Install deps
         run: npm ci
       - name: Install Playwright browsers + OS dependencies
@@ -16,8 +16,8 @@ jobs:
           npx playwright install --with-deps chromium
       - name: Start dev server
         run: |
-          nohup npm run start &>/tmp/app.log & disown
-          npx wait-on http://localhost:3000
+          nohup npm run start > /tmp/app.log 2>&1 &
+          npx wait-on http://localhost:3000 --timeout 180000
       - name: Run model-loading tests
         env:
           CI: "true"

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "setup": "bash scripts/setup.sh",
     "build": "vite build",
     "preview": "vite preview --port 4173",
+    "start": "node scripts/dev-server.js",
     "start:backend": "npm start --prefix backend",
     "ci": "if [ \"$SKIP_PW_DEPS\" = \"1\" ]; then npm ci --ignore-scripts; else npm ci; fi && npm run build --workspaces=false && npm test",
     "backend:ci": "npm run --prefix backend ci",

--- a/scripts/run-smoke.js
+++ b/scripts/run-smoke.js
@@ -166,10 +166,9 @@ function main() {
       execSync("npm ci --prefix frontend", { stdio: "inherit" });
       execSync("npm run build --prefix frontend", { stdio: "inherit" });
     }
-    const waitArgs = process.env.WAIT_ON_TIMEOUT
-      ? `-t ${process.env.WAIT_ON_TIMEOUT} `
-      : "";
-    console.log("WAIT_ON_TIMEOUT:", process.env.WAIT_ON_TIMEOUT || "default");
+    const waitTimeout = process.env.WAIT_ON_TIMEOUT || 180000;
+    const waitArgs = `-t ${waitTimeout} `;
+    console.log("WAIT_ON_TIMEOUT:", waitTimeout);
     const serve = "node scripts/dev-server.js | tee serve.log";
     const test = `npx -y wait-on ${waitArgs}http://localhost:3000 && npx playwright test --reporter=list --trace on e2e/smoke.test.js | tee pw.log`;
     const cmd = `npx -y concurrently -k -s first --verbose -n serve,pw "${serve}" "${test}"`;


### PR DESCRIPTION
## Summary
- start dev server via `npm run start` with logs for CI
- bound `wait-on` calls to 3 minutes to avoid six-hour hangs
- default smoke test wait timeout to 3 minutes

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` (backend) *(modified files reverted)*
- `npm test` (backend) *(fails: Missing DB_ENDPOINT or DB_PASSWORD)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Missing DB_ENDPOINT or DB_PASSWORD)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b2e1277ccc832dbb301bb795b4c996