### PR TITLE
fix: handle missing job before order validation

### DIFF
--- a/backend/src/routes/create-order.js
+++ b/backend/src/routes/create-order.js
@@ -21,7 +21,7 @@ router.post("/create-order", async (req, res) => {
       utmCampaign,
       adSubreddit,
     } = req.body || {};
-    if (!jobId || !price || !productType) {
+    if (!jobId) {
       res.status(400).json({ error: "bad_request" });
       return;
     }
@@ -32,6 +32,10 @@ router.post("/create-order", async (req, res) => {
     const job = jobRes.rows[0];
     if (!job) {
       res.status(404).json({ error: "not_found" });
+      return;
+    }
+    if (!price || !productType) {
+      res.status(400).json({ error: "bad_request" });
       return;
     }
     if (shippingInfo?.country && prohibited.includes(shippingInfo.country)) {

--- a/backend/src/routes/create-order.ts
+++ b/backend/src/routes/create-order.ts
@@ -24,7 +24,7 @@ router.post("/create-order", async (req, res) => {
       utmCampaign,
       adSubreddit,
     } = req.body || {};
-    if (!jobId || !price || !productType) {
+    if (!jobId) {
       res.status(400).json({ error: "bad_request" });
       return;
     }
@@ -35,6 +35,10 @@ router.post("/create-order", async (req, res) => {
     const job = jobRes.rows[0];
     if (!job) {
       res.status(404).json({ error: "not_found" });
+      return;
+    }
+    if (!price || !productType) {
+      res.status(400).json({ error: "bad_request" });
       return;
     }
     if (shippingInfo?.country && prohibited.includes(shippingInfo.country)) {


### PR DESCRIPTION
## Summary
- check for unknown jobs before validating other order fields so `/api/create-order` returns 404 when job doesn't exist

## Testing
- `npm run format` *(fails: bash: command not found: npm)*
- `npm test` *(fails: bash: command not found: npm)*
- `npm run ci` *(fails: bash: command not found: npm)*
- `npm run smoke` *(fails: bash: command not found: npm)*


------
https://chatgpt.com/codex/tasks/task_e_68b839cbcae4832db3004208a6b290e1