### PR TITLE
fix: load model-viewer fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,8 +84,6 @@
       crossorigin
     />
 
-    <!-- Google <model-viewer> -->
-    <script type="module" src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js"></script>
     <script type="module" src="js/modelLoader.js"></script>
 
     <style>
@@ -599,6 +597,7 @@
     <script type="module" src="js/subredditLanding.js" defer></script>
     <script type="module" src="js/exitDiscount.js" defer></script>
     <script type="module" src="js/printclub.js" defer></script>
+    <script type="module" src="js/modelViewerFallback.js" defer></script>
     <script type="module">
       document
         .getElementById("profile-link")

--- a/js/modelViewerFallback.js
+++ b/js/modelViewerFallback.js
@@ -1,0 +1,39 @@
+const MODEL_SRC = "https://modelviewer.dev/shared-assets/models/Astronaut.glb";
+const ENV_SRC =
+  "https://modelviewer.dev/shared-assets/environments/neutral.hdr";
+
+function ensureModelViewerLoaded() {
+  if (window.customElements?.get("model-viewer")) {
+    return Promise.resolve();
+  }
+  const cdnUrl =
+    "https://cdn.jsdelivr.net/npm/@google/model-viewer@1.12.0/dist/model-viewer.min.js";
+  const localUrl = "js/model-viewer.min.js";
+
+  function loadScript(src) {
+    return new Promise((resolve, reject) => {
+      const s = document.createElement("script");
+      s.type = "module";
+      s.src = src;
+      s.onload = resolve;
+      s.onerror = reject;
+      document.head.appendChild(s);
+    });
+  }
+
+  return loadScript(cdnUrl).catch(() => loadScript(localUrl));
+}
+
+window.addEventListener("DOMContentLoaded", async () => {
+  try {
+    await ensureModelViewerLoaded();
+    document.querySelectorAll("model-viewer").forEach((el) => {
+      el.src = MODEL_SRC;
+      if (!el.getAttribute("environment-image")) {
+        el.setAttribute("environment-image", ENV_SRC);
+      }
+    });
+  } catch (err) {
+    console.error("model-viewer still unavailable", err);
+  }
+});

--- a/payment.html
+++ b/payment.html
@@ -36,8 +36,6 @@
     <!-- Font Awesome (back-arrow icon) -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" referrerpolicy="no-referrer">
 
-    <!-- model-viewer -->
-    <script type="module" src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js"></script>
     <script type="module" src="js/modelLoader.js"></script>
     <style>
       /* Add rainbow shimmer effect used on the index submit arrow */
@@ -748,6 +746,7 @@
     <script type="module" src="js/print-slots.js" defer></script>
     <script type="module" src="js/payment.js" defer></script>
     <script type="module" src="js/exitDiscount.js" defer></script>
+    <script type="module" src="js/modelViewerFallback.js" defer></script>
     <script>
       document.addEventListener('DOMContentLoaded', () => {
         const link = document.getElementById('back-link');


### PR DESCRIPTION
## Summary
- add post-load script that ensures `<model-viewer>` loads from jsDelivr or local fallback
- include fallback script on index and payment pages to set astronaut model source

## Testing
- `npx prettier -w index.html payment.html js/modelViewerFallback.js`
- `cd backend && npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68bd8328fa54832da652ee2396125488