### PR TITLE
fix: handle missing whenDefined in model viewer fallback

### DIFF
--- a/js/modelViewerFallback.js
+++ b/js/modelViewerFallback.js
@@ -15,8 +15,13 @@ function ensureModelViewerLoaded() {
       const s = document.createElement("script");
       s.type = "module";
       s.src = src;
-      s.onload = () =>
-        window.customElements.whenDefined("model-viewer").then(resolve);
+      s.onload = () => {
+        if (window.customElements?.whenDefined) {
+          window.customElements.whenDefined("model-viewer").then(resolve);
+        } else {
+          resolve();
+        }
+      };
       s.onerror = reject;
       document.head.appendChild(s);
     });


### PR DESCRIPTION
## Summary
- safeguard model viewer fallback when `customElements.whenDefined` is unavailable

## Testing
- `npx prettier js/modelViewerFallback.js --write`
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68be9df8ba20832d918adff326dd2633