### PR TITLE
ci: run npm ci in offline mode

### DIFF
--- a/scripts/__tests__/run-npm-ci-offline.test.9f4b2c8d5e6a7b1c.ts
+++ b/scripts/__tests__/run-npm-ci-offline.test.9f4b2c8d5e6a7b1c.ts
@@ -1,0 +1,14 @@
+jest.mock("child_process", () => ({ execSync: jest.fn() }));
+const { execSync } = require("child_process");
+
+test("run-npm-ci uses offline mode when network unavailable", () => {
+  process.env.SKIP_NET_CHECKS = "1";
+  const { runNpmCi } = require("../run-npm-ci.js");
+  runNpmCi(".", { ignoreScripts: true });
+  expect(execSync).toHaveBeenCalledWith(
+    expect.stringContaining(
+      "npm ci --no-audit --no-fund --ignore-scripts --prefer-offline",
+    ),
+    expect.objectContaining({ stdio: "inherit" }),
+  );
+});

--- a/scripts/run-npm-ci.js
+++ b/scripts/run-npm-ci.js
@@ -45,16 +45,17 @@ function cleanupNpmCache() {
 }
 
 function runNpmCi(dir = ".", opts = {}) {
-  if (isOffline()) {
-    console.log(
-      `offline mode: skipping npm ci${dir !== "." ? ` in ${dir}` : ""}`,
-    );
-    return;
-  }
   const options = { stdio: "inherit" };
   if (dir !== ".") options.cwd = dir;
   const ignoreScripts = opts.ignoreScripts || process.env.NPM_IGNORE_SCRIPTS;
-  const ciCmd = `npm ci --no-audit --no-fund${ignoreScripts ? " --ignore-scripts" : ""}`;
+  const offline = isOffline();
+  const baseCmd = `npm ci --no-audit --no-fund${ignoreScripts ? " --ignore-scripts" : ""}`;
+  const ciCmd = offline ? `${baseCmd} --prefer-offline` : baseCmd;
+  if (offline) {
+    console.log(
+      `offline mode: running npm ci${dir !== "." ? ` in ${dir}` : ""}`,
+    );
+  }
   try {
     execSync(ciCmd, options);
   } catch (err) {


### PR DESCRIPTION
## Summary
- handle offline environments by running `npm ci --prefer-offline` instead of skipping
- add a test covering the offline `npm ci` behavior

## Testing
- `npm run format`
- `node scripts/run-jest.js scripts/__tests__/run-npm-ci-offline.test.9f4b2c8d5e6a7b1c.ts` *(fails: Jest is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b86769ca38832d863d8712d1ce891d