### PR TITLE
test: add stripe env setup for jest

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -4,7 +4,10 @@ try {
   require.resolve("ts-jest");
   config = {
     rootDir: ".",
-    setupFiles: ["<rootDir>/tests/setupGlobals.js"],
+    setupFiles: [
+      "<rootDir>/tests/setupEnv.js",
+      "<rootDir>/tests/setupGlobals.js",
+    ],
     setupFilesAfterEnv: [
       "<rootDir>/tests/utils/testEnv.ts",
       "<rootDir>/tests/setup.js",

--- a/backend/tests/setupEnv.js
+++ b/backend/tests/setupEnv.js
@@ -1,0 +1,10 @@
+// backend/tests/setupEnv.js
+// Jest setup file for environment variables
+process.env.STRIPE_PUBLISHABLE_KEY = "test_key";
+process.env.STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY || "sk_test_mock";
+process.env.STRIPE_WEBHOOK_SECRET =
+  process.env.STRIPE_WEBHOOK_SECRET || "whsec_mock";
+process.env.FRONTEND_SUCCESS_URL =
+  process.env.FRONTEND_SUCCESS_URL || "https://example.com/success";
+process.env.FRONTEND_CANCEL_URL =
+  process.env.FRONTEND_CANCEL_URL || "https://example.com/cancel";


### PR DESCRIPTION
## Summary
- add Jest setup file to define Stripe and frontend env vars
- load setup file via `setupFiles` to avoid missing env during tests

## Testing
- `npm run validate-env`
```
✅ environment OK
```
- `npm run format`
```
> backend@1.0.0 format
> prettier --log-level warn --write "**/*.{ts,tsx,js,jsx,json,md}"
```
- `npm test`
```
Test Suites: 3 passed, 3 total
Tests:       68 skipped, 7 passed, 75 total
```
- `SKIP_PW_DEPS=1 npm run ci`
```
> npm ci --no-audit --no-fund --prefix frontend && npm --prefix frontend run build
...
offline mode: skipping jest
```


------
https://chatgpt.com/codex/tasks/task_e_68bafc182bc0832d83ab381a726a2cb1