### PR TITLE
test: validate aws-sdk mock dependency

### DIFF
--- a/scripts/test-image-pipeline.js
+++ b/scripts/test-image-pipeline.js
@@ -9,6 +9,23 @@ function run(cmd) {
 delete process.env.npm_config_http_proxy;
 delete process.env.npm_config_https_proxy;
 
+// Ensure required mock dependency is present
+try {
+  require.resolve("aws-sdk-client-mock");
+} catch {
+  console.error("aws-sdk-client-mock is missing; run npm install");
+  process.exit(1);
+}
+
+// Warn if dependency tree is out of sync
+try {
+  execSync("npm ls aws-sdk-client-mock --silent", { stdio: "pipe" });
+} catch {
+  console.warn(
+    "aws-sdk-client-mock may be extraneous or mismatched; run npm install"
+  );
+}
+
 // Bail if manual offline flags are present
 for (const key of ["CI_NO_NET", "CI_SANDBOX", "SKIP_NET_CHECKS"]) {
   if (process.env[key]) {


### PR DESCRIPTION
## Summary
- ensure aws-sdk-client-mock is installed before image pipeline tests run
- warn if aws-sdk-client-mock installation is extraneous or mismatched

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run setup` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@actions%2fcore)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Cannot find module '@aws-sdk/client-s3')*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: skipping smoke)*

<details><summary>npm run format</summary>

```
> backend@1.0.0 format
> prettier --log-level warn --write "**/*.{ts,tsx,js,jsx,json,md}"
```

</details>

<details><summary>npm test</summary>

```
PASS tests/additionalApi.test.js
PASS tests/users.test.z9x8c7v6b5n4m3l2.js
PASS tests/getEnv.test.p7q8r9s0t1u2v3w4.js
Test Suites: 3 passed, 3 total
Tests:       68 skipped, 7 passed, 75 total
```

</details>

<details><summary>SKIP_PW_DEPS=1 npm run setup (failure)</summary>

```
npm ci failed in  due to lock mismatch. Running npm install...
npm error code E403
npm error 403 403 Forbidden - GET https://registry.npmjs.org/@actions%2fcore
```

</details>

<details><summary>SKIP_PW_DEPS=1 npm run ci (failure)</summary>

```
Error: Cannot find module '@aws-sdk/client-s3'
...
Error: Command failed: npm run build --workspaces=false
```

</details>

<details><summary>SKIP_PW_DEPS=1 npm run smoke</summary>

```
> mvp-website@1.0.0 smoke
> node scripts/smoke.mjs
offline mode: skipping smoke
```

</details>

------
https://chatgpt.com/codex/tasks/task_e_68bc5264eef4832dbbefc9f900d650ad