### PR TITLE
fix: load test globals before listing tests

### DIFF
--- a/backend/scripts/ensure-tests-exist.js
+++ b/backend/scripts/ensure-tests-exist.js
@@ -15,6 +15,14 @@ for (const dep of ["jest", "ts-jest"]) {
   }
 }
 
+// Load test globals so required environment variables are populated when
+// Jest scans test files via `--listTests`.
+try {
+  require(path.join(__dirname, "..", "tests", "setupGlobals.js"));
+} catch (err) {
+  console.warn("Failed to preload test globals", err);
+}
+
 const required = [
   "tests/stripe/webhook.valid-signature.spec.ts",
   "tests/stripe/webhook.invalid-signature.spec.ts",


### PR DESCRIPTION
## Summary
- preload test global setup in ensure-tests-exist script so required env vars like CLOUDFRONT_DOMAIN are available when Jest lists tests

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format`
- `npm test` *(fails: many API and route tests)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Unable to reach npm registry: https://registry.npmjs.org/-/ping)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68b839995f68832d95ed62112563802d