### PR TITLE
fix: support default getEnv export

### DIFF
--- a/backend/utils/getEnv.js
+++ b/backend/utils/getEnv.js
@@ -13,4 +13,6 @@ function getEnv(name, options = {}) {
   return undefined;
 }
 
-module.exports = { getEnv };
+// Support both CommonJS default and named imports
+module.exports = getEnv;
+module.exports.getEnv = getEnv;


### PR DESCRIPTION
## Summary
- add default export to `backend/utils/getEnv` so it works with both default and named imports

## Testing
- `npm run format` (backend)
- `npm test` (backend) *(fails: GET /api/status returns job, Stripe create-order flow, etc.)*
- `npm run ci` *(fails: syntax errors and missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68b8677a5e8c832d8c2676145909a5a7