### PR TITLE
fix: ensure ts-jest dependency check

### DIFF
--- a/scripts/ensure-root-deps.js
+++ b/scripts/ensure-root-deps.js
@@ -59,9 +59,22 @@ const winstonPath = path.join(
   "winston",
   "package.json",
 );
+const tsJestPath = path.join(
+  __dirname,
+  "..",
+  "node_modules",
+  "ts-jest",
+  "package.json",
+);
 
 const networkCheck = path.join(__dirname, "network-check.js");
-const requiredPaths = [pluginPath, expressPath, playwrightPath, winstonPath];
+const requiredPaths = [
+  pluginPath,
+  expressPath,
+  playwrightPath,
+  winstonPath,
+  tsJestPath,
+];
 const skipNetChecks = Boolean(process.env.SKIP_NET_CHECKS);
 
 function cleanupNpmCache() {


### PR DESCRIPTION
## Summary
- add ts-jest to required dependency list so tests reinstall missing package automatically

## Testing
- `npx prettier -w scripts/ensure-root-deps.js`
- `npm run format --prefix backend`
- `SKIP_PW_DEPS=1 npm test` *(fails: Unable to reach npm registry)*
- `SKIP_PW_DEPS=1 npm test --prefix backend` *(fails: CLOUDFRONT_DOMAIN is required)*

------
https://chatgpt.com/codex/tasks/task_e_68b83b07adac832db8c200bcf9290819