### PR TITLE
test: add astronaut download debug suite

### DIFF
--- a/.github/workflows/debug-astronaut-download.yml
+++ b/.github/workflows/debug-astronaut-download.yml
@@ -1,0 +1,17 @@
+name: "Debugging 'incomplete response' when downloading astronaut .glb for tests"
+
+on:
+  push:
+    branches: [dev, "00000production"]
+  pull_request:
+    branches: [dev, "00000production"]
+
+jobs:
+  debug-astronaut-download:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.6
+      - uses: actions/setup-node@v4.0.2
+        with:
+          node-version: 20
+      - run: node --test tests/fetch-assets.test.x9dh37as6fk9p4b2.js

--- a/tests/fetch-assets.test.x9dh37as6fk9p4b2.js
+++ b/tests/fetch-assets.test.x9dh37as6fk9p4b2.js
@@ -1,0 +1,174 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const fsp = require('node:fs/promises');
+const { join } = require('node:path');
+const os = require('node:os');
+const http = require('node:http');
+
+async function inTempDir(fn) {
+  const dir = await fsp.mkdtemp(join(os.tmpdir(), 'fa-'));
+  const prev = process.cwd();
+  process.chdir(dir);
+  try {
+    await fn(dir);
+  } finally {
+    process.chdir(prev);
+    delete process.env.ASTRONAUT_MODEL_URL;
+    delete process.env.BOOMBOX_MODEL_URL;
+  }
+}
+
+async function startServer(handler) {
+  const server = http.createServer(handler);
+  await new Promise((resolve) => server.listen(0, resolve));
+  const { port } = server.address();
+  return { server, url: `http://127.0.0.1:${port}` };
+}
+
+function loadModule() {
+  delete require.cache[require.resolve('../scripts/fetch-assets.cjs')];
+  return require('../scripts/fetch-assets.cjs');
+}
+
+test('ensureDir creates directory', { concurrency: false }, async () => {
+  await inTempDir(async (dir) => {
+    const { ensureDir } = loadModule();
+    const file = join(dir, 'a/b/c.txt');
+    await ensureDir(file);
+    assert.ok(fs.existsSync(join(dir, 'a/b')));
+  });
+});
+
+test('download saves file', { concurrency: false }, async () => {
+  await inTempDir(async (dir) => {
+    const { download } = loadModule();
+    const body = Buffer.from('hello');
+    const { server, url } = await startServer((req, res) => {
+      res.writeHead(200, { 'Content-Length': body.length });
+      res.end(body);
+    });
+    const dest = join(dir, 'file.bin');
+    await download(url, dest);
+    const data = await fsp.readFile(dest);
+    assert.deepEqual(data, body);
+    server.close();
+  });
+});
+
+test('download throws on http error', { concurrency: false }, async () => {
+  await inTempDir(async (dir) => {
+    const { download } = loadModule();
+    const { server, url } = await startServer((req, res) => {
+      res.writeHead(500);
+      res.end('fail');
+    });
+    await assert.rejects(() => download(url, join(dir, 'file')), /HTTP 500/);
+    server.close();
+  });
+});
+
+test('fetchBoombox creates placeholder when URL missing', { concurrency: false }, async () => {
+  await inTempDir(async (dir) => {
+    const { fetchBoombox } = loadModule();
+    await fetchBoombox();
+    const dest = join(dir, 'frontend', 'public', 'models', 'boombox.glb');
+    const stats = await fsp.stat(dest);
+    assert.equal(stats.size, 0);
+  });
+});
+
+test('fetchBoombox downloads model', { concurrency: false }, async () => {
+  await inTempDir(async (dir) => {
+    const { fetchBoombox } = loadModule();
+    const body = Buffer.from('boom');
+    const { server, url } = await startServer((req, res) => {
+      res.writeHead(200, { 'Content-Length': body.length });
+      res.end(body);
+    });
+    process.env.BOOMBOX_MODEL_URL = url;
+    await fetchBoombox();
+    const dest = join(dir, 'frontend', 'public', 'models', 'boombox.glb');
+    const data = await fsp.readFile(dest);
+    assert.deepEqual(data, body);
+    server.close();
+  });
+});
+
+test('fetchAstronaut throws when URL missing', { concurrency: false }, async () => {
+  await inTempDir(async () => {
+    const { fetchAstronaut } = loadModule();
+    await assert.rejects(fetchAstronaut, /ASTRONAUT_MODEL_URL not set/);
+  });
+});
+
+test('fetchAstronaut downloads file', { concurrency: false }, async () => {
+  await inTempDir(async (dir) => {
+    const { fetchAstronaut } = loadModule();
+    const body = Buffer.from('astro');
+    const { server, url } = await startServer((req, res) => {
+      res.writeHead(200, { 'Content-Length': body.length });
+      res.end(body);
+    });
+    process.env.ASTRONAUT_MODEL_URL = url;
+    const dest = await fetchAstronaut();
+    const data = await fsp.readFile(dest);
+    assert.deepEqual(data, body);
+    server.close();
+  });
+});
+
+test('fetchAstronaut retries on incomplete response and succeeds', { concurrency: false }, async () => {
+  await inTempDir(async (dir) => {
+    const { fetchAstronaut } = loadModule();
+    const body = Buffer.from('astro');
+    let count = 0;
+    const { server, url } = await startServer((req, res) => {
+      res.writeHead(200, { 'Content-Length': body.length });
+      if (count++ === 0) {
+        res.end(body.slice(0, body.length - 1));
+      } else {
+        res.end(body);
+      }
+    });
+    process.env.ASTRONAUT_MODEL_URL = url;
+    const dest = await fetchAstronaut();
+    const data = await fsp.readFile(dest);
+    assert.deepEqual(data, body);
+    assert.equal(count, 2);
+    server.close();
+  });
+});
+
+test('fetchAstronaut fails after retries', { concurrency: false }, async () => {
+  await inTempDir(async () => {
+    const { fetchAstronaut } = loadModule();
+    const body = Buffer.from('astro');
+    const { server, url } = await startServer((req, res) => {
+      res.writeHead(200, { 'Content-Length': body.length });
+      res.end(body.slice(0, body.length - 1));
+    });
+    process.env.ASTRONAUT_MODEL_URL = url;
+    await assert.rejects(fetchAstronaut, /(incomplete response|terminated)/);
+    server.close();
+  });
+});
+
+test('fetchAstronaut uses cached file on second call', { concurrency: false }, async () => {
+  await inTempDir(async (dir) => {
+    const mod = loadModule();
+    const body = Buffer.from('astro');
+    let count = 0;
+    const { server, url } = await startServer((req, res) => {
+      count += 1;
+      res.writeHead(200, { 'Content-Length': body.length });
+      res.end(body);
+    });
+    process.env.ASTRONAUT_MODEL_URL = url;
+    const dest1 = await mod.fetchAstronaut();
+    const dest2 = await mod.fetchAstronaut();
+    assert.equal(dest1, dest2);
+    assert.equal(count, 1);
+    server.close();
+  });
+});


### PR DESCRIPTION
## Summary
- add node-based tests for fetch-assets to examine astronaut and boombox downloads
- introduce dedicated CI workflow that runs the new suite on dev and 00000production

## Testing
- `node --test tests/fetch-assets.test.x9dh37as6fk9p4b2.js`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68bd9caedb00832d9ad0e890bc55e7c5