### PR TITLE
fix: update asset bucket paths

### DIFF
--- a/scripts/fetch-assets.cjs
+++ b/scripts/fetch-assets.cjs
@@ -57,7 +57,8 @@ async function fetchBoombox() {
 }
 
 async function fetchRepoAssets() {
-  const bucket = "repo-assets";
+  const bucket = "glb-models-prod";
+  const prefix = "repo-assets/";
   const files = [
     "astro-image.png",
     "box logo.png",
@@ -71,7 +72,7 @@ async function fetchRepoAssets() {
       console.log(`${file} already present`);
       continue;
     }
-    await downloadFromS3(bucket, file, dest);
+    await downloadFromS3(bucket, prefix + file, dest);
   }
 }
 

--- a/tests/assets/astronaut-placeholder.pipeline.k3n8p1r6t2w9z4q7.test.js
+++ b/tests/assets/astronaut-placeholder.pipeline.k3n8p1r6t2w9z4q7.test.js
@@ -354,7 +354,10 @@ describe("pipeline integrity", () => {
     };
     for (const [key, body] of Object.entries(bodies)) {
       s3Mock
-        .on(GetObjectCommand, { Bucket: "repo-assets", Key: key })
+        .on(GetObjectCommand, {
+          Bucket: "glb-models-prod",
+          Key: `repo-assets/${key}`,
+        })
         .resolves({ Body: Readable.from(body) });
     }
     nock("https://example.com").get("/astro.glb").reply(200, "model");
@@ -372,7 +375,10 @@ describe("pipeline integrity", () => {
     };
     for (const [key, body] of Object.entries(bodies)) {
       s3Mock
-        .on(GetObjectCommand, { Bucket: "repo-assets", Key: key })
+        .on(GetObjectCommand, {
+          Bucket: "glb-models-prod",
+          Key: `repo-assets/${key}`,
+        })
         .resolves({ Body: Readable.from(body) });
     }
     nock("https://fail.test").get("/astro.glb").reply(500);

--- a/tests/assets/image-pipeline.no-safeguards.test.a4b5c6d7e8f9g0h1.js
+++ b/tests/assets/image-pipeline.no-safeguards.test.a4b5c6d7e8f9g0h1.js
@@ -45,7 +45,10 @@ beforeAll(async () => {
   };
   for (const [key, body] of Object.entries(bodies)) {
     s3Mock
-      .on(GetObjectCommand, { Bucket: "repo-assets", Key: key })
+      .on(GetObjectCommand, {
+        Bucket: "glb-models-prod",
+        Key: `repo-assets/${key}`,
+      })
       .resolves({ Body: Readable.from(body) });
   }
 

--- a/tests/assets/image-pipeline.regression.p61qn2j819opg4sc.test.js
+++ b/tests/assets/image-pipeline.regression.p61qn2j819opg4sc.test.js
@@ -37,19 +37,25 @@ describe("call stage", () => {
   });
   test.each(ASSETS)("fetchRepoAssets downloads %s", async (file) => {
     s3Mock
-      .on(GetObjectCommand, { Bucket: "repo-assets", Key: file })
+      .on(GetObjectCommand, {
+        Bucket: "glb-models-prod",
+        Key: `repo-assets/${file}`,
+      })
       .resolves({ Body: Readable.from(file) });
     await fetchRepoAssets();
     const calls = s3Mock.commandCalls(GetObjectCommand, {
-      Bucket: "repo-assets",
-      Key: file,
+      Bucket: "glb-models-prod",
+      Key: `repo-assets/${file}`,
     });
     expect(calls.length).toBe(1);
   });
 
   test("throws on missing object", async () => {
     s3Mock
-      .on(GetObjectCommand, { Bucket: "repo-assets", Key: ASSETS[0] })
+      .on(GetObjectCommand, {
+        Bucket: "glb-models-prod",
+        Key: `repo-assets/${ASSETS[0]}`,
+      })
       .rejects(new Error("NotFound"));
     await expect(fetchRepoAssets()).rejects.toThrow();
     expect(fs.existsSync(path.join(IMG_DIR, ASSETS[0]))).toBe(false);
@@ -64,7 +70,10 @@ describe("display stage", () => {
       const body = Buffer.from(`body-${f}`);
       bodies[f] = body;
       s3Mock
-        .on(GetObjectCommand, { Bucket: "repo-assets", Key: f })
+        .on(GetObjectCommand, {
+          Bucket: "glb-models-prod",
+          Key: `repo-assets/${f}`,
+        })
         .resolves({ Body: Readable.from(body) });
     }
     await fetchRepoAssets();
@@ -102,7 +111,10 @@ describe("pipeline integrity", () => {
       const body = Buffer.from(`con-${f}`);
       bodies[f] = body;
       s3Mock
-        .on(GetObjectCommand, { Bucket: "repo-assets", Key: f })
+        .on(GetObjectCommand, {
+          Bucket: "glb-models-prod",
+          Key: `repo-assets/${f}`,
+        })
         .resolves({ Body: Readable.from(body) });
     }
     await fetchRepoAssets();
@@ -114,7 +126,10 @@ describe("pipeline integrity", () => {
 
   test("fetchRepoAssets surfaces errors", async () => {
     s3Mock
-      .on(GetObjectCommand, { Bucket: "repo-assets", Key: ASSETS[0] })
+      .on(GetObjectCommand, {
+        Bucket: "glb-models-prod",
+        Key: `repo-assets/${ASSETS[0]}`,
+      })
       .rejects(new Error("boom"));
     await expect(fetchRepoAssets()).rejects.toThrow();
   });

--- a/tests/assets/image-pipeline.test.h5f2k9d1s3a7l0q8.js
+++ b/tests/assets/image-pipeline.test.h5f2k9d1s3a7l0q8.js
@@ -45,7 +45,10 @@ beforeAll(async () => {
   };
   for (const [key, body] of Object.entries(bodies)) {
     s3Mock
-      .on(GetObjectCommand, { Bucket: "repo-assets", Key: key })
+      .on(GetObjectCommand, {
+        Bucket: "glb-models-prod",
+        Key: `repo-assets/${key}`,
+      })
       .resolves({ Body: Readable.from(body) });
   }
 


### PR DESCRIPTION
## Summary
- switch asset downloader to `glb-models-prod` bucket with `repo-assets/` prefix
- update asset tests to expect new bucket path

## Testing
- `npm run format`
- `npm test` *(fails: Jest is not installed. Run `npm run setup` to install dependencies.)*


------
https://chatgpt.com/codex/tasks/task_e_68bc5667b85c832da6bf05fc06180c28