### PR TITLE
ci: run slots pipeline test directly

### DIFF
--- a/.github/workflows/slots-pipeline.yml
+++ b/.github/workflows/slots-pipeline.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
-          cache: 'npm'
+          node-version: "20.x"
+          cache: "npm"
       - run: npm ci
-      - run: node scripts/run-jest.js tests/slots
+      - run: node scripts/run-jest.js tests/slots/print-slots.pipeline.y3hfcklm0t8hz92wbg.test.js


### PR DESCRIPTION
## Summary
- run the slots pipeline CI job against the explicit test file so jest can detect the suite

## Testing
- `prettier -w .github/workflows/slots-pipeline.yml`
- `SKIP_ROOT_DEPS_CHECK=1 SKIP_NET_CHECKS=1 node scripts/run-jest.js tests/slots/print-slots.pipeline.y3hfcklm0t8hz92wbg.test.js` *(fails: Jest is not installed)*


------
https://chatgpt.com/codex/tasks/task_e_68bb42cab464832d81f9a91ebfaee715