### PR TITLE
fix: remove duplicate runCLI initialization

### DIFF
--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -1,15 +1,6 @@
 #!/usr/bin/env node
 const fs = require("fs");
 const path = require("path");
-let runCLI;
-try {
-  ({ runCLI } = require("@jest/core"));
-} catch {
-  console.error(
-    "Jest is not installed. Run `npm run setup` to install dependencies.",
-  );
-  process.exit(1);
-}
 
 const repoRoot = path.resolve(__dirname, "..");
 const backendRoot = path.join(repoRoot, "backend");
@@ -23,15 +14,6 @@ function resolveFromPaths(mod) {
     }
   }
   return null;
-}
-
-if (!process.env.SKIP_ROOT_DEPS_CHECK) {
-  require("./ensure-root-deps.js");
-}
-
-if (!resolveFromPaths("ts-jest")) {
-  console.error("Missing ts-jest; run `npm run setup` before testing.");
-  process.exit(1);
 }
 
 function verifyFiles(args) {
@@ -56,16 +38,6 @@ async function run(args) {
   if (isOfflineEnv()) {
     logOfflineSkip("jest");
     return;
-  }
-
-  let runCLI;
-  try {
-    ({ runCLI } = require("@jest/core"));
-  } catch {
-    console.error(
-      "Jest is not installed. Run `npm run setup` to install dependencies.",
-    );
-    process.exit(1);
   }
 
   if (!process.env.SKIP_ROOT_DEPS_CHECK) {


### PR DESCRIPTION
## Summary
- prevent `scripts/run-jest.js` from crashing by removing a second `runCLI` declaration

## Testing
- `npm run validate-env`
- `npm test` *(fails: offline mode: skipping jest)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: offline mode: skipping jest)*
- `npm test --prefix backend` *(fails: db.query.mockClear is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68b84c893ef0832db46757feda82d0ab