### PR TITLE
fix: use supported Stripe API version

### DIFF
--- a/backend/src/routes/checkout.js
+++ b/backend/src/routes/checkout.js
@@ -61,7 +61,7 @@ router.post("/checkout/create", async (req, res) => {
       normalized.push({ price: item.price, quantity: qty });
     }
     const realStripe = new Stripe(secretKey, {
-      apiVersion: "2025-06-30.basil",
+      apiVersion: "2022-11-15",
     });
     const stripe = isTest()
       ? require("../../tests/utils/stripeMock").stripe

--- a/backend/src/routes/checkout.ts
+++ b/backend/src/routes/checkout.ts
@@ -56,7 +56,7 @@ router.post("/checkout/create", async (req, res) => {
     }
 
     const realStripe = new Stripe(secretKey, {
-      apiVersion: "2025-06-30.basil",
+      apiVersion: "2022-11-15",
     });
     const stripe = isTest()
       ? require("../../tests/utils/stripeMock").stripe

--- a/backend/src/routes/create-order.js
+++ b/backend/src/routes/create-order.js
@@ -64,7 +64,7 @@ router.post("/create-order", async (req, res) => {
     const finalTotal = price * quantity - discountCents;
     const stripeSecret = process.env.STRIPE_SECRET_KEY || "test";
     const stripe = new Stripe(stripeSecret, {
-      apiVersion: "2025-06-30.basil",
+      apiVersion: "2022-11-15",
     });
     const session = await stripe.checkout.sessions.create({
       mode: "payment",

--- a/backend/src/routes/create-order.ts
+++ b/backend/src/routes/create-order.ts
@@ -74,7 +74,7 @@ router.post("/create-order", async (req, res) => {
     const finalTotal = price * quantity - discountCents;
     const stripeSecret = process.env.STRIPE_SECRET_KEY || "test";
     const stripe = new Stripe(stripeSecret, {
-      apiVersion: "2025-06-30.basil",
+      apiVersion: "2022-11-15",
     });
     const session = await stripe.checkout.sessions.create({
       mode: "payment",

--- a/backend/src/routes/orders.js
+++ b/backend/src/routes/orders.js
@@ -8,7 +8,7 @@ const prohibited = require("../../prohibited_countries.json");
 
 const router = Router();
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || "", {
-  apiVersion: "2025-06-30.basil",
+  apiVersion: "2022-11-15",
 });
 
 function getUserId(req) {

--- a/backend/src/routes/orders.ts
+++ b/backend/src/routes/orders.ts
@@ -8,7 +8,7 @@ import prohibited from "../../prohibited_countries.json" assert { type: "json" }
 const router = Router();
 // Lazily read the Stripe secret so tests don't require full env configuration
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || "", {
-  apiVersion: "2025-06-30.basil",
+  apiVersion: "2022-11-15",
 });
 
 function getUserId(req: any): string | null {

--- a/backend/src/routes/payments.js
+++ b/backend/src/routes/payments.js
@@ -9,7 +9,7 @@ const PRICE_MAP = {
 
 const { STRIPE_SECRET_KEY } = getEnv();
 const realStripe = new Stripe(STRIPE_SECRET_KEY, {
-  apiVersion: "2025-06-30.basil",
+  apiVersion: "2022-11-15",
 });
 const stripe = isTest()
   ? require("../../tests/utils/stripeMock").stripe

--- a/backend/src/routes/payments.ts
+++ b/backend/src/routes/payments.ts
@@ -23,7 +23,7 @@ const PRICE_MAP: Record<string, number> = {
 
 const { STRIPE_SECRET_KEY } = getEnv();
 const realStripe = new Stripe(STRIPE_SECRET_KEY, {
-  apiVersion: "2025-06-30.basil",
+  apiVersion: "2022-11-15",
 });
 const stripe = isTest()
   ? require("../../tests/utils/stripeMock").stripe

--- a/backend/src/routes/stripe/create-checkout-session.ts
+++ b/backend/src/routes/stripe/create-checkout-session.ts
@@ -35,7 +35,7 @@ try {
 }
 
 const realStripe = new Stripe(stripeKey, {
-  apiVersion: "2025-06-30.basil",
+  apiVersion: "2022-11-15",
 });
 const stripe = isTest()
   ? require("../../../tests/utils/stripeMock").stripe

--- a/backend/src/routes/stripe/webhook.ts
+++ b/backend/src/routes/stripe/webhook.ts
@@ -20,7 +20,7 @@ try {
 }
 
 const realStripe = new Stripe(stripeKey, {
-  apiVersion: "2025-06-30.basil",
+  apiVersion: "2022-11-15",
 });
 const stripe = isTest()
   ? require("../../../tests/utils/stripeMock").stripe

--- a/backend/src/routes/stripeCheckout.ts
+++ b/backend/src/routes/stripeCheckout.ts
@@ -18,7 +18,7 @@ try {
   process.exit(1);
 }
 const realStripe = new Stripe(STRIPE_SECRET_KEY as string, {
-  apiVersion: "2025-06-30.basil",
+  apiVersion: "2022-11-15",
 });
 const stripe = isTest()
   ? require("../../tests/utils/stripeMock").stripe

--- a/backend/src/routes/stripeWebhook.js
+++ b/backend/src/routes/stripeWebhook.js
@@ -12,7 +12,7 @@ const db_1 = require("../db");
 const env_1 = require("../env");
 const { STRIPE_SECRET_KEY } = (0, env_1.getEnv)();
 const realStripe = new stripe_1.default(STRIPE_SECRET_KEY, {
-  apiVersion: "2025-06-30.basil",
+  apiVersion: "2022-11-15",
 });
 const stripe = (0, env_1.isTest)()
   ? require("../../tests/utils/stripeMock").stripe

--- a/backend/src/routes/stripeWebhook.ts
+++ b/backend/src/routes/stripeWebhook.ts
@@ -9,7 +9,7 @@ import { getEnv } from "../../utils/getEnv";
 
 const { STRIPE_SECRET_KEY } = getBackendEnv();
 const realStripe = new Stripe(STRIPE_SECRET_KEY, {
-  apiVersion: "2025-06-30.basil",
+  apiVersion: "2022-11-15",
 });
 const stripe = isTest()
   ? require("../../tests/utils/stripeMock").stripe

--- a/backend/src/routes/subscription.js
+++ b/backend/src/routes/subscription.js
@@ -9,7 +9,7 @@ const { isTest } = require("../env");
 
 const router = Router();
 const realStripe = new Stripe(config.stripeKey, {
-  apiVersion: "2025-06-30.basil",
+  apiVersion: "2022-11-15",
 });
 const stripe = isTest()
   ? require("../../tests/utils/stripeMock").stripe

--- a/backend/src/routes/subscription.ts
+++ b/backend/src/routes/subscription.ts
@@ -15,7 +15,7 @@ import { isTest } from "../env";
 
 const router = Router();
 const realStripe = new Stripe(config.stripeKey, {
-  apiVersion: "2025-06-30.basil",
+  apiVersion: "2022-11-15",
 });
 const stripe = isTest()
   ? require("../../tests/utils/stripeMock").stripe

--- a/backend/tests/diagnostic-stripe-validate-2fb39dcee74.test.ts
+++ b/backend/tests/diagnostic-stripe-validate-2fb39dcee74.test.ts
@@ -32,7 +32,7 @@ if (skip) {
   });
 
   test("stripe client boots and lists customers", async () => {
-    const stripe = new Stripe(secret, { apiVersion: "2025-06-30.basil" });
+    const stripe = new Stripe(secret, { apiVersion: "2022-11-15" });
     const list = await stripe.customers.list({ limit: 1 });
     expect(Array.isArray(list.data)).toBe(true);
   });


### PR DESCRIPTION
## Summary
- use 2022-11-15 Stripe API version across backend routes
- align diagnostic test with new Stripe API version

## Testing
- `npm run format`
- `npm test -- tests/api.test.ts -t "Stripe create-order flow"` *(fails: Expected 200 Received 500)*

------
https://chatgpt.com/codex/tasks/task_e_68b82fe1d144832db2725b4850e21560