### PR TITLE
test: fix frontend import and db mock

### DIFF
--- a/backend/tests/subscriptions.test.js
+++ b/backend/tests/subscriptions.test.js
@@ -33,7 +33,6 @@ const mockDb = {
   insertReferredOrder: jest.fn(),
 };
 jest.mock("../db", () => mockDb);
-jest.mock("../../db", () => mockDb);
 const db = require("../db");
 
 const { stripe } = require("./utils/stripeMock");

--- a/src/generated_frontend_abcd.test.js
+++ b/src/generated_frontend_abcd.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable */
 /** @jest-environment jsdom */
-import React from "react";
-import { render, screen, fireEvent, act } from "@testing-library/react";
+const React = require("react");
+const { render, screen, fireEvent, act } = require("@testing-library/react");
 
 function Cart() {
   const [items, setItems] = React.useState(() => {


### PR DESCRIPTION
## Summary
- replace ES module imports with CommonJS requires in generated frontend test to avoid Jest syntax errors
- remove unused database mock path in subscriptions backend test

## Testing
- `npx prettier -w src/generated_frontend_abcd.test.js backend/tests/subscriptions.test.js`
- `npm run format --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: server-endpoints, stripe webhook, and other tests 404/500)*

------
https://chatgpt.com/codex/tasks/task_e_68b870d64644832d8c47f8159f5bdfad