### PR TITLE
fix: remove duplicate ts-jest check

### DIFF
--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -55,7 +55,6 @@ async function run(args) {
     require("./ensure-root-deps.js");
   }
 
-
   const skipNetChecks = process.env.SKIP_NET_CHECKS === "1";
   let tsJestMissing = false;
   try {
@@ -128,16 +127,6 @@ async function run(args) {
 
   if (!offline && isBackendTest && !process.env.SKIP_BACKEND_DEPS_CHECK) {
     require(path.join(backendRoot, "scripts", "ensure-deps.js"));
-  }
-  let tsJestMissing = false;
-  try {
-    require.resolve("ts-jest");
-  } catch {
-    tsJestMissing = true;
-    if (!offline) {
-      console.error("Missing ts-jest; run `npm run setup` before testing.");
-      process.exit(1);
-    }
   }
   if (offline && tsJestMissing) {
     parsed.config = isBackendTest ? backendOfflineConfig : defaultOfflineConfig;


### PR DESCRIPTION
## Summary
- remove redundant ts-jest check in run-jest to avoid SyntaxError

## Testing
- `npx prettier -w scripts/run-jest.js`
- `npm test -- --maxWorkers=2 --runTestsByPath tests/config/package-scripts.smoke.*.spec.ts tests/smoke/healthcheck.*.spec.ts` *(offline mode: skipping jest)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: skipping smoke)*
- `SKIP_PW_DEPS=1 npm run ci` *(offline mode: skipping ci)*


------
https://chatgpt.com/codex/tasks/task_e_68b870e938ec832dae6c6ba0ca6f9a35