### PR TITLE
fix: avoid npx registry lookup during linting

### DIFF
--- a/scripts/ensure-eslint-targets.js
+++ b/scripts/ensure-eslint-targets.js
@@ -1,15 +1,13 @@
 #!/usr/bin/env node
 const { spawnSync } = require("child_process");
+const path = require("path");
 
+const eslintBin = path.resolve(__dirname, "../node_modules/.bin/eslint");
 const args = process.argv.slice(2);
-const result = spawnSync(
-  "npx",
-  ["eslint", "--error-on-unmatched-pattern", ...args],
-  {
-    encoding: "utf-8",
-    stdio: ["inherit", "inherit", "pipe"],
-  },
-);
+const result = spawnSync(eslintBin, ["--error-on-unmatched-pattern", ...args], {
+  encoding: "utf-8",
+  stdio: ["inherit", "inherit", "pipe"],
+});
 
 if (result.status !== 0) {
   const stderr = result.stderr || "";


### PR DESCRIPTION
## Summary
- avoid `npx` network lookups by calling eslint binary directly in lint helper

## Testing
- `npm run lint`
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: Jest global coverage thresholds not met)*
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b97976d440832d9ac2cd4522ee7586