### PR TITLE
fix: load subscription router without env

### DIFF
--- a/backend/src/routes/subscription.js
+++ b/backend/src/routes/subscription.js
@@ -5,7 +5,7 @@ const config = require("../../config");
 const { authRequired, authOptional } = require("../lib/auth");
 const logger = require("../logger.js");
 const { capture } = require("../lib/logger");
-const { isTest } = require("../env");
+const isTest = () => process.env.NODE_ENV === "test";
 
 const router = Router();
 const realStripe = new Stripe(config.stripeKey, {

--- a/backend/src/routes/subscription.ts
+++ b/backend/src/routes/subscription.ts
@@ -11,7 +11,8 @@ import config from "../../config";
 import { authRequired, authOptional } from "../lib/auth";
 import logger from "../logger";
 import { capture } from "../lib/logger";
-import { isTest } from "../env";
+
+const isTest = () => process.env.NODE_ENV === "test";
 
 const router = Router();
 const realStripe = new Stripe(config.stripeKey, {


### PR DESCRIPTION
## Summary
- avoid requiring env module in subscription routes to prevent 404s when env vars are missing

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend tests/subscriptions.test.js`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b844f7ea68832da7e54b96de5df423