### PR TITLE
fix: resolve test paths from repo root

### DIFF
--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -18,19 +18,30 @@ function resolveFromPaths(mod) {
 
 function verifyFiles(args) {
   let checking = false;
+  const normalized = [];
   for (const arg of args) {
     if (arg === "--runTestsByPath") {
       checking = true;
+      normalized.push(arg);
       continue;
     }
     if (checking || /\.(test|spec)\.(js|ts|tsx)$/.test(arg)) {
-      const file = path.resolve(process.cwd(), arg);
-      if (!fs.existsSync(file)) {
+      const candidates = [
+        path.resolve(process.cwd(), arg),
+        path.resolve(repoRoot, arg),
+        path.resolve(backendRoot, arg),
+      ];
+      const file = candidates.find((p) => fs.existsSync(p));
+      if (!file) {
         console.error(`Test file not found: ${arg}`);
         process.exit(1);
       }
+      normalized.push(file);
+    } else {
+      normalized.push(arg);
     }
   }
+  return normalized;
 }
 
 async function run(args) {
@@ -55,10 +66,9 @@ async function run(args) {
     require("./ensure-root-deps.js");
   }
 
-
   const skipNetChecks = process.env.SKIP_NET_CHECKS === "1";
 
-  verifyFiles(args);
+  args = verifyFiles(args);
   console.log("run-jest cwd:", process.cwd());
   const corePath = resolveFromPaths("@jest/core");
   if (!corePath) {


### PR DESCRIPTION
## Summary
- avoid false "Test file not found" errors by resolving Jest paths against repo and backend roots

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npx prettier -w scripts/run-jest.js`
- `npm run format --prefix backend`
- `CI_FORCE=1 SKIP_NET_CHECKS=1 node ../scripts/run-jest.js --coverage=false --runTestsByPath backend/tests/stripe/webhook.valid-signature.spec.ts backend/tests/stripe/webhook.invalid-signature.spec.ts backend/tests/stripe/webhook.idempotency.spec.ts backend/tests/stripe/webhook.event-types.spec.ts backend/tests/stripe/webhook.performance.spec.ts backend/tests/stripe/webhook.logging.spec.ts backend/tests/stripe/checkout.session.success.spec.ts backend/tests/stripe/checkout.session.errors.spec.ts` *(dependencies missing)*
- `SKIP_PW_DEPS=1 npm run ci` *(offline mode, build aborted)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: jest skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68babf64a360832d9e400ecdfd961940