### PR TITLE
fix: enable babel transform for js tests

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -9,6 +9,7 @@ try {
         "ts-jest",
         { tsconfig: "tsconfig.json", diagnostics: false },
       ],
+      "^.+\\.jsx?$": "babel-jest",
     },
     moduleFileExtensions: ["ts", "tsx", "js", "json"],
     passWithNoTests: true,


### PR DESCRIPTION
## Summary
- configure Jest to transform .js and .jsx files with `babel-jest`

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend -- tests/api.test.js -t "GET /api/status returns job"` *(fails: Expected 200, Received 404)*
- `node backend/node_modules/jest/bin/jest.js src/generated_frontend_abcd.test.js --config jest.config.cjs` *(fails: Cannot use import statement outside a module)*
- `SKIP_PW_DEPS=1 npm run ci` *(skipped: offline mode)*
- `SKIP_PW_DEPS=1 npm run smoke` *(skipped: offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_68b8705b0f30832da0144a5601e3f7ae