### PR TITLE
fix: run smoke tests in offline mode

### DIFF
--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -9,6 +9,9 @@ EventEmitter.defaultMaxListeners = Math.max(
 );
 
 const offline = isOfflineEnv();
+if (offline) {
+  console.warn("offline mode detected; running smoke tests");
+}
 if (
   offline &&
   process.env.SKIP_PW_DEPS === "1" &&


### PR DESCRIPTION
## Summary
- warn when running smoke tests offline but continue execution

## Testing
- `npm run format --prefix backend`
- `npm test` *(fails: Cannot find module 'babel-preset-current-node-syntax')*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Cannot find module 'babel-preset-current-node-syntax')*

------
https://chatgpt.com/codex/tasks/task_e_68b85bf15ac4832da94822d6c3477b3b