### PR TITLE
fix: silence curl proxy errors in net mode check

### DIFF
--- a/scripts/net-mode.mjs
+++ b/scripts/net-mode.mjs
@@ -17,8 +17,10 @@ export function isOfflineEnv() {
   }
   if (proxyEnv) {
     try {
+      // Pipe curl output to avoid noisy errors when the proxy blocks the request
       execSync(
         "curl -sSIL --max-time 10 -o /dev/null https://registry.npmjs.org/-/ping",
+        { stdio: "pipe" },
       );
     } catch {
       setOfflineEnv();


### PR DESCRIPTION
## Summary
- suppress noisy curl output when proxy blocks registry ping to reduce confusion during smoke checks

## Testing
- `npm run validate-env`
- `npm run format --prefix backend` *(fails: Code style issues found in 4 files)*
- `npm test --prefix backend` *(fails: CLOUDFRONT_DOMAIN is required)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: checkout session tests)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: analytics tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b8298e8cf8832daaaf03d8c9d3f42a