### PR TITLE
fix: robust getEnv import

### DIFF
--- a/backend/config.js
+++ b/backend/config.js
@@ -6,9 +6,16 @@
  *
  * @module backend/config
  */
-// Ensure compatibility with both default and named exports
+// Ensure compatibility with various CommonJS/ESM export patterns
 const envModule = require("./src/lib/getEnv");
-const getEnv = envModule.getEnv || envModule.default || envModule;
+const getEnv =
+  // Named export
+  envModule.getEnv ||
+  // ESM default export which may itself wrap named exports
+  (envModule.default && envModule.default.getEnv) ||
+  envModule.default ||
+  // Fallback to module itself if it's the function
+  envModule;
 const { applyMockEnv, mockSecrets } = require("./src/lib/mockEnv");
 const logger = require("./src/logger.js");
 


### PR DESCRIPTION
## Summary
- ensure backend config can load getEnv across different module systems

## Testing
- `npm run format`
- `npm test` *(fails: duplicate manual mocks, 404 responses)*

------
https://chatgpt.com/codex/tasks/task_e_68b85c0e4780832d84b882332f7cf5b7