### PR TITLE
fix: run ci and smoke in offline mode

### DIFF
--- a/scripts/ci.mjs
+++ b/scripts/ci.mjs
@@ -2,7 +2,14 @@
 import { execSync } from "child_process";
 import { isOfflineEnv } from "./net-mode.mjs";
 
-isOfflineEnv();
+const offline = isOfflineEnv();
+if (
+  offline &&
+  process.env.SKIP_PW_DEPS === "1" &&
+  !process.env.SKIP_NET_CHECKS
+) {
+  process.env.SKIP_NET_CHECKS = "1";
+}
 
 if (process.env.SKIP_PW_DEPS === "1") {
   process.env.PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1";

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { EventEmitter } from "events";
 import { execSync } from "child_process";
-import { isOfflineEnv, logOfflineSkip } from "./net-mode.mjs";
+import { isOfflineEnv } from "./net-mode.mjs";
 
 EventEmitter.defaultMaxListeners = Math.max(
   25,
@@ -9,15 +9,12 @@ EventEmitter.defaultMaxListeners = Math.max(
 );
 
 const offline = isOfflineEnv();
-if (offline) {
-  if (process.env.SKIP_PW_DEPS === "1") {
-    if (!process.env.SKIP_NET_CHECKS) {
-      process.env.SKIP_NET_CHECKS = "1";
-    }
-  } else {
-    logOfflineSkip("smoke");
-    process.exit(0);
-  }
+if (
+  offline &&
+  process.env.SKIP_PW_DEPS === "1" &&
+  !process.env.SKIP_NET_CHECKS
+) {
+  process.env.SKIP_NET_CHECKS = "1";
 }
 
 execSync(


### PR DESCRIPTION
## Summary
- avoid early exit when running CI offline
- allow smoke tests to continue in offline mode

## Testing
- `npx prettier -w scripts/ci.mjs scripts/smoke.mjs`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Preset ts-jest not found)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Preset ts-jest not found)*
- `npm test` *(fails: Preset ts-jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b852806634832d8131b831b85cd807