### PR TITLE
fix: place trust badge below 3d viewer

### DIFF
--- a/luckybox-payment.html
+++ b/luckybox-payment.html
@@ -218,9 +218,10 @@
         class="relative flex flex-col md:flex-row items-start justify-center w-full max-w-4xl gap-8"
       >
         <!-- Model Preview -->
+        <div class="w-full md:w-1/2 max-w-lg flex flex-col items-center">
         <section
           id="preview-wrapper"
-          class="relative w-full md:w-1/2 max-w-lg h-80 bg-[#2A2A2E] border border-white/10 rounded-3xl overflow-visible"
+          class="relative w-full h-80 bg-[#2A2A2E] border border-white/10 rounded-3xl overflow-visible"
         >
           <img
             id="preview-img"
@@ -272,7 +273,8 @@
               class="h-10 w-10 border-4 border-white border-t-transparent rounded-full animate-spin"
             ></div>
           </div>
-          <div class="mt-4 text-center text-sm text-gray-400">
+        </section>
+        <div id="trust-badge" class="mt-4 text-center text-sm text-gray-400">
             <p class="mb-1">
               Trusted by <span class="text-white">thousands of makers:</span>
             </p>
@@ -281,8 +283,8 @@
               questions asked:
               <span class="text-white">enquiries@domain.com</span>
             </p>
-          </div>
-        </section>
+        </div>
+        </div>
 
         <!-- Checkout Form -->
         <div

--- a/minis-checkout.html
+++ b/minis-checkout.html
@@ -241,9 +241,10 @@
         class="relative flex flex-col md:flex-row items-start justify-center w-full max-w-4xl gap-8"
       >
         <!-- Model Preview -->
+        <div class="w-full md:w-1/2 max-w-lg flex flex-col items-center">
         <section
           id="preview-wrapper"
-          class="relative w-full md:w-1/2 max-w-lg h-80 bg-[#2A2A2E] border border-white/10 rounded-3xl overflow-visible"
+          class="relative w-full h-80 bg-[#2A2A2E] border border-white/10 rounded-3xl overflow-visible"
         >
           <img
             id="preview-img"
@@ -301,7 +302,8 @@
               class="h-10 w-10 border-4 border-white border-t-transparent rounded-full animate-spin"
             ></div>
           </div>
-          <div class="mt-4 text-center text-sm text-gray-400">
+        </section>
+        <div id="trust-badge" class="mt-4 text-center text-sm text-gray-400">
             <p class="mb-1">
               Trusted by <span class="text-white">thousands of makers:</span>
             </p>
@@ -310,8 +312,8 @@
               questions asked:
               <span class="text-white">enquiries@domain.com</span>
             </p>
-          </div>
-        </section>
+        </div>
+        </div>
 
         <!-- Checkout Form -->
         <div

--- a/payment.html
+++ b/payment.html
@@ -216,9 +216,10 @@
         class="relative flex flex-col md:flex-row items-start justify-center w-full max-w-4xl gap-8"
       >
         <!-- Model Preview -->
+        <div class="w-full md:w-1/2 max-w-lg flex flex-col items-center">
         <section
           id="preview-wrapper"
-          class="relative w-full md:w-1/2 max-w-lg h-80 bg-[#2A2A2E] border border-white/10 rounded-3xl overflow-visible"
+          class="relative w-full h-80 bg-[#2A2A2E] border border-white/10 rounded-3xl overflow-visible"
         >
           <img
             id="preview-img"
@@ -276,15 +277,16 @@
               class="h-10 w-10 border-4 border-white border-t-transparent rounded-full animate-spin"
             ></div>
           </div>
-          <div class="mt-4 text-center text-sm text-gray-400">
+        </section>
+        <div id="trust-badge" class="mt-4 text-center text-sm text-gray-400">
             <p class="mb-1">Trusted by <span class="text-white">thousands of makers:</span></p>
             <p>
               ✅︎ If you don’t love it, we’ll reprint or refund you – no <br />
               questions asked:
               <span class="text-white">enquiries@domain.com</span>
             </p>
-          </div>
-        </section>
+        </div>
+        </div>
 
         <!-- Checkout Form -->
         <div

--- a/tests/e2e/payment-layout.spec.a1b2c3d4e5f6g7h8.ts
+++ b/tests/e2e/payment-layout.spec.a1b2c3d4e5f6g7h8.ts
@@ -1,0 +1,34 @@
+import { test, expect } from "@playwright/test";
+
+test("trust badge positioned correctly", async ({ page }) => {
+  await page.goto("/payment.html");
+  await page.waitForSelector("#trust-badge");
+
+  const viewer = page.locator("#preview-wrapper");
+  const badge = page.locator("#trust-badge");
+  const slot = page.locator("text=print slots remaining");
+
+  const viewerBox = await viewer.boundingBox();
+  const badgeBox = await badge.boundingBox();
+  const slotBox = await slot.boundingBox();
+
+  expect(viewerBox).not.toBeNull();
+  expect(badgeBox).not.toBeNull();
+  expect(slotBox).not.toBeNull();
+
+  // 1. badge is below viewer
+  expect(badgeBox!.y).toBeGreaterThanOrEqual(viewerBox!.y + viewerBox!.height);
+
+  // 2. badge is horizontally centered relative to viewer
+  const viewerCenter = viewerBox!.x + viewerBox!.width / 2;
+  const badgeCenter = badgeBox!.x + badgeBox!.width / 2;
+  expect(Math.abs(viewerCenter - badgeCenter)).toBeLessThanOrEqual(1);
+
+  // 3. badge does not overlap the slot count label
+  const overlap =
+    badgeBox!.x < slotBox!.x + slotBox!.width &&
+    badgeBox!.x + badgeBox!.width > slotBox!.x &&
+    badgeBox!.y < slotBox!.y + slotBox!.height &&
+    badgeBox!.y + badgeBox!.height > slotBox!.y;
+  expect(overlap).toBeFalsy();
+});


### PR DESCRIPTION
## Summary
- move "trusted by" trust badge below the model viewer on payment pages
- cover trust badge placement with a new Playwright e2e test

## Testing
- `npm run format` (backend)
- `npm test` (backend)
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`
- `npx playwright test tests/e2e/payment-layout.spec.a1b2c3d4e5f6g7h8.ts` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68ba01e4c4f4832d8e81b018d915412e