### PR TITLE
test: ensure repo assets exist without network

### DIFF
--- a/tests/assets/repo-assets.no-nock.test.y5v1r3p8s2k4n6m7.js
+++ b/tests/assets/repo-assets.no-nock.test.y5v1r3p8s2k4n6m7.js
@@ -1,0 +1,33 @@
+const fs = require("fs");
+const path = require("path");
+const nock = require("nock");
+
+let fetchRepoAssets;
+
+const IMG_DIR = path.join("frontend", "public", "img");
+const ASSETS = [
+  "astro-image.png",
+  "box logo.png",
+  "luckybox-preview.png",
+  "text logo.png",
+];
+
+beforeAll(async () => {
+  ({ fetchRepoAssets } = await import("../../scripts/fetch-assets.cjs"));
+});
+
+test("existing repo assets are non-empty without network", async () => {
+  nock.disableNetConnect();
+  try {
+    await fetchRepoAssets();
+  } finally {
+    nock.enableNetConnect();
+  }
+
+  for (const file of ASSETS) {
+    const filePath = path.join(IMG_DIR, file);
+    expect(fs.existsSync(filePath)).toBe(true);
+    const stat = fs.statSync(filePath);
+    expect(stat.size).toBeGreaterThan(0);
+  }
+});


### PR DESCRIPTION
## Summary
- add offline-safe test verifying fetchRepoAssets keeps repo images non-empty

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `NODE_PATH=backend/node_modules SKIP_ROOT_DEPS_CHECK=1 SKIP_NET_CHECKS=1 node scripts/run-jest.js tests/assets/repo-assets.no-nock.test.y5v1r3p8s2k4n6m7.js` *(fails: Cannot find module 'babel-preset-current-node-syntax')*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: ASTRONAUT_MODEL_URL not set)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68bc221bf35c832da238b8ed9a469599