### PR TITLE
fix: allow smoke tests offline

### DIFF
--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { EventEmitter } from "events";
 import { execSync } from "child_process";
-import { isOfflineEnv, logOfflineSkip } from "./net-mode.mjs";
+import { isOfflineEnv } from "./net-mode.mjs";
 
 EventEmitter.defaultMaxListeners = Math.max(
   25,
@@ -10,13 +10,12 @@ EventEmitter.defaultMaxListeners = Math.max(
 
 const offline = isOfflineEnv();
 if (offline) {
-  if (process.env.SKIP_PW_DEPS === "1") {
-    if (!process.env.SKIP_NET_CHECKS) {
-      process.env.SKIP_NET_CHECKS = "1";
-    }
-  } else {
-    logOfflineSkip("smoke");
-    process.exit(0);
+  console.log("offline mode: running smoke tests");
+  if (!process.env.SKIP_NET_CHECKS) {
+    process.env.SKIP_NET_CHECKS = "1";
+  }
+  if (!process.env.SKIP_PW_DEPS) {
+    process.env.SKIP_PW_DEPS = "1";
   }
 }
 


### PR DESCRIPTION
## Summary
- run smoke tests even when offline by skipping network checks and Playwright deps

## Testing
- `npm run validate-env`
- `npm run format`
- `npm test` *(fails: Jest is not installed)*
- `npm run smoke` *(fails: Jest is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b85270740c832dbeae6f23272a14de