### PR TITLE
fix: run jest with skip net checks

### DIFF
--- a/backend/tests/runJestCli.test.js
+++ b/backend/tests/runJestCli.test.js
@@ -31,4 +31,14 @@ describe("run-jest CLI", () => {
     ]);
     expect(result.status).toBe(0);
   });
+
+  test("runs tests with SKIP_NET_CHECKS", () => {
+    const envSkip = { ...env, SKIP_NET_CHECKS: "1" };
+    const result = spawnSync(
+      process.execPath,
+      [script, "tests/openapi/no-removed-paths.m1n3p5q7r9s2t4u6.spec.ts"],
+      { encoding: "utf8", env: envSkip },
+    );
+    expect(result.status).toBe(0);
+  });
 });

--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -1,15 +1,6 @@
 #!/usr/bin/env node
 const fs = require("fs");
 const path = require("path");
-let runCLI;
-try {
-  ({ runCLI } = require("@jest/core"));
-} catch {
-  console.error(
-    "Jest is not installed. Run `npm run setup` to install dependencies.",
-  );
-  process.exit(1);
-}
 
 const repoRoot = path.resolve(__dirname, "..");
 const backendRoot = path.join(repoRoot, "backend");
@@ -53,7 +44,8 @@ function verifyFiles(args) {
 
 async function run(args) {
   const { isOfflineEnv, logOfflineSkip } = await import("./net-mode.mjs");
-  if (isOfflineEnv()) {
+  const offline = isOfflineEnv();
+  if (offline && process.env.SKIP_NET_CHECKS !== "1") {
     logOfflineSkip("jest");
     return;
   }
@@ -86,7 +78,7 @@ async function run(args) {
     console.error("Missing jest core; run `npm run setup` before testing.");
     process.exit(1);
   }
-  const { runCLI } = require(corePath);
+  ({ runCLI } = require(corePath));
   const defaultConfig = path.resolve(repoRoot, "jest.config.cjs");
   const backendConfig = path.resolve(backendRoot, "jest.config.js");
   const parsed = { _: [], config: defaultConfig };


### PR DESCRIPTION
## Summary
- prevent `run-jest` from skipping tests when `SKIP_NET_CHECKS=1`
- cover offline execution with a new CLI test

## Testing
- `npm run format --prefix backend`
- `SKIP_NET_CHECKS=1 npm test --prefix backend` *(fails: process.exit called with "1")*
- `SKIP_PW_DEPS=1 SKIP_NET_CHECKS=1 npm run ci` *(offline mode: skipping ci)*
- `SKIP_PW_DEPS=1 SKIP_NET_CHECKS=1 npm run smoke` *(Missing ts-jest; run `npm run setup` before testing.)*

------
https://chatgpt.com/codex/tasks/task_e_68b84c6603f4832d9b20309d4205b579