### PR TITLE
fix: provide timer globals to VM context

### DIFF
--- a/tests/astronaut-fallback/astronaut-fallback.test.p4s9r2t7y3u1v8w6.js
+++ b/tests/astronaut-fallback/astronaut-fallback.test.p4s9r2t7y3u1v8w6.js
@@ -5,7 +5,8 @@ const { JSDOM } = require("jsdom");
 
 function loadModule(file, context) {
   const code = fs.readFileSync(file, "utf8").replace(/export\s+/g, "");
-  vm.createContext(context);
+  const timers = { setTimeout, clearTimeout };
+  vm.createContext(Object.assign(context, timers));
   vm.runInContext(code, context);
   return context;
 }


### PR DESCRIPTION
## Summary
- supply setTimeout/clearTimeout when loading modules in astronaut-fallback tests

## Testing
- `node scripts/run-jest.js tests/astronaut-fallback` *(fails: Jest is not installed. Run `npm run setup` to install dependencies.)*

------
https://chatgpt.com/codex/tasks/task_e_68beb9a58f18832d93eccd03fc2317c0