### PR TITLE
fix: ensure backend config uses JS getEnv module

### DIFF
--- a/backend/config.js
+++ b/backend/config.js
@@ -6,8 +6,10 @@
  *
  * @module backend/config
  */
-// Ensure compatibility with both default and named exports
-const envModule = require("./src/lib/getEnv");
+// Ensure compatibility with both default and named exports. Explicitly
+// require the JavaScript implementation so Jest doesn't resolve the
+// TypeScript re-export which returns a non-function default export.
+const envModule = require("./src/lib/getEnv.js");
 const getEnv = envModule.getEnv || envModule.default || envModule;
 const { applyMockEnv, mockSecrets } = require("./src/lib/mockEnv");
 const logger = require("./src/logger.js");


### PR DESCRIPTION
## Summary
- fix backend config to explicitly require JavaScript getEnv to avoid Jest resolving TS wrapper

## Testing
- `npm run validate-env`
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: process.exit called due to missing SHIPPING_API_URL)*
- `npm run ci` *(fails: multiple backend tests failing)*
- `npm run smoke` *(fails: backend tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_68b85c9d208c832d99f93464027f225f