### PR TITLE
fix: handle offline mode in ci and smoke

### DIFF
--- a/scripts/ci.mjs
+++ b/scripts/ci.mjs
@@ -4,24 +4,16 @@ import { isOfflineEnv, logOfflineSkip } from "./net-mode.mjs";
 
 const offline = isOfflineEnv();
 if (offline) {
+  if (process.env.SKIP_PW_DEPS === "1" && !process.env.SKIP_NET_CHECKS) {
+    process.env.SKIP_NET_CHECKS = "1";
+  }
   logOfflineSkip("ci");
+  console.log("offline mode: skipping build and tests");
   process.exit(0);
-}
-if (
-  offline &&
-  process.env.SKIP_PW_DEPS === "1" &&
-  !process.env.SKIP_NET_CHECKS
-) {
-  process.env.SKIP_NET_CHECKS = "1";
 }
 
 if (process.env.SKIP_PW_DEPS === "1") {
   process.env.PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1";
-}
-
-if (offline) {
-  console.log("offline mode: skipping build and tests");
-  process.exit(0);
 }
 
 execSync("node scripts/run-npm-ci.js", { stdio: "inherit" });

--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -38,7 +38,7 @@ async function run(args) {
   const offline = isOfflineEnv();
   if (offline) {
     logOfflineSkip("jest");
-    return;
+    process.exit(0);
   }
 
   let runCLI;
@@ -54,7 +54,6 @@ async function run(args) {
   if (!offline && !process.env.SKIP_ROOT_DEPS_CHECK) {
     require("./ensure-root-deps.js");
   }
-
 
   const skipNetChecks = process.env.SKIP_NET_CHECKS === "1";
   let tsJestMissing = false;
@@ -128,16 +127,6 @@ async function run(args) {
 
   if (!offline && isBackendTest && !process.env.SKIP_BACKEND_DEPS_CHECK) {
     require(path.join(backendRoot, "scripts", "ensure-deps.js"));
-  }
-  let tsJestMissing = false;
-  try {
-    require.resolve("ts-jest");
-  } catch {
-    tsJestMissing = true;
-    if (!offline) {
-      console.error("Missing ts-jest; run `npm run setup` before testing.");
-      process.exit(1);
-    }
   }
   if (offline && tsJestMissing) {
     parsed.config = isBackendTest ? backendOfflineConfig : defaultOfflineConfig;

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -11,20 +11,16 @@ EventEmitter.defaultMaxListeners = Math.max(
 
 const offline = isOfflineEnv();
 
-if (offline) {
+if (offline || process.env.CI_NO_SMOKE === "1") {
+  if (
+    offline &&
+    process.env.SKIP_PW_DEPS === "1" &&
+    !process.env.SKIP_NET_CHECKS
+  ) {
+    process.env.SKIP_NET_CHECKS = "1";
+  }
   logOfflineSkip("smoke");
   process.exit(0);
-}
-if (process.env.CI_NO_SMOKE === "1") {
-  logOfflineSkip("smoke");
-  process.exit(0);
-}
-if (
-  offline &&
-  process.env.SKIP_PW_DEPS === "1" &&
-  !process.env.SKIP_NET_CHECKS
-) {
-  process.env.SKIP_NET_CHECKS = "1";
 }
 
 const require = createRequire(import.meta.url);


### PR DESCRIPTION
## Summary
- streamline offline handling in ci and smoke scripts
- ensure run-jest exits cleanly when offline

## Testing
- `npx prettier --write scripts/smoke.mjs scripts/ci.mjs scripts/run-jest.js`
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: Expected 200 Received 404)*
- `CI_NO_NET=1 npm test`
- `CI_NO_NET=1 SKIP_PW_DEPS=1 npm run ci`
- `CI_NO_NET=1 SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b86fa38218832db37a36fc5dddeb4b