### PR TITLE
fix: expose default model src globally

### DIFF
--- a/js/modelLoader.js
+++ b/js/modelLoader.js
@@ -1,5 +1,7 @@
-const DEFAULT_SRC =
+var DEFAULT_SRC =
+  globalThis.DEFAULT_SRC ||
   "https://modelviewer.dev/shared-assets/models/Astronaut.glb";
+globalThis.DEFAULT_SRC = DEFAULT_SRC;
 
 /**
  * Updates the src attribute on a model-viewer element.


### PR DESCRIPTION
## Summary
- expose model-loader default URL on global scope
- keep setModelSrc referencing same default and export both

## Testing
- `npx prettier -w js/modelLoader.js`
- `npm test` *(fails: Jest is not installed)*
- `npm run ci` *(fails: 403 Forbidden from npm registry and lockfile mismatch)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68bea9025ee0832da6eecf844527571d