### PR TITLE
ci: run tests in offline mode

### DIFF
--- a/scripts/ci.mjs
+++ b/scripts/ci.mjs
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 import { execSync } from "child_process";
-import { isOfflineEnv, logOfflineSkip } from "./net-mode.mjs";
+import { isOfflineEnv, logOfflineMode } from "./net-mode.mjs";
 
-if (isOfflineEnv()) {
-  logOfflineSkip("ci");
-  process.exit(0);
+const offline = isOfflineEnv();
+if (offline) {
+  logOfflineMode("ci");
 }
 
 if (process.env.SKIP_PW_DEPS === "1") {

--- a/scripts/net-mode.mjs
+++ b/scripts/net-mode.mjs
@@ -27,6 +27,10 @@ export function logOfflineSkip(step) {
   console.log(`offline mode: skipping ${step}`);
 }
 
+export function logOfflineMode(step) {
+  console.log(`offline mode: running ${step}`);
+}
+
 export function withRetries(cmd, { retries = 3, timeout = 10000 } = {}) {
   for (let attempt = 1; attempt <= retries; attempt++) {
     try {

--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -52,13 +52,11 @@ function verifyFiles(args) {
 }
 
 async function run(args) {
-  const { isOfflineEnv, logOfflineSkip } = await import("./net-mode.mjs");
+  const { isOfflineEnv, logOfflineMode } = await import("./net-mode.mjs");
   if (isOfflineEnv()) {
-    logOfflineSkip("jest");
-    return;
+    logOfflineMode("jest");
   }
 
-  let runCLI;
   try {
     ({ runCLI } = require("@jest/core"));
   } catch {


### PR DESCRIPTION
## Summary
- allow `npm run ci` to proceed in offline environments
- log offline execution instead of skipping

## Testing
- `SKIP_NET_CHECKS=1 npm run validate-env`
- `SKIP_PW_DEPS=1 SKIP_NET_CHECKS=1 npm run setup` *(fails: MaxListenersExceededWarning and network proxy errors)*
- `npx prettier scripts/ci.mjs scripts/net-mode.mjs scripts/run-jest.js -w`
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: process.exit called with "1")*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Unable to reach esm.sh/jsdelivr/apt archive)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Jest is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b84bb33f68832d91aa99971301bff2