### PR TITLE
fix: handle registry method errors

### DIFF
--- a/scripts/ensure-root-deps.js
+++ b/scripts/ensure-root-deps.js
@@ -113,8 +113,16 @@ function runNetworkCheck() {
 
 function canReachRegistry() {
   try {
-    const r = spawnSync("npm", ["ping"], { stdio: "ignore", env: getEnv() });
-    if (r.status !== 0) throw new Error("ping failed");
+    const r = spawnSync("npm", ["ping", "--fetch-retries=0"], {
+      stdio: "pipe",
+      env: getEnv(),
+    });
+    if (r.status !== 0) {
+      const stderr = String(r.stderr || r.stdout || "").trim();
+      if (!/(E403|403|E405|405|MethodNotAllowed)/i.test(stderr)) {
+        throw new Error("ping failed");
+      }
+    }
     return true;
   } catch {
     console.error(
@@ -135,11 +143,16 @@ if (!requiredPaths.every((p) => fs.existsSync(p))) {
     console.log("Dependencies missing. Installing root dependencies...");
     cleanupNpmCache();
     try {
-      const ping = spawnSync("npm", ["ping"], {
-        stdio: "ignore",
+      const ping = spawnSync("npm", ["ping", "--fetch-retries=0"], {
+        stdio: "pipe",
         env: getEnv(),
       });
-      if (ping.status !== 0) throw new Error();
+      if (ping.status !== 0) {
+        const stderr = String(ping.stderr || ping.stdout || "").trim();
+        if (!/(E403|403|E405|405|MethodNotAllowed)/i.test(stderr)) {
+          throw new Error();
+        }
+      }
     } catch {
       console.error(
         "Unable to reach the npm registry. Check network connectivity or proxy settings.",

--- a/scripts/network-check.js
+++ b/scripts/network-check.js
@@ -73,6 +73,12 @@ function check(target) {
     return null;
   } catch (err) {
     const stderr = err.stderr ? err.stderr.toString().trim() : err.message;
+    // Some proxies return HTTP errors for registry pings even though the host
+    // is reachable. Treat common HTTP method/authorization errors as success
+    // so the check only fails when the registry is truly unreachable.
+    if (npmPing && /(E403|403|E405|405|MethodNotAllowed)/i.test(stderr)) {
+      return null;
+    }
     // Treat HTTP 4xx/5xx responses from the Playwright CDN as success. Some
     // Codex environments proxy requests and respond with 4xx or 5xx even though
     // the host is reachable. Allowing this prevents false negatives during


### PR DESCRIPTION
## Summary
- tolerate 403/405 responses from `npm ping` during network checks
- allow root dependency checks to proceed when registry replies with method errors

## Testing
- `npx prettier --write scripts/network-check.js`
- `npm run format --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Unable to reach externals; Dependencies missing)*
- `SKIP_ROOT_DEPS_CHECK=1 SKIP_NET_CHECKS=1 npm test` *(fails: Cannot find module '@jest/core')*

------
https://chatgpt.com/codex/tasks/task_e_68b83bce2084832da2db3d03a8a70203