### PR TITLE
build: ignore frontend model files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ dist/
 .prettiercache
 
 frontend/public/models/boombox.glb
+frontend/public/models/*.glb
+frontend/public/models/*.gltf
+frontend/public/models/*.bin


### PR DESCRIPTION
## Summary
- ignore GLB/GLTF/bin assets in frontend models directory

## Testing
- `npm run validate-env`
- `curl -I https://registry.npmjs.org` *(fails: CONNECT tunnel failed 403)*
- `curl -I https://cdn.playwright.dev` *(fails: CONNECT tunnel failed 403)*
- `SKIP_PW_DEPS=1 npm run setup` *(aborted due to network stall)*
- `npm run format` *(fails: unable to reach npm registry)*
- `npm test` *(fails: unable to reach npm registry)*
- `SKIP_PW_DEPS=1 npm run ci` *(aborted due to network stall)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: skipping smoke)*


------
https://chatgpt.com/codex/tasks/task_e_68b415598ac8832daa52867e847a3626