### PR TITLE
ci: add lockfile check

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "format:check": "prettier -c .",
     "lint": "npm run lint --prefix frontend && npm run lint --prefix backend",
     "typecheck": "tsc --noEmit",
+    "check:lockfile": "npx lockfile-diff",
     "validate-env": "bash scripts/validate-env.sh",
     "setup": "bash scripts/setup.sh",
     "prebuild": "node scripts/fetch-assets.cjs",

--- a/scripts/ci.mjs
+++ b/scripts/ci.mjs
@@ -20,7 +20,14 @@ if (offline) {
   console.log("offline mode: running ci");
 }
 
+try {
+  execSync("npm run check:lockfile", { stdio: "inherit" });
+} catch (err) {
+  console.error(
+    "Lockfile mismatch detected. Run 'npm install' to regenerate package-lock.json.",
+  );
+  process.exit(1);
+}
 execSync("node scripts/run-npm-ci.js", { stdio: "inherit" });
 execSync("npm run build --workspaces=false", { stdio: "inherit" });
 execSync("npm test", { stdio: "inherit" });
-


### PR DESCRIPTION
## Summary
- add check:lockfile script
- ensure CI verifies lockfile before installing dependencies

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@actions%2fcore)*
- `npm run format` *(backend)*
- `npm test` *(backend)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68bc5257ab48832dbb762f63abb79117