### PR TITLE
fix: allow setModelSrc without viewer

### DIFF
--- a/js/modelLoader.js
+++ b/js/modelLoader.js
@@ -1,13 +1,20 @@
-const DEFAULT_SRC = "https://modelviewer.dev/shared-assets/models/Astronaut.glb";
+const DEFAULT_SRC =
+  "https://modelviewer.dev/shared-assets/models/Astronaut.glb";
 
-function setModelSrc(viewer, url) {
-  if (!viewer) return;
-  viewer.setAttribute("src", url || DEFAULT_SRC);
+/**
+ * Updates the src attribute on a model-viewer element.
+ *
+ * @param {string} [url] - Optional glb URL. Falls back to DEFAULT_SRC when falsy.
+ * @param {HTMLElement} [viewer] - Optional <model-viewer> element.
+ */
+function setModelSrc(url, viewer) {
+  const el = viewer || document.querySelector("model-viewer");
+  if (!el) return;
+  el.setAttribute("src", url || DEFAULT_SRC);
 }
 
 document.addEventListener("DOMContentLoaded", () => {
-  const viewer = document.querySelector('[data-testid="model-viewer"]');
-  setModelSrc(viewer);
+  setModelSrc();
 });
 
 export { DEFAULT_SRC, setModelSrc };


### PR DESCRIPTION
## Summary
- let `setModelSrc` locate its own `<model-viewer>` element and accept an optional viewer
- default to the astronaut model when no URL is supplied

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` in `backend/`
- `npm test` in `backend/`
- `npx prettier --log-level warn --write js/modelLoader.js`
- `node scripts/run-jest.js tests/astronaut-fallback/astronaut-fallback.test.p4s9r2t7y3u1v8w6.js` *(fails: Jest is not installed. Run `npm run setup` to install dependencies.)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Lockfile mismatch detected. Run 'npm install' to regenerate package-lock.json.)*
- `SKIP_PW_DEPS=1 npm run smoke` *(skipped in offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_68be9deeba08832dae33e8c5b03ccc26