### PR TITLE
feat: fetch repo assets before starting dev server

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "build": "npm ci --no-audit --no-fund --prefix frontend && npm --prefix frontend run build",
     "start:ci": "npm --prefix frontend run start:ci",
     "preview": "vite preview --port 4173",
+    "prestart": "node scripts/fetch-assets.mjs",
     "start": "node scripts/dev-server.js",
     "start:backend": "npm start --prefix backend",
     "ci": "node scripts/ci.mjs",

--- a/scripts/dev-server.js
+++ b/scripts/dev-server.js
@@ -3,6 +3,22 @@ const path = require("path");
 const http = require("http");
 const https = require("https");
 const selfsigned = require("selfsigned");
+const { existsSync } = require("fs");
+
+async function ensureRepoAssets() {
+  const asset = path.join(
+    __dirname,
+    "..",
+    "frontend",
+    "public",
+    "img",
+    "astro-image.png",
+  );
+  if (!existsSync(asset)) {
+    const { fetchRepoAssets } = await import("./fetch-assets.mjs");
+    await fetchRepoAssets();
+  }
+}
 
 const app = express();
 const root = path.join(__dirname, "..");
@@ -20,7 +36,9 @@ app.use(express.json());
 
 // Basic stub for API requests so smoke tests don't fail when the backend isn't running.
 app.post("/api/generate", (_req, res) => {
-  res.json({ glb_url: "https://modelviewer.dev/shared-assets/models/Astronaut.glb" });
+  res.json({
+    glb_url: "https://modelviewer.dev/shared-assets/models/Astronaut.glb",
+  });
 });
 
 app.get("/healthz", (_req, res) => {
@@ -57,7 +75,11 @@ function startDevServer(port = 3000, useHttps = process.env.USE_HTTPS === "1") {
 
 if (require.main === module) {
   const port = process.env.PORT || 3000;
-  startDevServer(port);
+  ensureRepoAssets()
+    .catch((err) => {
+      console.error("Failed to fetch repo assets", err);
+    })
+    .finally(() => startDevServer(port));
 }
 module.exports = app;
 module.exports.startDevServer = startDevServer;


### PR DESCRIPTION
## Summary
- add `prestart` script to fetch assets before starting
- ensure dev server downloads repo assets when missing

## Testing
- `npm run format`
```
> mvp-website@1.0.0 format
> prettier -w .
...
tests/load-model-pipeline/mocks/three.js 4ms
```
- `npm test`
```
> mvp-website@1.0.0 test
> node scripts/run-jest.js --passWithNoTests

offline mode: skipping jest
```
- `npm run ci`
```
> npm ci --no-audit --no-fund --prefix frontend && npm --prefix frontend run build
...
offline mode: skipping jest
```
- `npm run smoke`
```
> mvp-website@1.0.0 smoke
> node scripts/smoke.mjs

offline mode: skipping smoke
```

------
https://chatgpt.com/codex/tasks/task_e_68baf66c947c832da4d7a2ed84ba739e