### PR TITLE
feat: rotate discount and delivery banner

### DIFF
--- a/.github/workflows/discount-delivery-banner.yml
+++ b/.github/workflows/discount-delivery-banner.yml
@@ -1,0 +1,18 @@
+name: Discount/delivery banner test suite
+
+on:
+  push:
+    branches: [dev, "00000production"]
+  pull_request:
+    branches: [dev, "00000production"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.6
+      - uses: actions/setup-node@v4.0.3
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run test:banner

--- a/index.html
+++ b/index.html
@@ -106,6 +106,10 @@
         max-width: 100%;
       }
 
+      #theme-banner {
+        transition: opacity 1s ease;
+      }
+
       /* If you have any top-level wrappers using 100vw, prefer 100% + max-width: 100% */
       .transition-shape {
         transition:

--- a/js/index.js
+++ b/js/index.js
@@ -1177,12 +1177,21 @@ async function init() {
 
   const banner = document.getElementById("theme-banner");
   if (banner) {
-    function updateCountdown() {
+    initDiscountDeliveryBanner(banner);
+  }
+
+  function initDiscountDeliveryBanner(bannerEl) {
+    let countdownText = "";
+    let showDiscount = false;
+    bannerEl.style.opacity = "1";
+    bannerEl.style.transition = "opacity 1s";
+
+    function getCountdownText() {
       const now = new Date();
       const day = now.getDay();
       if (day === 0 || day === 6) {
-        banner.classList.add("hidden");
-        return;
+        bannerEl.classList.add("hidden");
+        return null;
       }
       const friday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
       friday.setDate(friday.getDate() + ((5 - day + 7) % 7));
@@ -1198,14 +1207,34 @@ async function init() {
         parts.push(`${hours.toString().padStart(2, "0")}h`);
         parts.push(`${minutes.toString().padStart(2, "0")}m`);
         parts.push(`${seconds.toString().padStart(2, "0")}s`);
-        banner.textContent = `${parts.join(" ")} left for weekend delivery`;
-        banner.classList.remove("hidden");
-      } else {
-        banner.classList.add("hidden");
+        return `${parts.join(" ")} left for weekend delivery`;
       }
+      bannerEl.classList.add("hidden");
+      return null;
     }
-    updateCountdown();
-    setInterval(updateCountdown, 1000);
+
+    function refresh() {
+      const text = getCountdownText();
+      if (!text) return;
+      countdownText = text;
+      bannerEl.classList.remove("hidden");
+      if (!showDiscount) bannerEl.textContent = countdownText;
+    }
+
+    function cycle() {
+      bannerEl.style.opacity = "0";
+      setTimeout(() => {
+        showDiscount = !showDiscount;
+        bannerEl.textContent = showDiscount
+          ? "24% off when you order 3 prints"
+          : countdownText;
+        bannerEl.style.opacity = "1";
+      }, 1000);
+    }
+
+    refresh();
+    setInterval(refresh, 1000);
+    setInterval(cycle, 7000);
   }
 
   document.getElementById("promo-optin")?.addEventListener("change", (e) => {
@@ -1235,7 +1264,17 @@ if (typeof process === "undefined" || process.env.NODE_ENV !== "test") {
 }
 
 if (typeof module !== "undefined") {
-  module.exports = { renderThumbnails, computeDailyPrintsSold, updateStats };
+  module.exports = {
+    renderThumbnails,
+    computeDailyPrintsSold,
+    updateStats,
+    initDiscountDeliveryBanner,
+  };
 }
 
-export { renderThumbnails, computeDailyPrintsSold, updateStats };
+export {
+  renderThumbnails,
+  computeDailyPrintsSold,
+  updateStats,
+  initDiscountDeliveryBanner,
+};

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "db:migrate:test": "npm run migrate --prefix backend",
     "prepare": "husky",
     "prepush": "echo \"(pre-push) no checks\"",
-    "test:fresh": "npm test"
+    "test:fresh": "npm test",
+    "test:banner": "node scripts/run-jest.js tests/frontend/discount-delivery-banner*.test.js"
   },
   "babel": {
     "presets": [

--- a/tests/frontend/discount-delivery-banner.k1m2n3b4v5c6x7z8.test.js
+++ b/tests/frontend/discount-delivery-banner.k1m2n3b4v5c6x7z8.test.js
@@ -1,0 +1,88 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+import { initDiscountDeliveryBanner } from "../../js/index.js";
+
+describe("Discount/delivery banner", () => {
+  let banner;
+  let now;
+  beforeEach(() => {
+    jest.useFakeTimers();
+    now = new Date("2024-01-02T12:00:00Z"); // Tuesday
+    jest.setSystemTime(now);
+    document.body.innerHTML = '<div id="theme-banner"></div>';
+    banner = document.getElementById("theme-banner");
+    initDiscountDeliveryBanner(banner);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  function advance(ms) {
+    now = new Date(now.getTime() + ms);
+    jest.setSystemTime(now);
+    jest.advanceTimersByTime(ms);
+  }
+
+  test("shows countdown on init", () => {
+    expect(banner.textContent).toMatch(/left for weekend delivery/);
+  });
+
+  test("countdown includes phrase", () => {
+    expect(banner.textContent).toContain("left for weekend delivery");
+  });
+
+  test("opacity drops before message change", () => {
+    advance(7000);
+    expect(banner.style.opacity).toBe("0");
+  });
+
+  test("discount message appears after rotation", () => {
+    advance(7000);
+    advance(1000);
+    expect(banner.textContent).toBe("24% off when you order 3 prints");
+  });
+
+  test("returns to countdown after second rotation", () => {
+    advance(7000);
+    advance(1000);
+    advance(7000);
+    expect(banner.style.opacity).toBe("0");
+    advance(1000);
+    expect(banner.textContent).toMatch(/left for weekend delivery/);
+  });
+
+  test("opacity resets after transition", () => {
+    advance(7000);
+    advance(1000);
+    expect(banner.style.opacity).toBe("1");
+  });
+
+  test("handles missing banner gracefully", () => {
+    expect(() => initDiscountDeliveryBanner(null)).not.toThrow();
+  });
+
+  test("hides banner on weekend", () => {
+    jest.useRealTimers();
+    jest.useFakeTimers();
+    now = new Date("2024-01-06T12:00:00Z"); // Saturday
+    jest.setSystemTime(now);
+    document.body.innerHTML = '<div id="theme-banner"></div>';
+    const weekendBanner = document.getElementById("theme-banner");
+    initDiscountDeliveryBanner(weekendBanner);
+    expect(weekendBanner.classList.contains("hidden")).toBe(true);
+  });
+
+  test("countdown updates over time", () => {
+    const first = banner.textContent;
+    advance(1000);
+    const second = banner.textContent;
+    expect(first).not.toBe(second);
+  });
+
+  test("banner remains visible during discount", () => {
+    advance(7000);
+    advance(1000);
+    expect(banner.classList.contains("hidden")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- alternate weekend delivery countdown with discount message
- add CI workflow and banner test suite with 10 tests

## Testing
- `npm run format`
- `npm run test:banner` *(fails: Jest is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68beaa1ef8e8832d8f1d72db72bdbee5