### PR TITLE
fix: propagate asset download failures

### DIFF
--- a/scripts/fetch-assets.cjs
+++ b/scripts/fetch-assets.cjs
@@ -14,10 +14,12 @@ async function download(url, dest) {
     await ensureDir(dest);
     await writeFile(dest, buf);
     console.log(`Downloaded ${url}`);
+    return true;
   } catch (err) {
     console.warn(`Failed to download ${url}: ${err}. Creating placeholder.`);
     await ensureDir(dest);
     await writeFile(dest, "");
+    return false;
   }
 }
 
@@ -27,17 +29,17 @@ async function fetchBoombox() {
 
   if (existsSync(dest)) {
     console.log("boombox model already present");
-    return;
+    return true;
   }
 
   if (!url) {
     console.warn("BOOMBOX_MODEL_URL not set; creating placeholder file");
     await ensureDir(dest);
     await writeFile(dest, "");
-    return;
+    return true;
   }
 
-  await download(url, dest);
+  return await download(url, dest);
 }
 
 async function fetchRepoAssets() {
@@ -49,6 +51,7 @@ async function fetchRepoAssets() {
     "text logo.png",
   ];
 
+  let ok = true;
   for (const file of files) {
     const dest = join("frontend", "public", "img", file);
     if (existsSync(dest)) {
@@ -56,15 +59,20 @@ async function fetchRepoAssets() {
       continue;
     }
     const url = `${base}/${encodeURIComponent(file)}`;
-    await download(url, dest);
+    const success = await download(url, dest);
+    if (!success) ok = false;
   }
+  return ok;
 }
 
 module.exports = { ensureDir, download, fetchBoombox, fetchRepoAssets };
 
 if (require.main === module) {
   (async () => {
-    await fetchBoombox();
-    await fetchRepoAssets();
+    const results = await Promise.allSettled([fetchBoombox(), fetchRepoAssets()]);
+    const failed = results.some(
+      (r) => r.status === "rejected" || r.value === false,
+    );
+    if (failed) process.exit(1);
   })();
 }

--- a/tests/assets/download-fail-hook.js
+++ b/tests/assets/download-fail-hook.js
@@ -1,4 +1,2 @@
 const mod = require("../../scripts/fetch-assets.cjs");
-mod.download = async () => {
-  throw new Error("forced failure");
-};
+mod.download = async () => false;


### PR DESCRIPTION
## Summary
- signal asset download failure and return exit code 1 when any download fails
- adjust test hook to mimic download failure for exit-code checks

## Testing
- `npm run format` (backend)
- `npm test` (backend)
- `node scripts/run-jest.js tests/assets/image-pipeline.regression.p61qn2j819opg4sc.test.js` *(fails: Jest is not installed)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: missing dependencies)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68bb4b50330c832d995c06d9e4f62bcd