### PR TITLE
test: remove ts-jest preset

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,7 +1,6 @@
 // backend/jest.config.js
 module.exports = {
   rootDir: ".",
-  preset: "ts-jest",
   setupFiles: ["<rootDir>/tests/setupGlobals.js"],
   setupFilesAfterEnv: [
     "<rootDir>/tests/utils/testEnv.ts",

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,5 +1,4 @@
 module.exports = {
-  preset: "ts-jest",
   testEnvironment: "node",
   roots: ["<rootDir>"],
   transform: {


### PR DESCRIPTION
## Summary
- avoid relying on the ts-jest preset in Jest configs

## Testing
- `npx prettier jest.config.cjs backend/jest.config.js -w`
- `npm test` (fails: Cannot find module 'babel-preset-current-node-syntax')
- `npm run ci` (fails: jest-environment-jsdom cannot be found)


------
https://chatgpt.com/codex/tasks/task_e_68b85cda4748832db0d74558d430d15e