### PR TITLE
fix: run smoke tests when offline

### DIFF
--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -9,7 +9,7 @@ EventEmitter.defaultMaxListeners = Math.max(
 );
 
 const offline = isOfflineEnv();
-if (process.env.CI_NO_SMOKE === "1") {
+if (process.env.CI_NO_SMOKE === "1" && !offline) {
   logOfflineSkip("smoke");
   process.exit(0);
 }


### PR DESCRIPTION
## Summary
- ensure smoke tests execute even when CI_NO_SMOKE is set in offline environments

## Testing
- `npm run format --prefix backend`
- `npx prettier -w scripts/smoke.mjs`
- `npm test --prefix backend` *(fails: GET /api/status returns job, etc.)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: multiple test suites could not run)*
- `CI_NO_SMOKE=1 SKIP_PW_DEPS=1 npm run smoke` *(fails: Jest is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b86781571c832db51931650a2c9d80