### PR TITLE
fix: ensure text-to-image logging import

### DIFF
--- a/backend/src/lib/textToImage.ts
+++ b/backend/src/lib/textToImage.ts
@@ -1,8 +1,11 @@
+import axios from "axios";
 import fs from "fs";
 import { pipeline } from "stream/promises";
 import path from "path";
 import { uploadFile } from "./uploadS3";
-import { capture } from "./logger.js";
+// Import the capture helper via the TypeScript wrapper so the CommonJS
+// export is handled consistently in both TS and compiled JS environments.
+import { capture } from "./logger";
 import logger from "../logger";
 
 /**

--- a/backend/tests/subscriptions.test.js
+++ b/backend/tests/subscriptions.test.js
@@ -1,6 +1,8 @@
 process.env.STRIPE_SECRET_KEY = "test";
 process.env.STRIPE_WEBHOOK_SECRET = "whsec";
 process.env.DB_URL = "postgres://user:pass@localhost/db";
+process.env.STRIPE_PUBLISHABLE_KEY = "pk_test";
+process.env.NODE_ENV = "test";
 
 jest.mock("../db", () => ({
   query: jest.fn().mockResolvedValue({ rows: [] }),


### PR DESCRIPTION
## Summary
- import axios and proper logger wrapper in text-to-image helper
- ensure subscription tests include required Stripe env vars

## Testing
- `npm test tests/textToImage.test.js tests/subscriptions.test.js` *(subscriptions tests still 404 - environment)*
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_68b82ffbe418832da91ed8a78498ccee