### PR TITLE
fix: skip jest when offline

### DIFF
--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -1,26 +1,6 @@
 #!/usr/bin/env node
 const fs = require("fs");
 const path = require("path");
-let runCLI;
-try {
-  ({ runCLI } = require("@jest/core"));
-} catch {
-  console.error(
-    "Jest is not installed. Run `npm run setup` to install dependencies.",
-  );
-  process.exit(1);
-}
-
-if (!process.env.SKIP_ROOT_DEPS_CHECK) {
-  require("./ensure-root-deps.js");
-}
-
-try {
-  require.resolve("ts-jest");
-} catch {
-  console.error("Missing ts-jest; run `npm run setup` before testing.");
-  process.exit(1);
-}
 
 function verifyFiles(args) {
   let checking = false;
@@ -43,11 +23,32 @@ async function run(args) {
   const { isOfflineEnv, logOfflineSkip } = await import("./net-mode.mjs");
   if (isOfflineEnv()) {
     logOfflineSkip("jest");
-    process.exit(0);
+    return;
   }
+
+  let runCLI;
+  try {
+    ({ runCLI } = require("@jest/core"));
+  } catch {
+    console.error(
+      "Jest is not installed. Run `npm run setup` to install dependencies.",
+    );
+    process.exit(1);
+  }
+
+  if (!process.env.SKIP_ROOT_DEPS_CHECK) {
+    require("./ensure-root-deps.js");
+  }
+
+  try {
+    require.resolve("ts-jest");
+  } catch {
+    console.error("Missing ts-jest; run `npm run setup` before testing.");
+    process.exit(1);
+  }
+
   verifyFiles(args);
   console.log("run-jest cwd:", process.cwd());
-  const { runCLI } = require("@jest/core");
   const configPath = path.resolve(__dirname, "..", "jest.config.cjs");
   const parsed = { _: [], config: configPath };
   let awaitingValue = null;


### PR DESCRIPTION
## Summary
- skip jest execution early when network connectivity is unavailable

## Testing
- `npm run validate-env`
- `npx prettier scripts/run-jest.js -w`
- `npm test` *(offline mode: skipping jest)*
- `SKIP_PW_DEPS=1 npm run ci` *(offline mode: skipping ci)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68b845f0adb8832d9a94bf95b4e0e14b