### PR TITLE
ci: improve e2e workflow startup

### DIFF
--- a/.github/workflows/playwright-deps-and-e2e.yml
+++ b/.github/workflows/playwright-deps-and-e2e.yml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 jobs:
   e2e:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       NPM_CONFIG_AUDIT: "false"
       NPM_CONFIG_FUND: "false"
@@ -34,10 +35,20 @@ jobs:
           npx playwright install --with-deps chromium
       - name: Start dev server
         run: |
-          nohup npm run start > /tmp/app.log 2>&1 &
-          npx wait-on http://localhost:3000 --timeout 180000
+          nohup npm run start:ci > /tmp/app.log 2>&1 &
+          if ! npx wait-on http://localhost:3000 --timeout 180000; then
+            cat /tmp/app.log
+            exit 1
+          fi
       - name: Run model-loading tests
         env:
           CI: "true"
         run: |
-          npx playwright test tests/e2e/model-loading.spec.ts
+          npx playwright test --trace on tests/e2e/model-loading.spec.ts
+      - name: Upload Playwright traces
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-traces
+          path: test-results
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary
- start app in CI mode and fail fast if wait-on times out
- capture and upload Playwright traces when e2e tests fail
- limit e2e job runtime to 30 minutes

## Testing
- `npm run format --prefix backend` *(fails: Network check failed. Ensure access to the npm registry and Playwright CDN.)*
- `npm test --prefix backend` *(fails: Network check failed. Ensure access to the npm registry and Playwright CDN.)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68b37709b0fc832d8239e01732c992d3