### PR TITLE
fix: support hashed test names

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -4,7 +4,10 @@ try {
   const babelConfig = require("./babel.config.js");
   const babelJestConfig = {
     ...babelConfig,
-    presets: [...(babelConfig.presets || []), "babel-preset-current-node-syntax"],
+    presets: [
+      ...(babelConfig.presets || []),
+      "babel-preset-current-node-syntax",
+    ],
   };
   config = {
     testEnvironment: "node",
@@ -17,6 +20,20 @@ try {
       "^.+\\.jsx?$": ["babel-jest", babelJestConfig],
     },
     moduleFileExtensions: ["ts", "tsx", "js", "json"],
+    testMatch: [
+      "**/*.spec.ts",
+      "**/*.spec.tsx",
+      "**/*.spec.js",
+      "**/*.spec.jsx",
+      "**/*.test.ts",
+      "**/*.test.tsx",
+      "**/*.test.js",
+      "**/*.test.jsx",
+      "**/*.test.*.ts",
+      "**/*.test.*.tsx",
+      "**/*.test.*.js",
+      "**/*.test.*.jsx",
+    ],
     passWithNoTests: true,
   };
 } catch {


### PR DESCRIPTION
## Summary
- allow Jest to discover hashed `*.test.*` files in root configuration

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm test`
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: fetch failed / offline mode)*
- `SKIP_PW_DEPS=1 npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_68bb0b7136f0832dabd1336cbfa45487