### PR TITLE
fix: support backend jest config in test runner

### DIFF
--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -6,11 +6,13 @@ if (!process.env.SKIP_ROOT_DEPS_CHECK) {
   require("./ensure-root-deps.js");
 }
 
-try {
-  require.resolve("ts-jest");
-} catch {
-  console.error("Missing ts-jest; run `npm run setup` before testing.");
-  process.exit(1);
+function ensureTsJest(dir) {
+  try {
+    require.resolve("ts-jest", { paths: [dir] });
+  } catch {
+    console.error("Missing ts-jest; run `npm run setup` before testing.");
+    process.exit(1);
+  }
 }
 
 function verifyFiles(args) {
@@ -38,9 +40,10 @@ async function run(args) {
   }
   verifyFiles(args);
   console.log("run-jest cwd:", process.cwd());
+  const repoRoot = path.resolve(__dirname, "..");
+  const backendDir = path.join(repoRoot, "backend");
   const { runCLI } = require("@jest/core");
-  const configPath = path.resolve(__dirname, "..", "jest.config.cjs");
-  const parsed = { _: [], config: configPath };
+  const parsed = { _: [], config: path.resolve(repoRoot, "jest.config.cjs") };
   let awaitingValue = null;
   for (const arg of args) {
     if (awaitingValue) {
@@ -61,7 +64,17 @@ async function run(args) {
       parsed._.push(arg);
     }
   }
-  const { results } = await runCLI(parsed, [process.cwd()]);
+
+  let projectDir = repoRoot;
+  if (parsed.config === path.resolve(repoRoot, "jest.config.cjs")) {
+    const hasBackendTest = parsed._.some((p) => p.startsWith("backend/"));
+    if (hasBackendTest) {
+      parsed.config = path.join(backendDir, "jest.config.js");
+      projectDir = backendDir;
+    }
+  }
+  ensureTsJest(projectDir);
+  const { results } = await runCLI(parsed, [projectDir]);
   process.exit(results.success ? 0 : 1);
 }
 


### PR DESCRIPTION
## Summary
- load ts-jest relative to project so tests can run without root dependencies
- automatically use backend Jest config when targeting backend tests

## Testing
- `npm run format --prefix backend`
- `SKIP_ROOT_DEPS_CHECK=1 npm test -- backend/tests/api.test.ts -t "Stripe create-order flow"` *(offline: skipped)*
- `SKIP_ROOT_DEPS_CHECK=1 SKIP_PW_DEPS=1 npm run ci` *(offline: skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68b8441be154832dacf6a976eea08b81