### PR TITLE
style: trim trailing newline in auth routes

### DIFF
--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -69,4 +69,3 @@ router.post("/login", async (req, res) => {
 
 module.exports = router;
 module.exports.default = router;
-

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -68,4 +68,3 @@ router.post("/login", async (req, res) => {
 });
 
 export default router;
-


### PR DESCRIPTION
## Summary
- run prettier on backend auth routes

## Testing
- `npm run format --prefix backend`
- `npm test` *(fails: GET /api/status returns job, etc.)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Cannot find module 'babel-preset-current-node-syntax')*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Cannot find module 'babel-preset-current-node-syntax')*


------
https://chatgpt.com/codex/tasks/task_e_68b85c535acc832da96f89448512d274