### PR TITLE
chore: add lockfile check script

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "db:check": "npm run db:check --prefix backend",
     "db:migrate:test": "npm run migrate --prefix backend",
     "prepare": "husky",
-    "prepush": "echo \"(pre-push) no checks\""
+    "prepush": "echo \"(pre-push) no checks\"",
+    "check:lockfile": "npx lockfile-diff"
   },
   "babel": {
     "presets": [


### PR DESCRIPTION
## Summary
- add `check:lockfile` script for verifying package-lock consistency

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@actions%2fcore)*
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Cannot find module '@aws-sdk/client-s3')*
- `SKIP_PW_DEPS=1 npm run smoke`
- `npm run check:lockfile` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*

------
https://chatgpt.com/codex/tasks/task_e_68bc51487fac832da2d128646805408d