### PR TITLE
fix: load model-viewer as module

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@
     />
 
     <!-- Google <model-viewer> -->
-    <script src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js"></script>
+    <script type="module" src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js"></script>
     <script type="module" src="js/modelLoader.js"></script>
 
     <style>

--- a/payment.html
+++ b/payment.html
@@ -37,7 +37,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" referrerpolicy="no-referrer">
 
     <!-- model-viewer -->
-    <script src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js"></script>
+    <script type="module" src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js"></script>
     <script type="module" src="js/modelLoader.js"></script>
     <style>
       /* Add rainbow shimmer effect used on the index submit arrow */


### PR DESCRIPTION
## Summary
- load @google/model-viewer via module script on index and payment pages

## Testing
- `npm run format`
- `npm test`
- `npm run smoke`
- `npm run ci` *(fails: Lockfile mismatch detected)*

------
https://chatgpt.com/codex/tasks/task_e_68bd66fbee48832d8534358ac90127a1