### PR TITLE
test: fix db mock path in API tests

### DIFF
--- a/backend/tests/api.test.js
+++ b/backend/tests/api.test.js
@@ -3,7 +3,7 @@ process.env.STRIPE_WEBHOOK_SECRET = "whsec";
 process.env.DB_URL = "postgres://user:pass@localhost/db";
 
 // mock the database module using the same relative path as the app code
-jest.mock("../../db", () => ({
+jest.mock("../db", () => ({
   query: jest.fn().mockResolvedValue({ rows: [] }),
   insertCommission: jest.fn().mockResolvedValue({}),
   upsertSubscription: jest.fn(),
@@ -27,7 +27,6 @@ jest.mock("../../db", () => ({
   insertGenerationLog: jest.fn(),
 }));
 
-jest.mock("../../db", () => require("../db"));
 const db = require("../db");
 
 jest.mock("../mail", () => ({ sendMail: jest.fn() }));

--- a/backend/tests/api.test.ts
+++ b/backend/tests/api.test.ts
@@ -3,7 +3,7 @@ process.env.STRIPE_WEBHOOK_SECRET = "whsec";
 process.env.DB_URL = "postgres://user:pass@localhost/db";
 
 // mock the database module using the same relative path as the app code
-jest.mock("../../db", () => ({
+jest.mock("../db", () => ({
   query: jest.fn().mockResolvedValue({ rows: [] }),
   insertCommission: jest.fn().mockResolvedValue({}),
   upsertSubscription: jest.fn(),
@@ -26,7 +26,6 @@ jest.mock("../../db", () => ({
   updateWeeklyOrderStreak: jest.fn(),
   insertGenerationLog: jest.fn(),
 }));
-jest.mock("../../db", () => require("../db"));
 const db = require("../db");
 
 jest.mock("../mail", () => ({ sendMail: jest.fn() }));


### PR DESCRIPTION
## Summary
- fix database mock path in API tests so db functions are jest mocks

## Testing
- `npm run format`
- `npm test -- tests/api.test.js -t "POST /api/generate returns glb url"`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: offline mode: skipping ci)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: SyntaxError: Identifier 'runCLI' has already been declared)*


------
https://chatgpt.com/codex/tasks/task_e_68b84b275644832d952eeb142da10894