### PR TITLE
fix: stop directly assigning viewer src

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -815,7 +815,7 @@ refs.submitBtn.addEventListener("click", async () => {
 
     editsPending = false;
 
-    refs.viewer.src = url;
+    // refs.viewer.src = url;
     await refs.viewer.updateComplete;
     showModel();
     if (window.addAutoItem) {
@@ -905,7 +905,7 @@ async function init() {
     const handleLoad = () => {
       if (refs.viewer.src === LOW_POLY_GLB) {
         hiStart = performance.now();
-        refs.viewer.src = FALLBACK_GLB;
+        // refs.viewer.src = FALLBACK_GLB;
       } else if (refs.viewer.src === FALLBACK_GLB && hiStart !== null) {
         const t = Math.round(performance.now() - hiStart);
         console.log("Model load time", t, "ms");
@@ -914,7 +914,7 @@ async function init() {
       }
     };
     refs.viewer.addEventListener("load", handleLoad);
-    refs.viewer.src = LOW_POLY_GLB;
+    // refs.viewer.src = LOW_POLY_GLB;
     localStorage.removeItem("print2JobId");
     refs.viewer.addEventListener(
       "load",
@@ -925,7 +925,7 @@ async function init() {
         loader.src = FALLBACK_GLB_HIGH;
         loader.addEventListener("load", () => {
           if (refs.viewer.src === FALLBACK_GLB_LOW) {
-            refs.viewer.src = FALLBACK_GLB_HIGH;
+            // refs.viewer.src = FALLBACK_GLB_HIGH;
           }
           loader.remove();
         });
@@ -952,7 +952,7 @@ async function init() {
     refs.viewer.addEventListener(
       "error",
       () => {
-        refs.viewer.src = FALLBACK_GLB;
+        // refs.viewer.src = FALLBACK_GLB;
         showModel();
       },
       { once: true },

--- a/js/payment.js
+++ b/js/payment.js
@@ -944,10 +944,12 @@ async function initPaymentPage() {
     if (viewer) {
       const tag = viewer.tagName.toLowerCase();
       if (tag === "img") {
-        if (item.snapshot) viewer.src = sanitizeUrl(item.snapshot);
+        if (item.snapshot) {
+          // viewer.src = sanitizeUrl(item.snapshot);
+        }
       } else {
-        const src = sanitizeUrl(item.modelUrl);
-        viewer.src = src || storedModel || FALLBACK_GLB;
+        // const src = sanitizeUrl(item.modelUrl);
+        // viewer.src = src || storedModel || FALLBACK_GLB;
       }
     }
     if (item.jobId) localStorage.setItem("print2JobId", item.jobId);
@@ -1161,7 +1163,9 @@ async function initPaymentPage() {
     loader.hidden = false;
     // Assign the model source only after the load/error listeners are in place
     const storedModel = sanitizeUrl(localStorage.getItem("print2Model"));
-    if (viewer) viewer.src = storedModel || FALLBACK_GLB;
+    if (viewer) {
+      // viewer.src = storedModel || FALLBACK_GLB;
+    }
   }
   // Load saved basket items unless this is the Luckybox page
   if (!window.location.pathname.endsWith("luckybox-payment.html")) {


### PR DESCRIPTION
## Summary
- avoid setting model-viewer src directly in generator flow
- remove payment script assignments to viewer src so placeholder controls model

## Testing
- `npm run format` (backend)
- `npm test` (backend)
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Lockfile mismatch and npm 403)*
- `SKIP_PW_DEPS=1 npm run smoke` *(skipped in offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc2e38ab4832db942faadea12d6ae