### PR TITLE
fix: ensure deps before loading jest

### DIFF
--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -40,6 +40,9 @@ async function run(args) {
     logOfflineSkip("jest");
     return;
   }
+  if (!offline && !process.env.SKIP_ROOT_DEPS_CHECK) {
+    require("./ensure-root-deps.js");
+  }
 
   let runCLI;
   try {
@@ -50,11 +53,6 @@ async function run(args) {
     );
     process.exit(1);
   }
-
-  if (!offline && !process.env.SKIP_ROOT_DEPS_CHECK) {
-    require("./ensure-root-deps.js");
-  }
-
 
   const skipNetChecks = process.env.SKIP_NET_CHECKS === "1";
   let tsJestMissing = false;
@@ -128,16 +126,6 @@ async function run(args) {
 
   if (!offline && isBackendTest && !process.env.SKIP_BACKEND_DEPS_CHECK) {
     require(path.join(backendRoot, "scripts", "ensure-deps.js"));
-  }
-  let tsJestMissing = false;
-  try {
-    require.resolve("ts-jest");
-  } catch {
-    tsJestMissing = true;
-    if (!offline) {
-      console.error("Missing ts-jest; run `npm run setup` before testing.");
-      process.exit(1);
-    }
   }
   if (offline && tsJestMissing) {
     parsed.config = isBackendTest ? backendOfflineConfig : defaultOfflineConfig;


### PR DESCRIPTION
## Summary
- run dependency check before requiring Jest so tests install missing packages

## Testing
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b870934570832db46d4708a751aed4