### PR TITLE
ci: verify package lockfile consistency

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -2,3 +2,4 @@
 set -e
 
 npm run prepush
+npx lockfile-diff package.json package-lock.json

--- a/ci/generated/full-ci.jobs.json
+++ b/ci/generated/full-ci.jobs.json
@@ -1021,7 +1021,7 @@
   },
   {
     "name": "lockfile-diff",
-    "command": "corepack enable",
+    "command": "corepack enable && npx lockfile-diff package.json package-lock.json",
     "paths": [],
     "needs": []
   },

--- a/ci/generated/full-ci.yml
+++ b/ci/generated/full-ci.yml
@@ -352,7 +352,9 @@ jobs:
           - name: verify
             command: |
           - name: lockfile-diff
-            command: corepack enable
+            command: |
+              corepack enable
+              npx lockfile-diff package.json package-lock.json
           - name: yamllint
             command: pip install yamllint
     steps:


### PR DESCRIPTION
## Summary
- fail CI when `package.json` and `package-lock.json` diverge using `npx lockfile-diff`
- run the same lockfile consistency check on `pre-push`

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`
- `npx lockfile-diff package.json package-lock.json` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*

------
https://chatgpt.com/codex/tasks/task_e_68bb017f9bf4832d9ec430ff26579521