### PR TITLE
fix: avoid requiring stripe in subscription routes

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -70,7 +70,7 @@ try {
     app.use("/api", r.default || r);
   })();
 } catch (err) {
-  logger.error("Failed to load admin router", err);
+  logger.error("Failed to load subscription router", err);
 }
 
 try {

--- a/backend/src/routes/credits.js
+++ b/backend/src/routes/credits.js
@@ -2,7 +2,7 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 const express_1 = require("express");
 const auth_1 = require("../lib/auth");
-const db = require("../../db.js");
+const db = require("../../db");
 const router = (0, express_1.Router)();
 router.get("/credits", auth_1.authRequired, async (req, res) => {
   try {

--- a/backend/src/routes/subscription.js
+++ b/backend/src/routes/subscription.js
@@ -1,6 +1,5 @@
 const { Router } = require("express");
-const Stripe = require("stripe");
-const db = require("../../db.js");
+const db = require("../../db");
 const config = require("../../config");
 const { authRequired, authOptional } = require("../lib/auth");
 const logger = require("../logger.js");
@@ -8,12 +7,13 @@ const { capture } = require("../lib/logger");
 const { isTest } = require("../env");
 
 const router = Router();
-const realStripe = new Stripe(config.stripeKey, {
-  apiVersion: "2022-11-15",
-});
-const stripe = isTest()
-  ? require("../../tests/utils/stripeMock").stripe
-  : realStripe;
+let stripe;
+if (isTest()) {
+  stripe = require("../../tests/utils/stripeMock").stripe;
+} else {
+  const Stripe = require("stripe");
+  stripe = new Stripe(config.stripeKey, { apiVersion: "2022-11-15" });
+}
 
 router.get("/subscription", authRequired, async (req, res) => {
   try {

--- a/backend/src/routes/subscription.ts
+++ b/backend/src/routes/subscription.ts
@@ -4,7 +4,6 @@ import {
   type Request,
   type Response,
 } from "express";
-import Stripe from "stripe";
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const db = require("../../db");
 import config from "../../config";
@@ -14,12 +13,15 @@ import { capture } from "../lib/logger";
 import { isTest } from "../env";
 
 const router = Router();
-const realStripe = new Stripe(config.stripeKey, {
-  apiVersion: "2022-11-15",
-});
-const stripe = isTest()
-  ? require("../../tests/utils/stripeMock").stripe
-  : realStripe;
+let stripe: any;
+if (isTest()) {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  stripe = require("../../tests/utils/stripeMock").stripe;
+} else {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const Stripe = require("stripe");
+  stripe = new Stripe(config.stripeKey, { apiVersion: "2022-11-15" });
+}
 
 router.get("/subscription", authRequired, async (req, res) => {
   try {


### PR DESCRIPTION
## Summary
- load Stripe lazily in subscription routes to skip missing dependency during tests
- use shared database import style for credits and subscription routers
- clarify subscription router load error message

## Testing
- `npm run format`
- `npm test tests/subscriptions.test.js` *(fails: Expected 200 Received 404)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Unable to reach npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68b83aa722a0832d847a8dc27a3df1d6