### PR TITLE
fix: run smoke tests offline with SKIP_PW_DEPS

### DIFF
--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -8,9 +8,16 @@ EventEmitter.defaultMaxListeners = Math.max(
   EventEmitter.defaultMaxListeners || 10,
 );
 
-if (isOfflineEnv()) {
-  logOfflineSkip("smoke");
-  process.exit(0);
+const offline = isOfflineEnv();
+if (offline) {
+  if (process.env.SKIP_PW_DEPS === "1") {
+    if (!process.env.SKIP_NET_CHECKS) {
+      process.env.SKIP_NET_CHECKS = "1";
+    }
+  } else {
+    logOfflineSkip("smoke");
+    process.exit(0);
+  }
 }
 
 execSync(


### PR DESCRIPTION
## Summary
- allow smoke script to run when offline if SKIP_PW_DEPS=1
- set SKIP_NET_CHECKS automatically to bypass registry checks in offline smoke runs

## Testing
- `npm run validate-env`
- `npx prettier --write scripts/smoke.mjs`
- `cd backend && npm run format`
- `cd backend && npm test` *(fails: SyntaxError: Unexpected end of input)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: offline mode: skipping ci)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing ts-jest; run npm run setup before testing)*

------
https://chatgpt.com/codex/tasks/task_e_68b84490a57c832d83e9b24affc18632