### PR TITLE
fix: guard shipping tracking from missing config

### DIFF
--- a/backend/shipping.js
+++ b/backend/shipping.js
@@ -53,6 +53,10 @@ function getTrackingUrl(carrier, trackingNumber) {
 
 async function getTrackingStatus(carrier, trackingNumber) {
   try {
+    if (!SHIPPING_API_URL || !SHIPPING_API_KEY) {
+      throw new Error("Shipping API not configured");
+    }
+
     const res = await fetch(
       `${SHIPPING_API_URL}/track?carrier=${encodeURIComponent(carrier)}&tracking=${encodeURIComponent(trackingNumber)}`,
       { headers: { Authorization: `Bearer ${SHIPPING_API_KEY}` } },


### PR DESCRIPTION
## Summary
- handle shipping tracking when API config is missing instead of failing

## Testing
- `npm run format` (backend)
- `npm test` (backend) *(fails: Expected 200 Received 404, etc.)*
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b870bf69e4832d980865ff269bb6a6