### PR TITLE
fix: remove hardcoded jest root

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,6 +1,5 @@
 // backend/jest.config.js
 module.exports = {
-  rootDir: ".",
   preset: "ts-jest",
   setupFiles: ["<rootDir>/tests/setupGlobals.js"],
   setupFilesAfterEnv: [

--- a/backend/jest.config.offline.js
+++ b/backend/jest.config.offline.js
@@ -1,6 +1,5 @@
 // backend/jest.config.offline.js
 module.exports = {
-  rootDir: ".",
   setupFiles: ["<rootDir>/tests/setupGlobals.js"],
   setupFilesAfterEnv: ["<rootDir>/tests/setup.js"],
   globalTeardown: "<rootDir>/tests/globalTeardown.js",


### PR DESCRIPTION
## Summary
- resolve ts-jest preset by removing hard-coded rootDir from backend jest configs

## Testing
- `npm run format --prefix backend`
- `npm test -- backend/tests/api.test.ts -t "Stripe create-order flow"` *(fails: Cannot find module 'electron-to-chromium/versions')*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Cannot find module 'babel-preset-current-node-syntax')*


------
https://chatgpt.com/codex/tasks/task_e_68b85bd9f9ac832d80193ba90e1122a9