### PR TITLE
fix: resolve jest module issues

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,4 +1,7 @@
 module.exports = {
-  presets: [["@babel/preset-react", { runtime: "automatic" }]],
+  presets: [
+    ["@babel/preset-env", { targets: { node: "current" }, modules: "commonjs" }],
+    ["@babel/preset-react", { runtime: "automatic" }],
+  ],
   plugins: [["@babel/plugin-syntax-typescript", { isTSX: true }]],
 };

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,11 @@
+const { config } = require('dotenv');
+config();
+
+const app = require('./src/app');
+const { getEnv } = require('./src/env');
+
+getEnv();
+
+module.exports = app;
+module.exports.default = app;
+module.exports.app = app;

--- a/backend/tests/utils/shouldSkipSuite.js
+++ b/backend/tests/utils/shouldSkipSuite.js
@@ -1,4 +1,4 @@
-const app = require("../server");
+const app = require("../../server");
 
 function shouldSkipSuite(path) {
   try {

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -9,6 +9,7 @@ try {
         "ts-jest",
         { tsconfig: "tsconfig.json", diagnostics: false },
       ],
+      "^.+\\.jsx?$": ["babel-jest", { configFile: "./babel.config.js" }],
     },
     moduleFileExtensions: ["ts", "tsx", "js", "json"],
     passWithNoTests: true,


### PR DESCRIPTION
## Summary
- configure Babel to transpile JS tests and React code
- expose backend app for tests via new server entry
- adjust test helper to load the new server path

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend -- backend/tests/subscriptions.test.js backend/tests/analytics.test.js backend/tests/additionalApi.test.js` *(fails: coverage thresholds not met)*


------
https://chatgpt.com/codex/tasks/task_e_68b86fed6a80832d9a0b97f469bb036d