### PR TITLE
fix: handle print run info storage errors

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -327,17 +327,25 @@ function getCycleKey() {
 }
 
 function resetPurchaseCount() {
-  const key = getCycleKey();
-  if (localStorage.getItem("slotCycle") !== key) {
-    localStorage.setItem("slotCycle", key);
-    localStorage.setItem("slotPurchases", "0");
+  try {
+    const key = getCycleKey();
+    if (localStorage.getItem("slotCycle") !== key) {
+      localStorage.setItem("slotCycle", key);
+      localStorage.setItem("slotPurchases", "0");
+    }
+  } catch {
+    /* ignore storage errors */
   }
 }
 
 function getPurchaseCount() {
-  resetPurchaseCount();
-  const n = parseInt(localStorage.getItem("slotPurchases"), 10);
-  return Number.isInteger(n) && n > 0 ? n : 0;
+  try {
+    resetPurchaseCount();
+    const n = parseInt(localStorage.getItem("slotPurchases"), 10);
+    return Number.isInteger(n) && n > 0 ? n : 0;
+  } catch {
+    return 0;
+  }
 }
 
 function adjustedSlots(base) {
@@ -1330,12 +1338,21 @@ function start() {
     init();
   }
 }
-if (document.readyState !== "loading") {
-  start();
+if (typeof process === "undefined" || process.env.NODE_ENV !== "test") {
+  if (document.readyState !== "loading") {
+    start();
+  }
+  window.addEventListener("DOMContentLoaded", start);
 }
-window.addEventListener("DOMContentLoaded", start);
 
 if (typeof module !== "undefined") {
   module.exports = { renderThumbnails };
 }
-export { renderThumbnails };
+export {
+  renderThumbnails,
+  computeSlotsByTime,
+  computePrintRunHours,
+  adjustedSlots,
+  updatePrintRunInfo,
+  getPurchaseCount,
+};

--- a/tests/frontend/print-run-info.4hb2oxnb2c7nx14by7.spec.js
+++ b/tests/frontend/print-run-info.4hb2oxnb2c7nx14by7.spec.js
@@ -1,0 +1,99 @@
+/** @jest-environment jsdom */
+import {
+  computeSlotsByTime,
+  computePrintRunHours,
+  adjustedSlots,
+  updatePrintRunInfo,
+} from "../../js/index.js";
+
+describe("print run info", () => {
+  let originalStorage;
+  beforeEach(() => {
+    jest.useFakeTimers();
+    originalStorage = window.localStorage;
+    document.body.innerHTML = `
+      <div id="print-run-info" class="invisible">
+        <span id="print-run-slots"></span> print slots left for next
+        <span id="print-run-hours"></span>
+        <span id="print-run-hours-label"></span>
+      </div>`;
+    global.fetch = undefined;
+    localStorage.clear();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+    Object.defineProperty(window, "localStorage", {
+      value: originalStorage,
+      configurable: true,
+    });
+    delete window.positionQuote;
+  });
+
+  test("computeSlotsByTime returns expected value for 1AM ET", () => {
+    jest.setSystemTime(new Date("2023-01-01T06:00:00Z"));
+    expect(computeSlotsByTime()).toBe(9);
+  });
+
+  test("computePrintRunHours returns remaining hours in six-hour cycle", () => {
+    jest.setSystemTime(new Date("2023-01-01T10:00:00Z"));
+    expect(computePrintRunHours()).toBe(1);
+  });
+
+  test("adjustedSlots subtracts purchase count", () => {
+    localStorage.setItem("slotPurchases", "2");
+    expect(adjustedSlots(5)).toBe(3);
+  });
+
+  test("updatePrintRunInfo populates slots when fetch fails", async () => {
+    jest.setSystemTime(new Date("2023-01-01T06:00:00Z"));
+    global.fetch = jest.fn().mockRejectedValue(new Error("net"));
+    await updatePrintRunInfo();
+    expect(document.getElementById("print-run-slots").textContent).toBe("9");
+  });
+
+  test("updatePrintRunInfo uses API slot count", async () => {
+    jest.setSystemTime(new Date("2023-01-01T06:00:00Z"));
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue({ ok: true, json: async () => ({ slots: 4 }) });
+    await updatePrintRunInfo();
+    expect(document.getElementById("print-run-slots").textContent).toBe("4");
+  });
+
+  test("updatePrintRunInfo handles singular hour label", async () => {
+    jest.setSystemTime(new Date("2023-01-01T16:00:00Z"));
+    global.fetch = jest.fn().mockRejectedValue(new Error("net"));
+    await updatePrintRunInfo();
+    expect(document.getElementById("print-run-hours-label").textContent).toBe(
+      "hour",
+    );
+  });
+
+  test("updatePrintRunInfo survives localStorage errors", async () => {
+    jest.setSystemTime(new Date("2023-01-01T06:00:00Z"));
+    global.fetch = jest.fn().mockRejectedValue(new Error("net"));
+    Object.defineProperty(window, "localStorage", {
+      value: {
+        getItem: () => {
+          throw new Error("denied");
+        },
+        setItem: () => {
+          throw new Error("denied");
+        },
+      },
+      configurable: true,
+    });
+    await updatePrintRunInfo();
+    expect(document.getElementById("print-run-slots").textContent).toBe("9");
+  });
+
+  test("updatePrintRunInfo removes invisible and calls positionQuote", async () => {
+    jest.setSystemTime(new Date("2023-01-01T06:00:00Z"));
+    global.fetch = jest.fn().mockRejectedValue(new Error("net"));
+    const info = document.getElementById("print-run-info");
+    window.positionQuote = jest.fn();
+    await updatePrintRunInfo();
+    expect(info.classList.contains("invisible")).toBe(false);
+    expect(window.positionQuote).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- prevent localStorage failures from hiding print-run slot count
- export print run helpers and skip auto init during tests
- add comprehensive print-run info tests

## Testing
- `npm run format` *(fails: Unable to reach the npm registry)*
- `npm test` *(fails: Missing DB_ENDPOINT or DB_PASSWORD)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: network issues during npm ci)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Unable to reach npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68b36b4a78a8832d95b8c3a481c5721b