### PR TITLE
fix: export model loader defaults

### DIFF
--- a/js/modelLoader.js
+++ b/js/modelLoader.js
@@ -1,12 +1,13 @@
 const DEFAULT_SRC = "https://modelviewer.dev/shared-assets/models/Astronaut.glb";
 
-export function setModelSrc(url = DEFAULT_SRC) {
-  const viewer = document.querySelector('[data-testid="model-viewer"]');
-  if (viewer) {
-    viewer.src = url || DEFAULT_SRC;
-  }
+function setModelSrc(viewer, url) {
+  if (!viewer) return;
+  viewer.setAttribute("src", url || DEFAULT_SRC);
 }
 
 document.addEventListener("DOMContentLoaded", () => {
-  setModelSrc();
+  const viewer = document.querySelector('[data-testid="model-viewer"]');
+  setModelSrc(viewer);
 });
+
+export { DEFAULT_SRC, setModelSrc };


### PR DESCRIPTION
## Summary
- export DEFAULT_SRC for tests
- adjust setModelSrc to use setAttribute and default astronaut src

## Testing
- `npm run format`
- `npm test`
- `npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `npm run smoke` *(skipped: offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_68be98986b84832dbdfd68397aa115c7