### PR TITLE
Use DB_URL everywhere; remove DB_ENDPOINT/DB_PASSWORD

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # .env.example
-DB_URL=postgres://user:password@localhost:5432/your_database
+DB_URL=postgres://postgres:postgres@localhost:5432/test
 STRIPE_SECRET_KEY=
 STRIPE_PUBLISHABLE_KEY=
 STRIPE_WEBHOOK_SECRET=

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Set the following environment variables so the build can download model assets:
 ## Local Setup
 
 1. Copy `.env.example` to `.env` in the repository root and update the values:
-   - `DB_URL` – connection string for your PostgreSQL database.
+   - `DB_URL` – connection string for your PostgreSQL database (e.g., `postgres://postgres:postgres@localhost:5432/test`).
 
    To start a local Postgres instance you can run:
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -3,7 +3,7 @@
 ## Database setup
 
 1. Start a Postgres instance locally (e.g. with `docker run --rm -e POSTGRES_PASSWORD=postgres -p 5432:5432 postgres`) or use an external database.
-2. Set `DB_URL` in `.env` to point at your database.
+2. Set `DB_URL` in `.env` to point at your database (e.g., `postgres://postgres:postgres@localhost:5432/test`).
 3. Apply migrations:
 
    ```bash

--- a/backend/src/__tests__/app.test.js
+++ b/backend/src/__tests__/app.test.js
@@ -1,5 +1,4 @@
-process.env.DB_ENDPOINT = "postgres://user:pass@localhost/db";
-process.env.DB_PASSWORD = "pass";
+process.env.DB_URL = "postgres://user:pass@localhost/db";
 process.env.CLOUDFRONT_DOMAIN = "cloud.test";
 process.env.STRIPE_TEST_KEY = "sk_test_dummy";
 

--- a/backend/src/__tests__/models.test.js
+++ b/backend/src/__tests__/models.test.js
@@ -1,5 +1,4 @@
-process.env.DB_ENDPOINT = "postgres://user:pass@localhost/db";
-process.env.DB_PASSWORD = "pass";
+process.env.DB_URL = "postgres://user:pass@localhost/db";
 process.env.CLOUDFRONT_DOMAIN = "cdn.example.com";
 process.env.STRIPE_TEST_KEY = "sk_test_dummy";
 

--- a/backend/src/db.js
+++ b/backend/src/db.js
@@ -1,13 +1,20 @@
 const { Pool } = require("pg");
-const { getEnv } = require("./env");
 
-const { DB_URL, NODE_ENV } = getEnv();
+function getPgPool() {
+  const url = process.env.DB_URL;
+  if (!url) {
+    throw new Error("DB_URL is required (postgres://user:pass@host:port/db)");
+  }
+  return new Pool({ connectionString: url });
+}
 
-const pool = new Pool({ connectionString: DB_URL });
+const pool = getPgPool();
 
 function close() {
   return pool.end();
 }
+
+const NODE_ENV = process.env.NODE_ENV;
 
 const jobs = new Map();
 const generationLogs = [];
@@ -73,7 +80,7 @@ async function insertGenerationLog(log) {
       ],
     );
   } catch {
-    if (process.env.NODE_ENV !== "production") {
+    if (NODE_ENV !== "production") {
       generationLogs.push(log);
     }
   }
@@ -148,6 +155,7 @@ async function upsertOrderPaid(input) {
   }
 }
 module.exports = {
+  getPgPool,
   pool,
   close,
   createJob,

--- a/backend/src/db.ts
+++ b/backend/src/db.ts
@@ -1,13 +1,20 @@
 import { Pool } from "pg";
-import { getEnv } from "./env";
 
-const { DB_URL, NODE_ENV } = getEnv();
+export function getPgPool(): Pool {
+  const url = process.env.DB_URL;
+  if (!url) {
+    throw new Error("DB_URL is required (postgres://user:pass@host:port/db)");
+  }
+  return new Pool({ connectionString: url });
+}
 
-export const pool = new Pool({ connectionString: DB_URL });
+export const pool = getPgPool();
 
 export function close(): Promise<void> {
   return pool.end();
 }
+
+const NODE_ENV = process.env.NODE_ENV;
 
 const jobs = new Map<string, any>();
 const generationLogs: any[] = [];
@@ -88,7 +95,7 @@ export async function insertGenerationLog(log: {
       ],
     );
   } catch {
-    if (process.env.NODE_ENV !== "production") {
+    if (NODE_ENV !== "production") {
       generationLogs.push(log);
     }
   }

--- a/backend/src/routes/items.js
+++ b/backend/src/routes/items.js
@@ -6,17 +6,12 @@ var __importDefault =
   };
 Object.defineProperty(exports, "__esModule", { value: true });
 const express_1 = require("express");
-const pg_1 = require("pg");
 const validate_js_1 = __importDefault(require("../../middleware/validate.js"));
 const logger_js_1 = __importDefault(require("../logger.js"));
 const items_1 = require("../lib/items");
+const db_js_1 = require("../db.js");
 const router = (0, express_1.Router)();
-const pool = new pg_1.Pool({
-  connectionString: process.env.DB_ENDPOINT,
-  user: "postgres",
-  password: process.env.DB_PASSWORD,
-  database: "postgres",
-});
+const pool = (0, db_js_1.getPgPool)();
 router.post(
   "/api/items",
   (0, validate_js_1.default)(items_1.insertItemSchema),

--- a/backend/src/routes/items.ts
+++ b/backend/src/routes/items.ts
@@ -1,27 +1,13 @@
 import { Router } from "express";
-import { Pool } from "pg";
 import validate from "../../middleware/validate.js";
 import logger from "../logger.js";
 import { capture } from "../lib/logger";
 import { insertItem, insertItemSchema } from "../lib/items";
-import { getEnv } from "../../utils/getEnv.js";
+import { getPgPool } from "../db.js";
 
 const router = Router();
 
-const dbEndpoint = getEnv("DB_ENDPOINT");
-const dbPassword = getEnv("DB_PASSWORD");
-
-if (!dbEndpoint || !dbPassword) {
-  logger.error("Missing DB_ENDPOINT or DB_PASSWORD");
-  process.exit(1);
-}
-
-const pool = new Pool({
-  connectionString: dbEndpoint,
-  user: "postgres",
-  password: dbPassword,
-  database: "postgres",
-});
+const pool = getPgPool();
 
 router.post("/api/items", validate(insertItemSchema), async (req, res) => {
   try {

--- a/backend/src/routes/models.ts
+++ b/backend/src/routes/models.ts
@@ -1,31 +1,14 @@
 import { Router } from "express";
-import { Pool } from "pg";
 import validate from "../../middleware/validate.js";
 import { z } from "zod";
 import logger from "../logger.js";
 import { capture } from "../lib/logger";
-import { getEnv as getEnvVar } from "../../utils/getEnv.js";
 import { getEnv as getEnvConfig } from "../env";
-
+import { getPgPool } from "../db.js";
 
 const router = Router();
 
-let dbEndpoint: string;
-let dbPassword: string;
-try {
-  dbEndpoint = getEnvVar("DB_ENDPOINT", { required: true })!;
-  dbPassword = getEnvVar("DB_PASSWORD", { required: true })!;
-} catch (err) {
-  logger.error((err as Error).message);
-  process.exit(1);
-}
-
-const pool = new Pool({
-  connectionString: dbEndpoint,
-  user: "postgres",
-  password: dbPassword,
-  database: "postgres",
-});
+const pool = getPgPool();
 
 export const createModelSchema = z.object({
   prompt: z.string().min(1, "prompt is required"),

--- a/backend/tests/routes/models.spec.ts
+++ b/backend/tests/routes/models.spec.ts
@@ -1,5 +1,4 @@
-process.env.DB_ENDPOINT = "postgres://user:pass@localhost/db";
-process.env.DB_PASSWORD = "pass";
+process.env.DB_URL = "postgres://user:pass@localhost/db";
 process.env.CLOUDFRONT_DOMAIN = "cdn.example.com";
 process.env.STRIPE_TEST_KEY = "sk_test_dummy";
 


### PR DESCRIPTION
## Summary
- add `getPgPool()` helper using `DB_URL`
- refactor routes and tests to rely solely on `DB_URL`
- document single DB variable in env examples and READMEs

## Testing
- `npm --prefix backend run format` *(fails: Unable to reach npm registry)*
- `npx --prefix backend prettier --log-level debug --write backend/src/db.ts backend/src/routes/items.ts backend/src/routes/models.ts backend/src/__tests__/app.test.js backend/src/__tests__/models.test.js backend/tests/routes/models.spec.ts backend/src/db.js backend/src/routes/items.js`
- `npm run build --if-present` *(fails: vite: not found)*
- `DB_URL=postgres://postgres:postgres@localhost:5432/test STRIPE_SECRET_KEY=sk_test STRIPE_PUBLISHABLE_KEY=pk_test FRONTEND_SUCCESS_URL=http://example.com/s FRONTEND_CANCEL_URL=http://example.com/c NODE_ENV=test npx --prefix backend jest --config backend/jest.config.js` *(fails: process.exit called during tests)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: test failures and missing modules)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: multiple test failures)*
- `SKIP_PW_DEPS=1 npm run diagnose` *(fails: multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68b71efc1fc0832d98919b1371210a7a