### PR TITLE
fix: skip test suites in offline environments

### DIFF
--- a/scripts/ci.mjs
+++ b/scripts/ci.mjs
@@ -3,25 +3,21 @@ import { execSync } from "child_process";
 import { isOfflineEnv, logOfflineSkip } from "./net-mode.mjs";
 
 const offline = isOfflineEnv();
+
 if (offline) {
+  if (
+    process.env.SKIP_PW_DEPS === "1" &&
+    !process.env.SKIP_NET_CHECKS
+  ) {
+    process.env.SKIP_NET_CHECKS = "1";
+  }
   logOfflineSkip("ci");
+  console.log("offline mode: skipping build and tests");
   process.exit(0);
-}
-if (
-  offline &&
-  process.env.SKIP_PW_DEPS === "1" &&
-  !process.env.SKIP_NET_CHECKS
-) {
-  process.env.SKIP_NET_CHECKS = "1";
 }
 
 if (process.env.SKIP_PW_DEPS === "1") {
   process.env.PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1";
-}
-
-if (offline) {
-  console.log("offline mode: skipping build and tests");
-  process.exit(0);
 }
 
 execSync("node scripts/run-npm-ci.js", { stdio: "inherit" });

--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -37,6 +37,9 @@ async function run(args) {
   const { isOfflineEnv, logOfflineSkip } = await import("./net-mode.mjs");
   const offline = isOfflineEnv();
   if (offline) {
+    if (!process.env.SKIP_NET_CHECKS) {
+      process.env.SKIP_NET_CHECKS = "1";
+    }
     logOfflineSkip("jest");
     return;
   }
@@ -54,7 +57,6 @@ async function run(args) {
   if (!offline && !process.env.SKIP_ROOT_DEPS_CHECK) {
     require("./ensure-root-deps.js");
   }
-
 
   const skipNetChecks = process.env.SKIP_NET_CHECKS === "1";
   let tsJestMissing = false;
@@ -128,16 +130,6 @@ async function run(args) {
 
   if (!offline && isBackendTest && !process.env.SKIP_BACKEND_DEPS_CHECK) {
     require(path.join(backendRoot, "scripts", "ensure-deps.js"));
-  }
-  let tsJestMissing = false;
-  try {
-    require.resolve("ts-jest");
-  } catch {
-    tsJestMissing = true;
-    if (!offline) {
-      console.error("Missing ts-jest; run `npm run setup` before testing.");
-      process.exit(1);
-    }
   }
   if (offline && tsJestMissing) {
     parsed.config = isBackendTest ? backendOfflineConfig : defaultOfflineConfig;

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -12,19 +12,18 @@ EventEmitter.defaultMaxListeners = Math.max(
 const offline = isOfflineEnv();
 
 if (offline) {
+  if (
+    process.env.SKIP_PW_DEPS === "1" &&
+    !process.env.SKIP_NET_CHECKS
+  ) {
+    process.env.SKIP_NET_CHECKS = "1";
+  }
   logOfflineSkip("smoke");
   process.exit(0);
 }
 if (process.env.CI_NO_SMOKE === "1") {
   logOfflineSkip("smoke");
   process.exit(0);
-}
-if (
-  offline &&
-  process.env.SKIP_PW_DEPS === "1" &&
-  !process.env.SKIP_NET_CHECKS
-) {
-  process.env.SKIP_NET_CHECKS = "1";
 }
 
 const require = createRequire(import.meta.url);


### PR DESCRIPTION
## Summary
- ensure `ci` script skips builds and tests when offline
- set up jest runner to flag offline mode and skip network checks
- allow smoke tests to exit early in offline environments

## Testing
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`
- `npx prettier -w scripts/ci.mjs scripts/smoke.mjs scripts/run-jest.js` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b86fa028cc832d9814222be90242d8