### PR TITLE
fix: safely remove script on model-viewer load error

### DIFF
--- a/js/modelViewerFallback.js
+++ b/js/modelViewerFallback.js
@@ -28,7 +28,8 @@ function ensureModelViewerLoaded() {
     };
     s.onerror = () => {
       clearTimeout(timer);
-      s.remove();
+      s.remove?.();
+      s.parentNode?.removeChild(s);
       const fallback = document.createElement("script");
       fallback.type = "module";
       fallback.src = localUrl;


### PR DESCRIPTION
## Summary
- ensure `modelViewerFallback` safely removes the failing `<script>` using optional chaining

## Testing
- `npm run format` *(fails: command not found)*
- `npm test` *(fails: command not found)*
- `npm run validate-env` *(fails: command not found)*
- `npm run setup` *(fails: command not found)*
- `npm run ci` *(fails: command not found)*
- `npm run smoke` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bebd5bfad0832db45490601a12f6fb