### PR TITLE
fix: stub frontend urls for stripe checkout

### DIFF
--- a/backend/tests/setupGlobals.js
+++ b/backend/tests/setupGlobals.js
@@ -56,6 +56,14 @@ if (!process.env.SPARC3D_TOKEN) {
   process.env.SPARC3D_TOKEN = "token";
 }
 
+// Provide dummy frontend URLs for Stripe checkout
+if (!process.env.FRONTEND_SUCCESS_URL) {
+  process.env.FRONTEND_SUCCESS_URL = "https://example.com/success";
+}
+if (!process.env.FRONTEND_CANCEL_URL) {
+  process.env.FRONTEND_CANCEL_URL = "https://example.com/cancel";
+}
+
 if (!process.env.CI_REQUIRE_EXTERNAL) {
   process.env.CI_REQUIRE_EXTERNAL = "0";
 }


### PR DESCRIPTION
## Summary
- add default frontend success/cancel URLs in test globals to avoid stripe checkout crash

## Testing
- `npm run format`
- `npm test` *(fails: GET /api/status returns job: Expected 200 Received 404)*
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b87131a3a0832db42fe9aebb646cc9