### PR TITLE
fix: skip size check for compressed asset downloads

### DIFF
--- a/scripts/fetch-assets.cjs
+++ b/scripts/fetch-assets.cjs
@@ -78,6 +78,7 @@ async function fetchAstronaut() {
       const attempts = 3;
       for (let attempt = 1; attempt <= attempts; attempt++) {
         let expected;
+        let encoding;
         let bytes = 0;
         const start = Date.now();
         const ac = new AbortController();
@@ -86,6 +87,7 @@ async function fetchAstronaut() {
           const res = await fetch(url, { signal: ac.signal });
           if (!res.ok) throw new Error(`HTTP ${res.status}`);
           expected = res.headers.get("content-length");
+          encoding = res.headers.get("content-encoding");
           if (!expected) {
             retryLogger(`attempt ${attempt}: missing Content-Length`);
           }
@@ -102,11 +104,17 @@ async function fetchAstronaut() {
             createWriteStream(dest, { mode: 0o644 }),
           );
           const elapsed = Date.now() - start;
-          if (expected && Number(expected) !== bytes) {
-            retryLogger(
-              `attempt ${attempt}: expected ${expected} bytes, received ${bytes} in ${elapsed}ms`,
+          if (expected && (!encoding || encoding === "identity")) {
+            if (Number(expected) !== bytes) {
+              retryLogger(
+                `attempt ${attempt}: expected ${expected} bytes, received ${bytes} in ${elapsed}ms`,
+              );
+              throw new Error("incomplete response");
+            }
+          } else if (encoding && encoding !== "identity") {
+            console.log(
+              `Skipping size check for compressed response (content-encoding: ${encoding})`,
             );
-            throw new Error("incomplete response");
           }
           lastAstronautUrl = url;
           return dest;


### PR DESCRIPTION
## Summary
- skip size check when downloaded asset is compressed and log why comparison was skipped

## Testing
- `cd backend && npm run format`
- `npm test` (backend)
- `npx prettier scripts/fetch-assets.cjs -w`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68bdfcc2b1a0832dbf9adbdc3b7ab16e