### PR TITLE
test: configure axios adapter for pipeline test

### DIFF
--- a/tests/assets/astronaut-placeholder.pipeline.k3n8p1r6t2w9z4q7.test.js
+++ b/tests/assets/astronaut-placeholder.pipeline.k3n8p1r6t2w9z4q7.test.js
@@ -1,6 +1,8 @@
 /** @jest-environment jsdom */
 const fs = require("fs");
 const path = require("path");
+const axios = require("axios");
+axios.defaults.adapter = require("axios/lib/adapters/http");
 const { TextEncoder, TextDecoder } = require("node:util");
 globalThis.TextEncoder = TextEncoder;
 globalThis.TextDecoder = TextDecoder;
@@ -15,6 +17,13 @@ let fetchRepoAssets;
 let download;
 let app;
 let loadModel;
+
+let lastRaf;
+const origRAF = global.requestAnimationFrame;
+global.requestAnimationFrame = (cb) => {
+  lastRaf = origRAF(cb);
+  return lastRaf;
+};
 
 const MODEL_DIR = path.join("frontend", "public", "models");
 const MODEL_PATH = path.join(MODEL_DIR, "astronaut.glb");
@@ -38,6 +47,13 @@ beforeEach(() => {
   if (fs.existsSync(MODEL_DIR)) {
     for (const f of fs.readdirSync(MODEL_DIR))
       fs.unlinkSync(path.join(MODEL_DIR, f));
+  }
+});
+
+afterEach(() => {
+  if (lastRaf !== undefined) {
+    cancelAnimationFrame(lastRaf);
+    lastRaf = undefined;
   }
 });
 


### PR DESCRIPTION
## Summary
- ensure pipeline test uses Node HTTP adapter for axios and cleans up requestAnimationFrame

## Testing
- `npm run format`
- `node scripts/run-jest.js tests/assets/astronaut-placeholder.pipeline.k3n8p1r6t2w9z4q7.test.js` *(fails: Jest is not installed)*
- `npm run ci` *(fails: ASTRONAUT_MODEL_URL not set)*
- `npm run smoke` *(skipped: offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_68bc220838b8832da77692ec78ed182b