### PR TITLE
fix: clear astronaut timeout

### DIFF
--- a/scripts/fetch-assets.cjs
+++ b/scripts/fetch-assets.cjs
@@ -80,8 +80,10 @@ async function fetchAstronaut() {
         let expected;
         let bytes = 0;
         const start = Date.now();
+        const ac = new AbortController();
+        const timer = setTimeout(() => ac.abort(), 10000).unref();
         try {
-          const res = await fetch(url, { signal: AbortSignal.timeout(10000) });
+          const res = await fetch(url, { signal: ac.signal });
           if (!res.ok) throw new Error(`HTTP ${res.status}`);
           expected = res.headers.get("content-length");
           if (!expected) {
@@ -110,7 +112,7 @@ async function fetchAstronaut() {
           return dest;
         } catch (err) {
           await unlink(dest).catch(() => {});
-          if (err && err.name === "TimeoutError") {
+          if (err && err.name === "AbortError") {
             err = new Error("incomplete response");
           }
           if (attempt === attempts) {
@@ -121,6 +123,8 @@ async function fetchAstronaut() {
           retryLogger(
             `Retrying astronaut download (${attempt}): ${err}; received ${bytes} of ${expected ?? "?"} bytes after ${elapsed}ms`,
           );
+        } finally {
+          clearTimeout(timer);
         }
       }
     } finally {


### PR DESCRIPTION
## Summary
- ensure fetchAstronaut abort timer is cleared to avoid leftover handles

## Testing
- `npm run validate-env`
- `node --test tests/fetch-assets.test.x9dh37as6fk9p4b2.js` *(fails: execution timed out in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68bde7c48ba4832dbd745f3b3eb1b16e