### PR TITLE
docs: document model env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ This repository contains the early MVP code for print2's website and backend.
 
 Run `docker compose up` to start the API and Postgres services.
 
+## Model fetching
+
+Set the following environment variables so the build can download model assets:
+
+- `GIT_LFS_SKIP_SMUDGE=1` – prevents Git LFS from automatically pulling large model files. Models are fetched separately during the build.
+- `MODEL_SOURCE_URL` **or** `MODEL_MANIFEST_JSON` – provide either a direct source URL or a JSON manifest describing the models to download.
+
 ## Local Setup
 
 1. Copy `.env.example` to `.env` in the repository root and update the values:


### PR DESCRIPTION
## Summary
- document required environment variables for model fetching in README

## Testing
- `npm run format` *(fails: Unable to reach npm registry)*
- `npm test` *(fails: Unable to reach npm registry)*
- `SKIP_PW_DEPS=1 npm run ci` *(terminated due to network restrictions)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: CONNECT tunnel failed, offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_68b415700610832db8bde4feced65e76