### PR TITLE
fix: clarify missing ts-jest dependency

### DIFF
--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -7,6 +7,13 @@ if (!process.env.SKIP_ROOT_DEPS_CHECK) {
   require("./ensure-root-deps.js");
 }
 
+try {
+  require.resolve("ts-jest");
+} catch {
+  console.error("Missing ts-jest; run `npm run setup` before testing.");
+  process.exit(1);
+}
+
 function verifyFiles(args) {
   let checking = false;
   for (const arg of args) {


### PR DESCRIPTION
## Summary
- provide an explicit error when ts-jest isn't installed before running tests

## Testing
- `npx prettier scripts/run-jest.js -w`
- `SKIP_NET_CHECKS=1 npm test` *(fails: Missing ts-jest; run `npm run setup` before testing.)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Unable to reach npm registry.)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68b8392af004832d904bb8146e5a7d2d