### PR TITLE
refactor: fallback to local model-viewer script

### DIFF
--- a/backend/tests/frontend/modelViewerLoader.test.js
+++ b/backend/tests/frontend/modelViewerLoader.test.js
@@ -10,43 +10,39 @@ function ensureModelViewerLoaded() {
     "https://cdn.jsdelivr.net/npm/@google/model-viewer@1.12.0/dist/model-viewer.min.js";
   const localUrl = "js/model-viewer.min.js";
 
-  function loadScript(src, done) {
-    const s = global.document.createElement("script");
-    s.type = "module";
-    s.src = src;
-    s.onload = done;
-    s.onerror = done;
-    global.document.head.appendChild(s);
-  }
-
   return new Promise((resolve, reject) => {
-    const finalize = (attemptedLocal) => {
+    const finalize = () => {
       if (global.window.customElements?.get("model-viewer")) {
         resolve();
-      } else if (!attemptedLocal) {
-        loadScript(localUrl, () => finalize(true));
       } else {
         reject(new Error("model-viewer failed to load"));
       }
     };
 
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), 3000);
-
-    global
-      .fetch(cdnUrl, {
-        method: "HEAD",
-        mode: "no-cors",
-        signal: controller.signal,
-      })
-      .then(() => {
-        clearTimeout(timer);
-        loadScript(cdnUrl, () => finalize(false));
-      })
-      .catch(() => {
-        clearTimeout(timer);
-        loadScript(localUrl, () => finalize(true));
-      });
+    const s = global.document.createElement("script");
+    s.type = "module";
+    s.src = cdnUrl;
+    let timer;
+    s.onload = () => {
+      clearTimeout(timer);
+      finalize();
+    };
+    s.onerror = () => {
+      clearTimeout(timer);
+      s.remove();
+      const fallback = global.document.createElement("script");
+      fallback.type = "module";
+      fallback.src = localUrl;
+      fallback.onload = finalize;
+      fallback.onerror = () => reject(new Error("model-viewer failed to load"));
+      global.document.head.appendChild(fallback);
+    };
+    global.document.head.appendChild(s);
+    timer = setTimeout(() => {
+      if (!global.window.customElements?.get("model-viewer")) {
+        s.onerror();
+      }
+    }, 3000);
   });
 }
 
@@ -85,11 +81,7 @@ test("falls back to local script when CDN fails", async () => {
     return origAppend(el);
   };
 
-  global.fetch = jest.fn().mockResolvedValue({});
-
   await ensureModelViewerLoaded();
-
-  expect(global.fetch).toHaveBeenCalled();
   expect(loaded.some((s) => s.includes("model-viewer.min.js"))).toBe(true);
   expect(global.window.customElements.get("model-viewer")).toBeDefined();
 });
@@ -111,43 +103,8 @@ test("rejects when both CDN and local scripts fail", async () => {
     return el;
   };
 
-  global.fetch = jest.fn().mockResolvedValue({});
-
   await expect(ensureModelViewerLoaded()).rejects.toThrow(
     /model-viewer failed to load/,
   );
 });
-
-test("falls back when HEAD request fails", async () => {
-  const dom = new JSDOM(
-    "<!doctype html><html><head></head><body></body></html>",
-    {
-      runScripts: "dangerously",
-      resources: "usable",
-      url: "http://localhost/",
-    },
-  );
-  global.window = dom.window;
-  global.document = dom.window.document;
-
-  const loaded = [];
-  const origAppend = global.document.head.appendChild.bind(
-    global.document.head,
-  );
-  global.document.head.appendChild = (el) => {
-    loaded.push(el.src);
-    if (el.src.includes("model-viewer.min.js")) {
-      global.window.customElements.define("model-viewer", class {});
-      setImmediate(() => el.onload && el.onload());
-    }
-    return origAppend(el);
-  };
-
-  global.fetch = jest.fn().mockRejectedValue(new Error("offline"));
-
-  await ensureModelViewerLoaded();
-
-  expect(global.fetch).toHaveBeenCalled();
-  expect(loaded.some((s) => s.includes("model-viewer.min.js"))).toBe(true);
-  expect(global.window.customElements.get("model-viewer")).toBeDefined();
 });

