### PR TITLE
fix: show print slot count on landing page

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -426,14 +426,17 @@ async function updatePrintRunInfo() {
   const hoursLabelEl = document.getElementById("print-run-hours-label");
   const slotsEl = document.getElementById("print-run-slots");
   const info = document.getElementById("print-run-info");
-  if (!hoursEl && !slotsEl) return;
+  if (!hoursEl || !slotsEl) return;
   let baseSlots = computeSlotsByTime();
+  // Show a provisional slot count while awaiting the API response.
+  slotsEl.textContent = `${adjustedSlots(baseSlots)}`;
   try {
     const resp = await fetch(`${API_BASE}/print-slots`);
     if (resp.ok) {
       const data = await resp.json();
       if (typeof data.slots === "number") {
         baseSlots = data.slots;
+        slotsEl.textContent = `${adjustedSlots(baseSlots)}`;
       }
     }
   } catch {
@@ -442,7 +445,6 @@ async function updatePrintRunInfo() {
   const hours = computePrintRunHours();
   hoursEl.textContent = hours;
   if (hoursLabelEl) hoursLabelEl.textContent = hours === 1 ? "hour" : "hours";
-  if (slotsEl) slotsEl.textContent = `${adjustedSlots(baseSlots)}`;
 
   if (info) info.classList.remove("invisible");
   if (typeof window.positionQuote === "function") {


### PR DESCRIPTION
## Summary
- ensure index page always displays the current print slot count
- populate a provisional slot value while fetching server data

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68ba015eec94832d803cc4a08980dbb3