### PR TITLE
test: use axios node build for astronaut placeholder

### DIFF
--- a/tests/assets/astronaut-placeholder.pipeline.k3n8p1r6t2w9z4q7.test.js
+++ b/tests/assets/astronaut-placeholder.pipeline.k3n8p1r6t2w9z4q7.test.js
@@ -1,11 +1,7 @@
 /** @jest-environment jsdom */
 const fs = require("fs");
 const path = require("path");
-const axios = require("axios");
-beforeAll(async () => {
-  const { default: httpAdapter } = await import("axios/lib/adapters/http.js");
-  axios.defaults.adapter = httpAdapter;
-});
+const axios = require("axios/dist/node/axios.cjs");
 const { TextEncoder, TextDecoder } = require("node:util");
 globalThis.TextEncoder = TextEncoder;
 globalThis.TextDecoder = TextDecoder;


### PR DESCRIPTION
## Summary
- use axios node build for astronaut placeholder tests

## Testing
- `npm run format`
- `node scripts/run-jest.js tests/assets` *(fails: Jest is not installed)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: ASTRONAUT_MODEL_URL not set)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3a279d14832d8dd842480721d4b8