### PR TITLE
fix: retry network check before offline mode

### DIFF
--- a/scripts/__tests__/net-mode-retry-h28f7k9m3n4p6r1s.test.ts
+++ b/scripts/__tests__/net-mode-retry-h28f7k9m3n4p6r1s.test.ts
@@ -1,0 +1,14 @@
+jest.mock("child_process", () => ({ execSync: jest.fn() }));
+const { execSync } = require("child_process");
+
+test("isOfflineEnv retries ping once before offline mode", async () => {
+  execSync
+    .mockImplementationOnce(() => {
+      throw new Error("fail");
+    })
+    .mockImplementationOnce(() => "HTTP/1.1 200 OK");
+  const { isOfflineEnv } = await import("../net-mode.mjs");
+  const result = isOfflineEnv({ retries: 2, timeout: 10 });
+  expect(result).toBe(false);
+  expect(execSync).toHaveBeenCalledTimes(2);
+});

--- a/scripts/net-mode.mjs
+++ b/scripts/net-mode.mjs
@@ -1,6 +1,9 @@
 import { execSync } from "child_process";
 
-export function isOfflineEnv() {
+export function isOfflineEnv({
+  retries = Number(process.env.NET_MODE_RETRIES || 2),
+  timeout = Number(process.env.NET_MODE_TIMEOUT || 10000),
+} = {}) {
   const force = process.env.CI_FORCE === "1";
   if (process.env.SKIP_NET_CHECKS === "1" || process.env.CI_NO_NET === "1") {
     setOfflineEnv();
@@ -12,14 +15,11 @@ export function isOfflineEnv() {
     return !force;
   }
   try {
-    // Fetch headers and inspect the HTTP status code so 4xx responses still
-    // trigger offline mode. Some environments return 403 yet exit with status 0
-    // which would previously be treated as online.
-    const res = execSync(
-      "curl -sI --max-time 10 https://registry.npmjs.org/-/ping",
-      { encoding: "utf8" },
+    const maxTime = Math.ceil(timeout / 1000);
+    withRetries(
+      `curl -sfI --max-time ${maxTime} https://registry.npmjs.org/-/ping`,
+      { retries, timeout },
     );
-    if (!/^HTTP\/\d\.\d 2\d\d/.test(res)) throw new Error("bad status");
   } catch {
     setOfflineEnv();
     return !force;


### PR DESCRIPTION
## Summary
- retry npm registry ping before setting offline mode
- allow configuring retry count and timeout for network check
- add test ensuring temporary ping failures are retried

## Testing
- `npm run format` *(pass)*
- `npm run format` (backend) *(pass)*
- `node scripts/run-jest.js` *(offline mode: skipping jest)*
- `npm test` (backend) *(pass)*
- `SKIP_PW_DEPS=1 npm run ci` *(offline mode: skipping jest)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: skipping jest)*

------
https://chatgpt.com/codex/tasks/task_e_68babb8921cc832db5ed633ebc463e36