### PR TITLE
fix: expand backend formatter

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -20,7 +20,7 @@
     "db:check": "node scripts/check-db.js",
     "seed": "node scripts/seed-db.js",
     "create-admin": "node scripts/create-admin.js",
-    "format": "prettier --log-level warn --write \"src/**/*.{ts,tsx,js,jsx,json,md}\"",
+    "format": "prettier --log-level warn --write \"**/*.{ts,tsx,js,jsx,json,md}\"",
     "send-reminders": "node scripts/send-purchase-reminders.js",
     "send-abandoned-offers": "node scripts/send-abandoned-offers.js",
     "send-followups": "node scripts/send-post-purchase-followups.js",
@@ -42,7 +42,7 @@
     "notify-clearing": "node scripts/notify-manual-clearing.js",
     "send-ops-report": "node scripts/send-ops-report.js",
     "flag-overdue-printers": "node scripts/flag-overdue-procurement-orders.js",
-    "format:check": "sh -c 'cd .. && prettier --log-level warn --check \"**/*.{js,jsx,json,md}\" --ignore-path .prettierignore'",
+    "format:check": "prettier --log-level warn --check \"**/*.{ts,tsx,js,jsx,json,md}\"",
     "test:db": "jest --runInBand --env=node tests/db/**/*.spec.{ts,js}"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- broaden backend formatter to cover all backend files
- align backend format check with new formatter scope

## Testing
- `npm run format` (backend)
- `npm test` (backend) *(fails: GET /api/status returns job, Stripe create-order flow, etc.)*
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b86fdd30f0832dbf5574d37c4a3703