### PR TITLE
fix: enable offline ci

### DIFF
--- a/scripts/ci.mjs
+++ b/scripts/ci.mjs
@@ -1,10 +1,9 @@
 #!/usr/bin/env node
 import { execSync } from "child_process";
-import { isOfflineEnv, logOfflineSkip } from "./net-mode.mjs";
+import { isOfflineEnv } from "./net-mode.mjs";
 
 if (isOfflineEnv()) {
-  logOfflineSkip("ci");
-  process.exit(0);
+  console.log("offline mode: running ci with existing dependencies");
 }
 
 if (process.env.SKIP_PW_DEPS === "1") {


### PR DESCRIPTION
## Summary
- allow `npm run ci` to proceed in offline mode while still skipping network-dependent steps

## Testing
- `npm run format` (backend)
- `npm test` (backend) *(fails: db.query.mockClear is not a function)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: SyntaxError: Identifier 'runCLI' has already been declared)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: SyntaxError: Identifier 'runCLI' has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_68b84b484ad8832dbfff3625f11c9105