### PR TITLE
fix: correct getEnv export

### DIFF
--- a/backend/src/lib/getEnv.ts
+++ b/backend/src/lib/getEnv.ts
@@ -1,1 +1,8 @@
-export * from "./getEnv";
+// Explicitly reference the JavaScript implementation to avoid Jest's
+// module resolution from picking this TypeScript file again and creating
+// a self-referential import cycle. Without the extension Jest resolves
+// `./getEnv` to this file, causing `getEnv` to be undefined at runtime.
+//
+// Using the .js extension ensures the CommonJS module is loaded and the
+// named export is preserved.
+export { getEnv } from "./getEnv.js";


### PR DESCRIPTION
## Summary
- fix circular self-import in `getEnv` type module

## Testing
- `npm run format --prefix backend`
- `SKIP_ROOT_DEPS_CHECK=1 SKIP_NET_CHECKS=1 SKIP_PW_DEPS=1 npm test --prefix backend` *(fails: Cannot read properties of undefined (reading 'clear'))*

------
https://chatgpt.com/codex/tasks/task_e_68b844d221f8832dbf55c17ed9d57a6b