### PR TITLE
fix: ensure backend deps for jest

### DIFF
--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -54,17 +54,6 @@ async function run(args) {
     require("./ensure-root-deps.js");
   }
 
-  let tsJestMissing = false;
-  try {
-    require.resolve("ts-jest");
-  } catch {
-    tsJestMissing = true;
-    if (!offline) {
-      console.error("Missing ts-jest; run `npm run setup` before testing.");
-      process.exit(1);
-    }
-  }
-
   verifyFiles(args);
   console.log("run-jest cwd:", process.cwd());
   const corePath = resolveFromPaths("@jest/core");
@@ -121,6 +110,19 @@ async function run(args) {
   });
   if (isBackendTest && !configProvided) {
     parsed.config = backendConfig;
+  }
+  if (!offline && isBackendTest && !process.env.SKIP_BACKEND_DEPS_CHECK) {
+    require(path.join(backendRoot, "scripts", "ensure-deps.js"));
+  }
+  let tsJestMissing = false;
+  try {
+    require.resolve("ts-jest");
+  } catch {
+    tsJestMissing = true;
+    if (!offline) {
+      console.error("Missing ts-jest; run `npm run setup` before testing.");
+      process.exit(1);
+    }
   }
   if (offline && tsJestMissing) {
     parsed.config = isBackendTest ? backendOfflineConfig : defaultOfflineConfig;


### PR DESCRIPTION
## Summary
- ensure backend test runs install backend dependencies
- check for ts-jest after dependency setup to handle offline fallback

## Testing
- `npm run format --prefix backend`
- `npx prettier -w scripts/run-jest.js`
- `npm test -- backend/tests/api.test.ts -t "Stripe create-order flow"` *(fails: Jest is not installed)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: various modules missing)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Jest is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b867533c30832d855f65f98232c204