### PR TITLE
test: handle mjs in jest

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -18,8 +18,13 @@ try {
         { tsconfig: "tsconfig.json", diagnostics: false },
       ],
       "^.+\\.jsx?$": ["babel-jest", babelJestConfig],
+      "^.+\\.mjs$": [
+        "babel-jest",
+        { plugins: ["@babel/plugin-transform-modules-commonjs"] },
+      ],
     },
-    moduleFileExtensions: ["ts", "tsx", "js", "json"],
+    moduleFileExtensions: ["ts", "tsx", "js", "json", "mjs"],
+    extensionsToTreatAsEsm: [".mjs"],
     testMatch: [
       "**/*.spec.ts",
       "**/*.spec.tsx",


### PR DESCRIPTION
## Summary
- allow `.mjs` modules in Jest tests
- run `.mjs` through `babel-jest` with `@babel/plugin-transform-modules-commonjs`

## Testing
- `npm run format`
- `npm test`
- `npm run test:image-pipeline` *(fails: Jest is not installed)*
- `npm run ci` *(fails: npm ci in frontend not executed due to offline mode)*
- `npm run smoke` *(skipped: offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_68bb16819aa0832db8fc6e7f99185193