### PR TITLE
chore: remove axios imports

### DIFF
--- a/backend/src/lib/sparc3dClient.ts
+++ b/backend/src/lib/sparc3dClient.ts
@@ -1,5 +1,3 @@
-import axios from "axios";
-
 export interface GenerateGlbParams {
   prompt: string;
   imageURL?: string;

--- a/backend/src/lib/textToImage.ts
+++ b/backend/src/lib/textToImage.ts
@@ -1,4 +1,3 @@
-import axios from "axios";
 import fs from "fs";
 import { pipeline } from "stream/promises";
 import path from "path";

--- a/backend/tests/text-to-model-api-call-7c8a9d.test.ts
+++ b/backend/tests/text-to-model-api-call-7c8a9d.test.ts
@@ -1,5 +1,3 @@
-import axios from "axios";
-
 describe("huggingface text-to-model", () => {
   const endpoint = process.env.SPARC3D_ENDPOINT;
   const token = process.env.SPARC3D_TOKEN;

--- a/scripts/ci/skip-detection-audit.ts
+++ b/scripts/ci/skip-detection-audit.ts
@@ -1,6 +1,5 @@
 import fs from "fs";
 import path from "path";
-import axios from "axios";
 
 interface Job {
   name: string;


### PR DESCRIPTION
## Summary
- remove axios import lines

## Testing
- `SKIP_PW_DEPS=1 SKIP_NET_CHECKS=1 npm run setup`
- `npx prettier -w scripts/ci/skip-detection-audit.ts backend/tests/text-to-model-api-call-7c8a9d.test.ts backend/src/lib/textToImage.ts backend/src/lib/sparc3dClient.ts`
- `npm run format --prefix backend` (fails: Unable to reach npm registry)
- `npm test --prefix backend` (fails: Unable to reach npm registry)
- `NPM_CONFIG_OFFLINE=true SKIP_PW_DEPS=1 npm run ci` (fails: zod not in cache)
- `SKIP_PW_DEPS=1 npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_68b74f654568832db658f1abf3faff54