### PR TITLE
ci: fetch parent commit for binary guard

### DIFF
--- a/.github/workflows/binary-guard.yml
+++ b/.github/workflows/binary-guard.yml
@@ -13,10 +13,9 @@ jobs:
         id: diff
         run: |
           set -euo pipefail
-          git fetch origin ${{ github.base_ref || 'dev' }} --depth=1 || true
-          BASE="${{ github.event.pull_request.base.sha || 'HEAD~1' }}"
-          HEAD="${{ github.sha }}"
-          git diff --name-only --diff-filter=AM "${BASE}" "${HEAD}" > changed.txt
+          git fetch origin ${{ github.base_ref || 'dev' }} --depth=2 || true
+          BASE="${{ github.event.pull_request.base.sha || github.event.before }}"
+          git diff --name-only --diff-filter=AM "$BASE" "${{ github.sha }}" > changed.txt
           cat changed.txt
 
       - name: Fail on binary files outside allowlist


### PR DESCRIPTION
## Summary
- ensure binary-guard action diffs against the prior commit from the event payload

## Testing
- `npm run validate-env`
- `npm run setup` *(warning: repeated MaxListenersExceededWarning, likely network related)*
- `npm run format`
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b987d988e4832daaeb9dd8139421dc