### PR TITLE
test: polyfill TextEncoder for jsdom

### DIFF
--- a/tests/assets/astronaut-placeholder.pipeline.k3n8p1r6t2w9z4q7.test.js
+++ b/tests/assets/astronaut-placeholder.pipeline.k3n8p1r6t2w9z4q7.test.js
@@ -1,6 +1,9 @@
 /** @jest-environment jsdom */
 const fs = require("fs");
 const path = require("path");
+const { TextEncoder, TextDecoder } = require("node:util");
+globalThis.TextEncoder = TextEncoder;
+globalThis.TextDecoder = TextDecoder;
 const nock = require("nock");
 const { JSDOM } = require("jsdom");
 const request = require("supertest");

--- a/tests/assets/image-pipeline.no-safeguards.test.a4b5c6d7e8f9g0h1.js
+++ b/tests/assets/image-pipeline.no-safeguards.test.a4b5c6d7e8f9g0h1.js
@@ -1,5 +1,8 @@
 const fs = require("fs");
 const path = require("path");
+const { TextEncoder, TextDecoder } = require("node:util");
+globalThis.TextEncoder = TextEncoder;
+globalThis.TextDecoder = TextDecoder;
 const { JSDOM } = require("jsdom");
 const nock = require("nock");
 const request = require("supertest");

--- a/tests/assets/image-pipeline.regression.p61qn2j819opg4sc.test.js
+++ b/tests/assets/image-pipeline.regression.p61qn2j819opg4sc.test.js
@@ -1,5 +1,8 @@
 const fs = require("fs");
 const path = require("path");
+const { TextEncoder, TextDecoder } = require("node:util");
+globalThis.TextEncoder = TextEncoder;
+globalThis.TextDecoder = TextDecoder;
 const { JSDOM } = require("jsdom");
 const nock = require("nock");
 const request = require("supertest");

--- a/tests/assets/image-pipeline.test.h5f2k9d1s3a7l0q8.js
+++ b/tests/assets/image-pipeline.test.h5f2k9d1s3a7l0q8.js
@@ -1,5 +1,8 @@
 const fs = require("fs");
 const path = require("path");
+const { TextEncoder, TextDecoder } = require("node:util");
+globalThis.TextEncoder = TextEncoder;
+globalThis.TextDecoder = TextDecoder;
 const { JSDOM } = require("jsdom");
 const nock = require("nock");
 const request = require("supertest");


### PR DESCRIPTION
## Summary
- polyfill TextEncoder/TextDecoder globally in asset pipeline tests before requiring jsdom

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup` *(fails: Skipping Playwright/apt deps)*
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Cannot find module 'axios')*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4b49cb14832d9313a63c40707526