### PR TITLE
fix: handle jest CLI flags

### DIFF
--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -16,7 +16,6 @@ function resolveFromPaths(mod) {
   return null;
 }
 
-
 function verifyFiles(args) {
   let checking = false;
   for (const arg of args) {
@@ -77,6 +76,7 @@ async function run(args) {
   const parsed = { _: [], config: defaultConfig };
   let awaitingValue = null;
   let configProvided = false;
+  const booleanArgs = new Set(["help", "runTestsByPath", "passWithNoTests"]);
   for (const arg of args) {
     if (awaitingValue) {
       parsed[awaitingValue] = arg;
@@ -84,12 +84,16 @@ async function run(args) {
       awaitingValue = null;
       continue;
     }
+    if (arg === "-t") {
+      awaitingValue = "testNamePattern";
+      continue;
+    }
     if (arg.startsWith("--")) {
       const [key, value] = arg.slice(2).split("=");
       if (value !== undefined) {
         parsed[key] = value;
         if (key === "config") configProvided = true;
-      } else if (["help", "runTestsByPath"].includes(key)) {
+      } else if (booleanArgs.has(key)) {
         parsed[key] = true;
       } else {
         awaitingValue = key;


### PR DESCRIPTION
## Summary
- support `-t`/`--testNamePattern` and boolean `--passWithNoTests` in `scripts/run-jest.js`

## Testing
- `npx prettier -w scripts/run-jest.js`
- `npm run format --prefix backend`
- `npm test -- backend/tests/api.test.ts -t "Stripe create-order flow"` *(fails: Cannot find module 'electron-to-chromium/versions')*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Preset ts-jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b852b50198832d8c5fedb8eb0e74b6