### PR TITLE
ci: inject astronaut model url into workflows

### DIFF
--- a/.github/workflows/api-removal-safety.yml
+++ b/.github/workflows/api-removal-safety.yml
@@ -39,6 +39,8 @@ jobs:
             npm ci
           fi
       - run: npm run build --if-present
+        env:
+          ASTRONAUT_MODEL_URL: ${{ secrets.ASTRONAUT_MODEL_URL }}
       - run: node scripts/ci-doctor.mjs
         env:
           STRIPE_SECRET_KEY: sk_test
@@ -70,6 +72,8 @@ jobs:
             npm ci
           fi
       - run: npm run build --if-present
+        env:
+          ASTRONAUT_MODEL_URL: ${{ secrets.ASTRONAUT_MODEL_URL }}
       - run: node scripts/ci-doctor.mjs
         env:
           STRIPE_SECRET_KEY: sk_test
@@ -107,6 +111,8 @@ jobs:
             npm ci
           fi
       - run: npm run build --if-present
+        env:
+          ASTRONAUT_MODEL_URL: ${{ secrets.ASTRONAUT_MODEL_URL }}
       - run: node scripts/ci-doctor.mjs
         env:
           STRIPE_SECRET_KEY: sk_test
@@ -141,6 +147,8 @@ jobs:
             npm ci
           fi
       - run: npm run build --if-present
+        env:
+          ASTRONAUT_MODEL_URL: ${{ secrets.ASTRONAUT_MODEL_URL }}
       - run: node scripts/ci-doctor.mjs
         env:
           STRIPE_SECRET_KEY: sk_test
@@ -173,6 +181,8 @@ jobs:
             npm ci
           fi
       - run: npm run build --if-present
+        env:
+          ASTRONAUT_MODEL_URL: ${{ secrets.ASTRONAUT_MODEL_URL }}
       - run: node scripts/ci-doctor.mjs
         env:
           STRIPE_SECRET_KEY: sk_test

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -58,6 +58,8 @@ jobs:
           fi
       - run: npm ci --prefix backend
       - run: npm run build --if-present
+        env:
+          ASTRONAUT_MODEL_URL: ${{ secrets.ASTRONAUT_MODEL_URL }}
       - run: node scripts/ci-doctor.mjs
         env:
           STRIPE_SECRET_KEY: sk_test

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -47,6 +47,8 @@ jobs:
           fi
 
       - run: npm run build --if-present
+        env:
+          ASTRONAUT_MODEL_URL: ${{ secrets.ASTRONAUT_MODEL_URL }}
 
       - run: node scripts/ci-doctor.mjs
         env:

--- a/.github/workflows/model-e2e.yml
+++ b/.github/workflows/model-e2e.yml
@@ -33,6 +33,8 @@ jobs:
           fi
       - run: npx playwright install --with-deps chromium
       - run: npm run build --if-present
+        env:
+          ASTRONAUT_MODEL_URL: ${{ secrets.ASTRONAUT_MODEL_URL }}
       - run: node scripts/ci-doctor.mjs
         env:
           STRIPE_SECRET_KEY: sk_test

--- a/.github/workflows/no-lfs-in-tests.yml
+++ b/.github/workflows/no-lfs-in-tests.yml
@@ -12,6 +12,8 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run build --if-present
+        env:
+          ASTRONAUT_MODEL_URL: ${{ secrets.ASTRONAUT_MODEL_URL }}
       - run: node scripts/ci-doctor.mjs
         env:
           STRIPE_SECRET_KEY: sk_test

--- a/.github/workflows/node-version-guard.yml
+++ b/.github/workflows/node-version-guard.yml
@@ -11,6 +11,8 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run build --if-present
+        env:
+          ASTRONAUT_MODEL_URL: ${{ secrets.ASTRONAUT_MODEL_URL }}
       - run: node scripts/ci-doctor.mjs
         env:
           STRIPE_SECRET_KEY: sk_test

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,6 +23,8 @@ jobs:
           node-version: "20"
       - run: npm ci
       - run: npm run build
+        env:
+          ASTRONAUT_MODEL_URL: ${{ secrets.ASTRONAUT_MODEL_URL }}
       - name: Copy static site files
         run: |
           cp -a *.html frontend/dist/

--- a/.github/workflows/playwright-deps-and-e2e.yml
+++ b/.github/workflows/playwright-deps-and-e2e.yml
@@ -37,6 +37,8 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install chromium
       - run: npm run build --if-present
+        env:
+          ASTRONAUT_MODEL_URL: ${{ secrets.ASTRONAUT_MODEL_URL }}
       - run: node scripts/ci-doctor.mjs
         env:
           STRIPE_SECRET_KEY: sk_test

--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -64,6 +64,8 @@ jobs:
 
       - name: Build
         run: npm run build --workspaces=false
+        env:
+          ASTRONAUT_MODEL_URL: ${{ secrets.ASTRONAUT_MODEL_URL }}
 
       - name: CI doctor
         run: node scripts/ci-doctor.mjs

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -33,6 +33,8 @@ jobs:
             npm ci
           fi
       - run: npm run build --if-present
+        env:
+          ASTRONAUT_MODEL_URL: ${{ secrets.ASTRONAUT_MODEL_URL }}
       - run: node scripts/ci-doctor.mjs
         env:
           STRIPE_SECRET_KEY: sk_test

--- a/.github/workflows/stripe-tests.yml
+++ b/.github/workflows/stripe-tests.yml
@@ -29,6 +29,8 @@ jobs:
             npm ci
           fi
       - run: npm run build --if-present
+        env:
+          ASTRONAUT_MODEL_URL: ${{ secrets.ASTRONAUT_MODEL_URL }}
       - run: node scripts/ci-doctor.mjs
         env:
           STRIPE_SECRET_KEY: sk_test_dummy


### PR DESCRIPTION
## Summary
- add `ASTRONAUT_MODEL_URL` env var to build steps in CI workflows

## Testing
- `npm run format`
- `npm test --prefix backend`


------
https://chatgpt.com/codex/tasks/task_e_68bd9a7cec20832d8cd896d6266521f9