### PR TITLE
fix: suppress curl proxy errors in smoke tests

### DIFF
--- a/scripts/net-mode.mjs
+++ b/scripts/net-mode.mjs
@@ -17,10 +17,10 @@ export function isOfflineEnv() {
   }
   if (proxyEnv) {
     try {
-      // Pipe curl output to avoid noisy errors when the proxy blocks the request
+      // Silence curl output; only the exit code matters for connectivity checks
       execSync(
-        "curl -sSIL --max-time 10 -o /dev/null https://registry.npmjs.org/-/ping",
-        { stdio: "pipe" },
+        "curl -sfI --max-time 10 https://registry.npmjs.org/-/ping >/dev/null 2>&1",
+        { stdio: "ignore" },
       );
     } catch {
       setOfflineEnv();


### PR DESCRIPTION
## Summary
- silence curl output when detecting offline mode so smoke tests don't print proxy errors

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format`
- `npm test` *(fails: Expected 200 Received 404)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: CONNECT tunnel failed, response 403)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b830bb3964832d933cfd099016a973