### PR TITLE
fix: use document event listener for model viewer

### DIFF
--- a/js/modelViewerFallback.js
+++ b/js/modelViewerFallback.js
@@ -30,7 +30,7 @@ function ensureModelViewerLoaded() {
   return loadScript(cdnUrl).catch(() => loadScript(localUrl));
 }
 
-window.addEventListener?.("DOMContentLoaded", async () => {
+document.addEventListener?.("DOMContentLoaded", async () => {
   const elements = document.querySelectorAll("model-viewer");
   await ensureModelViewerLoaded();
   elements.forEach((el) => {


### PR DESCRIPTION
## Summary
- replace `window.addEventListener` with `document.addEventListener` in model viewer fallback script

## Testing
- `npm run format` *(fails: bash: command not found: npm)*
- `cd backend && npm run format` *(fails: bash: command not found: npm)*
- `cd backend && npm test` *(fails: bash: command not found: npm)*
- `npm run validate-env` *(fails: bash: command not found: npm)*
- `npm run setup` *(fails: bash: command not found: npm)*
- `npm run ci` *(fails: bash: command not found: npm)*
- `npm run smoke` *(fails: bash: command not found: npm)*

------
https://chatgpt.com/codex/tasks/task_e_68bea90d56b8832d9d4680f280eed58f