### PR TITLE
fix: clarify astronaut retry log

### DIFF
--- a/scripts/fetch-assets.cjs
+++ b/scripts/fetch-assets.cjs
@@ -121,7 +121,7 @@ async function fetchAstronaut() {
           }
           const elapsed = Date.now() - start;
           retryLogger(
-            `Retrying astronaut download (${attempt}): ${err}; received ${bytes} of ${expected ?? "?"} bytes after ${elapsed}ms`,
+            `Retrying astronaut download (${attempt}): ${err}; expected ${expected ?? "?"} bytes, received ${bytes} after ${elapsed}ms`,
           );
         } finally {
           clearTimeout(timer);


### PR DESCRIPTION
## Summary
- clarify astronaut download retry log to include expected and received byte counts

## Testing
- `npm run format`
- `node --test tests/fetch-assets.test.x9dh37as6fk9p4b2.js`
- `npm test` *(fails: Jest is not installed)*
- `npm run ci` *(fails: 403 Forbidden to registry)*
- `npm run smoke` *(skipped: offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf883b9c0832d9a912d0b940d4ca7