### PR TITLE
ci: add pnpm guard workflow

### DIFF
--- a/.github/workflows/pnpm-guard.yml
+++ b/.github/workflows/pnpm-guard.yml
@@ -1,0 +1,14 @@
+name: PNPM Guard
+on: [push, pull_request]
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Ensure pnpm is not used
+        run: |
+          test ! -f pnpm-lock.yaml
+          if jq -r '.scripts | to_entries[].value' package.json | grep -q pnpm; then
+            echo "pnpm usage detected in package.json scripts"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- check repository for pnpm usage to enforce npm-only scripts

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` (backend)
- `npm test` (backend)
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b884a50f90832d960664c6080cf2ae