### PR TITLE
fix: throw error on failed asset download

### DIFF
--- a/scripts/fetch-assets.cjs
+++ b/scripts/fetch-assets.cjs
@@ -15,9 +15,8 @@ async function download(url, dest) {
     await writeFile(dest, buf);
     console.log(`Downloaded ${url}`);
   } catch (err) {
-    console.warn(`Failed to download ${url}: ${err}. Creating placeholder.`);
-    await ensureDir(dest);
-    await writeFile(dest, "");
+    console.warn(`Failed to download ${url}: ${err}`);
+    throw err;
   }
 }
 

--- a/tests/assets/image-pipeline.no-safeguards.test.a4b5c6d7e8f9g0h1.js
+++ b/tests/assets/image-pipeline.no-safeguards.test.a4b5c6d7e8f9g0h1.js
@@ -60,14 +60,14 @@ describe("download step", () => {
     });
   }
 
-  test("creates placeholder when download fails", async () => {
+  test("throws and leaves no file when download fails", async () => {
     nock("https://fail.test").get("/missing.png").reply(404);
     const dest = path.join(IMG_DIR, "missing.png");
     if (fs.existsSync(dest)) fs.unlinkSync(dest);
-    await download("https://fail.test/missing.png", dest);
-    expect(fs.existsSync(dest)).toBe(true);
-    const stat = fs.statSync(dest);
-    expect(stat.size).toBe(0);
+    await expect(
+      download("https://fail.test/missing.png", dest),
+    ).rejects.toThrow();
+    expect(fs.existsSync(dest)).toBe(false);
   });
 
   test("boombox placeholder when env missing", async () => {

--- a/tests/assets/image-pipeline.regression.p61qn2j819opg4sc.test.js
+++ b/tests/assets/image-pipeline.regression.p61qn2j819opg4sc.test.js
@@ -103,38 +103,26 @@ describe("call stage", () => {
     nock.cleanAll();
   });
 
-  test("404 surfaces as empty file", async () => {
+  test("404 surfaces error and no file", async () => {
     const target = "astro-image.png";
-    nock(base)
+    const scope = nock(base)
       .get(`/repo-assets/${encodeURIComponent(target)}`)
       .reply(404);
-    for (const f of ASSETS.filter((x) => x !== target)) {
-      nock(base)
-        .get(`/repo-assets/${encodeURIComponent(f)}`)
-        .reply(200, f);
-    }
-    await fetchRepoAssets();
+    await expect(fetchRepoAssets()).rejects.toThrow();
     const p = path.join(IMG_DIR, target);
-    expect(fs.existsSync(p)).toBe(true);
-    expect(fs.statSync(p).size).toBe(0);
-    expect(nock.isDone()).toBe(true);
+    expect(fs.existsSync(p)).toBe(false);
+    expect(scope.isDone()).toBe(true);
   });
 
-  test("500 surfaces as empty file", async () => {
+  test("500 surfaces error and no file", async () => {
     const target = "box logo.png";
-    nock(base)
+    const scope = nock(base)
       .get(`/repo-assets/${encodeURIComponent(target)}`)
       .reply(500);
-    for (const f of ASSETS.filter((x) => x !== target)) {
-      nock(base)
-        .get(`/repo-assets/${encodeURIComponent(f)}`)
-        .reply(200, f);
-    }
-    await fetchRepoAssets();
+    await expect(fetchRepoAssets()).rejects.toThrow();
     const p = path.join(IMG_DIR, target);
-    expect(fs.existsSync(p)).toBe(true);
-    expect(fs.statSync(p).size).toBe(0);
-    expect(nock.isDone()).toBe(true);
+    expect(fs.existsSync(p)).toBe(false);
+    expect(scope.isDone()).toBe(true);
   });
 });
 
@@ -176,14 +164,17 @@ describe("fetch stage", () => {
     expect(nock.isDone()).toBe(true);
   });
 
-  test("corrupted response creates placeholder", async () => {
+  test("corrupted response throws and no file", async () => {
     const file = ASSETS[0];
     const dest = path.join(IMG_DIR, file);
+    if (fs.existsSync(dest)) fs.unlinkSync(dest);
     nock(base)
       .get(`/repo-assets/${encodeURIComponent(file)}`)
       .replyWithError("boom");
-    await download(`${base}/repo-assets/${encodeURIComponent(file)}`, dest);
-    expect(fs.statSync(dest).size).toBe(0);
+    await expect(
+      download(`${base}/repo-assets/${encodeURIComponent(file)}`, dest),
+    ).rejects.toThrow();
+    expect(fs.existsSync(dest)).toBe(false);
     expect(nock.isDone()).toBe(true);
   });
 });
@@ -285,29 +276,14 @@ describe("pipeline integrity", () => {
     expect(nock.isDone()).toBe(true);
   });
 
-  test("failed image does not block others", async () => {
+  test("failed image aborts fetchRepoAssets", async () => {
     const fail = ASSETS[0];
-    for (const f of ASSETS) {
-      if (f === fail) {
-        nock(base)
-          .get(`/repo-assets/${encodeURIComponent(f)}`)
-          .reply(500);
-      } else {
-        nock(base)
-          .get(`/repo-assets/${encodeURIComponent(f)}`)
-          .reply(200, Buffer.from(`ok-${f}`));
-      }
-    }
-    await fetchRepoAssets();
-    for (const f of ASSETS) {
-      const data = fs.readFileSync(path.join(IMG_DIR, f));
-      if (f === fail) {
-        expect(data.length).toBe(0);
-      } else {
-        expect(data.length).toBeGreaterThan(0);
-      }
-    }
-    expect(nock.isDone()).toBe(true);
+    const scope = nock(base)
+      .get(`/repo-assets/${encodeURIComponent(fail)}`)
+      .reply(500);
+    await expect(fetchRepoAssets()).rejects.toThrow();
+    expect(fs.existsSync(path.join(IMG_DIR, fail))).toBe(false);
+    expect(scope.isDone()).toBe(true);
   });
 
   test("build script exits non-zero on failure", () => {

--- a/tests/assets/image-pipeline.test.h5f2k9d1s3a7l0q8.js
+++ b/tests/assets/image-pipeline.test.h5f2k9d1s3a7l0q8.js
@@ -60,14 +60,14 @@ describe("download step", () => {
     });
   }
 
-  test("creates placeholder when download fails", async () => {
+  test("throws and leaves no file when download fails", async () => {
     nock("https://fail.test").get("/missing.png").reply(404);
     const dest = path.join(IMG_DIR, "missing.png");
     if (fs.existsSync(dest)) fs.unlinkSync(dest);
-    await download("https://fail.test/missing.png", dest);
-    expect(fs.existsSync(dest)).toBe(true);
-    const stat = fs.statSync(dest);
-    expect(stat.size).toBe(0);
+    await expect(
+      download("https://fail.test/missing.png", dest),
+    ).rejects.toThrow();
+    expect(fs.existsSync(dest)).toBe(false);
   });
 
   test("boombox placeholder when env missing", async () => {


### PR DESCRIPTION
## Summary
- throw error when asset download fails instead of creating placeholder files
- update asset tests to expect failures and ensure no placeholder files remain

## Testing
- `npm run validate-env`
- `npm run format` (backend)
- `npm test` (backend)
- `node scripts/run-jest.js tests/assets/image-pipeline.test.h5f2k9d1s3a7l0q8.js tests/assets/image-pipeline.no-safeguards.test.a4b5c6d7e8f9g0h1.js tests/assets/image-pipeline.regression.p61qn2j819opg4sc.test.js tests/assets/astronaut-placeholder.pipeline.k3n8p1r6t2w9z4q7.test.js` *(failed: Jest is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bc22172190832d996d4f154512e14a