### PR TITLE
fix: align test mocks with backend paths

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -39,15 +39,6 @@ try {
 
 try {
   (() => {
-    const r = require("./routes/create-order");
-    app.use("/api", r.default || r);
-  })();
-} catch (err) {
-  logger.error("Failed to load create-order router", err);
-}
-
-try {
-  (() => {
     const r = require("./routes/auth");
     app.use("/api", r.default || r);
   })();
@@ -113,4 +104,3 @@ try {
 }
 
 app.use(errorHandler);
-

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -81,15 +81,6 @@ try {
 
 try {
   (() => {
-    const r = require("./routes/create-order");
-    app.use("/api", r.default || r);
-  })();
-} catch (err) {
-  logger.error("Failed to load create-order router", err as Error);
-}
-
-try {
-  (() => {
     const r = require("./routes/auth");
     app.use("/api", r.default || r);
   })();

--- a/backend/src/routes/status.ts
+++ b/backend/src/routes/status.ts
@@ -2,7 +2,8 @@ import { Router } from "express";
 import { emitter, getStatus } from "../queue/generation";
 import logger from "../logger";
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const db = require("../../db.js");
+// use path without extension so jest mocks can intercept
+const db = require("../../db");
 
 const router = Router();
 
@@ -87,4 +88,3 @@ router.get("/progress/:id", (req, res) => {
 });
 
 export default router;
-

--- a/backend/tests/api.test.js
+++ b/backend/tests/api.test.js
@@ -2,7 +2,8 @@ process.env.STRIPE_SECRET_KEY = "test";
 process.env.STRIPE_WEBHOOK_SECRET = "whsec";
 process.env.DB_URL = "postgres://user:pass@localhost/db";
 
-jest.mock("../db", () => ({
+// mock the database module using the same relative path as the app code
+jest.mock("../../db", () => ({
   query: jest.fn().mockResolvedValue({ rows: [] }),
   insertCommission: jest.fn().mockResolvedValue({}),
   upsertSubscription: jest.fn(),
@@ -25,7 +26,7 @@ jest.mock("../db", () => ({
   updateWeeklyOrderStreak: jest.fn(),
   insertGenerationLog: jest.fn(),
 }));
-const db = require("../db");
+const db = require("../../db");
 
 jest.mock("../mail", () => ({ sendMail: jest.fn() }));
 const { sendMail } = require("../mail");

--- a/backend/tests/api.test.ts
+++ b/backend/tests/api.test.ts
@@ -2,7 +2,8 @@ process.env.STRIPE_SECRET_KEY = "test";
 process.env.STRIPE_WEBHOOK_SECRET = "whsec";
 process.env.DB_URL = "postgres://user:pass@localhost/db";
 
-jest.mock("../db", () => ({
+// mock the database module using the same relative path as the app code
+jest.mock("../../db", () => ({
   query: jest.fn().mockResolvedValue({ rows: [] }),
   insertCommission: jest.fn().mockResolvedValue({}),
   upsertSubscription: jest.fn(),
@@ -25,7 +26,7 @@ jest.mock("../db", () => ({
   updateWeeklyOrderStreak: jest.fn(),
   insertGenerationLog: jest.fn(),
 }));
-const db = require("../db");
+const db = require("../../db");
 
 jest.mock("../mail", () => ({ sendMail: jest.fn() }));
 const { sendMail } = require("../mail");


### PR DESCRIPTION
## Summary
- use ../../db path in API tests so mocked DB matches app imports
- remove legacy create-order router to rely on orders router
- require db without extension in status route for easier mocking

## Testing
- `npm test` *(fails: create-order grants free print after three referrals, POST /api/login returns token, Stripe webhook updates order and awards badge, Stripe webhook awards weekly streak badge, Stripe webhook invalid signature, POST /api/generate accepts image upload, /api/generate 400 when no prompt or image, /api/generate falls back on server failure, /api/generate saves authenticated user id, /api/status/:id returns 404 when missing, GET /api/users/:username/profile returns profile, GET /api/users/:username/profile 404 when missing, POST /api/create-order saves etch name, POST /api/create-order saves UTM params, create-order inserts commission for marketplace sale, GET /api/my/orders returns orders, POST /api/discount-code returns discount, POST /api/discount-code invalid, POST /api/generate-discount creates code, create-order grants free print after three referrals (ts), create-order rejects unknown job (ts), POST /api/login returns token (ts), Stripe webhook updates order and awards badge (ts), Stripe webhook awards weekly streak badge (ts), Stripe webhook invalid signature (ts), POST /api/generate accepts image upload (ts), /api/generate 400 when no prompt or image (ts), /api/generate falls back on server failure (ts), /api/generate saves authenticated user id (ts), /api/status/:id returns 404 when missing (ts), GET /api/users/:username/profile returns profile (ts), GET /api/users/:username/profile 404 when missing (ts), POST /api/create-order saves etch name (ts), POST /api/create-order saves UTM params (ts), create-order inserts commission for marketplace sale (ts), GET /api/my/orders returns orders (ts), POST /api/discount-code returns discount (ts), POST /api/discount-code invalid (ts), POST /api/generate-discount creates code (ts))*
- `npm run format`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Unable to reach npm registry: https://registry.npmjs.org/-/ping)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b835295c20832d9abe71fe194a5301