### PR TITLE
fix: serve frontend images in dev server

### DIFF
--- a/scripts/dev-server.js
+++ b/scripts/dev-server.js
@@ -32,6 +32,15 @@ app.use(
   }),
 );
 
+app.use(
+  "/img",
+  express.static(path.join(root, "frontend", "public", "img"), {
+    setHeaders(res) {
+      res.setHeader("Cache-Control", "no-store");
+    },
+  }),
+);
+
 app.use(express.json());
 
 // Basic stub for API requests so smoke tests don't fail when the backend isn't running.


### PR DESCRIPTION
## Summary
- serve `frontend/public/img` via `/img` in the development server

## Testing
- `npm run validate-env` *(fails: command not found)*
- `npm run setup` *(fails: command not found)*
- `cd backend && npm run format` *(fails: command not found)*
- `cd backend && npm test` *(fails: command not found)*
- `npm run ci` *(fails: command not found)*
- `npm run smoke` *(fails: command not found)*
- `node scripts/dev-server.js` *(fails: command not found)*
- `node scripts/test-image-pipeline.js` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bb1688bb18832db5215481d58b26f4