### PR TITLE
ci: run tests in offline mode

### DIFF
--- a/scripts/ci.mjs
+++ b/scripts/ci.mjs
@@ -1,11 +1,8 @@
 #!/usr/bin/env node
 import { execSync } from "child_process";
-import { isOfflineEnv, logOfflineSkip } from "./net-mode.mjs";
+import { isOfflineEnv } from "./net-mode.mjs";
 
-if (isOfflineEnv()) {
-  logOfflineSkip("ci");
-  process.exit(0);
-}
+isOfflineEnv();
 
 if (process.env.SKIP_PW_DEPS === "1") {
   process.env.PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1";


### PR DESCRIPTION
## Summary
- allow `npm run ci` to build and test even when network checks are skipped by removing the offline early exit

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: TypeError: db.query.mockClear is not a function)*
- `SKIP_NET_CHECKS=1 SKIP_PW_DEPS=1 npm run ci` *(fails: Identifier 'runCLI' has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_68b84b138590832d9ae3a966d0e5ce02