### PR TITLE
fix: allow jest to run offline without ts-jest

### DIFF
--- a/backend/jest.config.offline.js
+++ b/backend/jest.config.offline.js
@@ -1,0 +1,55 @@
+// backend/jest.config.offline.js
+module.exports = {
+  rootDir: ".",
+  setupFiles: ["<rootDir>/tests/setupGlobals.js"],
+  setupFilesAfterEnv: ["<rootDir>/tests/setup.js"],
+  globalTeardown: "<rootDir>/tests/globalTeardown.js",
+  testEnvironment: "node",
+  transform: {},
+  testMatch: ["**/*.spec.js", "**/*.test.js"],
+  moduleFileExtensions: ["js", "json"],
+  testTimeout: 20000,
+  maxWorkers: "50%",
+  detectOpenHandles: true,
+  verbose: true,
+  bail: false,
+  reporters: ["default", "jest-junit"],
+  coverageDirectory: "coverage",
+  coverageReporters: ["text", "lcov", "json-summary"],
+  moduleNameMapper: {
+    "^stripe$": "<rootDir>/tests/stripe/__mocks__/stripe.js",
+    "^../../db$": "<rootDir>/tests/__mocks__/db.js",
+    "^pg$": "<rootDir>/tests/db/__mocks__/pg.js",
+    "^\\./server(?:\\.js)?$": "<rootDir>/src/app",
+    "^\\.\\./server(?:\\.js)?$": "<rootDir>/src/app",
+    "^\\.\\./\\.\\./server(?:\\.js)?$": "<rootDir>/src/app",
+  },
+};
+
+module.exports = {
+  ...module.exports,
+  collectCoverage: true,
+  collectCoverageFrom: [
+    "**/*.js",
+    "!<rootDir>/node_modules/**",
+    "!<rootDir>/coverage/**",
+    "!<rootDir>/tests/**",
+  ],
+  coveragePathIgnorePatterns: [
+    "<rootDir>/db.js",
+    "<rootDir>/shipping.js",
+    "<rootDir>/social.js",
+    "<rootDir>/utils/validateStl.js",
+    "<rootDir>/node_modules/",
+    "<rootDir>/tests/",
+    "<rootDir>/coverage/",
+  ],
+  coverageThreshold: {
+    global: {
+      lines: 80,
+      branches: 70,
+      functions: 75,
+      statements: 80,
+    },
+  },
+};

--- a/backend/tests/__mocks__/db.js
+++ b/backend/tests/__mocks__/db.js
@@ -1,0 +1,3 @@
+module.exports = {
+  query: jest.fn(async () => ({ rows: [] })),
+};

--- a/backend/tests/db/__mocks__/pg.js
+++ b/backend/tests/db/__mocks__/pg.js
@@ -1,0 +1,21 @@
+const { newDb } = require("pg-mem");
+const { randomUUID } = require("crypto");
+
+const g = globalThis;
+if (!g.__PGMEM_DB__) {
+  const db = newDb({ autoCreateForeignKeyIndices: true });
+  db.public.registerFunction({
+    name: "gen_random_uuid",
+    returns: "uuid",
+    implementation: randomUUID,
+    impure: true,
+  });
+  g.__PGMEM_DB__ = db;
+}
+
+const pg = g.__PGMEM_DB__.adapters.createPg();
+
+const Client = jest.fn(() => new pg.Client());
+const Pool = jest.fn(() => new pg.Pool());
+
+module.exports = { Client, Pool };

--- a/backend/tests/stripe/__mocks__/stripe.js
+++ b/backend/tests/stripe/__mocks__/stripe.js
@@ -1,0 +1,18 @@
+const createMock = jest.fn(async (_args, _opts) => ({
+  id: "cs_test_123",
+}));
+
+const Stripe = jest.fn().mockImplementation((_key, _opts) => ({
+  checkout: { sessions: { create: createMock } },
+  webhooks: {
+    constructEvent: jest.fn(),
+    generateTestHeaderString: jest.fn(() => "test"),
+  },
+}));
+
+Stripe.__mocks = { createMock };
+Stripe.webhooks = {
+  generateTestHeaderString: jest.fn(() => "test"),
+};
+
+module.exports = Stripe;

