### PR TITLE
test: fix db mocks in api tests

### DIFF
--- a/backend/tests/api.test.js
+++ b/backend/tests/api.test.js
@@ -3,7 +3,7 @@ process.env.STRIPE_WEBHOOK_SECRET = "whsec";
 process.env.DB_URL = "postgres://user:pass@localhost/db";
 
 // mock the database module using the same relative path as the app code
-jest.mock("../../db", () => ({
+jest.mock("../db", () => ({
   query: jest.fn().mockResolvedValue({ rows: [] }),
   insertCommission: jest.fn().mockResolvedValue({}),
   upsertSubscription: jest.fn(),
@@ -27,7 +27,6 @@ jest.mock("../../db", () => ({
   insertGenerationLog: jest.fn(),
 }));
 
-jest.mock("../../db", () => require("../db"));
 const db = require("../db");
 
 jest.mock("../mail", () => ({ sendMail: jest.fn() }));

--- a/backend/tests/api.test.ts
+++ b/backend/tests/api.test.ts
@@ -3,7 +3,7 @@ process.env.STRIPE_WEBHOOK_SECRET = "whsec";
 process.env.DB_URL = "postgres://user:pass@localhost/db";
 
 // mock the database module using the same relative path as the app code
-jest.mock("../../db", () => ({
+jest.mock("../db", () => ({
   query: jest.fn().mockResolvedValue({ rows: [] }),
   insertCommission: jest.fn().mockResolvedValue({}),
   upsertSubscription: jest.fn(),
@@ -26,7 +26,6 @@ jest.mock("../../db", () => ({
   updateWeeklyOrderStreak: jest.fn(),
   insertGenerationLog: jest.fn(),
 }));
-jest.mock("../../db", () => require("../db"));
 const db = require("../db");
 
 jest.mock("../mail", () => ({ sendMail: jest.fn() }));


### PR DESCRIPTION
## Summary
- fix API test setup to mock the database via '../db' and remove redundant mock override

## Testing
- `npm run format`
- `npm test` *(fails: GET /api/status returns job – Expected: 200 Received: 500)*
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: SyntaxError: Identifier 'runCLI' has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_68b84c0aa004832da1a98881865bcbc3