### PR TITLE
chore: capture backend test errors

### DIFF
--- a/scripts/test-backend.sh
+++ b/scripts/test-backend.sh
@@ -2,6 +2,6 @@
 set -e
 cd "$(git rev-parse --show-toplevel)"
 unset npm_config_http_proxy npm_config_https_proxy
-mise use -g node@20 >/dev/null
+mise use -g node@20 >/dev/null || true
 npm run validate-env >/dev/null
-npm test --prefix backend "$@" | tee /tmp/test.log
+npm test --prefix backend "$@" 2>&1 | tee /tmp/test.log


### PR DESCRIPTION
## Summary
- ensure backend test script captures stderr so failures appear in /tmp/test.log
- prevent network hiccups from aborting the script when selecting Node 20

## Testing
- `npm run format >/tmp/format.log && tail -n 20 /tmp/format.log`
- `npm test --prefix backend --runTestsByPath tests/api.test.js 2>&1 | tee /tmp/test.log >/tmp/test-backend.log && tail -n 20 /tmp/test.log`
- `SKIP_PW_DEPS=1 npm run ci >/tmp/ci.log && tail -n 20 /tmp/ci.log` *(fails: Unable to reach npm registry)*
- `SKIP_PW_DEPS=1 npm run smoke >/tmp/smoke.log && tail -n 20 /tmp/smoke.log`


------
https://chatgpt.com/codex/tasks/task_e_68b830d737d8832dbb57d03f9063d6ce