### PR TITLE
fix: allow ci to run without network

### DIFF
--- a/scripts/ci.mjs
+++ b/scripts/ci.mjs
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 import { execSync } from "child_process";
-import { isOfflineEnv, logOfflineSkip } from "./net-mode.mjs";
+import { isOfflineEnv } from "./net-mode.mjs";
 
-if (isOfflineEnv()) {
-  logOfflineSkip("ci");
-  process.exit(0);
+const offline = isOfflineEnv();
+if (offline && !process.env.SKIP_NET_CHECKS) {
+  process.env.SKIP_NET_CHECKS = "1";
 }
 
 if (process.env.SKIP_PW_DEPS === "1") {


### PR DESCRIPTION
## Summary
- allow `npm run ci` to execute even when offline by setting `SKIP_NET_CHECKS`

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `cd backend && npm run format`
- `cd backend && npm test` *(fails: db.query.mockClear is not a function)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Identifier 'runCLI' has already been declared)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Identifier 'runCLI' has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_68b84c768a6c832d97e04b04e82792cd