### PR TITLE
fix: export query function in db test mock

### DIFF
--- a/backend/tests/__mocks__/db.ts
+++ b/backend/tests/__mocks__/db.ts
@@ -1,4 +1,4 @@
-export default {
-  query: jest.fn(async () => ({ rows: [] })),
-};
+export const query = jest.fn(async () => ({ rows: [] }));
+
+export default { query };
 


### PR DESCRIPTION
## Summary
- ensure test db mock exports query function so tests can clear mocks

## Testing
- `node backend/node_modules/jest/bin/jest.js backend/tests/queue/jobQueue.test.js --config backend/jest.config.js`
- `npm run format`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Preset ts-jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b85293f4d0832d91feaf317a26cb7c