### PR TITLE
test: cover stats ticker fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
 name: CI
 
 on:
-  push: { branches: [main] }
+  push:
+    branches: [dev, "00000production"]
   pull_request:
+    branches: [dev, "00000production"]
 
 jobs:
   deps:
@@ -11,8 +13,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
       - name: Restore node_modules cache
         id: node-modules-cache
         uses: actions/cache/restore@v4
@@ -56,8 +58,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
       - name: Restore node_modules cache
         uses: actions/cache/restore@v4
         with:

--- a/ci/expected-suites.yml
+++ b/ci/expected-suites.yml
@@ -4,6 +4,8 @@ backend-integration:
   workflow: backend-tests.yml
 frontend-jest:
   workflow: ci.yml
+stats-ticker:
+  workflow: ci.yml
 playwright:
   workflow: ci.yml
 audit:

--- a/ci/expected-test-files.json
+++ b/ci/expected-test-files.json
@@ -2,6 +2,7 @@
   "files": [
     "tests/e2e/model-smoke.spec.ts",
     "tests/e2e/model-visual.spec.ts",
-    "backend/tests/stripe/webhook.valid-signature.spec.ts"
+    "backend/tests/stripe/webhook.valid-signature.spec.ts",
+    "tests/stats/stats-ticker.pipeline.n4h2k7p9q3t6v1s5.test.js"
   ]
 }

--- a/tests/stats/stats-ticker.pipeline.n4h2k7p9q3t6v1s5.test.js
+++ b/tests/stats/stats-ticker.pipeline.n4h2k7p9q3t6v1s5.test.js
@@ -1,0 +1,87 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import nock from "nock";
+
+let mod;
+
+async function loadModule() {
+  jest.resetModules();
+  mod = await import("../../js/index.js");
+}
+
+beforeEach(async () => {
+  const { webcrypto } = require("crypto");
+  global.crypto = webcrypto;
+  global.fetch = require("node-fetch");
+  document.body.innerHTML = '<p id="stats-ticker" class="text-[#30D5C8]"></p>';
+  window.API_ORIGIN = "http://example.com";
+  await loadModule();
+});
+
+afterEach(() => {
+  delete window.API_ORIGIN;
+  jest.restoreAllMocks();
+  expect(nock.isDone()).toBe(true);
+  nock.cleanAll();
+});
+
+describe("call stage", () => {
+  test("performs one GET to API_BASE/stats with no query", async () => {
+    nock("http://example.com")
+      .get("/api/stats")
+      .query({})
+      .reply(200, { printsSold: 5 });
+    await mod.updateStats();
+  });
+
+  test("missing API_BASE falls back to computed value", async () => {
+    delete window.API_ORIGIN;
+    await loadModule();
+    const spy = jest.spyOn(mod, "computeDailyPrintsSold").mockResolvedValue(7);
+    await mod.updateStats();
+    const text = document.getElementById("stats-ticker").textContent;
+    expect(text).toContain("7 prints sold");
+    expect(spy).toHaveBeenCalled();
+  });
+
+  test("500 response triggers fallback", async () => {
+    jest.spyOn(mod, "computeDailyPrintsSold").mockResolvedValue(8);
+    nock("http://example.com").get("/api/stats").reply(500);
+    await mod.updateStats();
+    const text = document.getElementById("stats-ticker").textContent;
+    expect(text).toContain("8 prints sold");
+  });
+});
+
+describe("fetch stage", () => {
+  test("successful fetch populates DOM", async () => {
+    nock("http://example.com").get("/api/stats").reply(200, { printsSold: 9 });
+    await mod.updateStats();
+    expect(document.getElementById("stats-ticker")).toHaveTextContent(
+      /9 prints sold/,
+    );
+  });
+
+  test("network failure uses computeDailyPrintsSold", async () => {
+    jest.spyOn(mod, "computeDailyPrintsSold").mockResolvedValue(10);
+    nock("http://example.com").get("/api/stats").replyWithError("network");
+    await mod.updateStats();
+    const text = document.getElementById("stats-ticker").textContent;
+    expect(text).toContain("10 prints sold");
+  });
+});
+
+describe("display stage", () => {
+  test("renders message with class", async () => {
+    nock("http://example.com").get("/api/stats").reply(200, { printsSold: 11 });
+    await mod.updateStats();
+    const el = document.getElementById("stats-ticker");
+    expect(el.classList.contains("text-[#30D5C8]")).toBe(true);
+    expect(el.textContent).toMatch(/11 prints sold\s*in last 24 hrs/);
+  });
+
+  test("removing element skips without error", async () => {
+    document.body.innerHTML = "";
+    await expect(mod.updateStats()).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add stats ticker pipeline tests for call/fetch/display stages
- run stats tests in CI and watch dev/00000production

## Testing
- `npm run format`
- `npm test` *(fails: offline mode: skipping jest)*
- `(cd backend && npm test)`

------
https://chatgpt.com/codex/tasks/task_e_68bb28de62b0832db6076376a427ebff