### PR TITLE
fix: remove unsynced babel preset dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
     "@types/node": "^24.0.10",
     "@typescript-eslint/eslint-plugin": "8.34.1",
     "@typescript-eslint/parser": "^8.36.0",
-    "babel-preset-current-node-syntax": "^1.0.1",
     "concurrently": "9.2.0",
     "coveralls": "^3.1.1",
     "cross-env": "^7.0.3",

--- a/tests/config/deps-lock-sync.test.q9n7x2p6r5m3t1v8.ts
+++ b/tests/config/deps-lock-sync.test.q9n7x2p6r5m3t1v8.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('dependencies present in lockfile', () => {
+  const root = join(__dirname, '..', '..');
+  const pkg = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'));
+  const lock = JSON.parse(readFileSync(join(root, 'package-lock.json'), 'utf8'));
+  const lockDeps = lock.dependencies || {};
+  const allDeps = { ...(pkg.dependencies || {}), ...(pkg.devDependencies || {}) };
+
+  for (const dep of Object.keys(allDeps)) {
+    it(`has ${dep} in package-lock.json`, () => {
+      expect(lockDeps[dep]).toBeDefined();
+    });
+  }
+});

--- a/tests/config/lockfile-no-extraneous.test.r4f7m1k2p9d8s6h3.ts
+++ b/tests/config/lockfile-no-extraneous.test.r4f7m1k2p9d8s6h3.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('lockfile has no extraneous deps', () => {
+  const root = join(__dirname, '..', '..');
+  const pkg = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'));
+  const lock = JSON.parse(readFileSync(join(root, 'package-lock.json'), 'utf8'));
+  const lockDeps = lock.dependencies || {};
+  const allDeps = { ...(pkg.dependencies || {}), ...(pkg.devDependencies || {}) };
+
+  for (const dep of Object.keys(lockDeps)) {
+    it(`lockfile dependency ${dep} listed in package.json`, () => {
+      expect(allDeps[dep]).toBeDefined();
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- remove `babel-preset-current-node-syntax` to align `package.json` with existing lockfile
- add tests ensuring `package.json` and `package-lock.json` list the same dependencies

## Testing
- `npm run format --prefix backend`
- `npm test`
- `SKIP_PW_DEPS=1 npm run setup` *(fails: connect ETIMEDOUT / forbidden)*
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68bacfbbb174832d97ad3569eea9187f