--- a/js/index.js
+++ b/js/index.js
@@ -170,45 +170,41 @@ function ensureModelViewerLoaded() {
     "https://cdn.jsdelivr.net/npm/@google/model-viewer@1.12.0/dist/model-viewer.min.js";
   const localUrl = "js/model-viewer.min.js";
 
-  function loadScript(src, done) {
-    const s = document.createElement("script");
-    s.type = "module";
-    s.src = src;
-    s.onload = done;
-    s.onerror = done;
-    document.head.appendChild(s);
-  }
-
   return new Promise((resolve, reject) => {
-    const finalize = (attemptedLocal) => {
+    const finalize = () => {
       if (window.customElements?.get("model-viewer")) {
         resolve();
-      } else if (!attemptedLocal) {
-        window.modelViewerSource = "local";
-        loadScript(localUrl, () => finalize(true));
       } else {
         reject(new Error("model-viewer failed to load"));
       }
     };
 
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), 3000);
-
-    fetch(cdnUrl, {
-      method: "HEAD",
-      mode: "no-cors",
-      signal: controller.signal,
-    })
-      .then(() => {
-        clearTimeout(timer);
-        window.modelViewerSource = "cdn";
-        loadScript(cdnUrl, () => finalize(false));
-      })
-      .catch(() => {
-        clearTimeout(timer);
-        window.modelViewerSource = "local";
-        loadScript(localUrl, () => finalize(true));
-      });
+    const s = document.createElement("script");
+    s.type = "module";
+    s.src = cdnUrl;
+    let timer;
+    s.onload = () => {
+      clearTimeout(timer);
+      window.modelViewerSource = "cdn";
+      finalize();
+    };
+    s.onerror = () => {
+      clearTimeout(timer);
+      s.remove();
+      window.modelViewerSource = "local";
+      const fallback = document.createElement("script");
+      fallback.type = "module";
+      fallback.src = localUrl;
+      fallback.onload = finalize;
+      fallback.onerror = () => reject(new Error("model-viewer failed to load"));
+      document.head.appendChild(fallback);
+    };
+    document.head.appendChild(s);
+    timer = setTimeout(() => {
+      if (!window.customElements?.get("model-viewer")) {
+        s.onerror();
+      }
+    }, 3000);
   });
 }
 

--- a/js/modelViewerFallback.js
+++ b/js/modelViewerFallback.js
@@ -10,24 +10,40 @@ function ensureModelViewerLoaded() {
     "https://cdn.jsdelivr.net/npm/@google/model-viewer@1.12.0/dist/model-viewer.min.js";
   const localUrl = "js/model-viewer.min.js";
 
-  function loadScript(src) {
-    return new Promise((resolve, reject) => {
-      const s = document.createElement("script");
-      s.type = "module";
-      s.src = src;
-      s.onload = () => {
-        if (window.customElements?.whenDefined) {
-          window.customElements.whenDefined("model-viewer").then(resolve);
-        } else {
-          resolve();
-        }
-      };
-      s.onerror = reject;
-      document.head.appendChild(s);
-    });
-  }
+  return new Promise((resolve, reject) => {
+    const finalize = () => {
+      if (window.customElements?.get("model-viewer")) {
+        resolve();
+      } else {
+        reject(new Error("model-viewer failed to load"));
+      }
+    };
 
-  return loadScript(cdnUrl).catch(() => loadScript(localUrl));
+    const s = document.createElement("script");
+    s.type = "module";
+    s.src = cdnUrl;
+    let timer;
+    s.onload = () => {
+      clearTimeout(timer);
+      finalize();
+    };
+    s.onerror = () => {
+      clearTimeout(timer);
+      s.remove();
+      const fallback = document.createElement("script");
+      fallback.type = "module";
+      fallback.src = localUrl;
+      fallback.onload = finalize;
+      fallback.onerror = () => reject(new Error("model-viewer failed to load"));
+      document.head.appendChild(fallback);
+    };
+    document.head.appendChild(s);
+    timer = setTimeout(() => {
+      if (!window.customElements?.get("model-viewer")) {
+        s.onerror();
+      }
+    }, 3000);
+  });
 }
 
 window.addEventListener?.("DOMContentLoaded", async () => {


### PR DESCRIPTION
## Summary
- load CDN model-viewer script with onerror fallback to local copy
- mirror updated loader in fallback helper and unit tests

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup` *(fails: hung, aborted)*
- `npm run format` *(fails: npm registry 403)*
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: lockfile-diff E403)*
- `SKIP_PW_DEPS=1 npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_68bea9120970832dbbc924aab4197b3a