### PR TITLE
ci: verify expected test files early

### DIFF
--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -27,6 +27,9 @@ jobs:
           node-version: "20.x"
           cache: "npm"
 
+      - name: Verify expected test files
+        run: node ci/check-test-files.js
+
       # ✅ NEW: fetch S3 assets before install/build
       - name: Fetch repo assets from S3
         uses: ./.github/actions/fetch-repo-assets
@@ -71,4 +74,3 @@ jobs:
 
       - name: Test
         run: npm test
-

--- a/ci/check-test-files.js
+++ b/ci/check-test-files.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+const fs = require("fs");
+const path = require("path");
+
+const repoRoot = path.join(__dirname, "..");
+const configPath = path.join(__dirname, "expected-test-files.json");
+
+let expected;
+try {
+  expected = JSON.parse(fs.readFileSync(configPath, "utf8"));
+} catch (err) {
+  console.error(`Failed to read ${configPath}:`, err);
+  process.exit(1);
+}
+
+const missing = expected.files.filter(
+  (p) => !fs.existsSync(path.join(repoRoot, p)),
+);
+
+if (missing.length) {
+  console.error(`Missing expected test files:\n${missing.join("\n")}`);
+  process.exit(1);
+}
+
+console.log("All expected test files exist.");

--- a/ci/expected-test-files.json
+++ b/ci/expected-test-files.json
@@ -1,0 +1,7 @@
+{
+  "files": [
+    "tests/e2e/model-smoke.spec.ts",
+    "tests/e2e/model-visual.spec.ts",
+    "backend/tests/stripe/webhook.valid-signature.spec.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- add check-test-files script to fail if expected tests are missing
- list key test files required by CI
- run test file guard early in root CI workflow

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup` *(hangs, aborted)*
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: fetch failed, killed)*
- `SKIP_PW_DEPS=1 npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_68bb0b38ce6c832dbc7fee37703fe5fe