### PR TITLE
ci: allow offline runs

### DIFF
--- a/scripts/ci.mjs
+++ b/scripts/ci.mjs
@@ -1,12 +1,9 @@
 #!/usr/bin/env node
 import { execSync } from "child_process";
-import { isOfflineEnv, logOfflineSkip } from "./net-mode.mjs";
+import { isOfflineEnv } from "./net-mode.mjs";
 
 const offline = isOfflineEnv();
-if (offline) {
-  logOfflineSkip("ci");
-  process.exit(0);
-}
+
 if (
   offline &&
   process.env.SKIP_PW_DEPS === "1" &&
@@ -20,10 +17,10 @@ if (process.env.SKIP_PW_DEPS === "1") {
 }
 
 if (offline) {
-  console.log("offline mode: skipping build and tests");
-  process.exit(0);
+  console.log("offline mode: running ci");
 }
 
 execSync("node scripts/run-npm-ci.js", { stdio: "inherit" });
 execSync("npm run build --workspaces=false", { stdio: "inherit" });
 execSync("npm test", { stdio: "inherit" });
+


### PR DESCRIPTION
## Summary
- run CI tasks even when network unreachable
- log offline mode instead of skipping build/test

## Testing
- `npm run format`
- `npm test` *(fails: Expected 200 Received 404 etc.)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: SyntaxError: Identifier 'tsJestMissing' has already been declared)*
- `SKIP_PW_DEPS=1 npm run smoke` *(skipped: offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_68b86f9c266c832d8e294918553c3e37