### PR TITLE
ci: skip boombox model check when missing

### DIFF
--- a/scripts/ci-doctor.mjs
+++ b/scripts/ci-doctor.mjs
@@ -1,47 +1,47 @@
 #!/usr/bin/env node
-import { existsSync, readdirSync } from 'node:fs';
-import { execSync } from 'node:child_process';
-import path from 'node:path';
+import { existsSync, readdirSync } from "node:fs";
+import { execSync } from "node:child_process";
+import path from "node:path";
 
 /** Collect check results */
 const checks = [];
 
-function add(check, ok, info = '') {
+function add(check, ok, info = "") {
   checks.push({ check, ok, info });
 }
 
 function checkPath(label, p) {
   const exists = existsSync(p);
-  add(`path:${label}`, exists, exists ? p : 'missing');
+  add(`path:${label}`, exists, exists ? p : "missing");
   return exists;
 }
 
 function checkEnv(name) {
   const val = process.env[name];
   const ok = !!val;
-  add(`env:${name}`, ok, ok ? '[set]' : 'missing');
+  add(`env:${name}`, ok, ok ? "[set]" : "missing");
   return ok;
 }
 
 function checkTool(name, cmd) {
   try {
-    const out = execSync(cmd, { stdio: ['ignore', 'pipe', 'pipe'] })
+    const out = execSync(cmd, { stdio: ["ignore", "pipe", "pipe"] })
       .toString()
       .trim();
     add(`tool:${name}`, true, out);
   } catch {
-    add(`tool:${name}`, false, 'missing');
+    add(`tool:${name}`, false, "missing");
   }
 }
 
 // Paths
-checkPath('backend/package.json', 'backend/package.json');
-checkPath('frontend/package.json', 'frontend/package.json');
-checkPath('wrangler.toml', 'wrangler.toml');
-const distExists = checkPath('frontend/dist', 'frontend/dist');
+checkPath("backend/package.json", "backend/package.json");
+checkPath("frontend/package.json", "frontend/package.json");
+checkPath("wrangler.toml", "wrangler.toml");
+const distExists = checkPath("frontend/dist", "frontend/dist");
 if (distExists) {
-  const modelsDir = path.join('frontend', 'dist', 'models');
-  let modelFile = 'missing';
+  const modelsDir = path.join("frontend", "dist", "models");
+  let modelFile;
   try {
     const files = readdirSync(modelsDir);
     if (files.length > 0) {
@@ -50,29 +50,38 @@ if (distExists) {
   } catch {
     // ignore
   }
-  add('path:frontend/dist/models', modelFile !== 'missing', modelFile);
+  if (modelFile) {
+    add("path:frontend/dist/models", true, modelFile);
+  } else {
+    add("path:frontend/dist/models", "skipped", "skipped");
+  }
 } else {
-  add('path:frontend/dist/models', false, 'missing');
+  add("path:frontend/dist/models", "skipped", "skipped");
 }
 
 // Env vars
-checkEnv('STRIPE_SECRET_KEY');
-checkEnv('STRIPE_WEBHOOK_SECRET');
-const dbUrl = process.env.DB_URL || process.env.TEST_DB_URL || process.env.DATABASE_URL;
-add('env:DB_URL', !!dbUrl, dbUrl ? '[set]' : 'missing');
+checkEnv("STRIPE_SECRET_KEY");
+checkEnv("STRIPE_WEBHOOK_SECRET");
+const dbUrl =
+  process.env.DB_URL || process.env.TEST_DB_URL || process.env.DATABASE_URL;
+add("env:DB_URL", !!dbUrl, dbUrl ? "[set]" : "missing");
 
 // Tooling
-checkTool('node', 'node -v');
-checkTool('npm', 'npm -v');
-if (process.env.SKIP_PW_DEPS === '1') {
-  add('tool:playwright', true, 'skipped');
+checkTool("node", "node -v");
+checkTool("npm", "npm -v");
+if (process.env.SKIP_PW_DEPS === "1") {
+  add("tool:playwright", true, "skipped");
 } else {
-  checkTool('playwright', 'npx --no-install playwright --version');
+  checkTool("playwright", "npx --no-install playwright --version");
 }
 
 // Output table and exit appropriately
 console.table(
-  checks.map((c) => ({ Check: c.check, Status: c.ok ? 'ok' : 'missing', Info: c.info }))
+  checks.map((c) => ({
+    Check: c.check,
+    Status: c.ok === "skipped" ? "skipped" : c.ok ? "ok" : "missing",
+    Info: c.info,
+  })),
 );
 
-process.exit(checks.every((c) => c.ok) ? 0 : 1);
+process.exit(checks.every((c) => c.ok || c.ok === "skipped") ? 0 : 1);


### PR DESCRIPTION
## Summary
- allow ci-doctor to skip boombox model check when file absent

## Testing
- `cd backend && npm run format`
- `cd backend && npm test`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b959ac1f0c832dad9b5b13f9cce570