### PR TITLE
build: add babel preset for jest transformer

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "@types/node": "^24.0.10",
     "@typescript-eslint/eslint-plugin": "8.34.1",
     "@typescript-eslint/parser": "^8.36.0",
+    "babel-preset-current-node-syntax": "^1.0.1",
     "concurrently": "9.2.0",
     "coveralls": "^3.1.1",
     "cross-env": "^7.0.3",


### PR DESCRIPTION
## Summary
- add `babel-preset-current-node-syntax` to dev dependencies

## Testing
- `npm run setup` *(fails: 403 Forbidden - GET https://registry.npmjs.org/babel-preset-current-node-syntax)*
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `CI_FORCE=1 node scripts/run-jest.js` *(fails: Jest is not installed. Run `npm run setup` to install dependencies.)*

------
https://chatgpt.com/codex/tasks/task_e_68babf95f81c832d88ea20792f05bde9