### PR TITLE
fix: guard backend tests against missing deps

### DIFF
--- a/backend/scripts/ensure-tests-exist.js
+++ b/backend/scripts/ensure-tests-exist.js
@@ -3,6 +3,18 @@ const { execSync } = require("child_process");
 const fs = require("fs");
 const path = require("path");
 
+// Ensure required dependencies exist before invoking Jest. When run without
+// installing dev dependencies, `npx jest` will download a transient Jest
+// binary which fails to locate `ts-jest`, leading to confusing preset errors.
+for (const dep of ["jest", "ts-jest"]) {
+  try {
+    require.resolve(dep);
+  } catch {
+    console.error(`Missing ${dep}; run \`npm run setup\` before testing.`);
+    process.exit(1);
+  }
+}
+
 const required = [
   "tests/stripe/webhook.valid-signature.spec.ts",
   "tests/stripe/webhook.invalid-signature.spec.ts",


### PR DESCRIPTION
## Summary
- check for jest and ts-jest before listing tests to avoid transient installs

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: 84 failing)*
- `SKIP_PW_DEPS=1 npm run ci` *(exited early)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b82785078c832d8ace5bfcea873b19