### PR TITLE
fix: preload astronaut model by default

### DIFF
--- a/index.html
+++ b/index.html
@@ -327,7 +327,9 @@
           <!-- 3-D Astronaut (always visible) -->
           <div data-testid="primary-model">
             <model-viewer
+              id="viewer"
               data-testid="model-viewer"
+              src="https://modelviewer.dev/shared-assets/models/Astronaut.glb"
               environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
               camera-controls
               ar

--- a/js/index.js
+++ b/js/index.js
@@ -277,7 +277,7 @@ const $ = (id) => document.getElementById(id);
 const refs = {
   previewImg: $("preview-img"),
   loader: $("loader"),
-  viewer: $("viewer"),
+  viewer: document.getElementById("viewer"),
   progressBar: $("progress-bar"),
   progressWrapper: $("progress-wrapper"),
   progressText: $("progress-text"),
@@ -331,7 +331,6 @@ let usingViewerProgress = false;
 let lastSnapshot = null;
 let errorFadeTimeout = null;
 let errorClearTimeout = null;
-
 
 async function updateWizardSlotCount() {
   if (!window.setWizardSlotCount) return;
@@ -866,6 +865,7 @@ async function init() {
       await customElements.whenDefined("model-viewer");
     } catch {}
   }
+  setModelSrc();
   syncUploadHeights();
   window.addEventListener("resize", syncUploadHeights);
   setStep("prompt");
@@ -935,34 +935,32 @@ async function init() {
       { once: true },
     );
   }
-  if (refs.viewer) {
-    refs.viewer.addEventListener("progress", (e) => {
-      if (!progressStart) progressStart = Date.now();
-      usingViewerProgress = true;
-      const pct = Math.round(e.detail.totalProgress * 100);
-      refs.progressBar.style.width = pct + "%";
-      const elapsed = Date.now() - progressStart;
-      if (pct < 100) {
-        const remaining = pct > 0 ? (elapsed * (100 - pct)) / pct : 0;
-        refs.progressText.textContent = `~${Math.ceil(remaining / 1000)}s remaining`;
-      } else {
-        stopProgress();
-      }
-    });
-    refs.viewer.addEventListener("load", showModel, { once: true });
-    refs.viewer.addEventListener(
-      "error",
-      () => {
-        // refs.viewer.src = FALLBACK_GLB;
-        showModel();
-      },
-      { once: true },
-    );
-    await refs.viewer.updateComplete;
-    try {
-      lastSnapshot = await captureModelSnapshot(refs.viewer.src);
-    } catch {}
-  }
+  refs.viewer.addEventListener("progress", (e) => {
+    if (!progressStart) progressStart = Date.now();
+    usingViewerProgress = true;
+    const pct = Math.round(e.detail.totalProgress * 100);
+    refs.progressBar.style.width = pct + "%";
+    const elapsed = Date.now() - progressStart;
+    if (pct < 100) {
+      const remaining = pct > 0 ? (elapsed * (100 - pct)) / pct : 0;
+      refs.progressText.textContent = `~${Math.ceil(remaining / 1000)}s remaining`;
+    } else {
+      stopProgress();
+    }
+  });
+  refs.viewer.addEventListener("load", showModel, { once: true });
+  refs.viewer.addEventListener(
+    "error",
+    () => {
+      // refs.viewer.src = FALLBACK_GLB;
+      showModel();
+    },
+    { once: true },
+  );
+  await refs.viewer.updateComplete;
+  try {
+    lastSnapshot = await captureModelSnapshot(refs.viewer.src);
+  } catch {}
   showModel();
   fetchProfile().then(() => {
     if (userProfile && refs.buyNowBtn) {
@@ -1020,7 +1018,7 @@ async function init() {
 
   // Ensure checkout uses the model currently shown in the viewer
   refs.checkoutBtn?.addEventListener("click", () => {
-    if (refs.viewer?.src) {
+    if (refs.viewer.src) {
       localStorage.setItem("print2Model", refs.viewer.src);
     }
     if (lastJobId) {
@@ -1043,7 +1041,7 @@ async function init() {
   });
 
   refs.addBasketBtn?.addEventListener("click", async () => {
-    if (!window.addToBasket || !refs.viewer?.src) return;
+    if (!window.addToBasket || !refs.viewer.src) return;
     let snapshot = refs.previewImg?.src;
     const host = (() => {
       try {

--- a/js/payment.js
+++ b/js/payment.js
@@ -46,7 +46,8 @@ import { setModelSrc } from "./modelLoader.js";
 let stripe = null;
 
 // Use a lightweight fallback model and upgrade to the high detail version after load.
-const FALLBACK_GLB_LOW = "https://modelviewer.dev/shared-assets/models/Astronaut.glb";
+const FALLBACK_GLB_LOW =
+  "https://modelviewer.dev/shared-assets/models/Astronaut.glb";
 const FALLBACK_GLB_HIGH = FALLBACK_GLB_LOW;
 const FALLBACK_GLB = FALLBACK_GLB_LOW;
 const PRICES = {
@@ -272,7 +273,6 @@ function ensureModelViewerLoaded() {
     }, 3000);
   });
 }
-
 
 function computeColorSlotsByTime() {
   const dtf = new Intl.DateTimeFormat("en-US", {
@@ -1155,6 +1155,8 @@ async function initPaymentPage() {
       // ignore if the element never upgrades
     }
   }
+  const storedModel = sanitizeUrl(localStorage.getItem("print2Model"));
+  setModelSrc(storedModel || FALLBACK_GLB);
 
   if (viewer && viewer.tagName.toLowerCase() === "img") {
     // The Luckybox page uses a static <img> preview, so skip the loading
@@ -1162,11 +1164,6 @@ async function initPaymentPage() {
     loader.hidden = true;
   } else {
     loader.hidden = false;
-    // Assign the model source only after the load/error listeners are in place
-    const storedModel = sanitizeUrl(localStorage.getItem("print2Model"));
-    if (viewer) {
-      setModelSrc(storedModel || FALLBACK_GLB);
-    }
   }
   // Load saved basket items unless this is the Luckybox page
   if (!window.location.pathname.endsWith("luckybox-payment.html")) {

--- a/payment.html
+++ b/payment.html
@@ -231,7 +231,9 @@
           />
         <div data-testid="primary-model">
           <model-viewer
+            id="viewer"
             data-testid="model-viewer"
+            src="https://modelviewer.dev/shared-assets/models/Astronaut.glb"
             environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
             camera-controls
             ar


### PR DESCRIPTION
## Summary
- ensure main pages initialize model-viewer with astronaut model
- simplify viewer handling and always set fallback model

## Testing
- `npx prettier -w index.html payment.html js/index.js js/payment.js`
- `npm test` *(fails: Jest is not installed)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68bccfb7c258832d97abbe90c2237c22