### PR TITLE
fix: handle getEnv named exports

### DIFF
--- a/backend/config.js
+++ b/backend/config.js
@@ -7,7 +7,8 @@
  * @module backend/config
  */
 // Ensure compatibility with both default and named exports
-const getEnv = require("./src/lib/getEnv");
+const envModule = require("./src/lib/getEnv");
+const getEnv = envModule.getEnv || envModule.default || envModule;
 const { applyMockEnv, mockSecrets } = require("./src/lib/mockEnv");
 const logger = require("./src/logger.js");
 


### PR DESCRIPTION
## Summary
- normalize getEnv import to support both default and named exports

## Testing
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` (backend)
- `npm test` (backend) *(fails: Expected 200, Received 500)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: multiple test failures)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Preset ts-jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b852aaa480832d9a023b978d4c08cc