### PR TITLE
fix: update axios adapter path in astronaut test

### DIFF
--- a/tests/assets/astronaut-placeholder.pipeline.k3n8p1r6t2w9z4q7.test.js
+++ b/tests/assets/astronaut-placeholder.pipeline.k3n8p1r6t2w9z4q7.test.js
@@ -2,7 +2,7 @@
 const fs = require("fs");
 const path = require("path");
 const axios = require("axios");
-axios.defaults.adapter = require("axios/lib/adapters/http");
+axios.defaults.adapter = require("axios/lib/adapters/http.js");
 const { TextEncoder, TextDecoder } = require("node:util");
 globalThis.TextEncoder = TextEncoder;
 globalThis.TextDecoder = TextDecoder;


### PR DESCRIPTION
## Summary
- fix axios require path in astronaut placeholder pipeline test

## Testing
- `npm run format` (failed: 403 Forbidden - GET https://registry.npmjs.org/npm)
- `npm test` (backend)
- `node scripts/run-jest.js tests/assets/astronaut-placeholder.pipeline.k3n8p1r6t2w9z4q7.test.js` (failed: Jest is not installed)


------
https://chatgpt.com/codex/tasks/task_e_68bc301495e4832d86714455071bf96d