### PR TITLE
test: update ensure-deps offline regex

### DIFF
--- a/scripts/__tests__/ensure-deps-offline.test.ts
+++ b/scripts/__tests__/ensure-deps-offline.test.ts
@@ -2,6 +2,6 @@ const { execSync } = require('child_process');
 
 test('ensure-deps skips Playwright setup when offline', () => {
   const out = execSync('SKIP_NET_CHECKS=1 node backend/scripts/ensure-deps.js', { encoding: 'utf8' });
-  expect(out).toMatch(/SKIP_NET_CHECKS detected; forcing SKIP_PW_DEPS/);
+  expect(out).toMatch(/Skipping network check due to SKIP_NET_CHECKS/);
 });
 


### PR DESCRIPTION
## Summary
- adjust ensure-deps offline test to match updated skip-network message

## Testing
- `npm run validate-env`
- `npm run format`
- `CI_FORCE=1 SKIP_ROOT_DEPS_CHECK=1 SKIP_NET_CHECKS=1 PATH="$(pwd)/fakebin:$PATH" node scripts/run-jest.js scripts/__tests__/ensure-deps-offline.test.ts`
- `SKIP_PW_DEPS=1 npm run ci` *(fails to run jest in offline mode)*
- `SKIP_PW_DEPS=1 npm run smoke` *(jest skipped in offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_68babfa0a7a4832d85274486cf1add88