### PR TITLE
test: document server import path

### DIFF
--- a/backend/tests/utils/shouldSkipSuite.js
+++ b/backend/tests/utils/shouldSkipSuite.js
@@ -1,3 +1,4 @@
+// Load the backend server so we can inspect its route stack
 const app = require("../../server");
 
 function shouldSkipSuite(path) {


### PR DESCRIPTION
## Summary
- clarify shouldSkipSuite utility server import so route lookup uses backend server

## Testing
- `npx prettier --log-level warn backend/tests/utils/shouldSkipSuite.js --write`
- `cd backend && npm test`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68baec01e74c832d968bda758c44904d