### PR TITLE
Fix failing model tests and drop winston dependency

### DIFF
--- a/backend/tests/apiModels.test.js
+++ b/backend/tests/apiModels.test.js
@@ -18,26 +18,30 @@ afterEach(() => {
 });
 
 test("GET /api/models returns list", async () => {
-  db.query.mockResolvedValueOnce({
-    rows: [{ id: 1, s3_key: "m1.glb", uploaded_at: "2024-01-01" }],
-  });
+  const rows = [
+    {
+      id: 1,
+      prompt: "p",
+      s3_key: "m1.glb",
+      cloudfront_url: "https://cdn.example.com/m1.glb",
+    },
+  ];
+  db.query.mockResolvedValueOnce({ rows });
   const res = await request(app).get("/api/models");
   expect(res.status).toBe(200);
-  expect(res.body).toEqual([
-    { id: 1, key: "m1.glb", uploaded_at: "2024-01-01" },
-  ]);
+  expect(res.body).toEqual(rows);
 });
 
 test("POST /api/models creates model with CDN url", async () => {
-  const body = { prompt: "cat", fileKey: "cat.glb" };
-  const url = `https://${process.env.CLOUDFRONT_MODEL_DOMAIN}/${body.fileKey}`;
+  const body = { prompt: "cat", s3_key: "cat.glb" };
+  const url = `https://${process.env.CLOUDFRONT_MODEL_DOMAIN}/${body.s3_key}`;
   db.query.mockResolvedValueOnce({
     rows: [
       {
         id: 2,
         prompt: body.prompt,
-        filekey: body.fileKey,
-        url,
+        s3_key: body.s3_key,
+        cloudfront_url: url,
         created_at: "2024-01-02",
       },
     ],
@@ -47,13 +51,13 @@ test("POST /api/models creates model with CDN url", async () => {
   expect(res.body).toEqual({
     id: 2,
     prompt: body.prompt,
-    filekey: body.fileKey,
-    url,
+    s3_key: body.s3_key,
+    cloudfront_url: url,
     created_at: "2024-01-02",
   });
   const call = db.query.mock.calls[0];
   expect(call[0]).toContain("INSERT INTO models");
-  expect(call[1]).toEqual([body.prompt, body.fileKey, url]);
+  expect(call[1]).toEqual([body.prompt, body.s3_key, url]);
 });
 
 test("POST /api/models requires fields", async () => {
@@ -61,20 +65,24 @@ test("POST /api/models requires fields", async () => {
   expect(res.status).toBe(400);
 });
 
-test("POST /api/models rejects invalid fileKey", async () => {
+test("POST /api/models rejects invalid s3_key", async () => {
   const res = await request(app)
     .post("/api/models")
-    .send({ prompt: "a", fileKey: "../bad" });
+    .send({ prompt: "a", s3_key: "../bad" });
   expect(res.status).toBe(400);
 });
 
 test("POST /api/models accepts hyphen and underscore", async () => {
-  const body = { prompt: "a", fileKey: "my-file_1.glb" };
-  const url = `https://${process.env.CLOUDFRONT_MODEL_DOMAIN}/${body.fileKey}`;
-  db.query.mockResolvedValueOnce({ rows: [{ id: 3, ...body, url }] });
+  const body = { prompt: "a", s3_key: "my-file_1.glb" };
+  const url = `https://${process.env.CLOUDFRONT_MODEL_DOMAIN}/${body.s3_key}`;
+  db.query.mockResolvedValueOnce({
+    rows: [
+      { id: 3, prompt: body.prompt, s3_key: body.s3_key, cloudfront_url: url },
+    ],
+  });
   const res = await request(app).post("/api/models").send(body);
   expect(res.status).toBe(201);
-  expect(res.body.url).toBe(url);
+  expect(res.body.cloudfront_url).toBe(url);
 });
 
 test("POST /api/models/:id/public toggles visibility", async () => {

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,50 +1,38 @@
-const { createLogger, format, transports } = require("winston");
-
 const isTest = process.env.NODE_ENV === "test";
-const level = process.env.LOG_LEVEL || (isTest ? "error" : "info");
-const consoleTransport = new transports.Console({ silent: isTest });
-
-const baseLogger = createLogger({
-  level,
-  format: format.combine(format.timestamp(), format.json()),
-  transports: [consoleTransport],
-});
 
 /**
- * Format a log entry and forward it to winston.
- * @param {"info"|"warn"|"error"} level - log level for the message
- * @param {string} msg - message to log
- * @param {object} [meta] - additional metadata for the log entry
+ * Write a structured log entry to the console.
+ * @param {"info"|"warn"|"error"} level
+ * @param {string} message
+ * @param {object} [meta]
  * @returns {void}
  */
-function output(level, msg, meta = {}) {
-  const { code, ...rest } = meta;
-  baseLogger.log({
+function output(level, message, meta = {}) {
+  if (isTest) return;
+  const entry = {
     level,
-    message: msg,
-    ...(code ? { code } : {}),
-    ...rest,
+    message,
+    ...meta,
     timestamp: new Date().toISOString(),
-  });
+  };
+  const line = JSON.stringify(entry);
+  if (level === "error") console.error(line);
+  else if (level === "warn") console.warn(line);
+  else console.log(line);
 }
 
+/**
+ * Minimal logger interface used across the project. Methods are no-ops during
+ * tests to keep output clean.
+ */
 const logger = {
-  info: (msg, meta) => {
-    if (isTest) return baseLogger.info(msg, meta);
-    output("info", msg, meta);
-  },
-  warn: (msg, meta) => {
-    if (isTest) return baseLogger.warn(msg, meta);
-    output("warn", msg, meta);
-  },
-  error: (msg, meta) => {
-    if (isTest) return baseLogger.error(msg, meta);
-    output("error", msg, meta);
-  },
-  add: (...args) => baseLogger.add(...args),
-  remove: (...args) => baseLogger.remove(...args),
-  transports: baseLogger.transports,
-  level: baseLogger.level,
+  info: (msg, meta) => output("info", msg, meta),
+  warn: (msg, meta) => output("warn", msg, meta),
+  error: (msg, meta) => output("error", msg, meta),
+  add: () => {},
+  remove: () => {},
+  transports: [],
+  level: "info",
 };
 
 module.exports = logger;


### PR DESCRIPTION
## Summary
- replace winston-based logger with lightweight console logger
- update model API tests to use `s3_key` and `cloudfront_url`

## Testing
- `npx prettier -w src/logger.js backend/tests/apiModels.test.js`
- `npm run format` (backend)
- `SKIP_NET_CHECKS=1 SKIP_PW_DEPS=1 node scripts/run-jest.js backend/tests/apiModels.test.js` *(fails: Jest is not installed. Run `npm run setup` to install dependencies.)*
- `SKIP_NET_CHECKS=1 SKIP_PW_DEPS=1 npm run ci` *(offline mode: skipping ci)*

------
https://chatgpt.com/codex/tasks/task_e_68b845da6df8832d87743a3b4f2b58a7