### PR TITLE
feat: add astronaut placeholder

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,6 +86,7 @@
 
     <!-- Google <model-viewer> -->
     <script src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js"></script>
+    <script type="module" src="js/astronautPlaceholder.js"></script>
 
     <style>
       html,
@@ -327,7 +328,7 @@
           <div data-testid="primary-model">
             <model-viewer
               data-testid="model-viewer"
-              data-model-src="models/astronaut.glb"
+              data-model-src="https://modelviewer.dev/shared-assets/models/Astronaut.glb"
               environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
               camera-controls
               ar

--- a/js/astronautPlaceholder.js
+++ b/js/astronautPlaceholder.js
@@ -1,0 +1,13 @@
+const DEFAULT_SRC = "https://modelviewer.dev/shared-assets/models/Astronaut.glb";
+
+async function loadPlaceholder() {
+  const viewer = document.querySelector('[data-testid="model-viewer"]');
+  if (!viewer) return;
+  const src = viewer.getAttribute("data-model-src") || DEFAULT_SRC;
+
+  if (window.customElements?.whenDefined) {
+    try { await customElements.whenDefined("model-viewer"); } catch {}
+  }
+  viewer.src = src;
+}
+document.addEventListener("DOMContentLoaded", loadPlaceholder);

--- a/payment.html
+++ b/payment.html
@@ -38,6 +38,7 @@
 
     <!-- model-viewer -->
     <script src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js"></script>
+    <script type="module" src="js/astronautPlaceholder.js"></script>
     <style>
       /* Add rainbow shimmer effect used on the index submit arrow */
       #multi-color-button {
@@ -231,7 +232,7 @@
         <div data-testid="primary-model">
           <model-viewer
             data-testid="model-viewer"
-            data-model-src="models/astronaut.glb"
+            data-model-src="https://modelviewer.dev/shared-assets/models/Astronaut.glb"
             environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
             camera-controls
             ar


### PR DESCRIPTION
## Summary
- render default astronaut model when main scripts fail
- load placeholder before other scripts on index and payment pages
- reference public astronaut model URL instead of missing local asset

## Testing
- `npm run validate-env` *(fails: 403 Forbidden - GET https://registry.npmjs.org/npm)*
- `SKIP_PW_DEPS=1 npm run setup` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest-runner)*
- `npm run format` in backend
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff; Lockfile mismatch detected)*
- `SKIP_PW_DEPS=1 npm run smoke`
- `node --input-type=module` verifying placeholder assignment to public URL and default fallback


------
https://chatgpt.com/codex/tasks/task_e_68bcb6532aa0832da57c696c90bcd59d