### PR TITLE
chore: disable lfs smudge

### DIFF
--- a/.lfsconfig
+++ b/.lfsconfig
@@ -1,3 +1,2 @@
 [lfs]
-  fetchinclude = "*.glb,*.gltf,*.png,*.jpg,*.jpeg,*.webp"
-  fetchexclude = ""
+    skipsmudge = true


### PR DESCRIPTION
## Summary
- configure Git LFS to skip smudge so large files aren't automatically downloaded

## Testing
- `npm run format` (fails: Unable to reach npm registry)
- `npm test` (fails: Unable to reach npm registry)
- `npm run ci` (fails: command interrupted in offline environment)
- `npm run smoke` (offline mode: skipping smoke)


------
https://chatgpt.com/codex/tasks/task_e_68b41552e394832dbd47deb073fc3dc8