### PR TITLE
fix: specify ts-jest preset

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,7 +1,7 @@
 // backend/jest.config.js
 module.exports = {
   rootDir: ".",
-  preset: "ts-jest",
+  preset: "ts-jest/presets/default",
   setupFiles: ["<rootDir>/tests/setupGlobals.js"],
   setupFilesAfterEnv: [
     "<rootDir>/tests/utils/testEnv.ts",

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,5 +1,5 @@
 module.exports = {
-  preset: "ts-jest",
+  preset: "ts-jest/presets/default",
   testEnvironment: "node",
   roots: ["<rootDir>"],
   transform: {


### PR DESCRIPTION
## Summary
- use explicit ts-jest preset in root jest config
- use explicit ts-jest preset in backend jest config

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: GET /api/status returns job, etc.)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Command failed: npm test)*

------
https://chatgpt.com/codex/tasks/task_e_68b85c1ffac0832d9eace9651bfc4d2a