### PR TITLE
refactor: remove axios imports

### DIFF
--- a/backend/src/lib/imageToText.ts
+++ b/backend/src/lib/imageToText.ts
@@ -1,5 +1,3 @@
-import axios from 'axios';
-
 /**
  * Generate a text prompt from an image URL using an external API.
  * @param imageURL URL of the image stored in S3
@@ -8,7 +6,7 @@ import axios from 'axios';
 export async function imageToText(imageURL: string): Promise<string> {
   const endpoint = process.env["IMAGE2TEXT_ENDPOINT"];
   const key = process.env["IMAGE2TEXT_KEY"];
-  if (!endpoint) throw new Error('IMAGE2TEXT_ENDPOINT is not set');
+  if (!endpoint) throw new Error("IMAGE2TEXT_ENDPOINT is not set");
   const config = {
     ...(key ? { headers: { Authorization: `Bearer ${key}` } } : {}),
     validateStatus: () => true,
@@ -19,7 +17,7 @@ export async function imageToText(imageURL: string): Promise<string> {
     throw new Error(msg);
   }
   if (!res.data?.prompt) {
-    throw new Error('invalid response from image2text');
+    throw new Error("invalid response from image2text");
   }
   return res.data.prompt as string;
 }

--- a/backend/src/lib/sparc3dClient.ts
+++ b/backend/src/lib/sparc3dClient.ts
@@ -1,5 +1,3 @@
-import axios from "axios";
-
 export interface GenerateGlbParams {
   prompt: string;
   imageURL?: string;

--- a/backend/src/lib/textToImage.ts
+++ b/backend/src/lib/textToImage.ts
@@ -1,4 +1,3 @@
-import axios from "axios";
 import fs from "fs";
 import { pipeline } from "stream/promises";
 import path from "path";

--- a/backend/tests/text-to-model-api-call-7c8a9d.test.ts
+++ b/backend/tests/text-to-model-api-call-7c8a9d.test.ts
@@ -1,5 +1,3 @@
-import axios from "axios";
-
 describe("huggingface text-to-model", () => {
   const endpoint = process.env.SPARC3D_ENDPOINT;
   const token = process.env.SPARC3D_TOKEN;

--- a/scripts/ci/skip-detection-audit.ts
+++ b/scripts/ci/skip-detection-audit.ts
@@ -1,6 +1,5 @@
 import fs from "fs";
 import path from "path";
-import axios from "axios";
 
 interface Job {
   name: string;


### PR DESCRIPTION
## Summary
- remove axios imports from backend and CI utilities

## Testing
- `npm run validate-env`
- `CI=1 SKIP_PW_DEPS=1 npm run setup` *(fails: process hung, aborted)*
- `npm run format` *(fails: Unable to reach npm registry, network error)*
- `npm test` *(fails: Unable to reach npm registry, network error)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: process hung, aborted)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68b74f654568832db658f1abf3faff54