### PR TITLE
fix: support default getEnv export

### DIFF
--- a/backend/config.js
+++ b/backend/config.js
@@ -6,7 +6,8 @@
  *
  * @module backend/config
  */
-const { getEnv } = require("./src/lib/getEnv");
+// Ensure compatibility with both default and named exports
+const getEnv = require("./src/lib/getEnv");
 const { applyMockEnv, mockSecrets } = require("./src/lib/mockEnv");
 const logger = require("./src/logger.js");
 

--- a/backend/src/lib/getEnv.js
+++ b/backend/src/lib/getEnv.js
@@ -10,4 +10,7 @@ function getEnv(name, options = {}) {
   }
   return value;
 }
-module.exports = { getEnv };
+
+// Support both CommonJS and named imports
+module.exports = getEnv;
+module.exports.getEnv = getEnv;


### PR DESCRIPTION
## Summary
- allow `src/lib/getEnv` to be imported as default or named export
- adjust backend config to use the helper directly

## Testing
- `npm run format` (failed: bash: command not found: npm)
- `npm test` (failed: bash: command not found: npm)

------
https://chatgpt.com/codex/tasks/task_e_68b84bd5f9a4832d8cdfd62fc03752de