### PR TITLE
ci: add npm lockfile drift check

### DIFF
--- a/ci/generated/full-ci.jobs.json
+++ b/ci/generated/full-ci.jobs.json
@@ -745,7 +745,7 @@
   },
   {
     "name": "lockfile-drift",
-    "command": "node scripts/check-lockfile-drift.js",
+    "command": "if [ -f pnpm-lock.yaml ]; then node scripts/check-lockfile-drift.js; else node scripts/check-npm-lockfile-drift.js; fi",
     "paths": [],
     "needs": []
   },

--- a/ci/generated/full-ci.yml
+++ b/ci/generated/full-ci.yml
@@ -260,7 +260,12 @@ jobs:
           - name: load
             command: |
           - name: lockfile-drift
-            command: node scripts/check-lockfile-drift.js
+            command: |
+              if [ -f pnpm-lock.yaml ]; then
+                node scripts/check-lockfile-drift.js
+              else
+                node scripts/check-npm-lockfile-drift.js
+              fi
           - name: md-link-check
             command: echo "historical job md-link-check"
           - name: nightly-cache-warmup

--- a/scripts/check-npm-lockfile-drift.js
+++ b/scripts/check-npm-lockfile-drift.js
@@ -1,0 +1,90 @@
+const fs = require("fs");
+const path = require("path");
+const core = require("@actions/core");
+
+function loadJSON(file) {
+  return JSON.parse(fs.readFileSync(path.join(process.cwd(), file), "utf8"));
+}
+
+const pkg = loadJSON("package.json");
+const lock = loadJSON("package-lock.json");
+const rootPkg = lock.packages && lock.packages[""] ? lock.packages[""] : {};
+const lockDeps = rootPkg.dependencies || {};
+const lockDevDeps = rootPkg.devDependencies || {};
+
+function diffSection(section, lockSection) {
+  const deps = pkg[section] || {};
+  const diffs = [];
+  for (const [name, spec] of Object.entries(deps)) {
+    const lockSpec = lockSection[name];
+    if (lockSpec !== spec) {
+      diffs.push({
+        section,
+        name,
+        expected: spec,
+        actual: lockSpec || "(missing)",
+      });
+    }
+  }
+  return diffs;
+}
+
+const diffs = [
+  ...diffSection("dependencies", lockDeps),
+  ...diffSection("devDependencies", lockDevDeps),
+];
+
+if (diffs.length === 0) {
+  process.exit(0);
+}
+
+const diffLines = diffs
+  .map(
+    (d) =>
+      `- ${d.section} ${d.name}: ${d.actual}\n+ ${d.section} ${d.name}: ${d.expected}`,
+  )
+  .join("\n");
+const summary = [
+  "## Lockfile drift detected",
+  "",
+  "```diff",
+  diffLines,
+  "```",
+  "",
+  "To fix:",
+  "",
+  "```sh",
+  "npm install && npm -C frontend install",
+  "```",
+  "",
+].join("\n");
+
+if (process.env.GITHUB_STEP_SUMMARY) {
+  fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, summary);
+} else {
+  console.log(summary);
+}
+
+let ciInstall = false;
+try {
+  const workflowDir = path.join(".github", "workflows");
+  if (fs.existsSync(workflowDir)) {
+    for (const file of fs.readdirSync(workflowDir)) {
+      const content = fs.readFileSync(path.join(workflowDir, file), "utf8");
+      if (content.includes("npm ci")) {
+        ciInstall = true;
+        break;
+      }
+    }
+  }
+} catch (err) {
+  // ignore
+}
+
+const message =
+  "Lockfile drift detected. Run: npm install && npm -C frontend install";
+if (ciInstall) {
+  core.warning(message);
+} else {
+  core.notice(message);
+}


### PR DESCRIPTION
## Summary
- add npm lockfile drift checker
- run pnpm or npm drift check in CI depending on available lockfile

## Testing
- `npm run format`
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Cannot find module '@aws-sdk/client-s3')*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68bc525fea40832dae530eaa55d6f597