### PR TITLE
fix: handle missing ts-jest preset

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,61 +1,65 @@
 // backend/jest.config.js
-module.exports = {
-  rootDir: ".",
-  preset: "ts-jest",
-  setupFiles: ["<rootDir>/tests/setupGlobals.js"],
-  setupFilesAfterEnv: [
-    "<rootDir>/tests/utils/testEnv.ts",
-    "<rootDir>/tests/setup.js",
-  ],
-  globalTeardown: "<rootDir>/tests/globalTeardown.js",
-  testEnvironment: "node",
-  transform: {
-    "^.+\\.[tj]s$": "ts-jest",
-  },
-  testMatch: ["**/*.spec.ts", "**/*.test.ts", "**/*.spec.js", "**/*.test.js"],
-  moduleFileExtensions: ["ts", "js", "json"],
-  testTimeout: 20000,
-  maxWorkers: "50%",
-  detectOpenHandles: true,
-  verbose: true,
-  bail: false,
-  reporters: ["default", "jest-junit"],
-  coverageDirectory: "coverage",
-  coverageReporters: ["text", "lcov", "json-summary"],
-  moduleNameMapper: {
-    "^stripe$": "<rootDir>/tests/stripe/__mocks__/stripe.ts",
-    "^../../db$": "<rootDir>/tests/__mocks__/db.ts",
-    "^pg$": "<rootDir>/tests/db/__mocks__/pg.ts",
-    "^\\./server(?:\\.js)?$": "<rootDir>/src/app",
-    "^\\.\\./server(?:\\.js)?$": "<rootDir>/src/app",
-    "^\\.\\./\\.\\./server(?:\\.js)?$": "<rootDir>/src/app",
-  },
-};
-
-module.exports = {
-  ...module.exports,
-  collectCoverage: true,
-  collectCoverageFrom: [
-    "**/*.{js,jsx,ts,tsx}",
-    "!<rootDir>/node_modules/**",
-    "!<rootDir>/coverage/**",
-    "!<rootDir>/tests/**",
-  ],
-  coveragePathIgnorePatterns: [
-    "<rootDir>/db.js",
-    "<rootDir>/shipping.js",
-    "<rootDir>/social.js",
-    "<rootDir>/utils/validateStl.js",
-    "<rootDir>/node_modules/",
-    "<rootDir>/tests/",
-    "<rootDir>/coverage/",
-  ],
-  coverageThreshold: {
-    global: {
-      lines: 80,
-      branches: 70,
-      functions: 75,
-      statements: 80,
+let config;
+try {
+  require.resolve("ts-jest");
+  config = {
+    rootDir: ".",
+    preset: "ts-jest",
+    setupFiles: ["<rootDir>/tests/setupGlobals.js"],
+    setupFilesAfterEnv: [
+      "<rootDir>/tests/utils/testEnv.ts",
+      "<rootDir>/tests/setup.js",
+    ],
+    globalTeardown: "<rootDir>/tests/globalTeardown.js",
+    testEnvironment: "node",
+    transform: {
+      "^.+\\.[tj]s$": "ts-jest",
     },
-  },
-};
+    testMatch: ["**/*.spec.ts", "**/*.test.ts", "**/*.spec.js", "**/*.test.js"],
+    moduleFileExtensions: ["ts", "js", "json"],
+    testTimeout: 20000,
+    maxWorkers: "50%",
+    detectOpenHandles: true,
+    verbose: true,
+    bail: false,
+    reporters: ["default", "jest-junit"],
+    coverageDirectory: "coverage",
+    coverageReporters: ["text", "lcov", "json-summary"],
+    moduleNameMapper: {
+      "^stripe$": "<rootDir>/tests/stripe/__mocks__/stripe.ts",
+      "^../../db$": "<rootDir>/tests/__mocks__/db.ts",
+      "^pg$": "<rootDir>/tests/db/__mocks__/pg.ts",
+      "^\\./server(?:\\.js)?$": "<rootDir>/src/app",
+      "^\\.\\./server(?:\\.js)?$": "<rootDir>/src/app",
+      "^\\.\\./\\.\\./server(?:\\.js)?$": "<rootDir>/src/app",
+    },
+    collectCoverage: true,
+    collectCoverageFrom: [
+      "**/*.{js,jsx,ts,tsx}",
+      "!<rootDir>/node_modules/**",
+      "!<rootDir>/coverage/**",
+      "!<rootDir>/tests/**",
+    ],
+    coveragePathIgnorePatterns: [
+      "<rootDir>/db.js",
+      "<rootDir>/shipping.js",
+      "<rootDir>/social.js",
+      "<rootDir>/utils/validateStl.js",
+      "<rootDir>/node_modules/",
+      "<rootDir>/tests/",
+      "<rootDir>/coverage/",
+    ],
+    coverageThreshold: {
+      global: {
+        lines: 80,
+        branches: 70,
+        functions: 75,
+        statements: 80,
+      },
+    },
+  };
+} catch {
+  config = require("./jest.config.offline.js");
+}
+
+module.exports = config;

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,13 +1,21 @@
-module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  roots: ["<rootDir>"],
-  transform: {
-    "^.+\\.tsx?$": [
-      "ts-jest",
-      { tsconfig: "tsconfig.json", diagnostics: false },
-    ],
-  },
-  moduleFileExtensions: ["ts", "tsx", "js", "json"],
-  passWithNoTests: true,
-};
+let config;
+try {
+  require.resolve("ts-jest");
+  config = {
+    preset: "ts-jest",
+    testEnvironment: "node",
+    roots: ["<rootDir>"],
+    transform: {
+      "^.+\\.tsx?$": [
+        "ts-jest",
+        { tsconfig: "tsconfig.json", diagnostics: false },
+      ],
+    },
+    moduleFileExtensions: ["ts", "tsx", "js", "json"],
+    passWithNoTests: true,
+  };
+} catch {
+  config = require("./jest.config.offline.cjs");
+}
+
+module.exports = config;


### PR DESCRIPTION
## Summary
- guard Jest configs to fall back to offline defaults when `ts-jest` isn't installed

## Testing
- `npm run validate-env`
- `npm run format --prefix backend`
- `npm test` *(fails: Cannot find module 'babel-preset-current-node-syntax')*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: command failed: npm test)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: command failed: npm test)*

------
https://chatgpt.com/codex/tasks/task_e_68b85c85e984832d808690bfb5e25efa