### PR TITLE
fix: allow offline smoke tests

### DIFF
--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { EventEmitter } from "events";
 import { execSync } from "child_process";
-import { isOfflineEnv, logOfflineSkip } from "./net-mode.mjs";
+import { isOfflineEnv } from "./net-mode.mjs";
 
 EventEmitter.defaultMaxListeners = Math.max(
   25,
@@ -9,15 +9,8 @@ EventEmitter.defaultMaxListeners = Math.max(
 );
 
 const offline = isOfflineEnv();
-if (offline) {
-  if (process.env.SKIP_PW_DEPS === "1") {
-    if (!process.env.SKIP_NET_CHECKS) {
-      process.env.SKIP_NET_CHECKS = "1";
-    }
-  } else {
-    logOfflineSkip("smoke");
-    process.exit(0);
-  }
+if (offline && !process.env.SKIP_NET_CHECKS) {
+  process.env.SKIP_NET_CHECKS = "1";
 }
 
 execSync(


### PR DESCRIPTION
## Summary
- run smoke tests even when network checks fail

## Testing
- `npm run validate-env`
- `npm run setup` *(fails: process interrupted)*
- `npm run format --prefix backend`
- `npx prettier -w scripts/smoke.mjs`
- `npm test --prefix backend` *(fails: getEnv is not a function)*
- `CI_NO_NET=1 SKIP_PW_DEPS=1 npm run smoke` *(fails: ts-jest preset not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8528f459c832d861cb3bfe5760272