### PR TITLE
fix: run smoke tests in offline mode

### DIFF
--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -9,7 +9,7 @@ EventEmitter.defaultMaxListeners = Math.max(
 );
 
 const offline = isOfflineEnv();
-if (process.env.CI_NO_SMOKE === "1") {
+if (process.env.CI_NO_SMOKE === "1" && !offline) {
   logOfflineSkip("smoke");
   process.exit(0);
 }


### PR DESCRIPTION
## Summary
- run smoke tests even when offline by only honoring `CI_NO_SMOKE` when network access is available

## Testing
- `npm run format` in `backend/`
- `npm test` in `backend/` *(fails: GET /api/status returns 404, missing modules, missing NODE_ENV)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Jest encountered unexpected token, missing modules)*
- `CI_NO_SMOKE=1 SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b8676072ec832d90ea00fb60881888