### PR TITLE
feat: disable unreleased nav links

### DIFF
--- a/index.html
+++ b/index.html
@@ -701,6 +701,7 @@
         />
       </filter>
     </svg>
+    <script type="module" src="js/disable-top-nav.js"></script>
     <script type="module" src="js/trackingPixel.js"></script>
     <script>
       (function normalizeInitialScale() {

--- a/js/disable-top-nav.js
+++ b/js/disable-top-nav.js
@@ -1,0 +1,19 @@
+const selectors = [
+  'a[href="competitions.html"]',
+  'a[href="addons.html"]',
+  'a[href="profile.html"]',
+  'a[href="CommunityCreations.html"]',
+  'a[href="marketplace.html"]',
+  "#earn-rewards-badge",
+  "#print-club-badge",
+];
+
+for (const selector of selectors) {
+  const el = document.querySelector(selector);
+  if (!el) continue;
+
+  el.classList.add("opacity-50", "cursor-not-allowed");
+  el.setAttribute("title", "Coming soon");
+  el.setAttribute("aria-disabled", "true");
+  el.addEventListener("click", (e) => e.preventDefault());
+}


### PR DESCRIPTION
## Summary
- gray out navigation links to unreleased pages and show a 'Coming soon' tooltip
- load lightweight toggle script on the landing page to keep inactive sections visible but non-clickable

## Testing
- `npm run validate-env`
- `npm run setup` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest-runner)*
- `npx prettier -w js/disable-top-nav.js`
- `npm run format`
- `npm test --prefix backend`
- `npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: skipping smoke)*
- `npm run diagnose` *(fails: Missing script: "diagnose")*


------
https://chatgpt.com/codex/tasks/task_e_68bcbe067430832d947feec8155069aa