### PR TITLE
fix: ensure stats ticker renders without web crypto

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -239,11 +239,50 @@ function showThemeBanner() {
 async function computeDailyPrintsSold(date = new Date()) {
   const eastern = new Date(date.toLocaleString("en-US", { timeZone: TZ }));
   const dateStr = eastern.toISOString().slice(0, 10);
-  const data = new TextEncoder().encode(dateStr);
-  const hash = await crypto.subtle.digest("SHA-256", data);
-  const int = new DataView(hash).getUint32(0);
+  let int;
+  if (crypto?.subtle?.digest) {
+    const data = new TextEncoder().encode(dateStr);
+    const hash = await crypto.subtle.digest("SHA-256", data);
+    int = new DataView(hash).getUint32(0);
+  } else {
+    int = 0;
+    for (let i = 0; i < dateStr.length; i++) {
+      int = (int * 31 + dateStr.charCodeAt(i)) >>> 0;
+    }
+  }
   const rand = int / UINT32_MAX;
   return Math.floor(rand * (PRINTS_MAX - PRINTS_MIN + 1)) + PRINTS_MIN;
+}
+
+async function updateStats(initial) {
+  const el = document.getElementById("stats-ticker");
+  if (!el) return;
+  let prints;
+  if (initial && typeof initial.printsSold === "number") {
+    prints = initial.printsSold;
+  } else {
+    try {
+      const res = await fetch(`${API_BASE}/stats`);
+      if (res.ok) {
+        const data = await res.json();
+        prints =
+          typeof data?.printsSold === "number"
+            ? data.printsSold
+            : await computeDailyPrintsSold();
+      } else {
+        prints = await computeDailyPrintsSold();
+      }
+    } catch {
+      prints = await computeDailyPrintsSold();
+    }
+  }
+  el.textContent = "";
+  const icon = document.createElement("i");
+  icon.className = "fas fa-fire mr-1";
+  el.appendChild(icon);
+  el.appendChild(document.createTextNode(` ${prints} prints sold`));
+  el.appendChild(document.createElement("br"));
+  el.appendChild(document.createTextNode("in last 24 hrs"));
 }
 const $ = (id) => document.getElementById(id);
 const refs = {
@@ -1153,37 +1192,6 @@ async function init() {
     // Animation and sound handled in basket.js
   });
 
-  async function updateStats(initial) {
-    const el = document.getElementById("stats-ticker");
-    if (!el) return;
-    let prints;
-    if (initial && typeof initial.printsSold === "number") {
-      prints = initial.printsSold;
-    } else {
-      try {
-        const res = await fetch(`${API_BASE}/stats`);
-        if (res.ok) {
-          const data = await res.json();
-          prints =
-            typeof data?.printsSold === "number"
-              ? data.printsSold
-              : await computeDailyPrintsSold();
-        } else {
-          prints = await computeDailyPrintsSold();
-        }
-      } catch {
-        prints = await computeDailyPrintsSold();
-      }
-    }
-    el.textContent = "";
-    const icon = document.createElement("i");
-    icon.className = "fas fa-fire mr-1";
-    el.appendChild(icon);
-    el.appendChild(document.createTextNode(` ${prints} prints sold`));
-    el.appendChild(document.createElement("br"));
-    el.appendChild(document.createTextNode("in last 24 hrs"));
-  }
-
   setInterval(updateStats, 3600000);
 
   // Keep the wizard UI in sync with the payment page
@@ -1336,6 +1344,6 @@ if (document.readyState !== "loading") {
 window.addEventListener("DOMContentLoaded", start);
 
 if (typeof module !== "undefined") {
-  module.exports = { renderThumbnails };
+  module.exports = { renderThumbnails, computeDailyPrintsSold, updateStats };
 }
-export { renderThumbnails };
+export { renderThumbnails, computeDailyPrintsSold, updateStats };

--- a/tests/frontend/stats-ticker.heubfxn983x849byxn0.test.js
+++ b/tests/frontend/stats-ticker.heubfxn983x849byxn0.test.js
@@ -1,0 +1,99 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+
+let computeDailyPrintsSold;
+let updateStats;
+
+beforeAll(async () => {
+  const { webcrypto } = require("crypto");
+  global.crypto = webcrypto;
+  const dummy = new Proxy(function () {}, {
+    get: () => dummy,
+    set: () => true,
+    apply: () => undefined,
+  });
+  window.getComputedStyle = () => ({ lineHeight: "16" });
+  document.getElementById = (id) => {
+    if (id === "stats-ticker") {
+      return document.querySelector("#stats-ticker") || dummy;
+    }
+    return dummy;
+  };
+  const mod = await import("../../js/index.js");
+  computeDailyPrintsSold = mod.computeDailyPrintsSold;
+  updateStats = mod.updateStats;
+});
+
+describe("computeDailyPrintsSold", () => {
+  beforeEach(() => {
+    const { webcrypto } = require("crypto");
+    global.crypto = webcrypto;
+  });
+
+  test("returns value within expected range", async () => {
+    const val = await computeDailyPrintsSold(new Date("2024-01-01"));
+    expect(val).toBeGreaterThanOrEqual(30);
+    expect(val).toBeLessThanOrEqual(50);
+  });
+
+  test("is deterministic for same date", async () => {
+    const d = new Date("2024-01-01");
+    const v1 = await computeDailyPrintsSold(d);
+    const v2 = await computeDailyPrintsSold(d);
+    expect(v1).toBe(43);
+    expect(v2).toBe(43);
+  });
+
+  test("falls back when crypto.subtle missing", async () => {
+    const orig = global.crypto;
+    global.crypto = {};
+    const val = await computeDailyPrintsSold(new Date("2024-01-01"));
+    expect(val).toBe(43);
+    global.crypto = orig;
+  });
+});
+
+describe("updateStats", () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<p id="stats-ticker"></p>';
+    const { webcrypto } = require("crypto");
+    global.crypto = webcrypto;
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    delete global.fetch;
+  });
+
+  test("uses provided initial stats", async () => {
+    await updateStats({ printsSold: 40 });
+    const el = document.getElementById("stats-ticker");
+    expect(el.textContent).toContain("40 prints sold");
+    expect(el.textContent).toContain("in last 24 hrs");
+    expect(el.querySelector("i.fas.fa-fire")).not.toBeNull();
+  });
+
+  test("fetches from API when no initial stats", async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({ printsSold: 41 }) });
+    await updateStats();
+    const el = document.getElementById("stats-ticker");
+    expect(el.textContent).toContain("41 prints sold");
+    expect(global.fetch).toHaveBeenCalled();
+  });
+
+  test("falls back to computed value when fetch fails", async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error("network"));
+    global.crypto = {};
+    await updateStats();
+    const text = document.getElementById("stats-ticker").textContent;
+    expect(text).toMatch(/prints sold/);
+    expect(text).toMatch(/in last 24 hrs/);
+  });
+
+  test("handles missing element gracefully", async () => {
+    document.body.innerHTML = "";
+    await expect(updateStats()).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- allow stats ticker to compute daily counts when Web Crypto is unavailable
- export and test stats ticker helpers
- add regression tests for stats ticker and daily print counts

## Testing
- `npm run format` *(passed)*
- `npm test` *(failed: Unable to reach npm registry: https://registry.npmjs.org/-/ping)*
- `node scripts/run-jest.js tests/frontend/stats-ticker.heubfxn983x849byxn0.test.js` *(passed)*
- `SKIP_PW_DEPS=1 npm run smoke` *(failed: Unable to reach npm registry: https://registry.npmjs.org/-/ping)*

------
https://chatgpt.com/codex/tasks/task_e_68b36b080324832d857741a6029046e6