### PR TITLE
fix: expose model viewer constants globally

### DIFF
--- a/js/modelLoader.js
+++ b/js/modelLoader.js
@@ -1,4 +1,6 @@
-const DEFAULT_SRC = "https://modelviewer.dev/shared-assets/models/Astronaut.glb";
+const DEFAULT_SRC =
+  "https://modelviewer.dev/shared-assets/models/Astronaut.glb";
+globalThis.DEFAULT_SRC = DEFAULT_SRC;
 
 function setModelSrc(viewer, url) {
   if (!viewer) return;

--- a/js/modelViewerFallback.js
+++ b/js/modelViewerFallback.js
@@ -1,6 +1,8 @@
 const MODEL_SRC = "https://modelviewer.dev/shared-assets/models/Astronaut.glb";
 const ENV_SRC =
   "https://modelviewer.dev/shared-assets/environments/neutral.hdr";
+globalThis.MODEL_SRC = MODEL_SRC;
+globalThis.ENV_SRC = ENV_SRC;
 
 function ensureModelViewerLoaded() {
   if (window.customElements?.get("model-viewer")) {


### PR DESCRIPTION
## Summary
- expose default model source on globalThis for VM access
- expose model and environment sources globally in fallback loader

## Testing
- `npx prettier --write js/modelLoader.js js/modelViewerFallback.js`
- `npm run format` (backend)
- `npm test` (backend)
- `SKIP_PW_DEPS=1 npm run ci` *(fails: lockfile mismatch, 403 Forbidden)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68be9df45190832db4ca529275224f3e