### PR TITLE
fix: resolve ts-jest for backend tests

### DIFF
--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -2,13 +2,25 @@
 const fs = require("fs");
 const path = require("path");
 
+const repoRoot = path.resolve(__dirname, "..");
+const backendRoot = path.join(repoRoot, "backend");
+
+function resolveFromPaths(mod) {
+  for (const p of [repoRoot, backendRoot]) {
+    try {
+      return require.resolve(mod, { paths: [p] });
+    } catch {
+      /* ignore */
+    }
+  }
+  return null;
+}
+
 if (!process.env.SKIP_ROOT_DEPS_CHECK) {
   require("./ensure-root-deps.js");
 }
 
-try {
-  require.resolve("ts-jest");
-} catch {
+if (!resolveFromPaths("ts-jest")) {
   console.error("Missing ts-jest; run `npm run setup` before testing.");
   process.exit(1);
 }
@@ -38,13 +50,21 @@ async function run(args) {
   }
   verifyFiles(args);
   console.log("run-jest cwd:", process.cwd());
-  const { runCLI } = require("@jest/core");
-  const configPath = path.resolve(__dirname, "..", "jest.config.cjs");
-  const parsed = { _: [], config: configPath };
+  const corePath = resolveFromPaths("@jest/core");
+  if (!corePath) {
+    console.error("Missing jest core; run `npm run setup` before testing.");
+    process.exit(1);
+  }
+  const { runCLI } = require(corePath);
+  const defaultConfig = path.resolve(repoRoot, "jest.config.cjs");
+  const backendConfig = path.resolve(backendRoot, "jest.config.js");
+  const parsed = { _: [], config: defaultConfig };
   let awaitingValue = null;
+  let configProvided = false;
   for (const arg of args) {
     if (awaitingValue) {
       parsed[awaitingValue] = arg;
+      if (awaitingValue === "config") configProvided = true;
       awaitingValue = null;
       continue;
     }
@@ -52,6 +72,7 @@ async function run(args) {
       const [key, value] = arg.slice(2).split("=");
       if (value !== undefined) {
         parsed[key] = value;
+        if (key === "config") configProvided = true;
       } else if (["help", "runTestsByPath"].includes(key)) {
         parsed[key] = true;
       } else {
@@ -60,6 +81,13 @@ async function run(args) {
     } else {
       parsed._.push(arg);
     }
+  }
+  const isBackendTest = parsed._.some((p) => {
+    const rel = path.relative(repoRoot, path.resolve(repoRoot, p));
+    return rel.startsWith("backend" + path.sep);
+  });
+  if (isBackendTest && !configProvided) {
+    parsed.config = backendConfig;
   }
   const { results } = await runCLI(parsed, [process.cwd()]);
   process.exit(results.success ? 0 : 1);


### PR DESCRIPTION
## Summary
- ensure `scripts/run-jest.js` resolves ts-jest and @jest/core from backend paths
- auto-select backend Jest config when running backend tests

## Testing
- `npm run validate-env`
- `npm run format --prefix backend`
- `node scripts/run-jest.js backend/tests/api.test.ts -t "Stripe create-order flow"` *(fails: offline mode: skipping jest)*
- `npm run ci` *(fails: offline mode: skipping ci)*
- `npm run smoke` *(fails: offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68b843fc5aec832d851c4fad8a3ca638