### PR TITLE
test: use percent-encoded logo paths

### DIFF
--- a/tests/assets/image-pipeline.no-safeguards.test.a4b5c6d7e8f9g0h1.js
+++ b/tests/assets/image-pipeline.no-safeguards.test.a4b5c6d7e8f9g0h1.js
@@ -92,10 +92,10 @@ describe("html references", () => {
   test("index.html references text and box logos", () => {
     const dom = new JSDOM(fs.readFileSync("index.html", "utf8"));
     const textLogo = dom.window.document.querySelector(
-      'img[src="img/text logo.png"]',
+      'img[src="img/text%20logo.png"]',
     );
     const boxLogo = dom.window.document.querySelector(
-      'img[src="img/box logo.png"]',
+      'img[src="img/box%20logo.png"]',
     );
     expect(textLogo).not.toBeNull();
     expect(boxLogo).not.toBeNull();


### PR DESCRIPTION
## Summary
- fix HTML asset checks in image pipeline tests to use percent-encoded logo paths

## Testing
- `npm run validate-env`
- `npm run setup` *(fails: connect tunnel 403 to registry.npmjs.org)*
- `npm run format`
- `CI_FORCE=1 node scripts/run-jest.js tests/assets/image-pipeline.no-safeguards.test.a4b5c6d7e8f9g0h1.js` *(fails: Jest is not installed)*
- `npm run test:image-pipeline` *(fails: Jest is not installed)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: fetch failed for repo assets)*
- `SKIP_PW_DEPS=1 npm run smoke` *(skipped: offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_68bb16919914832d8a078a91acd1623d