### PR TITLE
fix: allow smoke tests in offline mode

### DIFF
--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -11,10 +11,6 @@ EventEmitter.defaultMaxListeners = Math.max(
 
 const offline = isOfflineEnv();
 
-if (offline) {
-  logOfflineSkip("smoke");
-  process.exit(0);
-}
 if (process.env.CI_NO_SMOKE === "1") {
   logOfflineSkip("smoke");
   process.exit(0);
@@ -33,6 +29,10 @@ try {
 } catch {
   logOfflineSkip("smoke");
   process.exit(0);
+}
+
+if (offline) {
+  console.log("offline mode: running smoke tests");
 }
 
 execSync(


### PR DESCRIPTION
## Summary
- allow smoke tests to run even when offline instead of skipping
- note offline execution when running the smoke script

## Testing
- `SKIP_PW_DEPS=1 npm run validate-env`
- `npx prettier scripts/smoke.mjs -w`
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Identifier 'tsJestMissing' already declared)*

------
https://chatgpt.com/codex/tasks/task_e_68b86f921b5c832db962b03798748a71