### PR TITLE
ci: include static assets in pages deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,9 +23,13 @@ jobs:
           node-version: "20"
       - run: npm ci
       - run: npm run build
+      - name: Copy static site files
+        run: |
+          cp -a *.html frontend/dist/
+          if [ -d img ]; then cp -a img frontend/dist/; fi
       - uses: actions/upload-pages-artifact@v3
         with:
-          path: frontend/dist
+          path: ./frontend/dist
   deploy:
     needs: build
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- copy repository-level HTML files and `img` directory into the built `frontend/dist` before uploading
- ensure Pages artifact points at `./frontend/dist`

## Testing
- `npm run format` (backend)
```
> backend@1.0.0 format
> prettier --log-level warn --write "**/*.{ts,tsx,js,jsx,json,md}"
```
- `npm test` (backend)
```
Test Suites: 3 passed, 3 total
Tests:       68 skipped, 7 passed, 75 total
```
- `SKIP_PW_DEPS=1 npm run ci`
```
vite v7.1.4 building for production...
✓ built in 70ms
offline mode: skipping jest
```
- `SKIP_PW_DEPS=1 npm run smoke`
```
offline mode: running smoke tests
offline mode: skipping jest
```


------
https://chatgpt.com/codex/tasks/task_e_68baf6745154832da3d1640789bb67dd