### PR TITLE
fix: skip network checks in offline mode

### DIFF
--- a/scripts/validate-env.sh
+++ b/scripts/validate-env.sh
@@ -155,6 +155,10 @@ fi
 OFFLINE=0
 if node -e "import('./scripts/net-mode.mjs').then(m=>process.exit(m.isOfflineEnv()?0:1))" >/dev/null 2>&1; then
   OFFLINE=1
+  if [[ -z "${SKIP_NET_CHECKS:-}" ]]; then
+    echo "offline mode: skipping network checks" >&2
+    export SKIP_NET_CHECKS=1
+  fi
 fi
 
 if [[ -z "${SKIP_PW_DEPS:-}" ]]; then


### PR DESCRIPTION
## Summary
- skip network checks in `validate-env.sh` when offline

## Testing
- `npm run format --prefix backend`
- `npm run validate-env`
- `npm test -- backend/tests/api.test.ts -t "Stripe create-order flow"` *(fails: Jest is not installed)*
- `SKIP_PW_DEPS=1 CI_NO_NET=1 npm run ci` *(fails: Preset ts-jest not found)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Preset ts-jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b852c40b14832daee8cc9472c673e1