### PR TITLE
docs: require npm for scripts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,10 @@ Thank you for helping improve this project! Please follow these steps to keep ou
 - Format each message as `type: short description` (e.g. `fix: handle null user`).
 - Allowed types include `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `style`, `perf`, `ci`, and `build`.
 
+## Package manager
+
+All dependency installs and script runs must use `npm`. Other package managers such as `pnpm` are not supported.
+
 ## Pull Requests
 
 1. Run `npm run setup` after checking out the repo. This installs dependencies and Playwright browsers.


### PR DESCRIPTION
## Summary
- clarify in contributing guide that npm is the required package manager and pnpm is unsupported

## Testing
- `npm run setup` *(fails: connect tunnel failed, response 403)*
- `npm run format`
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b884a9ec3c832d957debd4a1596c8a