### PR TITLE
ci: run backend migrations in postgres service

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -3,6 +3,20 @@ on: [push, pull_request]
 jobs:
   backend:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_DB: test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U postgres"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -11,4 +25,16 @@ jobs:
           cache: "npm"
       - run: npm ci
       - run: npm run db:migrate:test
-      - run: npm test --prefix backend
+        working-directory: backend
+        env:
+          DB_URL: postgres://postgres:postgres@localhost:5432/test
+          NODE_ENV: test
+          STRIPE_SECRET_KEY: sk_test
+          STRIPE_PUBLISHABLE_KEY: pk_test
+      - run: npm test
+        working-directory: backend
+        env:
+          DB_URL: postgres://postgres:postgres@localhost:5432/test
+          NODE_ENV: test
+          STRIPE_SECRET_KEY: sk_test
+          STRIPE_PUBLISHABLE_KEY: pk_test


### PR DESCRIPTION
## Summary
- run backend db migrations in CI with a temporary postgres service
- ensure migrations and tests execute from the backend working directory with required env vars

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: Unable to reach npm registry; CONNECT tunnel failed 403)*
- `npm run ci` *(incomplete: command produced deprecation warnings and did not finish due to environment limits)*
- `npm run smoke` *(fails: Unable to reach npm registry; CONNECT tunnel failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b366033234832db16121653ca6b9b7