### PR TITLE
ci: allow offline ci run when deps installed

### DIFF
--- a/scripts/ci.mjs
+++ b/scripts/ci.mjs
@@ -1,8 +1,18 @@
 #!/usr/bin/env node
 import { execSync } from "child_process";
-import { isOfflineEnv } from "./net-mode.mjs";
+import { isOfflineEnv, logOfflineSkip } from "./net-mode.mjs";
 
-isOfflineEnv();
+const offline = isOfflineEnv();
+if (offline) {
+  if (process.env.SKIP_PW_DEPS === "1") {
+    if (!process.env.SKIP_NET_CHECKS) {
+      process.env.SKIP_NET_CHECKS = "1";
+    }
+  } else {
+    logOfflineSkip("ci");
+    process.exit(0);
+  }
+}
 
 if (process.env.SKIP_PW_DEPS === "1") {
   process.env.PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1";


### PR DESCRIPTION
## Summary
- let `npm run ci` proceed in offline mode when Playwright deps are skipped

## Testing
- `npm run validate-env`
- `npm run format`
- `npm test` *(fails: Preset ts-jest not found)*
- `CI_NO_NET=1 SKIP_PW_DEPS=1 npm run ci` *(fails: Preset ts-jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8528bb424832dae705895b512fc51