### PR TITLE
fix: run image pipeline asset tests

### DIFF
--- a/scripts/test-image-pipeline.js
+++ b/scripts/test-image-pipeline.js
@@ -36,4 +36,4 @@ if (networkOk) {
 }
 
 // Force tests to run even when offline
-run("CI_FORCE=1 node scripts/run-jest.js tests/assets");
+run("CI_FORCE=1 node scripts/run-jest.js --testPathPattern tests/assets");


### PR DESCRIPTION
## Summary
- run image pipeline tests using `--testPathPattern tests/assets`

## Testing
- `npm run format` (backend)
- `npm test` (backend)
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`
- `node scripts/test-image-pipeline.js` *(fails: Missing ts-jest; run `npm run setup` before testing.)*


------
https://chatgpt.com/codex/tasks/task_e_68bafa2fbcb0832db8256418ce08bcfc