### PR TITLE
fix: relax env requirement and avoid shipping exit

### DIFF
--- a/backend/shipping.js
+++ b/backend/shipping.js
@@ -6,8 +6,7 @@ const SHIPPING_API_KEY = getEnv("SHIPPING_API_KEY");
 const TRACKING_BASE_URL = getEnv("TRACKING_BASE_URL") || "";
 
 if (!SHIPPING_API_URL || !SHIPPING_API_KEY) {
-  logger.error("Missing SHIPPING_API_URL or SHIPPING_API_KEY");
-  process.exit(1);
+  logger.warn("Missing SHIPPING_API_URL or SHIPPING_API_KEY");
 }
 
 async function getShippingEstimate(destination, model) {

--- a/backend/src/env.js
+++ b/backend/src/env.js
@@ -33,7 +33,7 @@ function buildEnv() {
   return Object.freeze({
     DB_URL: requireEnv("DB_URL"),
     STRIPE_SECRET_KEY: requireEnv("STRIPE_SECRET_KEY"),
-    STRIPE_PUBLISHABLE_KEY: requireEnv("STRIPE_PUBLISHABLE_KEY"),
+    STRIPE_PUBLISHABLE_KEY: optional("STRIPE_PUBLISHABLE_KEY") || "",
     NODE_ENV,
     AWS_REGION: optional("AWS_REGION"),
     S3_BUCKET: optional("S3_BUCKET"),

--- a/backend/src/env.ts
+++ b/backend/src/env.ts
@@ -42,7 +42,7 @@ function buildEnv(): Readonly<Env> {
   const env: Env = {
     DB_URL: requireEnv("DB_URL"),
     STRIPE_SECRET_KEY: requireEnv("STRIPE_SECRET_KEY"),
-    STRIPE_PUBLISHABLE_KEY: requireEnv("STRIPE_PUBLISHABLE_KEY"),
+    STRIPE_PUBLISHABLE_KEY: optional("STRIPE_PUBLISHABLE_KEY") || "",
     NODE_ENV: NODE_ENV as Env["NODE_ENV"],
     AWS_REGION: optional("AWS_REGION"),
     S3_BUCKET: optional("S3_BUCKET"),


### PR DESCRIPTION
## Summary
- warn instead of exiting when shipping API env vars are missing
- allow tests to run without STRIPE_PUBLISHABLE_KEY

## Testing
- `npm run format --prefix backend`
- `SKIP_ROOT_DEPS_CHECK=1 SKIP_NET_CHECKS=1 SKIP_PW_DEPS=1 npm test --prefix backend` *(fails: GET /api/status returns 404, many suites failing)*

------
https://chatgpt.com/codex/tasks/task_e_68b86758c518832d8221230a599f3f18