### PR TITLE
fix: enable commonjs transform for tests

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,4 +1,13 @@
 module.exports = {
-  presets: [["@babel/preset-react", { runtime: "automatic" }]],
-  plugins: [["@babel/plugin-syntax-typescript", { isTSX: true }]],
+  presets: [
+    [
+      "@babel/preset-env",
+      { targets: { node: "current" }, modules: "commonjs" },
+    ],
+    ["@babel/preset-react", { runtime: "automatic" }],
+  ],
+  plugins: [
+    ["@babel/plugin-syntax-typescript", { isTSX: true }],
+    ["@babel/plugin-transform-modules-commonjs"],
+  ],
 };


### PR DESCRIPTION
## Summary
- ensure Babel transforms ES modules to CommonJS for Jest

## Testing
- `npx prettier -w babel.config.js`
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: many API tests failing with 404 and TypeErrors)*
- `SKIP_PW_DEPS=1 npm run ci` *(offline mode: skipping ci)*

------
https://chatgpt.com/codex/tasks/task_e_68b8706d44a0832d812ef63c502c8471