### PR TITLE
fix: ensure subscription routes are available in tests

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -7,6 +7,10 @@ module.exports = app;
 module.exports.app = app;
 module.exports.default = app;
 
+// ensure middleware stack exists before loading routers
+app.use(express.json());
+
+// load routers individually without failing the whole app if a require errors
 try {
   const r = require("./routes/stripeWebhook");
   app.use(r.default || r);
@@ -14,7 +18,12 @@ try {
   logger.error("Failed to load stripe webhook router", err);
 }
 
-app.use(express.json());
+try {
+  const r = require("./routes/subscription");
+  app.use("/api", r.default || r);
+} catch (err) {
+  logger.error("Failed to load subscription router", err);
+}
 
 try {
   const r = require("./routes/health");
@@ -74,15 +83,6 @@ try {
 }
 
 try {
-  (() => {
-    const r = require("./routes/subscription");
-    app.use("/api", r.default || r);
-  })();
-} catch (err) {
-  logger.error("Failed to load admin router", err);
-}
-
-try {
   const r = require("./routes/orders");
   app.use("/api", r.default || r);
 } catch (err) {
@@ -113,4 +113,3 @@ try {
 }
 
 app.use(errorHandler);
-

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -5,16 +5,22 @@ import errorHandler from "./middleware/errorHandler";
 const app = express();
 export { app };
 
+// ensure middleware stack exists even if route loading fails
+app.use(express.json());
+
 try {
-  (() => {
-    const r = require("./routes/stripeWebhook");
-    app.use(r.default || r);
-  })();
+  const r = require("./routes/stripeWebhook");
+  app.use(r.default || r);
 } catch (err) {
   logger.error("Failed to load stripe webhook router", err as Error);
 }
 
-app.use(express.json());
+try {
+  const r = require("./routes/subscription");
+  app.use("/api", r.default || r);
+} catch (err) {
+  logger.error("Failed to load subscription router", err as Error);
+}
 
 try {
   (() => {
@@ -113,15 +119,6 @@ try {
   })();
 } catch (err) {
   logger.error("Failed to load discount router", err as Error);
-}
-
-try {
-  (() => {
-    const r = require("./routes/subscription");
-    app.use("/api", r.default || r);
-  })();
-} catch (err) {
-  logger.error("Failed to load subscription router", err as Error);
 }
 
 try {

--- a/backend/tests/subscriptions.test.js
+++ b/backend/tests/subscriptions.test.js
@@ -4,7 +4,14 @@ process.env.DB_URL = "postgres://user:pass@localhost/db";
 process.env.STRIPE_PUBLISHABLE_KEY = "pk_test";
 process.env.NODE_ENV = "test";
 
-jest.mock("../db", () => ({
+jest.mock("../config", () => ({
+  dbUrl: process.env.DB_URL,
+  stripeKey: process.env.STRIPE_SECRET_KEY,
+  stripeWebhook: process.env.STRIPE_WEBHOOK_SECRET,
+  stripePublishable: process.env.STRIPE_PUBLISHABLE_KEY,
+}));
+
+const mockDb = {
   query: jest.fn().mockResolvedValue({ rows: [] }),
   insertCommission: jest.fn().mockResolvedValue({}),
   upsertSubscription: jest
@@ -24,16 +31,18 @@ jest.mock("../db", () => ({
   getSubscriptionMetrics: jest.fn(),
   getOrCreateOrderReferralLink: jest.fn(),
   insertReferredOrder: jest.fn(),
-}));
+};
+jest.mock("../db", () => mockDb);
+jest.mock("../../db", () => mockDb);
 const db = require("../db");
 
-jest.mock("stripe");
-const Stripe = require("stripe");
-const stripeMock = { billingPortal: { sessions: { create: jest.fn() } } };
-Stripe.mockImplementation(() => stripeMock);
+const { stripe } = require("./utils/stripeMock");
+stripe.billingPortal.sessions.create = jest.fn(
+  stripe.billingPortal.sessions.create,
+);
 
 const request = require("supertest");
-const app = require("../src/app");
+const app = require("./utils/createTestApp");
 const jwt = require("jsonwebtoken");
 
 beforeEach(() => {
@@ -44,6 +53,7 @@ beforeEach(() => {
   db.getCurrentWeekCredits.mockClear();
   db.insertSubscriptionEvent.mockClear();
   db.getSubscriptionMetrics.mockClear();
+  stripe.billingPortal.sessions.create.mockClear();
 });
 
 test("GET /api/subscription returns subscription", async () => {
@@ -86,14 +96,14 @@ test("GET /api/subscription/summary returns subscription and credits", async () 
 
 test("POST /api/subscription/portal returns url", async () => {
   db.getSubscription.mockResolvedValueOnce({ stripe_customer_id: "cus_1" });
-  stripeMock.billingPortal.sessions.create.mockResolvedValueOnce({ url: "u" });
+  stripe.billingPortal.sessions.create.mockResolvedValueOnce({ url: "u" });
   const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .post("/api/subscription/portal")
     .set("authorization", `Bearer ${token}`);
   expect(res.status).toBe(200);
   expect(res.body.url).toBe("u");
-  expect(stripeMock.billingPortal.sessions.create).toHaveBeenCalled();
+  expect(stripe.billingPortal.sessions.create).toHaveBeenCalled();
 });
 
 test("POST /api/subscription/portal 404 without customer", async () => {

--- a/backend/tests/utils/createTestApp.js
+++ b/backend/tests/utils/createTestApp.js
@@ -1,7 +1,12 @@
 const app = require("../../src/app");
 const db = require("../../db");
 const bcrypt = require("bcryptjs");
-const { getShippingEstimate } = require("../../shipping");
+let getShippingEstimate;
+try {
+  ({ getShippingEstimate } = require("../../shipping"));
+} catch {
+  getShippingEstimate = async () => ({ cost: 0 });
+}
 
 function hasRoute(method, path) {
   const m = String(method).toLowerCase();
@@ -15,14 +20,14 @@ function hasRoute(method, path) {
         : route.path === path;
 
       return matchesPath && route.methods?.[m];
-    })
+    }),
   );
 }
 
-if (process.env.NODE_ENV === 'test') {
-  if (!hasRoute('post', '/api/generate')) {
-    app.post('/api/generate', (_req, res) =>
-      res.json({ glb_url: '/models/test.glb' })
+if (process.env.NODE_ENV === "test") {
+  if (!hasRoute("post", "/api/generate")) {
+    app.post("/api/generate", (_req, res) =>
+      res.json({ glb_url: "/models/test.glb" }),
     );
   }
 
@@ -100,6 +105,11 @@ if (process.env.NODE_ENV === 'test') {
       );
       res.json({ code: result.rows[0].code });
     });
+  }
+
+  if (!hasRoute("get", "/api/subscription")) {
+    const sub = require("../../src/routes/subscription");
+    app.use("/api", sub.default || sub);
   }
 
   if (!hasRoute("post", "/api/dalle")) {

--- a/backend/tests/utils/stripeMock.js
+++ b/backend/tests/utils/stripeMock.js
@@ -4,6 +4,11 @@ const stripe = {
       create: async () => ({ id: "sess", url: "/checkout" }),
     },
   },
+  billingPortal: {
+    sessions: {
+      create: async () => ({ url: "/portal" }),
+    },
+  },
   webhooks: {
     constructEvent: () => ({}),
   },


### PR DESCRIPTION
## Summary
- load subscription router early in app and test utilities
- provide test helpers for subscription APIs
- expand Stripe mock and update subscription tests

## Testing
- `npm run format >/tmp/format.log && tail -n 20 /tmp/format.log`
- `node node_modules/jest/bin/jest.js -c jest.config.js tests/textToImage.test.js tests/subscriptions.test.js --coverage=false >/tmp/test.log && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_68b8358cdec8832d89139f58ce2b4da0