### PR TITLE
fix: allow offline frontend build

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "validate-env": "bash scripts/validate-env.sh",
     "setup": "bash scripts/setup.sh",
     "prebuild": "node scripts/fetch-boombox.mjs",
-    "build": "npm ci --no-audit --no-fund --prefix frontend && npm --prefix frontend run build",
+    "build": "node scripts/build-frontend.mjs",
     "start:ci": "npm --prefix frontend run start:ci",
     "preview": "vite preview --port 4173",
     "start": "node scripts/dev-server.js",

--- a/scripts/__tests__/build-frontend.test.qw3r8t9y6u1i2o3p.ts
+++ b/scripts/__tests__/build-frontend.test.qw3r8t9y6u1i2o3p.ts
@@ -1,0 +1,13 @@
+jest.mock("../run-npm-ci.js", () => ({ runNpmCi: jest.fn() }));
+jest.mock("child_process", () => ({ execSync: jest.fn() }));
+
+test("build-frontend installs deps offline and runs build", async () => {
+  const { runNpmCi } = require("../run-npm-ci.js");
+  const { execSync } = require("child_process");
+  await import("../build-frontend.mjs");
+  expect(runNpmCi).toHaveBeenCalledWith("frontend");
+  expect(execSync).toHaveBeenCalledWith("npm run build", {
+    cwd: "frontend",
+    stdio: "inherit",
+  });
+});

--- a/scripts/build-frontend.mjs
+++ b/scripts/build-frontend.mjs
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+import { execSync } from "node:child_process";
+import { createRequire } from "node:module";
+const require = createRequire(import.meta.url);
+const { runNpmCi } = require("./run-npm-ci.js");
+
+runNpmCi("frontend");
+execSync("npm run build", { cwd: "frontend", stdio: "inherit" });


### PR DESCRIPTION
## Summary
- ensure frontend build installs deps using offline-aware runNpmCi script
- add test verifying build script calls runNpmCi and runs build

## Testing
- `npx prettier -w package.json scripts/build-frontend.mjs scripts/__tests__/build-frontend.test.qw3r8t9y6u1i2o3p.ts`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_68bab78177fc832dabb6ab8da2902b6e