### PR TITLE
fix: run ci and smoke offline

### DIFF
--- a/scripts/ci.mjs
+++ b/scripts/ci.mjs
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 import { execSync } from "child_process";
-import { isOfflineEnv, logOfflineSkip } from "./net-mode.mjs";
+import { isOfflineEnv } from "./net-mode.mjs";
 
-if (isOfflineEnv()) {
-  logOfflineSkip("ci");
-  process.exit(0);
+const offline = isOfflineEnv();
+if (offline) {
+  console.warn("offline mode detected; running CI without network checks");
 }
 
 if (process.env.SKIP_PW_DEPS === "1") {

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { EventEmitter } from "events";
 import { execSync } from "child_process";
-import { isOfflineEnv, logOfflineSkip } from "./net-mode.mjs";
+import { isOfflineEnv } from "./net-mode.mjs";
 
 EventEmitter.defaultMaxListeners = Math.max(
   25,
@@ -10,14 +10,15 @@ EventEmitter.defaultMaxListeners = Math.max(
 
 const offline = isOfflineEnv();
 if (offline) {
-  if (process.env.SKIP_PW_DEPS === "1") {
-    if (!process.env.SKIP_NET_CHECKS) {
-      process.env.SKIP_NET_CHECKS = "1";
-    }
-  } else {
-    logOfflineSkip("smoke");
-    process.exit(0);
+  if (process.env.SKIP_PW_DEPS !== "1") {
+    process.env.SKIP_PW_DEPS = "1";
   }
+  if (!process.env.SKIP_NET_CHECKS) {
+    process.env.SKIP_NET_CHECKS = "1";
+  }
+  console.warn(
+    "offline mode detected; running smoke tests with cached dependencies",
+  );
 }
 
 execSync(


### PR DESCRIPTION
## Summary
- continue running `npm run ci` and `npm run smoke` when offline
- auto-set offline flags so smoke tests use cached Playwright deps

## Testing
- `npm run format`
- `npm test` *(fails: db.query.mockClear is not a function)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Identifier 'runCLI' has already been declared)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Identifier 'runCLI' has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_68b84bf62010832daf4127d4e386857a