### PR TITLE
build: use packaged three.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,6 +169,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.2.0",
     "react-places-autocomplete": "^7.3.0",
+    "three": "^0.152.2",
     "vite": "^5.4.3",
     "winston": "^3.17.0",
     "winston-format": "^1.0.1"

--- a/src/js/loadModel.js
+++ b/src/js/loadModel.js
@@ -13,12 +13,8 @@ export async function loadModel(url, containerId, key = "default") {
   let GLTFLoader;
   try {
     const [threeMod, gltfMod] = await Promise.all([
-      import(
-        "https://cdn.jsdelivr.net/npm/three@0.152.2/build/three.module.js"
-      ),
-      import(
-        "https://cdn.jsdelivr.net/npm/three@0.152.2/examples/jsm/loaders/GLTFLoader.js"
-      ),
+      import("three"),
+      import("three/examples/jsm/loaders/GLTFLoader.js"),
     ]);
     THREE = threeMod;
     ({ GLTFLoader } = gltfMod);
@@ -45,25 +41,25 @@ export async function loadModel(url, containerId, key = "default") {
   light.position.set(1, 1, 1);
   scene.add(light);
 
-const loader = new GLTFLoader();
-try {
-  await new Promise((resolve, reject) => {
-    loader.load(
-      url,
-      gltf => {
-        scene.add(gltf.scene);
-        window.markModelLoaded(key);
-        resolve();
-      },
-      undefined,
-      reject
-    );
-  });
-} catch (err) {
-  console.error('GLTF load failed', err);
-  container.textContent = 'model not available';
-  return;
-}
+  const loader = new GLTFLoader();
+  try {
+    await new Promise((resolve, reject) => {
+      loader.load(
+        url,
+        (gltf) => {
+          scene.add(gltf.scene);
+          window.markModelLoaded(key);
+          resolve();
+        },
+        undefined,
+        reject,
+      );
+    });
+  } catch (err) {
+    console.error("GLTF load failed", err);
+    container.textContent = "model not available";
+    return;
+  }
 
   window.__viewerFrames = 0;
   function animate() {


### PR DESCRIPTION
## Summary
- load Three.js and GLTFLoader from local packages instead of CDN
- declare `three` dependency for the project

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Cannot find module 'axios')*
- `SKIP_PW_DEPS=1 npm run smoke` *(skipped: offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_68bb64d02b8c832d862a6e49c57faa68