### PR TITLE
fix: improve missing jest error

### DIFF
--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -1,7 +1,15 @@
 #!/usr/bin/env node
 const fs = require("fs");
 const path = require("path");
-const { runCLI } = require("@jest/core");
+let runCLI;
+try {
+  ({ runCLI } = require("@jest/core"));
+} catch {
+  console.error(
+    "Jest is not installed. Run `npm run setup` to install dependencies.",
+  );
+  process.exit(1);
+}
 
 if (!process.env.SKIP_ROOT_DEPS_CHECK) {
   require("./ensure-root-deps.js");


### PR DESCRIPTION
## Summary
- show clear message when Jest is missing before running tests

## Testing
- `npx prettier scripts/run-jest.js -w`
- `SKIP_NET_CHECKS=1 npm test` *(fails: Preset ts-jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b83b87a984832db07a2e54735f7676