### PR TITLE
fix: expose fetched assets at root

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,6 +23,7 @@ jobs:
           node-version: "20"
       - run: npm ci
       - run: npm run build
+      - run: cp -r img frontend/dist
       - uses: actions/upload-pages-artifact@v3
         with:
           path: frontend/dist

--- a/scripts/dev-server.js
+++ b/scripts/dev-server.js
@@ -6,6 +6,9 @@ const selfsigned = require("selfsigned");
 
 const app = express();
 const root = path.join(__dirname, "..");
+const publicDir = path.join(root, "frontend", "public");
+
+app.use(express.static(publicDir));
 
 app.use(
   express.static(root, {
@@ -20,7 +23,9 @@ app.use(express.json());
 
 // Basic stub for API requests so smoke tests don't fail when the backend isn't running.
 app.post("/api/generate", (_req, res) => {
-  res.json({ glb_url: "https://modelviewer.dev/shared-assets/models/Astronaut.glb" });
+  res.json({
+    glb_url: "https://modelviewer.dev/shared-assets/models/Astronaut.glb",
+  });
 });
 
 app.get("/healthz", (_req, res) => {

--- a/scripts/fetch-assets.mjs
+++ b/scripts/fetch-assets.mjs
@@ -1,4 +1,4 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, writeFile, symlink } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -21,6 +21,22 @@ export async function download(url, dest) {
     console.warn(`Failed to download ${url}: ${err}. Creating placeholder.`);
     await ensureDir(dest);
     await writeFile(dest, "");
+  }
+}
+
+async function linkToRootImg(file) {
+  const src = join("frontend", "public", "img", file);
+  const dest = join("img", file);
+  if (existsSync(dest)) {
+    return;
+  }
+  await ensureDir(dest);
+  try {
+    await symlink(src, dest);
+  } catch (err) {
+    if (err.code !== "EEXIST") {
+      throw err;
+    }
   }
 }
 
@@ -56,10 +72,11 @@ export async function fetchRepoAssets() {
     const dest = join("frontend", "public", "img", file);
     if (existsSync(dest)) {
       console.log(`${file} already present`);
-      continue;
+    } else {
+      const url = `${base}/${encodeURIComponent(file)}`;
+      await download(url, dest);
     }
-    const url = `${base}/${encodeURIComponent(file)}`;
-    await download(url, dest);
+    await linkToRootImg(file);
   }
 }
 


### PR DESCRIPTION
## Summary
- symlink downloaded repo assets into a top-level `img/` directory
- serve `frontend/public` from the dev server root for consistent asset paths
- ensure deployment workflow copies the `img` directory into the published artifact

## Testing
- `npm run validate-env`
- `npm run setup` *(fails: fetch to npm registry returns 403)*
- `npm run format` (backend)
- `npm test` (backend)
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68baf66830f0832db555e13a166b7107