### PR TITLE
fix: ensure getEnv export compatibility

### DIFF
--- a/backend/config.js
+++ b/backend/config.js
@@ -6,16 +6,13 @@
  *
  * @module backend/config
  */
-// Ensure compatibility with various CommonJS/ESM export patterns
 const envModule = require("./src/lib/getEnv");
 const getEnv =
-  // Named export
-  envModule.getEnv ||
-  // ESM default export which may itself wrap named exports
-  (envModule.default && envModule.default.getEnv) ||
-  envModule.default ||
-  // Fallback to module itself if it's the function
-  envModule;
+  typeof envModule === "function"
+    ? envModule
+    : typeof envModule.getEnv === "function"
+      ? envModule.getEnv
+      : envModule.default;
 const { applyMockEnv, mockSecrets } = require("./src/lib/mockEnv");
 const logger = require("./src/logger.js");
 

--- a/backend/src/lib/getEnv.js
+++ b/backend/src/lib/getEnv.js
@@ -11,6 +11,7 @@ function getEnv(name, options = {}) {
   return value;
 }
 
-// Support both CommonJS and named imports
+// Support both CommonJS and ES module import styles
 module.exports = getEnv;
 module.exports.getEnv = getEnv;
+module.exports.default = getEnv;


### PR DESCRIPTION
## Summary
- refine getEnv resolution in backend/config.js using type checks
- export getEnv as both default and named for consistent usage

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`
- `node backend/node_modules/jest/bin/jest.js backend/tests/config.test.js --config backend/jest.config.js --runInBand --coverage=false`


------
https://chatgpt.com/codex/tasks/task_e_68baec0b8ec4832da72a8273fe9b6fc2