### PR TITLE
fix: verify job ID before validating order fields

### DIFF
--- a/backend/src/routes/create-order.js
+++ b/backend/src/routes/create-order.js
@@ -21,7 +21,7 @@ router.post("/create-order", async (req, res) => {
       utmCampaign,
       adSubreddit,
     } = req.body || {};
-    if (!jobId || !price || !productType) {
+    if (!jobId) {
       res.status(400).json({ error: "bad_request" });
       return;
     }
@@ -32,6 +32,10 @@ router.post("/create-order", async (req, res) => {
     const job = jobRes.rows[0];
     if (!job) {
       res.status(404).json({ error: "not_found" });
+      return;
+    }
+    if (!price || !productType) {
+      res.status(400).json({ error: "bad_request" });
       return;
     }
     if (shippingInfo?.country && prohibited.includes(shippingInfo.country)) {

--- a/backend/src/routes/create-order.ts
+++ b/backend/src/routes/create-order.ts
@@ -24,7 +24,7 @@ router.post("/create-order", async (req, res) => {
       utmCampaign,
       adSubreddit,
     } = req.body || {};
-    if (!jobId || !price || !productType) {
+    if (!jobId) {
       res.status(400).json({ error: "bad_request" });
       return;
     }
@@ -35,6 +35,10 @@ router.post("/create-order", async (req, res) => {
     const job = jobRes.rows[0];
     if (!job) {
       res.status(404).json({ error: "not_found" });
+      return;
+    }
+    if (!price || !productType) {
+      res.status(400).json({ error: "bad_request" });
       return;
     }
     if (shippingInfo?.country && prohibited.includes(shippingInfo.country)) {

--- a/backend/src/routes/orders.js
+++ b/backend/src/routes/orders.js
@@ -41,7 +41,7 @@ router.post("/create-order", async (req, res) => {
       adSubreddit,
     } = req.body || {};
 
-    if (!jobId || (!price && !useCredit) || !productType) {
+    if (!jobId) {
       return res.status(400).json({ error: "bad_request" });
     }
 
@@ -53,6 +53,10 @@ router.post("/create-order", async (req, res) => {
       return res.status(404).json({ error: "job_not_found" });
     }
     const job = jobRes.rows[0];
+
+    if ((!price && !useCredit) || !productType) {
+      return res.status(400).json({ error: "bad_request" });
+    }
     const buyerId = getUserId(req);
 
     if (shippingInfo?.country && prohibited.includes(shippingInfo.country)) {

--- a/backend/src/routes/orders.ts
+++ b/backend/src/routes/orders.ts
@@ -40,7 +40,7 @@ router.post("/create-order", async (req, res) => {
       adSubreddit,
     } = req.body || {};
 
-    if (!jobId || (!price && !useCredit) || !productType) {
+    if (!jobId) {
       return res.status(400).json({ error: "bad_request" });
     }
 
@@ -52,6 +52,10 @@ router.post("/create-order", async (req, res) => {
       return res.status(404).json({ error: "job_not_found" });
     }
     const job = jobRes.rows[0];
+
+    if ((!price && !useCredit) || !productType) {
+      return res.status(400).json({ error: "bad_request" });
+    }
     const buyerId = getUserId(req);
 
     if (shippingInfo?.country && prohibited.includes(shippingInfo.country)) {


### PR DESCRIPTION
## Summary
- ensure create-order route checks job existence before price/product validation
- mirror the change in legacy create-order handler

## Testing
- `npm run validate-env`
- `npm run setup`
- `(cd backend && npm run format)`
- `(cd backend && npm test)` *(fails: TypeError: getEnv is not a function)*
- `npm run ci` *(offline mode: skipping ci)*
- `npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68b8446f57b8832d9e8ca4749b61256a