### PR TITLE
fix: supply default model domain for tests

### DIFF
--- a/backend/scripts/ensure-tests-exist.js
+++ b/backend/scripts/ensure-tests-exist.js
@@ -15,6 +15,12 @@ for (const dep of ["jest", "ts-jest"]) {
   }
 }
 
+// Provide a default domain so requiring routes that depend on
+// `CLOUDFRONT_MODEL_DOMAIN` doesn't throw when the variable is missing.
+if (!process.env.CLOUDFRONT_MODEL_DOMAIN) {
+  process.env.CLOUDFRONT_MODEL_DOMAIN = "cdn.test";
+}
+
 // Load test globals so required environment variables are populated when
 // Jest scans test files via `--listTests`.
 try {


### PR DESCRIPTION
## Summary
- supply a default `CLOUDFRONT_MODEL_DOMAIN` during test setup to keep subscription router from crashing when the env var is missing

## Testing
- `npm run format --prefix backend`
- `SKIP_PW_DEPS=1 SKIP_ROOT_DEPS_CHECK=1 SKIP_NET_CHECKS=1 npm test --prefix backend` *(fails: Missing SHIPPING_API_URL or SHIPPING_API_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68b85c3f9ebc832d89be37f81973e1fa