### PR TITLE
ci: add dev/prod fresh test workflow

### DIFF
--- a/.github/workflows/dev-prod-fresh-tests.yml
+++ b/.github/workflows/dev-prod-fresh-tests.yml
@@ -1,0 +1,25 @@
+name: DevProd Fresh Tests
+
+on:
+  push:
+    branches: [dev, 00000production]
+  pull_request:
+    branches: [dev, 00000production]
+
+permissions:
+  contents: read
+
+jobs:
+  fresh-tests:
+    runs-on: ubuntu-latest
+    env:
+      NPM_CONFIG_AUDIT: "false"
+      NPM_CONFIG_FUND: "false"
+      CI_NETWORK_OK: "1"
+    steps:
+      - uses: actions/checkout@v4.1.6
+      - uses: actions/setup-node@v4.0.3
+        with:
+          node-version: "20"
+      - run: npm ci
+      - run: npm run test:fresh

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "scripts": {
     "test": "node scripts/run-jest.js",
+    "test:fresh": "npm test",
     "test:image-pipeline": "node scripts/test-image-pipeline.js",
     "preinstall": "corepack enable && node scripts/check-node-version.js",
     "preformat": "true",


### PR DESCRIPTION
## Summary
- add DevProd Fresh Tests workflow for dev and 00000production branches
- expose test:fresh npm script used by workflow

## Testing
- `npm run format` (backend)
- `npm test` (backend)
- `npm run test:fresh` *(fails: Jest is not installed)*
- `npm run ci` *(fails: Cannot find module 'axios')*
- `npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6c56ea74832dbef2a1bdf38f234c