### PR TITLE
test: dynamically import axios http adapter

### DIFF
--- a/tests/assets/astronaut-placeholder.pipeline.k3n8p1r6t2w9z4q7.test.js
+++ b/tests/assets/astronaut-placeholder.pipeline.k3n8p1r6t2w9z4q7.test.js
@@ -2,7 +2,10 @@
 const fs = require("fs");
 const path = require("path");
 const axios = require("axios");
-axios.defaults.adapter = require("axios/lib/adapters/http.js");
+beforeAll(async () => {
+  const { default: httpAdapter } = await import("axios/lib/adapters/http.js");
+  axios.defaults.adapter = httpAdapter;
+});
 const { TextEncoder, TextDecoder } = require("node:util");
 globalThis.TextEncoder = TextEncoder;
 globalThis.TextDecoder = TextDecoder;


### PR DESCRIPTION
## Summary
- replace static require of axios http adapter with dynamic import in astronaut test

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `cd backend && npm run format`
- `cd backend && npm test`
- `SKIP_PW_DEPS=1 npm run ci` (fails: ASTRONAUT_MODEL_URL not set)
- `SKIP_PW_DEPS=1 npm run smoke` (offline mode: skipping smoke)
- `node scripts/run-jest.js tests/assets` (fails: Jest is not installed)


------
https://chatgpt.com/codex/tasks/task_e_68bc329fdb3c832d926814cafc3002ab