### PR TITLE
ci: cache playwright system dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,16 @@ jobs:
         with:
           path: ~/.cache/ms-playwright
           key: pw-${{ runner.os }}-chromium
+      - name: Prepare apt cache
+        run: |
+          sudo mkdir -p /var/cache/apt/archives
+          sudo chown -R $USER:$USER /var/cache/apt/archives
+      - uses: actions/cache@v4
+        with:
+          path: /var/cache/apt/archives
+          key: pw-apt-${{ runner.os }}
+          restore-keys: |
+            pw-apt-${{ runner.os }}
       - name: Prime deps & browsers
         run: |
           chmod +x scripts/ci/prime-deps.sh

--- a/.github/workflows/playwright-deps-and-e2e.yml
+++ b/.github/workflows/playwright-deps-and-e2e.yml
@@ -20,6 +20,16 @@ jobs:
           key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-playwright-
+      - name: Prepare apt cache
+        run: |
+          sudo mkdir -p /var/cache/apt/archives
+          sudo chown -R $USER:$USER /var/cache/apt/archives
+      - uses: actions/cache@v4
+        with:
+          path: /var/cache/apt/archives
+          key: ${{ runner.os }}-apt-playwright-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-apt-playwright-
       - name: mode
         run: |
           echo "Mode: ${{ env.CI_NO_NET == '1' && 'Offline' || 'Online' }}"
@@ -30,9 +40,10 @@ jobs:
           else
             npm ci
           fi
-      - name: Install Playwright browsers + OS dependencies
-        run: |
-          npx playwright install --with-deps chromium
+      - name: Install Playwright system dependencies
+        run: npx playwright install-deps chromium
+      - name: Install Playwright browsers
+        run: npx playwright install chromium
       - run: npm run build --if-present
       - run: node scripts/ci-doctor.mjs
         env:

--- a/ci/playwright.Dockerfile
+++ b/ci/playwright.Dockerfile
@@ -1,0 +1,5 @@
+# Base image with Playwright system dependencies preinstalled
+FROM node:20-bullseye
+
+# Install required Playwright OS packages upfront so CI can skip network installs
+RUN npx --yes playwright install-deps chromium

--- a/scripts/ci/prime-deps.sh
+++ b/scripts/ci/prime-deps.sh
@@ -10,4 +10,5 @@ npm ci
 popd
 
 export PLAYWRIGHT_BROWSERS_PATH="${HOME}/.cache/ms-playwright"
-npx playwright install --with-deps chromium
+npx playwright install-deps chromium
+npx playwright install chromium


### PR DESCRIPTION
## Summary
- cache Playwright system packages in CI
- separate OS deps and browser installs for Playwright workflows
- add optional Dockerfile with Playwright dependencies preinstalled

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b98119b1d0832dbc626afa1e7d87d7