### PR TITLE
build: add current node syntax preset

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,6 +1,11 @@
 let config;
 try {
   require.resolve("ts-jest");
+  const babelConfig = require("./babel.config.js");
+  const babelJestConfig = {
+    ...babelConfig,
+    presets: [...(babelConfig.presets || []), "babel-preset-current-node-syntax"],
+  };
   config = {
     testEnvironment: "node",
     roots: ["<rootDir>"],
@@ -9,7 +14,7 @@ try {
         "ts-jest",
         { tsconfig: "tsconfig.json", diagnostics: false },
       ],
-      "^.+\\.jsx?$": ["babel-jest", { configFile: "./babel.config.js" }],
+      "^.+\\.jsx?$": ["babel-jest", babelJestConfig],
     },
     moduleFileExtensions: ["ts", "tsx", "js", "json"],
     passWithNoTests: true,

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "@types/node": "^24.0.10",
     "@typescript-eslint/eslint-plugin": "8.34.1",
     "@typescript-eslint/parser": "^8.36.0",
+    "babel-preset-current-node-syntax": "^1.0.1",
     "concurrently": "9.2.0",
     "coveralls": "^3.1.1",
     "cross-env": "^7.0.3",


### PR DESCRIPTION
## Summary
- add `babel-preset-current-node-syntax` dev dependency
- configure `babel-jest` to load the preset alongside existing Babel config

## Testing
- `npm run format --prefix backend`
- `npm test` *(fails: offline mode: skipping jest)*
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_68bafc134f78832db0cef33c444ff741