### PR TITLE
fix: use axios for asset downloads

### DIFF
--- a/scripts/fetch-assets.cjs
+++ b/scripts/fetch-assets.cjs
@@ -8,11 +8,9 @@ async function ensureDir(filePath) {
 
 async function download(url, dest) {
   try {
-    const res = await fetch(url);
-    if (!res.ok) {
-      throw new Error(`HTTP ${res.status} ${res.statusText}`);
-    }
-    const buf = Buffer.from(await res.arrayBuffer());
+    const axios = require("axios");
+    const res = await axios.get(url, { responseType: "arraybuffer" });
+    const buf = Buffer.from(res.data);
     await ensureDir(dest);
     await writeFile(dest, buf);
     console.log(`Downloaded ${url}`);


### PR DESCRIPTION
## Summary
- use axios for asset downloads to allow nock interception

## Testing
- `CI_FORCE=1 node scripts/run-jest.js tests/assets/image-pipeline.no-safeguards.test.a4b5c6d7e8f9g0h1.js` *(fails: Jest is not installed. Run `npm run setup` to install dependencies.)*
- `npx prettier scripts/fetch-assets.cjs -w`


------
https://chatgpt.com/codex/tasks/task_e_68bb20c45838832d959363dc059002ca