### PR TITLE
chore: log offline reason when skipping smoke tests

### DIFF
--- a/scripts/__tests__/smoke-offline.test.y9v6k2q1m5s7d3r4.ts
+++ b/scripts/__tests__/smoke-offline.test.y9v6k2q1m5s7d3r4.ts
@@ -1,0 +1,8 @@
+import { execSync } from "child_process";
+
+test("smoke script logs offline reason", () => {
+  const output = execSync("SKIP_NET_CHECKS=1 node scripts/smoke.mjs", {
+    encoding: "utf8",
+  });
+  expect(output).toMatch(/offline mode: skipping smoke \(SKIP_NET_CHECKS=1\)/);
+});

--- a/scripts/net-mode.mjs
+++ b/scripts/net-mode.mjs
@@ -1,7 +1,15 @@
 import { execSync } from "child_process";
 
+let offlineReason;
+
 export function isOfflineEnv() {
-  if (process.env.SKIP_NET_CHECKS === "1" || process.env.CI_NO_NET === "1") {
+  if (process.env.SKIP_NET_CHECKS === "1") {
+    offlineReason = "SKIP_NET_CHECKS=1";
+    setOfflineEnv();
+    return true;
+  }
+  if (process.env.CI_NO_NET === "1") {
+    offlineReason = "CI_NO_NET=1";
     setOfflineEnv();
     return true;
   }
@@ -12,6 +20,7 @@ export function isOfflineEnv() {
     process.env.HTTPS_PROXY;
   const sandbox = process.env.CI_SANDBOX === "1";
   if (sandbox) {
+    offlineReason = "CI_SANDBOX=1";
     setOfflineEnv();
     return true;
   }
@@ -23,15 +32,18 @@ export function isOfflineEnv() {
         { stdio: "ignore" },
       );
     } catch {
+      offlineReason = "npm registry unreachable";
       setOfflineEnv();
       return true;
     }
   }
+  offlineReason = undefined;
   return false;
 }
 
 export function logOfflineSkip(step) {
-  console.log(`offline mode: skipping ${step}`);
+  const reason = offlineReason ? ` (${offlineReason})` : "";
+  console.log(`offline mode: skipping ${step}${reason}`);
 }
 
 export function withRetries(cmd, { retries = 3, timeout = 10000 } = {}) {


### PR DESCRIPTION
## Summary
- report why smoke tests are skipped when running offline
- test that smoke script surfaces the offline reason

## Testing
- `SKIP_NET_CHECKS=1 npm run validate-env`
- `npx prettier -w scripts/net-mode.mjs scripts/__tests__/smoke-offline.test.y9v6k2q1m5s7d3r4.ts`
- `npm run format`
- `SKIP_NET_CHECKS=1 npm test` *(fails: Cannot find module '@jest/core')*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b83a1bff60832da4caccf8f3f4a23f