### PR TITLE
fix: allow offline jest runs during smoke

### DIFF
--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -53,7 +53,7 @@ function verifyFiles(args) {
 
 async function run(args) {
   const { isOfflineEnv, logOfflineSkip } = await import("./net-mode.mjs");
-  if (isOfflineEnv()) {
+  if (!process.env.SKIP_NET_CHECKS && isOfflineEnv()) {
     logOfflineSkip("jest");
     return;
   }
@@ -86,7 +86,7 @@ async function run(args) {
     console.error("Missing jest core; run `npm run setup` before testing.");
     process.exit(1);
   }
-  const { runCLI } = require(corePath);
+  ({ runCLI } = require(corePath));
   const defaultConfig = path.resolve(repoRoot, "jest.config.cjs");
   const backendConfig = path.resolve(backendRoot, "jest.config.js");
   const parsed = { _: [], config: defaultConfig };


### PR DESCRIPTION
## Summary
- allow smoke tests to run Jest even when network checks are skipped
- avoid redeclaration of runCLI when resolving Jest core

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format`
- `npm test` (failed: TypeError: db.query.mockClear is not a function)
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke` (failed: Missing ts-jest; run `npm run setup` before testing.)

------
https://chatgpt.com/codex/tasks/task_e_68b84b56403c832d85523559582df1ff