### PR TITLE
feat: remove unreleased nav links

### DIFF
--- a/index.html
+++ b/index.html
@@ -701,6 +701,7 @@
         />
       </filter>
     </svg>
+    <script type="module" src="js/disable-top-nav.js"></script>
     <script type="module" src="js/trackingPixel.js"></script>
     <script>
       (function normalizeInitialScale() {

--- a/js/disable-top-nav.js
+++ b/js/disable-top-nav.js
@@ -1,0 +1,14 @@
+const targets = [
+  { selector: 'a[href="competitions.html"]', removeParent: true },
+  { selector: 'a[href="CommunityCreations.html"]', removeParent: true },
+  { selector: "#earn-rewards-badge", removeParent: false },
+  { selector: "#print-club-badge", removeParent: false },
+];
+
+for (const { selector, removeParent } of targets) {
+  const el = document.querySelector(selector);
+  if (el) {
+    const node = removeParent && el.parentElement ? el.parentElement : el;
+    node.remove();
+  }
+}


### PR DESCRIPTION
## Summary
- remove top navigation links for unreleased pages so they disappear entirely

## Testing
- `npx prettier -w js/disable-top-nav.js`
- `npm run format`
- `npm test --prefix backend`
- `npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68bcbe067430832d947feec8155069aa