### PR TITLE
fix: handle model-viewer fallback loading

### DIFF
--- a/js/modelViewerFallback.js
+++ b/js/modelViewerFallback.js
@@ -45,17 +45,23 @@ function ensureModelViewerLoaded() {
   });
 }
 
-document.addEventListener?.("DOMContentLoaded", async () => {
+document.addEventListener?.("DOMContentLoaded", () => {
   const elements = document.querySelectorAll("model-viewer");
-  await ensureModelViewerLoaded();
-  elements.forEach((el) => {
-    if (!el.hasAttribute("src")) {
-      el.setAttribute("src", MODEL_SRC);
-    }
-    if (!el.hasAttribute("environment-image")) {
-      el.setAttribute("environment-image", ENV_SRC);
-    }
-  });
+  const applyAttrs = () => {
+    elements.forEach((el) => {
+      if (!el.hasAttribute("src")) {
+        el.setAttribute("src", MODEL_SRC);
+      }
+      if (!el.hasAttribute("environment-image")) {
+        el.setAttribute("environment-image", ENV_SRC);
+      }
+    });
+  };
+  if (window.customElements?.get("model-viewer")) {
+    applyAttrs();
+  } else {
+    ensureModelViewerLoaded().then(applyAttrs);
+  }
 });
 
 export { MODEL_SRC, ENV_SRC, ensureModelViewerLoaded };


### PR DESCRIPTION
## Summary
- apply fallback model attributes immediately when model-viewer is already defined

## Testing
- `npm run format` *(fails: tests/frontend/modelViewerLoader.test.js syntax error)*
- `npm test`
- `npm run ci` *(fails: 403 Forbidden fetching lockfile-diff)*
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68bebd6da708832d9b5896bf5c7ffb60