### PR TITLE
fix: preserve mocks between tests

### DIFF
--- a/backend/tests/api.test.js
+++ b/backend/tests/api.test.js
@@ -114,7 +114,8 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  jest.restoreAllMocks();
+  // Preserve mocked modules between tests but reset their call history
+  jest.clearAllMocks();
 });
 
 test("POST /api/generate returns glb url", async () => {

--- a/backend/tests/api.test.ts
+++ b/backend/tests/api.test.ts
@@ -114,7 +114,8 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  jest.restoreAllMocks();
+  // Preserve mocked modules between tests but reset their call history
+  jest.clearAllMocks();
 });
 
 test("POST /api/generate returns glb url", async () => {


### PR DESCRIPTION
## Summary
- keep mocked modules across test cases by clearing instead of restoring mocks

## Testing
- `npm run format`
- `node scripts/run-jest.js backend/tests/api.test.ts -t "Stripe create-order flow"` *(fails: Preset ts-jest not found)*
- `npm run ci` *(fails: Preset ts-jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b83a082334832dab350f7c0cfdaa2c