### PR TITLE
ci: run e2e job in playwright container

### DIFF
--- a/.github/workflows/playwright-deps-and-e2e.yml
+++ b/.github/workflows/playwright-deps-and-e2e.yml
@@ -3,6 +3,10 @@ on: [push, pull_request]
 jobs:
   e2e:
     runs-on: ubuntu-latest
+    container:
+      build:
+        context: .
+        dockerfile: ci/playwright.Dockerfile
     timeout-minutes: 30
     env:
       NPM_CONFIG_AUDIT: "false"
@@ -20,16 +24,6 @@ jobs:
           key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-playwright-
-      - name: Prepare apt cache
-        run: |
-          sudo mkdir -p /var/cache/apt/archives
-          sudo chown -R $USER:$USER /var/cache/apt/archives
-      - uses: actions/cache@v4
-        with:
-          path: /var/cache/apt/archives
-          key: ${{ runner.os }}-apt-playwright-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-apt-playwright-
       - name: mode
         run: |
           echo "Mode: ${{ env.CI_NO_NET == '1' && 'Offline' || 'Online' }}"
@@ -40,8 +34,6 @@ jobs:
           else
             npm ci
           fi
-      - name: Install Playwright system dependencies
-        run: npx playwright install-deps chromium
       - name: Install Playwright browsers
         run: npx playwright install chromium
       - run: npm run build --if-present

--- a/ci/playwright.Dockerfile
+++ b/ci/playwright.Dockerfile
@@ -1,5 +1,5 @@
-# Base image with Playwright system dependencies preinstalled
-FROM node:20-bullseye
+# Base image with Playwright and required system libraries preinstalled
+FROM mcr.microsoft.com/playwright:v1.54.0-jammy
 
-# Install required Playwright OS packages upfront so CI can skip network installs
+# Ensure Chromium dependencies are installed during image build
 RUN npx --yes playwright install-deps chromium


### PR DESCRIPTION
## Summary
- build Playwright-based Docker image with Chromium deps preinstalled
- run Playwright E2E job inside this container
- drop redundant install-deps step while keeping browser cache

## Testing
- `npm run format`
- `npm test`
- `cd backend && npm run format`
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b999af9cc0832db72a3c5f62244944