### PR TITLE
ci: run all e2e tests

### DIFF
--- a/.github/workflows/playwright-deps-and-e2e.yml
+++ b/.github/workflows/playwright-deps-and-e2e.yml
@@ -49,15 +49,10 @@ jobs:
             cat /tmp/app.log
             exit 1
           fi
-      - name: Run model-loading tests
+      - name: Run Playwright tests
         env:
           CI: "true"
-        run: |
-          if [ -f tests/e2e/model-loading.spec.ts ]; then
-            npx playwright test --trace on --pass-with-no-tests tests/e2e/model-loading.spec.ts
-          else
-            echo "No model-loading E2E spec present; skipping."
-          fi
+        run: npx playwright test --trace on --pass-with-no-tests tests/e2e
       - name: Upload Playwright traces
         if: failure()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- run Playwright on all e2e specs instead of a single hard-coded file

## Testing
- `npx prettier -w .github/workflows/playwright-deps-and-e2e.yml`
- `npm --prefix backend run format`
- `npm test`
- `npm run ci`
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68bb16dfda40832d8bcd4fee07b413ae