--- a/jest.config.offline.cjs
+++ b/jest.config.offline.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  testEnvironment: "node",
+  roots: ["<rootDir>"],
+  moduleFileExtensions: ["js", "json"],
+  passWithNoTests: true,
+};

--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -16,7 +16,6 @@ function resolveFromPaths(mod) {
   return null;
 }
 
-
 function verifyFiles(args) {
   let checking = false;
   for (const arg of args) {
@@ -55,10 +54,12 @@ async function run(args) {
     require("./ensure-root-deps.js");
   }
 
-  if (!offline) {
-    try {
-      require.resolve("ts-jest");
-    } catch {
+  let tsJestMissing = false;
+  try {
+    require.resolve("ts-jest");
+  } catch {
+    tsJestMissing = true;
+    if (!offline) {
       console.error("Missing ts-jest; run `npm run setup` before testing.");
       process.exit(1);
     }
@@ -74,9 +75,18 @@ async function run(args) {
   ({ runCLI } = require(corePath));
   const defaultConfig = path.resolve(repoRoot, "jest.config.cjs");
   const backendConfig = path.resolve(backendRoot, "jest.config.js");
+  const defaultOfflineConfig = path.resolve(
+    repoRoot,
+    "jest.config.offline.cjs",
+  );
+  const backendOfflineConfig = path.resolve(
+    backendRoot,
+    "jest.config.offline.js",
+  );
   const parsed = { _: [], config: defaultConfig };
   let awaitingValue = null;
   let configProvided = false;
+  const shortMap = { t: "testNamePattern" };
   for (const arg of args) {
     if (awaitingValue) {
       parsed[awaitingValue] = arg;
@@ -89,10 +99,17 @@ async function run(args) {
       if (value !== undefined) {
         parsed[key] = value;
         if (key === "config") configProvided = true;
-      } else if (["help", "runTestsByPath"].includes(key)) {
+      } else if (["help", "runTestsByPath", "passWithNoTests"].includes(key)) {
         parsed[key] = true;
       } else {
         awaitingValue = key;
+      }
+    } else if (arg.startsWith("-") && arg.length > 1) {
+      const key = arg.slice(1);
+      if (shortMap[key]) {
+        awaitingValue = shortMap[key];
+      } else {
+        parsed._.push(arg);
       }
     } else {
       parsed._.push(arg);
@@ -104,6 +121,19 @@ async function run(args) {
   });
   if (isBackendTest && !configProvided) {
     parsed.config = backendConfig;
+  }
+  if (offline && tsJestMissing) {
+    parsed.config = isBackendTest ? backendOfflineConfig : defaultOfflineConfig;
+    parsed._ = parsed._.map((p) => {
+      if (p.endsWith(".ts")) {
+        const jsPath = p.replace(/\.ts$/, ".js");
+        if (fs.existsSync(jsPath)) return jsPath;
+      }
+      return p;
+    });
+  }
+  if (parsed._.length) {
+    parsed.runTestsByPath = true;
   }
   const { results } = await runCLI(parsed, [process.cwd()]);
   process.exit(results.success ? 0 : 1);


### PR DESCRIPTION
## Summary
- detect missing ts-jest and fall back to offline configs
- add offline Jest configs and JS mocks for backend tests

## Testing
- `npm --prefix backend run format`
- `npx prettier --write scripts/run-jest.js jest.config.offline.cjs backend/jest.config.offline.js backend/tests/stripe/__mocks__/stripe.js backend/tests/__mocks__/db.js backend/tests/db/__mocks__/pg.js`
- `SKIP_ROOT_DEPS_CHECK=1 npm test -- backend/tests/api.test.ts -t "Stripe create-order flow"` *(fails: Cannot find module 'electron-to-chromium/versions')*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Cannot find module 'babel-preset-current-node-syntax')*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: npm test -- --maxWorkers=2 --runTestsByPath tests/config/package-scripts.smoke.*.spec.ts tests/smoke/healthcheck.*.spec.ts)*


------
https://chatgpt.com/codex/tasks/task_e_68b8527b0a38832d93b5197139b6e385