### PR TITLE
fix: instantiate Stripe client per request

### DIFF
--- a/backend/src/routes/orders.js
+++ b/backend/src/routes/orders.js
@@ -7,9 +7,6 @@ const { capture } = require("../lib/logger");
 const prohibited = require("../../prohibited_countries.json");
 
 const router = Router();
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || "", {
-  apiVersion: "2022-11-15",
-});
 
 function getUserId(req) {
   const auth = req.headers["authorization"] || "";
@@ -25,6 +22,9 @@ function getUserId(req) {
 
 router.post("/create-order", async (req, res) => {
   try {
+    const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || "", {
+      apiVersion: "2022-11-15",
+    });
     const {
       jobId,
       price,

--- a/backend/src/routes/orders.ts
+++ b/backend/src/routes/orders.ts
@@ -6,10 +6,6 @@ import logger from "../logger.js";
 import { capture } from "../lib/logger";
 import prohibited from "../../prohibited_countries.json" assert { type: "json" };
 const router = Router();
-// Lazily read the Stripe secret so tests don't require full env configuration
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || "", {
-  apiVersion: "2022-11-15",
-});
 
 function getUserId(req: any): string | null {
   const auth = req.headers["authorization"] || "";
@@ -25,6 +21,9 @@ function getUserId(req: any): string | null {
 
 router.post("/create-order", async (req, res) => {
   try {
+    const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || "", {
+      apiVersion: "2022-11-15",
+    });
     const {
       jobId,
       price,


### PR DESCRIPTION
## Summary
- create a fresh Stripe client inside the `/create-order` handler so tests can mock it correctly

## Testing
- `npm run format`
- `npm test -- backend/tests/api.test.ts -t "Stripe create-order flow"` *(fails: Unable to reach npm registry)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Unable to reach npm registry)*
- `SKIP_PW_DEPS=1 npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_68b835c11ee8832db043d854044905f0