### PR TITLE
ci: check dependency versions before install

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "typecheck": "tsc --noEmit",
     "validate-env": "bash scripts/validate-env.sh",
     "setup": "bash scripts/setup.sh",
+    "check-dependency-versions": "node scripts/check-dependency-versions.js",
     "prebuild": "node scripts/fetch-assets.cjs",
     "build": "npm ci --no-audit --no-fund --prefix frontend && npm --prefix frontend run build",
     "start:ci": "npm --prefix frontend run start:ci",

--- a/scripts/check-dependency-versions.js
+++ b/scripts/check-dependency-versions.js
@@ -1,0 +1,34 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+function checkDependencyVersions(pkgPath = path.join(process.cwd(), 'package.json')) {
+  const absPath = path.resolve(pkgPath);
+  const pkg = JSON.parse(fs.readFileSync(absPath, 'utf8'));
+  const deps = { ...(pkg.dependencies || {}), ...(pkg.devDependencies || {}) };
+  const missing = [];
+  for (const [name, version] of Object.entries(deps)) {
+    try {
+      execSync(`npm view ${name}@${version} version`, { stdio: 'ignore' });
+    } catch (err) {
+      missing.push(`${name}@${version}`);
+    }
+  }
+  if (missing.length > 0) {
+    for (const dep of missing) {
+      if (process.env.GITHUB_ACTIONS) {
+        console.warn(`::warning::missing package version ${dep}`);
+      } else {
+        console.error(`missing package version ${dep}`);
+      }
+    }
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  const target = process.argv[2];
+  checkDependencyVersions(target);
+}
+
+module.exports = { checkDependencyVersions };

--- a/scripts/ci/prime-deps.sh
+++ b/scripts/ci/prime-deps.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 echo "==> Prime root deps"
 if [ ! -d node_modules ]; then
+  node scripts/check-dependency-versions.js
   npm ci
 else
   echo "root node_modules already present"
@@ -10,6 +11,7 @@ fi
 
 echo "==> Prime backend deps"
 if [ ! -d backend/node_modules ]; then
+  node scripts/check-dependency-versions.js backend/package.json
   pushd backend
   npm ci
   popd

--- a/scripts/ci/run-backend-offline-safe.sh
+++ b/scripts/ci/run-backend-offline-safe.sh
@@ -26,6 +26,7 @@ export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 
 echo "==> Install (backend)"
 if [ ! -d backend/node_modules ]; then
+  node scripts/check-dependency-versions.js backend/package.json
   npm ci --prefix backend
 else
   echo "backend node_modules already present, skipping install"

--- a/scripts/run-npm-ci.js
+++ b/scripts/run-npm-ci.js
@@ -2,6 +2,7 @@ const { execSync } = require("child_process");
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
+const { checkDependencyVersions } = require("./check-dependency-versions.js");
 
 function isOffline() {
   if (process.env.SKIP_NET_CHECKS === "1" || process.env.CI_NO_NET === "1") {
@@ -57,6 +58,8 @@ function runNpmCi(dir = ".", opts = {}) {
     );
   }
   try {
+    const pkgPath = dir === "." ? "package.json" : path.join(dir, "package.json");
+    checkDependencyVersions(pkgPath);
     execSync(ciCmd, options);
   } catch (err) {
     const output = String(err.stderr || err.stdout || err.message || "");


### PR DESCRIPTION
## Summary
- add script to verify dependency versions using npm view
- run dependency version check in npm ci helpers and CI scripts
- expose check-dependency-versions script in package.json

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Cannot find module '@aws-sdk/client-s3')*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68bc525a6d38832d97fcfe7233a8b798