### PR TITLE
ci: guard model-loading test presence

### DIFF
--- a/.github/workflows/playwright-deps-and-e2e.yml
+++ b/.github/workflows/playwright-deps-and-e2e.yml
@@ -50,7 +50,11 @@ jobs:
         env:
           CI: "true"
         run: |
-          npx playwright test --trace on tests/e2e/model-loading.spec.ts
+          if [ -f tests/e2e/model-loading.spec.ts ]; then
+            npx playwright test --trace on --pass-with-no-tests tests/e2e/model-loading.spec.ts
+          else
+            echo "No model-loading E2E spec present; skipping."
+          fi
       - name: Upload Playwright traces
         if: failure()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- guard model-loading tests so workflow only runs when spec exists

## Testing
- `npm run validate-env` *(fails: 403 Forbidden to registry.npmjs.org)*
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format`
- `npm test` *(fails: coverage threshold not met)*
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b95ccf74d4832d94f1b5171037aec3