### PR TITLE
ci: resolve backend root dynamically

### DIFF
--- a/.github/actions/ci-toolbox/action.yml
+++ b/.github/actions/ci-toolbox/action.yml
@@ -41,12 +41,36 @@ runs:
         else
           echo "manager=npm" >> "$GITHUB_OUTPUT"
         fi
+    - id: backend
+      name: Resolve backend directory
+      shell: bash
+      run: |
+        node - <<'NODE' >> "$GITHUB_ENV"
+        const fs = require('fs');
+        const path = require('path');
+        function find(start) {
+          let dir = start;
+          while (true) {
+            const candidate = path.join(dir, 'backend', 'package.json');
+            if (fs.existsSync(candidate)) return path.dirname(candidate);
+            const parent = path.dirname(dir);
+            if (parent === dir) return null;
+            dir = parent;
+          }
+        }
+        const backend = find(process.cwd());
+        if (!backend) {
+          console.error('backend/package.json not found');
+          process.exit(1);
+        }
+        process.stdout.write(`BACKEND_DIR=${backend}`);
+        NODE
     - name: Cache node modules
       uses: actions/cache@v4
       with:
         path: |
           node_modules
-          backend/node_modules
+          ${{ env.BACKEND_DIR }}/node_modules
           frontend/node_modules
         key: ${{ steps.pm.outputs.manager }}-${{ hashFiles('**/pnpm-lock.yaml', '**/package-lock.json', '**/yarn.lock') }}-${{ runner.os }}
     - name: Cache Playwright browsers

--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -17,9 +17,24 @@ if (!process.env.SKIP_ROOT_DEPS_CHECK) {
   }
 }
 
+function findBackendRoot(start) {
+  let dir = start;
+  while (true) {
+    const candidate = path.join(dir, "backend", "package.json");
+    if (fs.existsSync(candidate)) return path.dirname(candidate);
+    const parent = path.dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
 const cliArgs = process.argv.slice(2);
-const repoRoot = path.resolve(__dirname, "..");
-const backendDir = path.join(repoRoot, "backend");
+const backendDir = findBackendRoot(process.cwd());
+if (!backendDir || !fs.existsSync(path.join(backendDir, "package.json"))) {
+  console.error("backend/package.json not found");
+  process.exit(1);
+}
+const repoRoot = path.dirname(backendDir);
 const requiresBackendDeps = cliArgs
   .filter((a) => !a.startsWith("-"))
   .some((arg) => {
@@ -39,7 +54,6 @@ if (requiresBackendDeps) {
 }
 
 function verifyFiles(args) {
-  const repoRoot = path.resolve(__dirname, "..");
   let checking = false;
   for (const arg of args) {
     if (arg === "--runTestsByPath") {
@@ -58,8 +72,6 @@ function verifyFiles(args) {
 
 function runJest(args) {
   verifyFiles(args);
-  const repoRoot = path.resolve(__dirname, "..");
-  const backendDir = path.join(repoRoot, "backend");
   const jestBin = path.join(backendDir, "node_modules", ".bin", "jest");
 
   let jestArgs = [...args];
@@ -152,18 +164,17 @@ function runJest(args) {
       process.exit(1);
     }
     result = spawnSync(rootJestBin, jestArgs, options);
-} else if (fs.existsSync(jestBin)) {
-  result = spawnSync(jestBin, jestArgs, options);
-} else {
-  if (!fs.existsSync(rootJestBin)) {
-    console.error(
-      "Missing root Jest binary. Run 'npm install' in the repo root first.",
-    );
-    process.exit(1);
+  } else if (fs.existsSync(jestBin)) {
+    result = spawnSync(jestBin, jestArgs, options);
+  } else {
+    if (!fs.existsSync(rootJestBin)) {
+      console.error(
+        "Missing root Jest binary. Run 'npm install' in the repo root first.",
+      );
+      process.exit(1);
+    }
+    result = spawnSync(rootJestBin, jestArgs, options);
   }
-  result = spawnSync(rootJestBin, jestArgs, options);
-}
-
 
   if (tempConfigPath) {
     try {


### PR DESCRIPTION
## Summary
- dynamically locate backend root in run-jest
- resolve backend path in ci-toolbox action and assert backend/package.json exists

## Testing
- `npx prettier -w scripts/run-jest.js .github/actions/ci-toolbox/action.yml`
- `npm test --prefix backend` *(fails: 403 CONNECT tunnel failed)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: network restrictions)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: 403 CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b36260f7f4832d9a51150a73f82ff5