### PR TITLE
fix: use correct db mock in api tests

### DIFF
--- a/backend/tests/api.test.js
+++ b/backend/tests/api.test.js
@@ -26,9 +26,7 @@ jest.mock("../../db", () => ({
   updateWeeklyOrderStreak: jest.fn(),
   insertGenerationLog: jest.fn(),
 }));
-
-jest.mock("../../db", () => require("../db"));
-const db = require("../db");
+const db = require("../../db");
 
 jest.mock("../mail", () => ({ sendMail: jest.fn() }));
 const { sendMail } = require("../mail");

--- a/backend/tests/api.test.ts
+++ b/backend/tests/api.test.ts
@@ -26,8 +26,7 @@ jest.mock("../../db", () => ({
   updateWeeklyOrderStreak: jest.fn(),
   insertGenerationLog: jest.fn(),
 }));
-jest.mock("../../db", () => require("../db"));
-const db = require("../db");
+const db = require("../../db");
 
 jest.mock("../mail", () => ({ sendMail: jest.fn() }));
 const { sendMail } = require("../mail");


### PR DESCRIPTION
## Summary
- ensure API tests import the mocked database via the correct relative path

## Testing
- `npm run format` (backend)
- `npm test` (backend) *(fails: create-order and Stripe tests)*
- `SKIP_PW_DEPS=1 npm run ci` *(offline mode: skipping ci)*

------
https://chatgpt.com/codex/tasks/task_e_68b84b3632e4832d873efe242552df85