### PR TITLE
ci: inject astronaut model url into minimal workflow

### DIFF
--- a/.github/workflows/ci-minimal.yml
+++ b/.github/workflows/ci-minimal.yml
@@ -20,6 +20,8 @@ jobs:
       - run: npm ci --prefix frontend
       # Build
       - run: npm run build --if-present
+        env:
+          ASTRONAUT_MODEL_URL: ${{ secrets.ASTRONAUT_MODEL_URL }}
       - run: node scripts/ci-doctor.mjs
         env:
           STRIPE_SECRET_KEY: sk_test
@@ -43,6 +45,8 @@ jobs:
       - run: npm ci --prefix backend
       # Build
       - run: npm run build --if-present
+        env:
+          ASTRONAUT_MODEL_URL: ${{ secrets.ASTRONAUT_MODEL_URL }}
       - run: node scripts/ci-doctor.mjs
         env:
           STRIPE_SECRET_KEY: sk_test


### PR DESCRIPTION
## Summary
- ensure Astronaut model URL secret is passed to build steps in minimal CI workflow

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_68bd948711fc832dae2157ade06c3c3b