### PR TITLE
fix: allow Playwright CDN 4xx responses

### DIFF
--- a/scripts/network-check.js
+++ b/scripts/network-check.js
@@ -86,7 +86,8 @@ function check(target) {
     if (
       !npmPing &&
       url.includes("cdn.playwright.dev") &&
-      /error:\s*[45][0-9]{2}/.test(stderr)
+      (/error:\s*[45][0-9]{2}/i.test(stderr) ||
+        /response\s+[45][0-9]{2}/i.test(stderr))
     ) {
       return null;
     }


### PR DESCRIPTION
## Summary
- broaden network check to treat Playwright CDN 'response 4xx' messages as connectivity success

## Testing
- `npm run validate-env`
- `npm run format --prefix backend`
- `npm test` *(fails: SyntaxError: Identifier 'tsJestMissing' has already been declared)*

------
https://chatgpt.com/codex/tasks/task_e_68b87009281c832d88741bdfa075939a