### PR TITLE
fix: clean up backend lint issues

### DIFF
--- a/backend/src/routes/analytics.js
+++ b/backend/src/routes/analytics.js
@@ -5,7 +5,6 @@ const { Router } = require("express");
 // module to load and resulting in uncalled mock functions in tests.
 // Allow tests to inject a mocked DB via global.__db. If not provided, fall back
 // to requiring the real database module.
-// eslint-disable-next-line no-undef
 const db = global.__db || require("../../db");
 
 const router = Router();

--- a/backend/src/routes/create-order.js
+++ b/backend/src/routes/create-order.js
@@ -64,7 +64,9 @@ router.post("/create-order", async (req, res) => {
           }
         }
       }
-    } catch {}
+    } catch (err) {
+      console.error("auth_lookup_failed", err);
+    }
     const finalTotal = price * quantity - discountCents;
     const stripeSecret = process.env.STRIPE_SECRET_KEY || "test";
     const stripe = new Stripe(stripeSecret, {
@@ -105,6 +107,7 @@ router.post("/create-order", async (req, res) => {
     );
     res.json({ checkoutUrl: session.url, success: true });
   } catch (err) {
+    console.error("create_order_failed", err);
     res.status(500).json({ error: "internal_error" });
   }
 });
@@ -120,7 +123,8 @@ router.get("/my/orders", async (req, res) => {
     try {
       const payload = jwt.verify(auth, process.env.AUTH_SECRET || "secret");
       userId = payload.id;
-    } catch {
+    } catch (err) {
+      console.error("order_list_auth_failed", err);
       res.status(401).json({ error: "unauthorized" });
       return;
     }
@@ -130,6 +134,7 @@ router.get("/my/orders", async (req, res) => {
     );
     res.json(rows);
   } catch (err) {
+    console.error("order_list_failed", err);
     res.status(500).json({ error: "internal_error" });
   }
 });

--- a/backend/src/routes/orders.js
+++ b/backend/src/routes/orders.js
@@ -108,7 +108,6 @@ router.post("/create-order", async (req, res) => {
     if (discount) {
       discountTotal += discount;
     }
-    let firstOrder = false;
     if (buyerId) {
       const countRes = await db.query(
         "SELECT COUNT(*) FROM orders WHERE user_id=$1",
@@ -117,7 +116,6 @@ router.post("/create-order", async (req, res) => {
       if (countRes.rows?.[0]?.count === "0") {
         const first = Math.round(total * 0.1);
         discountTotal += first;
-        firstOrder = true;
       }
     }
     let referrerId = null;

--- a/backend/src/routes/status.js
+++ b/backend/src/routes/status.js
@@ -4,13 +4,11 @@ const { capture } = require("../lib/logger");
 const db = require("../../db");
 
 let getStatus = () => undefined;
-let emitter;
 try {
   const gen = require("../queue/generation.ts");
   getStatus = gen.getStatus || getStatus;
-  emitter = gen.emitter;
 } catch {
-  emitter = new (require("events").EventEmitter)();
+  // ignore missing generation module
 }
 
 const router = Router();

--- a/backend/src/routes/users.js
+++ b/backend/src/routes/users.js
@@ -14,6 +14,7 @@ router.get("/users/:username/profile", async (req, res) => {
     }
     res.json(rows[0]);
   } catch (err) {
+    console.error("user_profile_fetch_failed", err);
     res.status(500).json({ error: "unexpected_error" });
   }
 });

--- a/backend/tests/analytics.test.js
+++ b/backend/tests/analytics.test.js
@@ -27,7 +27,6 @@ const db = {
   insertReferredOrder: jest.fn(),
   getMarginalCacMetrics: jest.fn(),
 };
-// eslint-disable-next-line no-undef
 global.__db = db;
 
 const request = require("supertest");


### PR DESCRIPTION
## Summary
- remove unused ESLint disable directives in analytics code and tests
- log errors and avoid empty catch blocks in order routes
- drop unused variables in status and orders routes

## Testing
- `npx prettier backend/src/routes/analytics.js backend/src/routes/create-order.js backend/src/routes/orders.js backend/src/routes/status.js backend/src/routes/users.js backend/tests/analytics.test.js --write`
```
backend/src/routes/analytics.js 108ms (unchanged)
backend/src/routes/create-order.js 28ms (unchanged)
backend/src/routes/orders.js 29ms (unchanged)
backend/src/routes/status.js 12ms (unchanged)
backend/src/routes/users.js 3ms (unchanged)
backend/tests/analytics.test.js 19ms (unchanged)
```
- `npm test --prefix backend`
```
Test Suites: 1 passed, 1 total
Tests:       68 skipped, 1 passed, 69 total
Snapshots:   0 total
Time:        3.868 s
Ran all test suites matching tests/additionalApi.test.js.
```
- `npm run lint --prefix backend`
```
> backend@1.0.0 lint
> node ../scripts/ensure-eslint-targets.js . --max-warnings=0 --no-warn-ignored
```
- `SKIP_PW_DEPS=1 npm run ci`
```
> npm ci --no-audit --no-fund --prefix frontend && npm --prefix frontend run build

added 110 packages in 2s

> frontend@1.0.0 build
> vite build
...
> mvp-website@1.0.0 test
> node scripts/run-jest.js --passWithNoTests

offline mode: skipping jest
```
- `SKIP_PW_DEPS=1 npm run smoke`
```
> mvp-website@1.0.0 smoke
> node scripts/smoke.mjs

offline mode: running smoke tests

> mvp-website@1.0.0 test
> node scripts/run-jest.js --passWithNoTests --maxWorkers=2 --runTestsByPath tests/config/package-scripts.smoke.e7082164ae33772d.spec.ts tests/smoke/healthcheck.a7a3f7a4a4adf630.spec.ts

offline mode: skipping jest
```

------
https://chatgpt.com/codex/tasks/task_e_68b9690b59ec832d968bcc727dcbe40a