### PR TITLE
test: add setup env for stripe

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -4,7 +4,10 @@ try {
   require.resolve("ts-jest");
   config = {
     rootDir: ".",
-    setupFiles: ["<rootDir>/tests/setupGlobals.js"],
+    setupFiles: [
+      "<rootDir>/tests/setupEnv.js",
+      "<rootDir>/tests/setupGlobals.js",
+    ],
     setupFilesAfterEnv: [
       "<rootDir>/tests/utils/testEnv.ts",
       "<rootDir>/tests/setup.js",

--- a/backend/tests/setupEnv.js
+++ b/backend/tests/setupEnv.js
@@ -1,0 +1,9 @@
+process.env.NODE_ENV = process.env.NODE_ENV || "test";
+process.env.DB_URL = process.env.DB_URL || "postgres://user:pass@localhost/db";
+process.env.STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY || "sk_test_mock";
+process.env.STRIPE_PUBLISHABLE_KEY =
+  process.env.STRIPE_PUBLISHABLE_KEY || "test_key";
+process.env.FRONTEND_SUCCESS_URL =
+  process.env.FRONTEND_SUCCESS_URL || "https://print2.io/index.html";
+process.env.FRONTEND_CANCEL_URL =
+  process.env.FRONTEND_CANCEL_URL || "https://print2.io/payment.html";


### PR DESCRIPTION
## Summary
- add backend/tests/setupEnv.js to define STRIPE_PUBLISHABLE_KEY and other defaults
- load new setupEnv.js via setupFiles in backend/jest.config.js

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68baec068aec832daca99dab096c0a34