### PR TITLE
fix: load cloudflare env aliases in verify script

### DIFF
--- a/verify-cloudflare.sh
+++ b/verify-cloudflare.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -e
 
+# Normalize Cloudflare env variable names so either CF_* or CLOUDFLARE_* work
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$DIR/scripts/env/aliases.sh"
+
 # Ensure required variables are set
 for var in CF_PAGES_API_TOKEN CF_ACCOUNT_ID CF_PAGES_PROJECT; do
   if [[ -z "${!var}" ]]; then


### PR DESCRIPTION
## Summary
- source Cloudflare env alias mappings in `verify-cloudflare.sh` so CF_* and CLOUDFLARE_* variables are interchangeable

## Testing
- `npm run format` (backend)
- `npm test` (backend, fails: Stripe create-order flow, create-order applies discount, etc.)
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Unable to reach npm registry)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b835eae3a4832db44b7d9c39f8a801