### PR TITLE
test: fail when specified test files missing

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "src/server.js",
   "scripts": {
-    "test": "NODE_ENV=test node scripts/ensure-tests-exist.js && PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 jest --runInBand tests/additionalApi.test.js tests/getEnv.test.p7q8r9s0t1u2v3w4.js tests/users.test.z9x8c7v6b5n4m3l2.js",
+    "test": "NODE_ENV=test node scripts/ensure-tests-exist.js && PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 jest --runInBand --passWithNoTests=false tests/additionalApi.test.js tests/getEnv.test.p7q8r9s0t1u2v3w4.js tests/users.test.z9x8c7v6b5n4m3l2.js",
     "test-ci": "node scripts/ensure-tests-exist.js && jest --ci --passWithNoTests=false",
     "test:unit": "npm test",
     "test:backend": "jest --runInBand",
@@ -43,7 +43,7 @@
     "send-ops-report": "node scripts/send-ops-report.js",
     "flag-overdue-printers": "node scripts/flag-overdue-procurement-orders.js",
     "format:check": "prettier --log-level warn --check \"**/*.{ts,tsx,js,jsx,json,md}\"",
-    "test:db": "jest --runInBand --env=node tests/db/**/*.spec.{ts,js}"
+    "test:db": "jest --runInBand --env=node --passWithNoTests=false tests/db/**/*.spec.{ts,js}"
   },
   "keywords": [],
   "author": "",

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -17,7 +17,7 @@ try {
       "^.+\\.jsx?$": ["babel-jest", babelJestConfig],
     },
     moduleFileExtensions: ["ts", "tsx", "js", "json"],
-    passWithNoTests: true,
+    passWithNoTests: false,
   };
 } catch {
   config = require("./jest.config.offline.cjs");

--- a/jest.config.offline.cjs
+++ b/jest.config.offline.cjs
@@ -2,6 +2,6 @@ module.exports = {
   testEnvironment: "node",
   roots: ["<rootDir>"],
   moduleFileExtensions: ["js", "json"],
-  passWithNoTests: true,
+  passWithNoTests: false,
   transform: {},
 };

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "doc": "docs"
   },
   "scripts": {
-    "test": "node scripts/run-jest.js --passWithNoTests",
+    "test": "node scripts/run-jest.js",
     "test:image-pipeline": "node scripts/test-image-pipeline.js",
     "preinstall": "corepack enable && node scripts/check-node-version.js",
     "preformat": "true",


### PR DESCRIPTION
## Summary
- ensure Jest fails when no tests are found by default
- make targeted backend test scripts pass only when files exist

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` (in backend)
- `npm test` (in backend)
- `npm test` (root) *(fails: offline mode: skipping jest)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: fetch errors, placeholder assets)*
- `SKIP_PW_DEPS=1 npm run smoke` *(skipped: offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0b5594ec832daefc6d6a6f0429f1