### PR TITLE
fix: ensure subscription routes use proper dependencies

### DIFF
--- a/backend/config.js
+++ b/backend/config.js
@@ -6,7 +6,7 @@
  *
  * @module backend/config
  */
-const { getEnv } = require("./src/lib/getEnv");
+const { getEnv } = require("./src/lib/getEnv.js");
 const { applyMockEnv, mockSecrets } = require("./src/lib/mockEnv");
 const logger = require("./src/logger.js");
 

--- a/backend/src/routes/subscription.js
+++ b/backend/src/routes/subscription.js
@@ -5,15 +5,11 @@ const config = require("../../config");
 const { authRequired, authOptional } = require("../lib/auth");
 const logger = require("../logger.js");
 const { capture } = require("../lib/logger");
-const { isTest } = require("../env");
 
 const router = Router();
-const realStripe = new Stripe(config.stripeKey, {
+const stripe = new Stripe(config.stripeKey, {
   apiVersion: "2022-11-15",
 });
-const stripe = isTest()
-  ? require("../../tests/utils/stripeMock").stripe
-  : realStripe;
 
 router.get("/subscription", authRequired, async (req, res) => {
   try {

--- a/backend/src/routes/subscription.ts
+++ b/backend/src/routes/subscription.ts
@@ -6,20 +6,16 @@ import {
 } from "express";
 import Stripe from "stripe";
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-const db = require("../../db");
+const db = require("../../db.js");
 import config from "../../config";
 import { authRequired, authOptional } from "../lib/auth";
 import logger from "../logger";
 import { capture } from "../lib/logger";
-import { isTest } from "../env";
 
 const router = Router();
-const realStripe = new Stripe(config.stripeKey, {
+const stripe = new Stripe(config.stripeKey, {
   apiVersion: "2022-11-15",
 });
-const stripe = isTest()
-  ? require("../../tests/utils/stripeMock").stripe
-  : realStripe;
 
 router.get("/subscription", authRequired, async (req, res) => {
   try {


### PR DESCRIPTION
## Summary
- fix config to import getEnv.js directly to avoid Jest resolution issues
- use explicit db.js path and real Stripe constructor in subscription routes

## Testing
- `npm test tests/subscriptions.test.js`
- `npm run format`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Unable to reach npm registry)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68b83ac32bf0832da079fddc5b2e659b