### PR TITLE
fix: enhance setup debugging and engine compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,8 +63,8 @@
   "author": "",
   "license": "ISC",
   "engines": {
-    "node": "20.16.x",
-    "npm": "10"
+    "node": ">=20.16 <21",
+    "npm": ">=10"
   },
   "type": "commonjs",
   "packageManager": "npm@10.8.2",

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+# Enable detailed Node warnings to help trace setup issues
+export NODE_OPTIONS="--trace-warnings --trace-deprecation ${NODE_OPTIONS:-}"
+
 OFFLINE=0
 if node -e "import('./scripts/net-mode.mjs').then(m=>process.exit(m.isOfflineEnv()?0:1))" >/dev/null 2>&1; then
   OFFLINE=1


### PR DESCRIPTION
## Summary
- broaden Node and npm engine ranges
- trace Node warnings and deprecations during setup for easier debugging

## Testing
- `npm run format` (backend)
- `npm test` (backend)
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Unable to reach npm registry: https://registry.npmjs.org/-/ping)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b830a78920832da64b13773e89b54e