### PR TITLE
fix: use stripe package in checkout route

### DIFF
--- a/backend/src/__tests__/items.routes.parallel-qa-7b2e9.spec.ts
+++ b/backend/src/__tests__/items.routes.parallel-qa-7b2e9.spec.ts
@@ -22,10 +22,10 @@ jest.mock("pg", () => {
 });
 
 // mock logger
-jest.mock("../logger.js", () => ({
+jest.mock("../logger", () => ({
   error: jest.fn(),
 }));
-const logger = require("../logger.js");
+const logger = require("../logger");
 
 function setDb(rows: any[]) {
   mockRows = rows;

--- a/backend/src/routes/checkout.ts
+++ b/backend/src/routes/checkout.ts
@@ -2,7 +2,6 @@ import { Router } from "express";
 import Stripe from "stripe";
 import logger from "../logger";
 import { capture } from "../lib/logger";
-import { isTest } from "../env";
 
 // simple in-memory store used by tests to track orders
 export const orders = new Map<
@@ -14,7 +13,8 @@ const router = Router();
 
 router.post("/checkout/create", async (req, res) => {
   try {
-    const secretKey = process.env.STRIPE_SECRET_KEY;
+    const secretKey =
+      process.env.STRIPE_SECRET_KEY || process.env.STRIPE_TEST_KEY || "";
     const successUrl = process.env.FRONTEND_SUCCESS_URL;
     const cancelUrl = process.env.FRONTEND_CANCEL_URL;
 
@@ -61,12 +61,9 @@ router.post("/checkout/create", async (req, res) => {
       normalized.push({ price: item.price, quantity: qty });
     }
 
-    const realStripe = new Stripe(secretKey, {
+    const stripe = new Stripe(secretKey, {
       apiVersion: "2022-11-15",
     });
-    const stripe = isTest()
-      ? require("../../tests/utils/stripeMock").stripe
-      : realStripe;
 
     const metadataSanitized =
       metadata &&


### PR DESCRIPTION
## Summary
- use actual Stripe client in checkout route with test key fallback
- ensure items route test spies on the correct logger module

## Testing
- `npm run format --prefix backend`
- `SKIP_ROOT_DEPS_CHECK=1 SKIP_NET_CHECKS=1 SKIP_PW_DEPS=1 npm test --prefix backend tests/stripe/checkout.session.spec.ts src/__tests__/items.routes.parallel-qa-7b2e9.spec.ts`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Cannot find module 'babel-preset-current-node-syntax')*

------
https://chatgpt.com/codex/tasks/task_e_68b85bddfb24832da20771f314dd9486