### PR TITLE
feat: grey out unavailable nav links

### DIFF
--- a/index.html
+++ b/index.html
@@ -701,6 +701,7 @@
         />
       </filter>
     </svg>
+    <script type="module" src="js/disable-top-nav.js"></script>
     <script type="module" src="js/trackingPixel.js"></script>
     <script>
       (function normalizeInitialScale() {

--- a/js/disable-top-nav.js
+++ b/js/disable-top-nav.js
@@ -1,0 +1,18 @@
+const selectors = [
+  'a[href="competitions.html"]',
+  "#addons-link",
+  "#profile-link",
+  'a[href="CommunityCreations.html"]',
+  'a[href="marketplace.html"]',
+  "#earn-rewards-badge",
+  "#print-club-badge",
+];
+
+for (const selector of selectors) {
+  const el = document.querySelector(selector);
+  if (el) {
+    el.classList.add("opacity-50", "cursor-not-allowed");
+    el.addEventListener("click", (e) => e.preventDefault());
+    el.setAttribute("title", "Coming soon");
+  }
+}


### PR DESCRIPTION
## Summary
- grey out top navigation links for unreleased pages and show a "Coming soon" tooltip

## Testing
- `npm run format`
- `npx prettier -w index.html js/disable-top-nav.js`
- `npm test --prefix backend`
- `npm run ci` *(fails: 403 Forbidden fetching lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68bcbe067430832d947feec8155069aa