### PR TITLE
fix: correctly re-export getEnv

### DIFF
--- a/backend/src/lib/getEnv.ts
+++ b/backend/src/lib/getEnv.ts
@@ -1,1 +1,1 @@
-export * from "./getEnv";
+export { getEnv } from "./getEnv.js";


### PR DESCRIPTION
## Summary
- correct getEnv re-export to point to implementation

## Testing
- `npm run format` (backend)
- `npm test` (backend) *(fails: TypeError: db.query.mockClear is not a function)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: GET /api/referral-link returns code → expected 200, received 500)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Cannot find module 'async/forEach')*


------
https://chatgpt.com/codex/tasks/task_e_68b8442faad0832db9d2b60e8248f501