### PR TITLE
docs: add workflow update checklist

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,14 @@ All dependency installs and script runs must use `npm`. Other package managers s
 5. Do not use Git LFS for files under `frontend/`. Commit real assets or host large files externally (e.g., S3/CDN).
 6. Test fixtures may not use Git LFS; use generated fixtures or commit tiny files. See `.gitattributes` and the `lfs-prevent-pointers` workflow.
 
+## Workflow updates
+
+Use this checklist when adding or modifying CI workflows:
+
+1. Add or adjust the workflow files.
+2. Update `ci/expected-suites.yml` and `ci/expected-test-files.json`.
+3. Run the suite locally (e.g., `npm run ci`) to confirm the failure before committing the fix.
+
 ## Tests
 
 - All new code should include appropriate tests.


### PR DESCRIPTION
## Summary
- document workflow update checklist in contributing guide

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run setup` *(fails: 403 Forbidden to registry.npmjs.org)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: missing axios / dependencies)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68bb34343df8832da48825c4ab5ccec6