### PR TITLE
fix: reuse ts-jest flag in run-jest

### DIFF
--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -129,7 +129,8 @@ async function run(args) {
   if (!offline && isBackendTest && !process.env.SKIP_BACKEND_DEPS_CHECK) {
     require(path.join(backendRoot, "scripts", "ensure-deps.js"));
   }
-  let tsJestMissing = false;
+  // Reuse the earlier tsJestMissing flag rather than redeclaring it
+  tsJestMissing = false;
   try {
     require.resolve("ts-jest");
   } catch {


### PR DESCRIPTION
## Summary
- avoid redeclaration of `tsJestMissing` in run-jest script

## Testing
- `npm run format --prefix backend`
- `npm test` *(offline mode: skipping jest)*
- `npm run ci` *(offline mode: skipping ci)*

------
https://chatgpt.com/codex/tasks/task_e_68b86fa7732c832d8a3f7f00968e07d7