### PR TITLE
fix: skip apt check when offline

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -2,5 +2,5 @@
 idiomatic_version_file_enable_tools = ["node"]
 
 [tools]
-node = "20.19.2"
+node = "20.19.4"
 npm = "10.9.2"

--- a/scripts/validate-env.sh
+++ b/scripts/validate-env.sh
@@ -152,8 +152,16 @@ if [[ -n "${npm_config_http_proxy:-}" || -n "${npm_config_https_proxy:-}" ]]; th
 fi
 
 
+OFFLINE=0
+if node -e "import('./scripts/net-mode.mjs').then(m=>process.exit(m.isOfflineEnv()?0:1))" >/dev/null 2>&1; then
+  OFFLINE=1
+fi
+
 if [[ -z "${SKIP_PW_DEPS:-}" ]]; then
-  if ! node scripts/check-apt.js >/dev/null 2>&1; then
+  if [ "$OFFLINE" -eq 1 ]; then
+    echo "offline mode: skipping apt check" >&2
+    export SKIP_PW_DEPS=1
+  elif ! node scripts/check-apt.js >/dev/null 2>&1; then
     echo "APT repository check failed. Falling back to SKIP_PW_DEPS=1." >&2
     export SKIP_PW_DEPS=1
   fi


### PR DESCRIPTION
## Summary
- avoid noisy apt failures in offline environments
- align mise node version with installed runtime

## Testing
- `npm run validate-env`
- `npm run format`
- `npm test` *(fails: Identifier 'runCLI' has already been declared)*
- `npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Identifier 'runCLI' has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_68b84b677b38832dae4c28181699ad74