### PR TITLE
fix: handle getEnv default export

### DIFF
--- a/backend/config.js
+++ b/backend/config.js
@@ -7,7 +7,8 @@
  * @module backend/config
  */
 // Ensure compatibility with both default and named exports
-const getEnv = require("./src/lib/getEnv");
+const getEnvModule = require("./src/lib/getEnv");
+const getEnv = getEnvModule.getEnv || getEnvModule;
 const { applyMockEnv, mockSecrets } = require("./src/lib/mockEnv");
 const logger = require("./src/logger.js");
 


### PR DESCRIPTION
## Summary
- ensure backend config loads getEnv whether module uses named or default export

## Testing
- `SKIP_ROOT_DEPS_CHECK=1 SKIP_NET_CHECKS=1 SKIP_PW_DEPS=1 npm test --prefix backend` *(fails: GET /api/status returns job Expected: 200 Received: 500)*
- `npm run format --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_68b852af3428832d9f082c31a04f3689