### PR TITLE
fix: correctly re-export logger capture

### DIFF
--- a/backend/src/lib/logError.ts
+++ b/backend/src/lib/logError.ts
@@ -1,5 +1,5 @@
 import logger from "../logger";
-import { capture } from "./logger";
+import { capture } from "./logger.js";
 
 export function logError(...args: unknown[]): void {
   if (process.env.NODE_ENV !== "test") {

--- a/backend/src/lib/logger.ts
+++ b/backend/src/lib/logger.ts
@@ -1,2 +1,1 @@
-const { capture } = require("./logger");
-export { capture };
+export { capture } from "./logger.js";

--- a/backend/src/lib/textToImage.ts
+++ b/backend/src/lib/textToImage.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 import { pipeline } from "stream/promises";
 import path from "path";
 import { uploadFile } from "./uploadS3";
-import { capture } from "./logger";
+import { capture } from "./logger.js";
 import logger from "../logger";
 
 /**


### PR DESCRIPTION
## Summary
- fix logger capture re-export to avoid undefined function errors
- reference logger.js explicitly when logging errors and in text-to-image

## Testing
- `npm run format`
- `npm test` *(fails: Stripe create-order flow etc.)*
- `npm run ci` *(fails: tests did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68b82963c478832d9b7831a380172f9a