### PR TITLE
chore: ignore pnpm lockfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,5 @@ sw.js
 
 .next/
 .husky/_
+
+pnpm-lock.yaml


### PR DESCRIPTION
## Summary
- ignore pnpm lockfile in git

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b8849f9c20832db601113e6c2ac656