### PR TITLE
fix: apply defaults to all model-viewer elements

### DIFF
--- a/js/modelViewerFallback.js
+++ b/js/modelViewerFallback.js
@@ -26,10 +26,16 @@ function ensureModelViewerLoaded() {
 }
 
 window.addEventListener?.("DOMContentLoaded", async () => {
-  const el = document.querySelector('[data-testid="viewer"]');
+  const elements = document.querySelectorAll("model-viewer");
   await ensureModelViewerLoaded();
-  if (el) el.setAttribute("src", MODEL_SRC);
-  el?.setAttribute("environment-image", ENV_SRC);
+  elements.forEach((el) => {
+    if (!el.hasAttribute("src")) {
+      el.setAttribute("src", MODEL_SRC);
+    }
+    if (!el.hasAttribute("environment-image")) {
+      el.setAttribute("environment-image", ENV_SRC);
+    }
+  });
 });
 
 export { MODEL_SRC, ENV_SRC, ensureModelViewerLoaded };


### PR DESCRIPTION
## Summary
- ensure fallback script sets default `src` and `environment-image` on every `model-viewer`

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup` *(fails: process did not complete)*
- `npm run format` *(backend)*
- `npm test` *(backend)*
- `node scripts/run-jest.js tests/astronaut-fallback` *(fails: Jest is not installed)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: lockfile-diff 403 Forbidden)*
- `SKIP_PW_DEPS=1 npm run smoke` *(skipped: offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_68be9dfe2ca0832d9e63a887a9c8d6b5