### PR TITLE
test: add extension to getEnv import

### DIFF
--- a/backend/tests/utils/getEnv.test.ts
+++ b/backend/tests/utils/getEnv.test.ts
@@ -1,4 +1,4 @@
-const { getEnv } = require("../../utils/getEnv");
+const { getEnv } = require("../../utils/getEnv.js");
 
 describe("getEnv", () => {
   const KEY = "TEST_ENV_VAR";


### PR DESCRIPTION
## Summary
- fix getEnv test to require the `.js` file explicitly

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68babf9b7ec8832d85dfa8f051f60259