### PR TITLE
fix: add babel preset for jest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "@types/node": "^24.0.10",
         "@typescript-eslint/eslint-plugin": "8.34.1",
         "@typescript-eslint/parser": "^8.36.0",
+        "babel-preset-current-node-syntax": "^1.2.0",
         "concurrently": "9.2.0",
         "coveralls": "^3.1.1",
         "cross-env": "^7.0.3",

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "@types/node": "^24.0.10",
     "@typescript-eslint/eslint-plugin": "8.34.1",
     "@typescript-eslint/parser": "^8.36.0",
+    "babel-preset-current-node-syntax": "^1.2.0",
     "concurrently": "9.2.0",
     "coveralls": "^3.1.1",
     "cross-env": "^7.0.3",


### PR DESCRIPTION
## Summary
- add missing `babel-preset-current-node-syntax` so jest can transform Node syntax

## Testing
- `npm test` *(fails: Cannot find module '../server' etc.)*
- `npm run format --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68b8671efe18832d82ff23a8034a4bf3