### PR TITLE
ci: cache node_modules to speed up CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,14 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
+      - name: Restore node_modules cache
+        id: node-modules-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            node_modules
+            backend/node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json', 'backend/package-lock.json') }}
       - name: Cache Playwright browsers
         uses: actions/cache@v4
         with:
@@ -32,6 +40,14 @@ jobs:
         run: |
           chmod +x scripts/ci/prime-deps.sh
           ./scripts/ci/prime-deps.sh
+      - name: Save node_modules cache
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            node_modules
+            backend/node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json', 'backend/package-lock.json') }}
 
   backend:
     needs: deps
@@ -42,6 +58,13 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
+      - name: Restore node_modules cache
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            node_modules
+            backend/node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('package-lock.json', 'backend/package-lock.json') }}
       - name: Restore Playwright cache
         uses: actions/cache@v4
         with:

--- a/scripts/ci/prime-deps.sh
+++ b/scripts/ci/prime-deps.sh
@@ -2,12 +2,20 @@
 set -euo pipefail
 
 echo "==> Prime root deps"
-npm ci
+if [ ! -d node_modules ]; then
+  npm ci
+else
+  echo "root node_modules already present"
+fi
 
 echo "==> Prime backend deps"
-pushd backend
-npm ci
-popd
+if [ ! -d backend/node_modules ]; then
+  pushd backend
+  npm ci
+  popd
+else
+  echo "backend node_modules already present"
+fi
 
 export PLAYWRIGHT_BROWSERS_PATH="${HOME}/.cache/ms-playwright"
 npx playwright install-deps chromium

--- a/scripts/ci/run-backend-offline-safe.sh
+++ b/scripts/ci/run-backend-offline-safe.sh
@@ -25,7 +25,11 @@ export PLAYWRIGHT_BROWSERS_PATH="${PLAYWRIGHT_DIR}"
 export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 
 echo "==> Install (backend)"
-npm ci --prefix backend
+if [ ! -d backend/node_modules ]; then
+  npm ci --prefix backend
+else
+  echo "backend node_modules already present, skipping install"
+fi
 
 echo "==> Format (backend)"
 npm run format --prefix backend


### PR DESCRIPTION
## Summary
- cache root and backend node_modules between jobs
- skip redundant npm installs when caches are present

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b99f6fb6f0832d868c15d0ac4efc09