### PR TITLE
fix: ensure smoke tests run setup

### DIFF
--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -55,7 +55,6 @@ async function run(args) {
     require("./ensure-root-deps.js");
   }
 
-
   const skipNetChecks = process.env.SKIP_NET_CHECKS === "1";
   let tsJestMissing = false;
   try {
@@ -128,16 +127,6 @@ async function run(args) {
 
   if (!offline && isBackendTest && !process.env.SKIP_BACKEND_DEPS_CHECK) {
     require(path.join(backendRoot, "scripts", "ensure-deps.js"));
-  }
-  let tsJestMissing = false;
-  try {
-    require.resolve("ts-jest");
-  } catch {
-    tsJestMissing = true;
-    if (!offline) {
-      console.error("Missing ts-jest; run `npm run setup` before testing.");
-      process.exit(1);
-    }
   }
   if (offline && tsJestMissing) {
     parsed.config = isBackendTest ? backendOfflineConfig : defaultOfflineConfig;

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -27,9 +27,11 @@ if (
   process.env.SKIP_NET_CHECKS = "1";
 }
 
+execSync("npm run setup", { stdio: "inherit" });
+
 const require = createRequire(import.meta.url);
 try {
-  require.resolve("jest");
+  require.resolve("@jest/core");
 } catch {
   logOfflineSkip("smoke");
   process.exit(0);


### PR DESCRIPTION
## Summary
- run setup before smoke tests to install dependencies
- remove duplicate ts-jest check in Jest runner

## Testing
- `npx prettier scripts/smoke.mjs -w`
- `npx prettier scripts/run-jest.js -w`
- `npm test` *(offline mode: skipping jest)*
- `npm run ci` *(offline mode: skipping ci)*
- `npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68b8710619c8832d8833a89826501f57