### PR TITLE
fix: register referral router

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -61,7 +61,16 @@ try {
     app.use("/api", r.default || r);
   })();
 } catch (err) {
-  logger.error("Failed to load discount router", err);
+  logger.error("Failed to load rewards router", err);
+}
+
+try {
+  (() => {
+    const r = require("./routes/referral");
+    app.use("/api", r.default || r);
+  })();
+} catch (err) {
+  logger.error("Failed to load referral router", err);
 }
 
 try {
@@ -74,7 +83,6 @@ try {
 }
 
 try {
-
   (() => {
     const r = require("./routes/subscription");
     app.use("/api", r.default || r);


### PR DESCRIPTION
## Summary
- load rewards router with correct error message
- register referral router in backend app

## Testing
- `npm run format` (backend)
- `npm test` *(fails: db.query.mockClear is not a function)*
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Identifier 'runCLI' has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_68b84c1da2d0832dadc3ba0e03d9067a