### PR TITLE
test: stub customElements with defineProperty

### DIFF
--- a/tests/astronaut-fallback/astronaut-fallback.test.p4s9r2t7y3u1v8w6.js
+++ b/tests/astronaut-fallback/astronaut-fallback.test.p4s9r2t7y3u1v8w6.js
@@ -323,13 +323,28 @@ describe("modelViewerFallback.js behaviour", () => {
       );
       const document = dom.window.document;
       const window = dom.window;
-      window.customElements = { get: () => true };
-      loadModule(file, { document, window });
-      window.document.dispatchEvent(new window.Event("DOMContentLoaded"));
-      const viewers = document.querySelectorAll("model-viewer");
-      viewers.forEach((v) =>
-        expect(v.getAttribute("src")).toMatch(/Astronaut\.glb$/),
+      const originalDescriptor = Object.getOwnPropertyDescriptor(
+        window,
+        "customElements",
       );
+      Object.defineProperty(window, "customElements", {
+        value: { get: () => true },
+        configurable: true,
+      });
+      try {
+        loadModule(file, { document, window });
+        window.document.dispatchEvent(new window.Event("DOMContentLoaded"));
+        const viewers = document.querySelectorAll("model-viewer");
+        viewers.forEach((v) =>
+          expect(v.getAttribute("src")).toMatch(/Astronaut\.glb$/),
+        );
+      } finally {
+        if (originalDescriptor) {
+          Object.defineProperty(window, "customElements", originalDescriptor);
+        } else {
+          delete window.customElements;
+        }
+      }
     },
   );
 
@@ -343,13 +358,28 @@ describe("modelViewerFallback.js behaviour", () => {
       );
       const document = dom.window.document;
       const window = dom.window;
-      window.customElements = { get: () => true };
-      loadModule(file, { document, window });
-      window.document.dispatchEvent(new window.Event("DOMContentLoaded"));
-      const viewers = document.querySelectorAll("model-viewer");
-      viewers.forEach((v) =>
-        expect(v.getAttribute("environment-image")).toMatch(/neutral\.hdr$/),
+      const originalDescriptor = Object.getOwnPropertyDescriptor(
+        window,
+        "customElements",
       );
+      Object.defineProperty(window, "customElements", {
+        value: { get: () => true },
+        configurable: true,
+      });
+      try {
+        loadModule(file, { document, window });
+        window.document.dispatchEvent(new window.Event("DOMContentLoaded"));
+        const viewers = document.querySelectorAll("model-viewer");
+        viewers.forEach((v) =>
+          expect(v.getAttribute("environment-image")).toMatch(/neutral\.hdr$/),
+        );
+      } finally {
+        if (originalDescriptor) {
+          Object.defineProperty(window, "customElements", originalDescriptor);
+        } else {
+          delete window.customElements;
+        }
+      }
     },
   );
 });


### PR DESCRIPTION
## Summary
- replace direct customElements assignment with Object.defineProperty in astronaut fallback tests
- restore original customElements descriptor after each test for cleanup

## Testing
- `mise use -g node@20` *(fails: error sending request for url (https://nodejs.org/dist/v20.19.5/node-v20.19.5-linux-x64.tar.gz))*
- `npm run validate-env`
- `npm run setup`
- `npx prettier tests/astronaut-fallback/astronaut-fallback.test.p4s9r2t7y3u1v8w6.js -w`
- `cd backend && npm run format`
- `cd backend && npm test`
- `node scripts/run-jest.js tests/astronaut-fallback/astronaut-fallback.test.p4s9r2t7y3u1v8w6.js` *(fails: Jest is not installed)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_68be9e025ad0832db6e3924a6664eb05