### PR TITLE
feat: expand run-jest directories

### DIFF
--- a/scripts/__tests__/run-jest-directory-awrp9q3mx6vd4f3s.test.ts
+++ b/scripts/__tests__/run-jest-directory-awrp9q3mx6vd4f3s.test.ts
@@ -1,0 +1,39 @@
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const vm = require("vm");
+
+function getVerifyFiles() {
+  const src = fs.readFileSync(path.join(__dirname, "..", "run-jest.js"), "utf8");
+  const sandbox = {
+    module: { exports: {} },
+    require,
+    __dirname: path.join(__dirname, ".."),
+    process,
+    console,
+  };
+  vm.runInNewContext(src, sandbox);
+  return sandbox.verifyFiles;
+}
+
+test("expands directory into matching test files", () => {
+  const verifyFiles = getVerifyFiles();
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "rj-"));
+  const files = [
+    path.join(dir, "one.test.js"),
+    path.join(dir, "two.spec.js"),
+    path.join(dir, "note.js"),
+  ];
+  fs.writeFileSync(files[0], "");
+  fs.writeFileSync(files[1], "");
+  fs.writeFileSync(files[2], "");
+  try {
+    const result = verifyFiles([dir]);
+    expect(result).toContain(files[0]);
+    expect(result).toContain(files[1]);
+    expect(result).not.toContain(files[2]);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+

--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -5,6 +5,20 @@ const path = require("path");
 const repoRoot = path.resolve(__dirname, "..");
 const backendRoot = path.join(repoRoot, "backend");
 
+function collectTests(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const tests = [];
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      tests.push(...collectTests(full));
+    } else if (/\.(test|spec)\.(js|ts|tsx)$/.test(entry.name)) {
+      tests.push(full);
+    }
+  }
+  return tests;
+}
+
 function resolveFromPaths(mod) {
   for (const p of [repoRoot, backendRoot]) {
     try {
@@ -25,21 +39,32 @@ function verifyFiles(args) {
       normalized.push(arg);
       continue;
     }
-    if (checking || /\.(test|spec)\.(js|ts|tsx)$/.test(arg)) {
-      const candidates = [
-        path.resolve(process.cwd(), arg),
-        path.resolve(repoRoot, arg),
-        path.resolve(backendRoot, arg),
-      ];
-      const file = candidates.find((p) => fs.existsSync(p));
-      if (!file) {
-        console.error(`Test file not found: ${arg}`);
-        process.exit(1);
+    const candidates = [
+      path.resolve(process.cwd(), arg),
+      path.resolve(repoRoot, arg),
+      path.resolve(backendRoot, arg),
+    ];
+    const existing = candidates.find((p) => fs.existsSync(p));
+    const isTestArg = checking || /\.(test|spec)\.(js|ts|tsx)$/.test(arg);
+    if (existing) {
+      const stat = fs.statSync(existing);
+      if (stat.isDirectory()) {
+        const files = collectTests(existing);
+        if (!files.length) {
+          console.error(`No test files found in directory: ${arg}`);
+          process.exit(1);
+        }
+        normalized.push(...files);
+      } else {
+        normalized.push(existing);
       }
-      normalized.push(file);
-    } else {
-      normalized.push(arg);
+      continue;
     }
+    if (isTestArg) {
+      console.error(`Test file not found: ${arg}`);
+      process.exit(1);
+    }
+    normalized.push(arg);
   }
   return normalized;
 }


### PR DESCRIPTION
## Summary
- allow `scripts/run-jest.js` to accept directories by expanding them to individual test files
- add regression test ensuring directories resolve to contained tests

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` (in `backend/`)
- `npm test` (in `backend/`)
- `npm test` *(fails: Jest is not installed. Run `npm run setup` to install dependencies.)*
- `npm run ci` *(fails: Cannot find module 'axios')*
- `npm run smoke` *(skipped in offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_68bb42ffc2c8832d94507d94b95ec5c0