### PR TITLE
fix: expose getEnv implementation for tests

### DIFF
--- a/backend/src/lib/getEnv.ts
+++ b/backend/src/lib/getEnv.ts
@@ -1,1 +1,5 @@
-export * from "./getEnv";
+// Re-export the CommonJS implementation to ensure Jest and TypeScript
+// resolve the same module. Without the explicit file extension, ts-node
+// resolves this file again, resulting in an empty module and `getEnv` being
+// undefined during tests.
+export { getEnv } from "./getEnv.js";


### PR DESCRIPTION
## Summary
- export the CommonJS getEnv implementation from TypeScript to ensure Jest resolves the correct function

## Testing
- `npm run format` (backend)
- `npm test tests/api.test.js` *(fails: db.query.mockClear is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68b845c83cd8832dbf36a944faf0d93d