### PR TITLE
feat: add model viewer fallback

### DIFF
--- a/js/modelViewerFallback.js
+++ b/js/modelViewerFallback.js
@@ -15,7 +15,8 @@ function ensureModelViewerLoaded() {
       const s = document.createElement("script");
       s.type = "module";
       s.src = src;
-      s.onload = resolve;
+      s.onload = () =>
+        window.customElements.whenDefined("model-viewer").then(resolve);
       s.onerror = reject;
       document.head.appendChild(s);
     });
@@ -24,16 +25,11 @@ function ensureModelViewerLoaded() {
   return loadScript(cdnUrl).catch(() => loadScript(localUrl));
 }
 
-window.addEventListener("DOMContentLoaded", async () => {
-  try {
-    await ensureModelViewerLoaded();
-    document.querySelectorAll("model-viewer").forEach((el) => {
-      el.src = MODEL_SRC;
-      if (!el.getAttribute("environment-image")) {
-        el.setAttribute("environment-image", ENV_SRC);
-      }
-    });
-  } catch (err) {
-    console.error("model-viewer still unavailable", err);
-  }
+window.addEventListener?.("DOMContentLoaded", async () => {
+  const el = document.querySelector('[data-testid="viewer"]');
+  await ensureModelViewerLoaded();
+  if (el) el.setAttribute("src", MODEL_SRC);
+  el?.setAttribute("environment-image", ENV_SRC);
 });
+
+export { MODEL_SRC, ENV_SRC, ensureModelViewerLoaded };


### PR DESCRIPTION
## Summary
- export model viewer sources and loading helper
- load model-viewer from CDN with local fallback before initialization
- set demo model and environment image after model-viewer loads

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup` *(fails: 403 Forbidden to registry, command interrupted)*
- `npx prettier js/modelViewerFallback.js -w`
- `npm test` *(in backend)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: cannot fetch lockfile-diff, lockfile mismatch)*
- `SKIP_PW_DEPS=1 npm run smoke` *(skipped: offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_68be989c2450832db3d6eba857a988a1