### PR TITLE
ci: add slots pipeline workflow

### DIFF
--- a/.github/workflows/slots-pipeline.yml
+++ b/.github/workflows/slots-pipeline.yml
@@ -1,0 +1,23 @@
+name: Slots pipeline
+
+on:
+  push:
+    branches: [dev, 00000production]
+  pull_request:
+    branches: [dev, 00000production]
+
+jobs:
+  slots-tests:
+    runs-on: ubuntu-latest
+    env:
+      NPM_CONFIG_AUDIT: "false"
+      NPM_CONFIG_FUND: "false"
+      CI_NETWORK_OK: "1"
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+      - run: npm ci
+      - run: node scripts/run-jest.js tests/slots


### PR DESCRIPTION
## Summary
- add workflow to run slot tests on dev and 00000production

## Testing
- `npm run format`
- `CI_FORCE=1 node scripts/run-jest.js tests/slots` *(fails: Jest is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bb342fbfd8832d92f911ba6ad4b087