### PR TITLE
test: add live S3 asset checks

### DIFF
--- a/tests/assets/image-pipeline.live.test.p7v4x8t3n9q1z6d2.js
+++ b/tests/assets/image-pipeline.live.test.p7v4x8t3n9q1z6d2.js
@@ -1,0 +1,73 @@
+const fs = require("fs");
+const path = require("path");
+const axios = require("axios");
+const { JSDOM } = require("jsdom");
+
+let fetchRepoAssets;
+
+const IMG_DIR = path.join("frontend", "public", "img");
+const ASSETS = [
+  "astro-image.png",
+  "box logo.png",
+  "luckybox-preview.png",
+  "text logo.png",
+];
+const BASE_URL = "https://glb-models-prod.s3.amazonaws.com/repo-assets";
+
+beforeAll(async () => {
+  ({ fetchRepoAssets } = await import("../../scripts/fetch-assets.cjs"));
+  for (const file of ASSETS) {
+    const p = path.join(IMG_DIR, file);
+    if (fs.existsSync(p)) fs.unlinkSync(p);
+  }
+});
+
+describe("live S3 assets", () => {
+  test("S3 endpoints respond with image data", async () => {
+    for (const file of ASSETS) {
+      const url = `${BASE_URL}/${encodeURIComponent(file)}`;
+      const res = await axios.head(url);
+      expect(res.status).toBe(200);
+      const len = Number(res.headers["content-length"]);
+      expect(len).toBeGreaterThan(0);
+      expect(res.headers["content-type"]).toMatch(/^image\//);
+    }
+  });
+
+  test("downloads non-empty images without mocks", async () => {
+    await fetchRepoAssets();
+    for (const file of ASSETS) {
+      const p = path.join(IMG_DIR, file);
+      expect(fs.existsSync(p)).toBe(true);
+      const size = fs.statSync(p).size;
+      expect(size).toBeGreaterThan(0);
+    }
+  });
+
+  test("html pages reference existing images", () => {
+    const indexDom = new JSDOM(fs.readFileSync("index.html", "utf8"));
+    const addonsDom = new JSDOM(fs.readFileSync("addons.html", "utf8"));
+    const communityDom = new JSDOM(
+      fs.readFileSync("CommunityCreations.html", "utf8"),
+    );
+
+    const refs = [
+      indexDom.window.document.querySelector('img[src="img/text%20logo.png"]'),
+      indexDom.window.document.querySelector('img[src="img/box%20logo.png"]'),
+      addonsDom.window.document.querySelector(
+        'img[src="img/luckybox-preview.png"]',
+      ),
+      communityDom.window.document.querySelector(
+        'img[src="img/astro-image.png"]',
+      ),
+    ];
+
+    refs.forEach((ref, i) => {
+      expect(ref).not.toBeNull();
+      const file = ASSETS[i];
+      const p = path.join(IMG_DIR, file);
+      const size = fs.statSync(p).size;
+      expect(size).toBeGreaterThan(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- expand image asset pipeline coverage with live S3 checks
- verify S3 endpoints, downloads, and HTML references for repo assets

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup` *(partial: skipping Playwright/apt deps)*
- `cd backend && npm run format`
- `cd backend && npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: ASTRONAUT_MODEL_URL not set)*
- `SKIP_PW_DEPS=1 npm run smoke`
- `node scripts/run-jest.js tests/assets/image-pipeline.live.test.p7v4x8t3n9q1z6d2.js` *(fails: Jest is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc19a06910832d8dafb479779cb958