### PR TITLE
fix: make analytics routes testable

### DIFF
--- a/backend/src/routes/analytics.js
+++ b/backend/src/routes/analytics.js
@@ -1,5 +1,12 @@
 const { Router } = require("express");
-const db = require("../../db.js");
+// Use the module without an explicit extension so Jest's moduleNameMapper
+// and manual mocks for "../../db" take effect consistently during tests.
+// Requiring "../../db.js" bypasses those mocks, causing the real database
+// module to load and resulting in uncalled mock functions in tests.
+// Allow tests to inject a mocked DB via global.__db. If not provided, fall back
+// to requiring the real database module.
+// eslint-disable-next-line no-undef
+const db = global.__db || require("../../db");
 
 const router = Router();
 

--- a/backend/src/routes/analytics.ts
+++ b/backend/src/routes/analytics.ts
@@ -1,5 +1,8 @@
 import { Router } from "express";
-import * as db from "../../db";
+// Allow tests to inject a mocked DB via globalThis.__db. When present, use it;
+// otherwise fall back to requiring the real database module.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const db: any = (globalThis as any).__db ?? require("../../db");
 import logger from "../logger";
 import { capture } from "../lib/logger";
 

--- a/backend/tests/analytics.test.js
+++ b/backend/tests/analytics.test.js
@@ -2,7 +2,14 @@ process.env.STRIPE_SECRET_KEY = "test";
 process.env.STRIPE_WEBHOOK_SECRET = "whsec";
 process.env.DB_URL = "postgres://user:pass@localhost/db";
 
-jest.mock("../db", () => ({
+// Explicitly include the file extension so Jest's module system resolves the
+// same module path used by the analytics router (`../../db.js`). Without the
+// extension, the router would load the real database module while the tests
+// mock a different path, leading to the mock functions never being called.
+// Lightweight manual mock for the database module used by the analytics
+// router. The router checks for a `global.__db` variable first, allowing tests
+// to inject these spies without needing Jest's module mocking.
+const db = {
   query: jest.fn(),
   insertCommission: jest.fn(),
   insertAdClick: jest.fn(),
@@ -19,8 +26,9 @@ jest.mock("../db", () => ({
   getOrCreateOrderReferralLink: jest.fn(),
   insertReferredOrder: jest.fn(),
   getMarginalCacMetrics: jest.fn(),
-}));
-const db = require("../db");
+};
+// eslint-disable-next-line no-undef
+global.__db = db;
 
 const request = require("supertest");
 const app = require("../server");


### PR DESCRIPTION
## Summary
- allow injecting mock database into analytics routes
- mock analytics DB directly in tests for reliable spying

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend -- --runTestsByPath tests/analytics.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b82ff3631c832d8625258193b0c548