### PR TITLE
fix: delay jest dependency check until after setup

### DIFF
--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -1,15 +1,6 @@
 #!/usr/bin/env node
 const fs = require("fs");
 const path = require("path");
-let runCLI;
-try {
-  ({ runCLI } = require("@jest/core"));
-} catch {
-  console.error(
-    "Jest is not installed. Run `npm run setup` to install dependencies.",
-  );
-  process.exit(1);
-}
 
 const repoRoot = path.resolve(__dirname, "..");
 const backendRoot = path.join(repoRoot, "backend");
@@ -25,14 +16,7 @@ function resolveFromPaths(mod) {
   return null;
 }
 
-if (!process.env.SKIP_ROOT_DEPS_CHECK) {
-  require("./ensure-root-deps.js");
-}
-
-if (!resolveFromPaths("ts-jest")) {
-  console.error("Missing ts-jest; run `npm run setup` before testing.");
-  process.exit(1);
-}
+// Dependency checks and installation are performed lazily in `run()`
 
 function verifyFiles(args) {
   let checking = false;
@@ -57,19 +41,17 @@ async function run(args) {
     logOfflineSkip("jest");
     return;
   }
+  if (!process.env.SKIP_ROOT_DEPS_CHECK) {
+    require("./ensure-root-deps.js");
+  }
 
-  let runCLI;
   try {
-    ({ runCLI } = require("@jest/core"));
+    require.resolve("@jest/core");
   } catch {
     console.error(
       "Jest is not installed. Run `npm run setup` to install dependencies.",
     );
     process.exit(1);
-  }
-
-  if (!process.env.SKIP_ROOT_DEPS_CHECK) {
-    require("./ensure-root-deps.js");
   }
 
   try {


### PR DESCRIPTION
## Summary
- avoid requiring Jest before ensuring dependencies are installed
- handle missing Jest and ts-jest after running dependency setup

## Testing
- `npx prettier -w scripts/run-jest.js`
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: db.query.mockClear is not a function / process.exit called with "1")*
- `SKIP_PW_DEPS=1 npm run ci` *(skipped: offline mode)*
- `SKIP_PW_DEPS=1 npm run smoke` *(skipped: offline mode)*
- `SKIP_NET_CHECKS=1 SKIP_PW_DEPS=1 node scripts/run-jest.js backend/tests/apiModels.test.js` *(offline mode: skipping jest)*

------
https://chatgpt.com/codex/tasks/task_e_68b84b038c98832db6aa0d32671f071b