### PR TITLE
test: use node axios build for astronaut test

### DIFF
--- a/tests/assets/astronaut-placeholder.pipeline.k3n8p1r6t2w9z4q7.test.js
+++ b/tests/assets/astronaut-placeholder.pipeline.k3n8p1r6t2w9z4q7.test.js
@@ -1,7 +1,7 @@
 /** @jest-environment jsdom */
 const fs = require("fs");
 const path = require("path");
-const axios = require("axios/dist/axios.cjs");
+const axios = require("axios/dist/node/axios.cjs");
 const { TextEncoder, TextDecoder } = require("node:util");
 globalThis.TextEncoder = TextEncoder;
 globalThis.TextDecoder = TextDecoder;


### PR DESCRIPTION
## Summary
- use node-specific axios build in astronaut placeholder test
- remove manual adapter override (none remained)

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `node scripts/run-jest.js tests/assets` *(fails: Jest is not installed)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: ASTRONAUT_MODEL_URL not set)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3f60eae0832d9443a6d39f55a434