### PR TITLE
test: use axios cjs build in astronaut placeholder test

### DIFF
--- a/tests/assets/astronaut-placeholder.pipeline.k3n8p1r6t2w9z4q7.test.js
+++ b/tests/assets/astronaut-placeholder.pipeline.k3n8p1r6t2w9z4q7.test.js
@@ -1,7 +1,7 @@
 /** @jest-environment jsdom */
 const fs = require("fs");
 const path = require("path");
-const axios = require("axios/dist/node/axios.cjs");
+const axios = require("axios/dist/axios.cjs");
 const { TextEncoder, TextDecoder } = require("node:util");
 globalThis.TextEncoder = TextEncoder;
 globalThis.TextDecoder = TextDecoder;


### PR DESCRIPTION
## Summary
- load axios using the Node CJS build directly in astronaut placeholder pipeline test

## Testing
- `npm run format` (backend)
- `npm test` (backend)
- `node scripts/run-jest.js tests/assets` *(fails: Jest is not installed)*
- `npm run ci` *(fails: ASTRONAUT_MODEL_URL not set)*
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68bc42983020832da85255f10ad7c252