### PR TITLE
fix: support suffixed Jest test files

### DIFF
--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -12,7 +12,7 @@ function collectTests(dir) {
     const full = path.join(dir, entry.name);
     if (entry.isDirectory()) {
       tests.push(...collectTests(full));
-    } else if (/\.(test|spec)\.(js|ts|tsx)$/.test(entry.name)) {
+    } else if (/\.(test|spec)(?:\.[^.]+)?\.(js|ts|tsx)$/.test(entry.name)) {
       tests.push(full);
     }
   }
@@ -45,7 +45,8 @@ function verifyFiles(args) {
       path.resolve(backendRoot, arg),
     ];
     const existing = candidates.find((p) => fs.existsSync(p));
-    const isTestArg = checking || /\.(test|spec)\.(js|ts|tsx)$/.test(arg);
+    const isTestArg =
+      checking || /\.(test|spec)(?:\.[^.]+)?\.(js|ts|tsx)$/.test(arg);
     if (existing) {
       const stat = fs.statSync(existing);
       if (stat.isDirectory()) {


### PR DESCRIPTION
## Summary
- handle test files with extra dot segments before extensions so `collectTests` finds `*.test.<suffix>.js`
- apply same relaxed pattern when verifying test file arguments

## Testing
- `npx prettier -w scripts/run-jest.js`
- `SKIP_NET_CHECKS=1 node scripts/run-jest.js tests/assets --listTests=1` *(fails: Jest is not installed)*
- `node -e "...collectTests('tests/assets')"`

------
https://chatgpt.com/codex/tasks/task_e_68bc22032980832d9de0aacf901293a2