### PR TITLE
fix: allow CI run in offline env

### DIFF
--- a/scripts/net-mode.mjs
+++ b/scripts/net-mode.mjs
@@ -1,14 +1,15 @@
 import { execSync } from "child_process";
 
 export function isOfflineEnv() {
+  const force = process.env.CI_FORCE === "1";
   if (process.env.SKIP_NET_CHECKS === "1" || process.env.CI_NO_NET === "1") {
     setOfflineEnv();
-    return true;
+    return !force;
   }
   const sandbox = process.env.CI_SANDBOX === "1";
   if (sandbox) {
     setOfflineEnv();
-    return true;
+    return !force;
   }
   try {
     // Silence curl output; only the exit code matters for connectivity checks
@@ -18,7 +19,7 @@ export function isOfflineEnv() {
     );
   } catch {
     setOfflineEnv();
-    return true;
+    return !force;
   }
   return false;
 }


### PR DESCRIPTION
## Summary
- allow overriding offline detection in scripts via `CI_FORCE`

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup` *(failed: network)
- `npm run format` (backend)
- `npm test` *(failed: db.query.mockClear is not a function)*
- `CI_FORCE=1 SKIP_ROOT_DEPS_CHECK=1 SKIP_PW_DEPS=1 npm run ci` *(failed: runCLI already declared)*
- `CI_FORCE=1 SKIP_PW_DEPS=1 npm run smoke` *(failed: runCLI already declared)*


------
https://chatgpt.com/codex/tasks/task_e_68b84c520e30832dac56809bccb6ee14