### PR TITLE
test: deepen astronaut download diagnostics

### DIFF
--- a/.github/workflows/debug-astronaut-download.yml
+++ b/.github/workflows/debug-astronaut-download.yml
@@ -1,0 +1,17 @@
+name: "Debugging 'incomplete response' when downloading astronaut .glb for tests"
+
+on:
+  push:
+    branches: [dev, "00000production"]
+  pull_request:
+    branches: [dev, "00000production"]
+
+jobs:
+  debug-astronaut-download:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.6
+      - uses: actions/setup-node@v4.0.2
+        with:
+          node-version: 20
+      - run: node --test tests/fetch-assets.test.x9dh37as6fk9p4b2.js

--- a/scripts/fetch-assets.cjs
+++ b/scripts/fetch-assets.cjs
@@ -42,6 +42,11 @@ async function fetchBoombox() {
 let astronautPromise;
 let lastAstronautUrl;
 
+let retryLogger = (msg) => console.warn(msg);
+function setRetryLogger(fn) {
+  retryLogger = fn;
+}
+
 async function fetchAstronaut() {
   const dest = join("frontend", "public", "models", "astronaut.glb");
   const url = process.env.ASTRONAUT_MODEL_URL;
@@ -67,11 +72,16 @@ async function fetchAstronaut() {
     try {
       const attempts = 3;
       for (let attempt = 1; attempt <= attempts; attempt++) {
+        let expected;
+        let bytes = 0;
+        const start = Date.now();
         try {
           const res = await fetch(url, { signal: AbortSignal.timeout(10000) });
           if (!res.ok) throw new Error(`HTTP ${res.status}`);
-          const expected = res.headers.get("content-length");
-          let bytes = 0;
+          expected = res.headers.get("content-length");
+          if (!expected) {
+            retryLogger(`attempt ${attempt}: missing Content-Length`);
+          }
           const counter = new Transform({
             transform(chunk, enc, cb) {
               bytes += chunk.length;
@@ -84,7 +94,11 @@ async function fetchAstronaut() {
             counter,
             createWriteStream(dest, { mode: 0o644 }),
           );
+          const elapsed = Date.now() - start;
           if (expected && Number(expected) !== bytes) {
+            retryLogger(
+              `attempt ${attempt}: expected ${expected} bytes, received ${bytes} in ${elapsed}ms`,
+            );
             throw new Error("incomplete response");
           }
           lastAstronautUrl = url;
@@ -95,7 +109,10 @@ async function fetchAstronaut() {
             lastAstronautUrl = undefined;
             throw err;
           }
-          console.warn(`Retrying astronaut download (${attempt}): ${err}`);
+          const elapsed = Date.now() - start;
+          retryLogger(
+            `Retrying astronaut download (${attempt}): ${err}; received ${bytes} of ${expected ?? "?"} bytes after ${elapsed}ms`,
+          );
         }
       }
     } finally {
@@ -111,6 +128,7 @@ module.exports = {
   download,
   fetchBoombox,
   fetchAstronaut,
+  setRetryLogger,
 };
 
 if (require.main === module) {

--- a/tests/fetch-assets.test.x9dh37as6fk9p4b2.js
+++ b/tests/fetch-assets.test.x9dh37as6fk9p4b2.js
@@ -1,0 +1,711 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const fsp = require("node:fs/promises");
+const { join } = require("node:path");
+const os = require("node:os");
+const http = require("node:http");
+const { execFile } = require("node:child_process");
+
+async function inTempDir(fn) {
+  const dir = await fsp.mkdtemp(join(os.tmpdir(), "fa-"));
+  const prev = process.cwd();
+  process.chdir(dir);
+  try {
+    await fn(dir);
+  } finally {
+    process.chdir(prev);
+    delete process.env.ASTRONAUT_MODEL_URL;
+    delete process.env.BOOMBOX_MODEL_URL;
+  }
+}
+
+async function startServer(handler) {
+  const server = http.createServer(handler);
+  await new Promise((resolve) => server.listen(0, resolve));
+  const { port } = server.address();
+  return { server, url: `http://127.0.0.1:${port}` };
+}
+
+function loadModule() {
+  delete require.cache[require.resolve("../scripts/fetch-assets.cjs")];
+  return require("../scripts/fetch-assets.cjs");
+}
+
+test("ensureDir creates directory", { concurrency: false }, async () => {
+  await inTempDir(async (dir) => {
+    const { ensureDir } = loadModule();
+    const file = join(dir, "a/b/c.txt");
+    await ensureDir(file);
+    assert.ok(fs.existsSync(join(dir, "a/b")));
+  });
+});
+
+test("download saves file", { concurrency: false }, async () => {
+  await inTempDir(async (dir) => {
+    const { download } = loadModule();
+    const body = Buffer.from("hello");
+    const { server, url } = await startServer((req, res) => {
+      res.writeHead(200, { "Content-Length": body.length });
+      res.end(body);
+    });
+    const dest = join(dir, "file.bin");
+    await download(url, dest);
+    const data = await fsp.readFile(dest);
+    assert.deepEqual(data, body);
+    server.close();
+  });
+});
+
+test("download throws on http error", { concurrency: false }, async () => {
+  await inTempDir(async (dir) => {
+    const { download } = loadModule();
+    const { server, url } = await startServer((req, res) => {
+      res.writeHead(500);
+      res.end("fail");
+    });
+    await assert.rejects(() => download(url, join(dir, "file")), /HTTP 500/);
+    server.close();
+  });
+});
+
+test(
+  "fetchBoombox creates placeholder when URL missing",
+  { concurrency: false },
+  async () => {
+    await inTempDir(async (dir) => {
+      const { fetchBoombox } = loadModule();
+      await fetchBoombox();
+      const dest = join(dir, "frontend", "public", "models", "boombox.glb");
+      const stats = await fsp.stat(dest);
+      assert.equal(stats.size, 0);
+    });
+  },
+);
+
+test("fetchBoombox downloads model", { concurrency: false }, async () => {
+  await inTempDir(async (dir) => {
+    const { fetchBoombox } = loadModule();
+    const body = Buffer.from("boom");
+    const { server, url } = await startServer((req, res) => {
+      res.writeHead(200, { "Content-Length": body.length });
+      res.end(body);
+    });
+    process.env.BOOMBOX_MODEL_URL = url;
+    await fetchBoombox();
+    const dest = join(dir, "frontend", "public", "models", "boombox.glb");
+    const data = await fsp.readFile(dest);
+    assert.deepEqual(data, body);
+    server.close();
+  });
+});
+
+test(
+  "fetchAstronaut throws when URL missing",
+  { concurrency: false },
+  async () => {
+    await inTempDir(async () => {
+      const { fetchAstronaut } = loadModule();
+      await assert.rejects(fetchAstronaut, /ASTRONAUT_MODEL_URL not set/);
+    });
+  },
+);
+
+test("fetchAstronaut downloads file", { concurrency: false }, async () => {
+  await inTempDir(async (dir) => {
+    const { fetchAstronaut } = loadModule();
+    const body = Buffer.from("astro");
+    const { server, url } = await startServer((req, res) => {
+      res.writeHead(200, { "Content-Length": body.length });
+      res.end(body);
+    });
+    process.env.ASTRONAUT_MODEL_URL = url;
+    const dest = await fetchAstronaut();
+    const data = await fsp.readFile(dest);
+    assert.deepEqual(data, body);
+    server.close();
+  });
+});
+
+test(
+  "fetchAstronaut retries on incomplete response and succeeds",
+  { concurrency: false },
+  async () => {
+    await inTempDir(async (dir) => {
+      const { fetchAstronaut } = loadModule();
+      const body = Buffer.from("astro");
+      let count = 0;
+      const { server, url } = await startServer((req, res) => {
+        res.writeHead(200, { "Content-Length": body.length });
+        if (count++ === 0) {
+          res.end(body.slice(0, body.length - 1));
+        } else {
+          res.end(body);
+        }
+      });
+      process.env.ASTRONAUT_MODEL_URL = url;
+      const dest = await fetchAstronaut();
+      const data = await fsp.readFile(dest);
+      assert.deepEqual(data, body);
+      assert.equal(count, 2);
+      server.close();
+    });
+  },
+);
+
+test("fetchAstronaut fails after retries", { concurrency: false }, async () => {
+  await inTempDir(async () => {
+    const { fetchAstronaut } = loadModule();
+    const body = Buffer.from("astro");
+    const { server, url } = await startServer((req, res) => {
+      res.writeHead(200, { "Content-Length": body.length });
+      res.end(body.slice(0, body.length - 1));
+    });
+    process.env.ASTRONAUT_MODEL_URL = url;
+    await assert.rejects(fetchAstronaut, /(incomplete response|terminated)/);
+    server.close();
+  });
+});
+
+test(
+  "fetchAstronaut uses cached file on second call",
+  { concurrency: false },
+  async () => {
+    await inTempDir(async (dir) => {
+      const mod = loadModule();
+      const body = Buffer.from("astro");
+      let count = 0;
+      const { server, url } = await startServer((req, res) => {
+        count += 1;
+        res.writeHead(200, { "Content-Length": body.length });
+        res.end(body);
+      });
+      process.env.ASTRONAUT_MODEL_URL = url;
+      const dest1 = await mod.fetchAstronaut();
+      const dest2 = await mod.fetchAstronaut();
+      assert.equal(dest1, dest2);
+      assert.equal(count, 1);
+      server.close();
+    });
+  },
+);
+
+test("ensureDir no-op on existing path", { concurrency: false }, async () => {
+  await inTempDir(async (dir) => {
+    const { ensureDir } = loadModule();
+    const file = join(dir, "a.txt");
+    await ensureDir(file);
+    await ensureDir(file);
+    assert.ok(fs.existsSync(dir));
+  });
+});
+
+test(
+  "download creates nested directories",
+  { concurrency: false },
+  async () => {
+    await inTempDir(async (dir) => {
+      const { download } = loadModule();
+      const body = Buffer.from("hi");
+      const { server, url } = await startServer((req, res) => {
+        res.writeHead(200, { "Content-Length": body.length });
+        res.end(body);
+      });
+      const dest = join(dir, "nested/dir/file.bin");
+      await download(url, dest);
+      const data = await fsp.readFile(dest);
+      assert.deepEqual(data, body);
+      server.close();
+    });
+  },
+);
+
+test(
+  "download succeeds without Content-Length",
+  { concurrency: false },
+  async () => {
+    await inTempDir(async (dir) => {
+      const { download } = loadModule();
+      const body = Buffer.from("hi");
+      const { server, url } = await startServer((req, res) => {
+        res.writeHead(200);
+        res.end(body);
+      });
+      const dest = join(dir, "file.bin");
+      await download(url, dest);
+      const data = await fsp.readFile(dest);
+      assert.deepEqual(data, body);
+      server.close();
+    });
+  },
+);
+
+test("download fails on premature end", { concurrency: false }, async () => {
+  await inTempDir(async (dir) => {
+    const { download } = loadModule();
+    const body = Buffer.from("hello");
+    const { server, url } = await startServer((req, res) => {
+      res.writeHead(200, { "Content-Length": body.length });
+      res.end(body.slice(0, body.length - 1));
+    });
+    const dest = join(dir, "file.bin");
+    await assert.rejects(() => download(url, dest), /(incomplete|terminated)/);
+    server.close();
+  });
+});
+
+test("download aborts on socket destroy", { concurrency: false }, async () => {
+  await inTempDir(async (dir) => {
+    const { download } = loadModule();
+    const { server, url } = await startServer((req, res) => {
+      req.socket.destroy();
+    });
+    await assert.rejects(
+      () => download(url, join(dir, "file.bin")),
+      /(socket|fetch failed)/,
+    );
+    server.close();
+  });
+});
+
+test("fetchBoombox throws on HTTP error", { concurrency: false }, async () => {
+  await inTempDir(async () => {
+    const { fetchBoombox } = loadModule();
+    const { server, url } = await startServer((req, res) => {
+      res.writeHead(500);
+      res.end();
+    });
+    process.env.BOOMBOX_MODEL_URL = url;
+    await assert.rejects(fetchBoombox, /HTTP 500/);
+    server.close();
+  });
+});
+
+test(
+  "fetchBoombox rejects on truncated response",
+  { concurrency: false },
+  async () => {
+    await inTempDir(async (dir) => {
+      const { fetchBoombox } = loadModule();
+      const body = Buffer.from("boom");
+      const { server, url } = await startServer((req, res) => {
+        res.writeHead(200, { "Content-Length": body.length });
+        res.end(body.slice(0, body.length - 1));
+      });
+      process.env.BOOMBOX_MODEL_URL = url;
+      await assert.rejects(fetchBoombox, /(incomplete|terminated)/);
+      server.close();
+    });
+  },
+);
+
+test("fetchBoombox uses cached model", { concurrency: false }, async () => {
+  await inTempDir(async (dir) => {
+    const mod = loadModule();
+    const body = Buffer.from("boom");
+    let count = 0;
+    const { server, url } = await startServer((req, res) => {
+      count += 1;
+      res.writeHead(200, { "Content-Length": body.length });
+      res.end(body);
+    });
+    process.env.BOOMBOX_MODEL_URL = url;
+    await mod.fetchBoombox();
+    await mod.fetchBoombox();
+    assert.equal(count, 1);
+    const dest = join(dir, "frontend", "public", "models", "boombox.glb");
+    const data = await fsp.readFile(dest);
+    assert.deepEqual(data, body);
+    server.close();
+  });
+});
+
+test("fetchAstronaut rejects invalid URL", { concurrency: false }, async () => {
+  await inTempDir(async () => {
+    const { fetchAstronaut } = loadModule();
+    process.env.ASTRONAUT_MODEL_URL = "::::";
+    await assert.rejects(fetchAstronaut, TypeError);
+  });
+});
+
+test("fetchAstronaut rejects on HTTP 404", { concurrency: false }, async () => {
+  await inTempDir(async () => {
+    const { fetchAstronaut } = loadModule();
+    const { server, url } = await startServer((req, res) => {
+      res.writeHead(404);
+      res.end();
+    });
+    process.env.ASTRONAUT_MODEL_URL = url;
+    await assert.rejects(fetchAstronaut, /HTTP 404/);
+    server.close();
+  });
+});
+
+test(
+  "fetchAstronaut handles missing Content-Length",
+  { concurrency: false },
+  async () => {
+    await inTempDir(async (dir) => {
+      const { fetchAstronaut } = loadModule();
+      const body = Buffer.from("astro");
+      const { server, url } = await startServer((req, res) => {
+        res.writeHead(200);
+        res.end(body);
+      });
+      process.env.ASTRONAUT_MODEL_URL = url;
+      const dest = await fetchAstronaut();
+      const data = await fsp.readFile(dest);
+      assert.deepEqual(data, body);
+      server.close();
+    });
+  },
+);
+
+test(
+  "fetchAstronaut retries after socket hangup and succeeds",
+  { concurrency: false },
+  async () => {
+    await inTempDir(async (dir) => {
+      const { fetchAstronaut } = loadModule();
+      const body = Buffer.from("astro");
+      let count = 0;
+      const { server, url } = await startServer((req, res) => {
+        count += 1;
+        if (count === 1) {
+          req.socket.destroy();
+          return;
+        }
+        res.writeHead(200, { "Content-Length": body.length });
+        res.end(body);
+      });
+      process.env.ASTRONAUT_MODEL_URL = url;
+      const dest = await fetchAstronaut();
+      const data = await fsp.readFile(dest);
+      assert.deepEqual(data, body);
+      assert.equal(count, 2);
+      server.close();
+    });
+  },
+);
+
+test(
+  "fetchAstronaut removes partial file on failure",
+  { concurrency: false },
+  async () => {
+    await inTempDir(async (dir) => {
+      const { fetchAstronaut } = loadModule();
+      const body = Buffer.from("astro");
+      const { server, url } = await startServer((req, res) => {
+        res.writeHead(200, { "Content-Length": body.length });
+        res.end(body.slice(0, body.length - 1));
+      });
+      process.env.ASTRONAUT_MODEL_URL = url;
+      await assert.rejects(fetchAstronaut, /(incomplete response|terminated)/);
+      const dest = join(dir, "frontend", "public", "models", "astronaut.glb");
+      assert.equal(fs.existsSync(dest), false);
+      server.close();
+    });
+  },
+);
+
+test(
+  "fetchAstronaut redownloads when cached file is empty",
+  { concurrency: false },
+  async () => {
+    await inTempDir(async (dir) => {
+      const mod = loadModule();
+      const body = Buffer.from("astro");
+      let count = 0;
+      const { server, url } = await startServer((req, res) => {
+        count += 1;
+        res.writeHead(200, { "Content-Length": body.length });
+        res.end(body);
+      });
+      process.env.ASTRONAUT_MODEL_URL = url;
+      const dest = await mod.fetchAstronaut();
+      await fsp.truncate(dest, 0);
+      const dest2 = await mod.fetchAstronaut();
+      const data = await fsp.readFile(dest2);
+      assert.deepEqual(data, body);
+      assert.equal(count, 2);
+      server.close();
+    });
+  },
+);
+
+test(
+  "fetchAstronaut handles large multi-chunk download",
+  { concurrency: false },
+  async () => {
+    await inTempDir(async (dir) => {
+      const { fetchAstronaut } = loadModule();
+      const size = 1.5 * 1024 * 1024;
+      const body = Buffer.alloc(size, 0x61);
+      const { server, url } = await startServer((req, res) => {
+        res.writeHead(200, { "Content-Length": body.length });
+        for (let i = 0; i < body.length; i += 64 * 1024) {
+          res.write(body.slice(i, i + 64 * 1024));
+        }
+        res.end();
+      });
+      process.env.ASTRONAUT_MODEL_URL = url;
+      const dest = await fetchAstronaut();
+      const stats = await fsp.stat(dest);
+      assert.equal(stats.size, body.length);
+      server.close();
+    });
+  },
+);
+
+test(
+  "fetchAstronaut logs missing Content-Length",
+  { concurrency: false },
+  async () => {
+    await inTempDir(async () => {
+      const { fetchAstronaut, setRetryLogger } = loadModule();
+      const body = Buffer.from("hello");
+      const { server, url } = await startServer((req, res) => {
+        res.writeHead(200);
+        res.end(body);
+      });
+      const logs = [];
+      setRetryLogger((m) => logs.push(m));
+      process.env.ASTRONAUT_MODEL_URL = url;
+      await fetchAstronaut();
+      assert.ok(logs.some((l) => /missing Content-Length/.test(l)));
+      server.close();
+    });
+  },
+);
+
+test(
+  "fetchAstronaut logs expected vs received bytes",
+  { concurrency: false },
+  async () => {
+    await inTempDir(async () => {
+      const { fetchAstronaut, setRetryLogger } = loadModule();
+      const body = Buffer.from("hello world");
+      const { server, url } = await startServer((req, res) => {
+        res.writeHead(200, { "Content-Length": body.length });
+        res.end(body.slice(0, 5));
+      });
+      const logs = [];
+      setRetryLogger((m) => logs.push(m));
+      process.env.ASTRONAUT_MODEL_URL = url;
+      await assert.rejects(fetchAstronaut, /incomplete/);
+      assert.ok(logs.some((l) => /expected/.test(l) && /received/.test(l)));
+      server.close();
+    });
+  },
+);
+
+test(
+  "fetchAstronaut logs retry after size mismatch and succeeds",
+  { concurrency: false },
+  async () => {
+    await inTempDir(async () => {
+      const { fetchAstronaut, setRetryLogger } = loadModule();
+      const body = Buffer.from("abcdef");
+      let first = true;
+      const { server, url } = await startServer((req, res) => {
+        res.writeHead(200, { "Content-Length": body.length });
+        if (first) {
+          first = false;
+          res.end(body.slice(0, 3));
+        } else {
+          res.end(body);
+        }
+      });
+      const logs = [];
+      setRetryLogger((m) => logs.push(m));
+      process.env.ASTRONAUT_MODEL_URL = url;
+      await fetchAstronaut();
+      assert.ok(logs.some((l) => /Retrying astronaut download \(1\)/.test(l)));
+      server.close();
+    });
+  },
+);
+
+test(
+  "fetchAstronaut logs retry after socket destroy",
+  { concurrency: false },
+  async () => {
+    await inTempDir(async () => {
+      const { fetchAstronaut, setRetryLogger } = loadModule();
+      const body = Buffer.from("abcdef");
+      let first = true;
+      const { server, url } = await startServer((req, res) => {
+        res.writeHead(200, { "Content-Length": body.length });
+        if (first) {
+          first = false;
+          req.socket.destroy();
+        } else {
+          res.end(body);
+        }
+      });
+      const logs = [];
+      setRetryLogger((m) => logs.push(m));
+      process.env.ASTRONAUT_MODEL_URL = url;
+      await fetchAstronaut();
+      assert.ok(logs.filter((l) => /Retrying astronaut download/.test(l)).length >= 1);
+      server.close();
+    });
+  },
+);
+
+test(
+  "fetchAstronaut uses custom retry logger",
+  { concurrency: false },
+  async () => {
+    await inTempDir(async () => {
+      const { fetchAstronaut, setRetryLogger } = loadModule();
+      const body = Buffer.from("hi");
+      const { server, url } = await startServer((req, res) => {
+        res.writeHead(200, { "Content-Length": body.length });
+        res.end(body);
+      });
+      let called = false;
+      setRetryLogger(() => {
+        called = true;
+      });
+      process.env.ASTRONAUT_MODEL_URL = url;
+      await fetchAstronaut();
+      assert.ok(!called);
+      server.close();
+    });
+  },
+);
+
+test(
+  "download rejects malformed URL",
+  { concurrency: false },
+  async () => {
+    await inTempDir(async () => {
+      const { download } = loadModule();
+      await assert.rejects(download("::::", "file.bin"), /Invalid URL/);
+    });
+  },
+);
+
+test(
+  "download rejects on HTTP 404",
+  { concurrency: false },
+  async () => {
+    await inTempDir(async () => {
+      const { download } = loadModule();
+      const { server, url } = await startServer((req, res) => {
+        res.writeHead(404);
+        res.end();
+      });
+      await assert.rejects(download(url, "file.bin"), /HTTP 404/);
+      server.close();
+    });
+  },
+);
+
+test(
+  "download writes file with 644 mode",
+  { concurrency: false },
+  async () => {
+    await inTempDir(async () => {
+      const { download } = loadModule();
+      const body = Buffer.from("z");
+      const { server, url } = await startServer((req, res) => {
+        res.writeHead(200, { "Content-Length": body.length });
+        res.end(body);
+      });
+      const dest = "file.bin";
+      await download(url, dest);
+      const stats = await fsp.stat(dest);
+      assert.equal((stats.mode & 0o777).toString(8), "644");
+      server.close();
+    });
+  },
+);
+
+test(
+  "fetchBoombox replaces placeholder with download",
+  { concurrency: false },
+  async () => {
+    await inTempDir(async () => {
+      const { fetchBoombox } = loadModule();
+      const dest = join("frontend", "public", "models", "boombox.glb");
+      await fetchBoombox();
+      const placeholder = await fsp.readFile(dest);
+      assert.equal(placeholder.length, 0);
+      const body = Buffer.from("hi");
+      const { server, url } = await startServer((req, res) => {
+        res.writeHead(200, { "Content-Length": body.length });
+        res.end(body);
+      });
+      process.env.BOOMBOX_MODEL_URL = url;
+      await fetchBoombox();
+      const data = await fsp.readFile(dest);
+      assert.deepEqual(data, body);
+      server.close();
+    });
+  },
+);
+
+test(
+  "fetchAstronaut returns destination path",
+  { concurrency: false },
+  async () => {
+    await inTempDir(async () => {
+      const { fetchAstronaut } = loadModule();
+      const body = Buffer.from("hi");
+      const { server, url } = await startServer((req, res) => {
+        res.writeHead(200, { "Content-Length": body.length });
+        res.end(body);
+      });
+      process.env.ASTRONAUT_MODEL_URL = url;
+      const dest = await fetchAstronaut();
+      const data = await fsp.readFile(dest);
+      assert.deepEqual(data, body);
+      server.close();
+    });
+  },
+);
+
+test(
+  "integration: fetch-assets retries on truncation and succeeds",
+  { concurrency: false },
+  async () => {
+    await inTempDir(async (dir) => {
+      const body = Buffer.from("integration");
+      let first = true;
+      const { server, url } = await startServer((req, res) => {
+        res.writeHead(200, { "Content-Length": body.length });
+        if (first) {
+          first = false;
+          res.end(body.slice(0, body.length - 2));
+        } else {
+          res.end(body);
+        }
+      });
+      const logs = [];
+      const { setRetryLogger } = loadModule();
+      setRetryLogger((m) => logs.push(m));
+      await new Promise((resolve, reject) => {
+        execFile(
+          "node",
+          ["scripts/fetch-assets.cjs"],
+          {
+            env: { ...process.env, ASTRONAUT_MODEL_URL: url, BOOMBOX_MODEL_URL: url },
+            cwd: dir,
+          },
+          (err) => {
+            if (err) reject(err);
+            else resolve();
+          },
+        );
+      });
+      assert.ok(logs.some((l) => /Retrying astronaut download/.test(l)));
+      const data = await fsp.readFile(
+        join("frontend", "public", "models", "astronaut.glb"),
+      );
+      assert.equal(data.length, body.length);
+      server.close();
+    });
+  },
+);


### PR DESCRIPTION
## Summary
- instrument fetchAstronaut with byte and timing logs
- expand debug suite with additional unit and integration cases

## Testing
- `node --test tests/fetch-assets.test.x9dh37as6fk9p4b2.js` *(fails: command not found)*
- `npm run format tests/fetch-assets.test.x9dh37as6fk9p4b2.js .github/workflows/debug-astronaut-download.yml scripts/fetch-assets.cjs` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd9caedb00832d9ad0e890bc55e7c5