### PR TITLE
fix: allow skipping ts-jest when offline

### DIFF
--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -54,12 +54,13 @@ async function run(args) {
     require("./ensure-root-deps.js");
   }
 
+  const skipNetChecks = process.env.SKIP_NET_CHECKS === "1";
   let tsJestMissing = false;
   try {
     require.resolve("ts-jest");
   } catch {
     tsJestMissing = true;
-    if (!offline) {
+    if (!offline && !skipNetChecks) {
       console.error("Missing ts-jest; run `npm run setup` before testing.");
       process.exit(1);
     }
@@ -122,7 +123,7 @@ async function run(args) {
   if (isBackendTest && !configProvided) {
     parsed.config = backendConfig;
   }
-  if (offline && tsJestMissing) {
+  if ((offline || skipNetChecks) && tsJestMissing) {
     parsed.config = isBackendTest ? backendOfflineConfig : defaultOfflineConfig;
     parsed._ = parsed._.map((p) => {
       if (p.endsWith(".ts")) {


### PR DESCRIPTION
## Summary
- handle missing `ts-jest` when `SKIP_NET_CHECKS=1`
- fall back to offline jest configs when network checks are skipped

## Testing
- `SKIP_NET_CHECKS=1 npm test -- --maxWorkers=2 --runTestsByPath tests/config/package-scripts.smoke.e7082164ae33772d.spec.ts tests/smoke/healthcheck.a7a3f7a4a4adf630.spec.ts`
- `SKIP_NET_CHECKS=1 SKIP_PW_DEPS=1 npm run smoke`
- `npx prettier --write scripts/run-jest.js`


------
https://chatgpt.com/codex/tasks/task_e_68b8676dac4c832d95fae35c2b392952