### PR TITLE
fix: harden backend CI network script

### DIFF
--- a/scripts/ci/detect-network.ts
+++ b/scripts/ci/detect-network.ts
@@ -1,9 +1,19 @@
-import https from "https";
-const url = process.env.NPM_REGISTRY_PING ?? "https://registry.npmjs.org/-/ping";
-const req = https.get(url, { timeout: 4000 }, res => {
+declare function require(name: string): any;
+
+const https = require("https");
+const url =
+  (globalThis as any).process?.env.NPM_REGISTRY_PING ??
+  "https://registry.npmjs.org/-/ping";
+
+const req = https.get(url, { timeout: 4000 }, (res: any) => {
   const ok = res.statusCode && res.statusCode >= 200 && res.statusCode < 500;
   console.log(ok ? "ONLINE" : "OFFLINE");
-  process.exit(ok ? 0 : 1);
+  (globalThis as any).process?.exit(ok ? 0 : 1);
 });
-req.on("error", () => { console.log("OFFLINE"); process.exit(1); });
-req.setTimeout(4000, () => { req.destroy(new Error("timeout")); });
+req.on("error", () => {
+  console.log("OFFLINE");
+  (globalThis as any).process?.exit(1);
+});
+req.setTimeout(4000, () => {
+  req.destroy(new Error("timeout"));
+});

--- a/scripts/ci/run-backend-offline-safe.sh
+++ b/scripts/ci/run-backend-offline-safe.sh
@@ -24,6 +24,9 @@ fi
 export PLAYWRIGHT_BROWSERS_PATH="${PLAYWRIGHT_DIR}"
 export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 
+echo "==> Install (backend)"
+npm ci --prefix backend
+
 echo "==> Format (backend)"
 npm run format --prefix backend
 


### PR DESCRIPTION
## Summary
- make detect-network script compile without Node typings
- install backend dependencies before formatting and tests

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: many expectations not met)*

------
https://chatgpt.com/codex/tasks/task_e_68b82791f32c832daa0b81bff51276c2