### PR TITLE
fix: avoid ts-jest preset error

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -4,7 +4,6 @@ try {
   require.resolve("ts-jest");
   config = {
     rootDir: ".",
-    preset: "ts-jest",
     setupFiles: ["<rootDir>/tests/setupGlobals.js"],
     setupFilesAfterEnv: [
       "<rootDir>/tests/utils/testEnv.ts",

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -2,7 +2,6 @@ let config;
 try {
   require.resolve("ts-jest");
   config = {
-    preset: "ts-jest",
     testEnvironment: "node",
     roots: ["<rootDir>"],
     transform: {


### PR DESCRIPTION
## Summary
- remove ts-jest preset from Jest configs to avoid missing preset error

## Testing
- `prettier -w jest.config.cjs backend/jest.config.js`
- `npm test` *(fails: Jest is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b8677d7bb4832d973525f885e0859a