### PR TITLE
fix: replace t.teardown with t.after

### DIFF
--- a/tests/fetch-assets.test.x9dh37as6fk9p4b2.js
+++ b/tests/fetch-assets.test.x9dh37as6fk9p4b2.js
@@ -26,7 +26,7 @@ async function startServer(t, handler) {
   server.unref();
   server.keepAliveTimeout = 0;
   server.headersTimeout = 5000;
-  t.teardown(() => new Promise((r) => server.close(r)));
+  t.after(() => new Promise((r) => server.close(r)));
   const { port } = server.address();
   return { server, url: `http://127.0.0.1:${port}` };
 }
@@ -42,7 +42,7 @@ function execFileWithKill(t, file, args, opts) {
         resolve({ stdout, stderr });
       }
     });
-    t.teardown(() => {
+    t.after(() => {
       if (!child.killed) child.kill();
     });
   });


### PR DESCRIPTION
## Summary
- replace unsupported `t.teardown` calls in fetch-assets tests with `t.after`

## Testing
- `npx prettier tests/fetch-assets.test.x9dh37as6fk9p4b2.js -w`
- `node --test tests/fetch-assets.test.x9dh37as6fk9p4b2.js` *(fails: TimeoutError in later subtest)*
- `npm test` *(fails: Jest is not installed)*
- `npm run ci` *(fails: 403 Forbidden from registry and lockfile mismatch)*
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68bdd28270e4832db9bd52d852a3ed16