### PR TITLE
test: fix index validatePrompt setup

### DIFF
--- a/backend/tests/frontend/index.test.js
+++ b/backend/tests/frontend/index.test.js
@@ -42,9 +42,12 @@ describe("index validatePrompt", () => {
       .readFileSync(path.join(__dirname, "../../../js/index.js"), "utf8")
       .replace(/^\s*import[^\n]*\r?\n/gm, "")
       .replace(/export\s+function/g, "function")
-
-      .replace(/window\.addEventListener\(['"]DOMContentLoaded['"][\s\S]+$/, "")
-      .replace(/let savedProfile = null;\n?/, "");
+      .replace(
+        /if \(typeof process === "undefined"[\s\S]*?window\.addEventListener\(['"]DOMContentLoaded['"], start\);\n}\n/,
+        "",
+      )
+      .replace(/let savedProfile = null;\n?/, "")
+      .replace(/export\s+\{[\s\S]*?\};?\n?/, "");
 
     script += "\nwindow.validatePrompt = validatePrompt;";
     dom.window.eval(script);


### PR DESCRIPTION
## Summary
- remove startup block and export declarations when evaluating `index.js`
- ensure index validation tests can load script without syntax errors

## Testing
- `npm run format`
- `npm test tests/frontend/index.test.js`
- `SKIP_PW_DEPS=1 npm run ci` *(offline mode: skipping ci)*
- `SKIP_PW_DEPS=1 npm run smoke` *(SyntaxError: Identifier 'runCLI' has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_68b84ba3cd4c832db16a0bbea02baeaf