### PR TITLE
fix: expose model viewer fallback globals

### DIFF
--- a/js/modelViewerFallback.js
+++ b/js/modelViewerFallback.js
@@ -1,6 +1,5 @@
-const MODEL_SRC = "https://modelviewer.dev/shared-assets/models/Astronaut.glb";
-const ENV_SRC =
-  "https://modelviewer.dev/shared-assets/environments/neutral.hdr";
+var MODEL_SRC = "https://modelviewer.dev/shared-assets/models/Astronaut.glb";
+var ENV_SRC = "https://modelviewer.dev/shared-assets/environments/neutral.hdr";
 
 function ensureModelViewerLoaded() {
   if (window.customElements?.get("model-viewer")) {


### PR DESCRIPTION
## Summary
- use `var` for `MODEL_SRC` and `ENV_SRC` so the fallback script defines globals

## Testing
- `npx prettier js/modelViewerFallback.js -w`
- `npm test` (backend)
- `npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_68bea9092f8c832d9e3bfcbe1d61ce54