### PR TITLE
fix: allow jest to run without ts-jest when skipping net checks

### DIFF
--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -57,16 +57,6 @@ async function run(args) {
 
 
   const skipNetChecks = process.env.SKIP_NET_CHECKS === "1";
-  let tsJestMissing = false;
-  try {
-    require.resolve("ts-jest");
-  } catch {
-    tsJestMissing = true;
-    if (!offline && !skipNetChecks) {
-      console.error("Missing ts-jest; run `npm run setup` before testing.");
-      process.exit(1);
-    }
-  }
 
   verifyFiles(args);
   console.log("run-jest cwd:", process.cwd());
@@ -134,12 +124,12 @@ async function run(args) {
     require.resolve("ts-jest");
   } catch {
     tsJestMissing = true;
-    if (!offline) {
+    if (!offline && !skipNetChecks) {
       console.error("Missing ts-jest; run `npm run setup` before testing.");
       process.exit(1);
     }
   }
-  if (offline && tsJestMissing) {
+  if ((offline || skipNetChecks) && tsJestMissing) {
     parsed.config = isBackendTest ? backendOfflineConfig : defaultOfflineConfig;
     parsed._ = parsed._.map((p) => {
       if (p.endsWith(".ts")) {


### PR DESCRIPTION
## Summary
- avoid ts-jest errors when SKIP_NET_CHECKS is set by falling back to offline config

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup` *(fails: MaxListenersExceededWarning, deprecated modules)*
- `cd backend && npm run format`
- `CI_FORCE=1 SKIP_NET_CHECKS=1 SKIP_PW_DEPS=1 npm run smoke` *(fails: attempt to install dependencies but network access is restricted)*

------
https://chatgpt.com/codex/tasks/task_e_68b86f980dfc832da22bb81187ff637c