### PR TITLE
ci: ensure binary guard fetches base commit

### DIFF
--- a/.github/workflows/binary-guard.yml
+++ b/.github/workflows/binary-guard.yml
@@ -13,8 +13,9 @@ jobs:
         id: diff
         run: |
           set -euo pipefail
-          git fetch origin ${{ github.base_ref || 'dev' }} --depth=2 || true
           BASE="${{ github.event.pull_request.base.sha || github.event.before }}"
+          git fetch origin "${{ github.base_ref || 'dev' }}" || true
+          git fetch origin "$BASE" || true
           git diff --name-only --diff-filter=AM "$BASE" "${{ github.sha }}" > changed.txt
           cat changed.txt
 


### PR DESCRIPTION
## Summary
- fetch base commit hash and base branch before diffing in binary guard workflow

## Testing
- `npm run format`
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68baff5691d8832d99b7e1cc455bfafe