### PR TITLE
fix: resolve model-viewer load without custom element

### DIFF
--- a/js/modelViewerFallback.js
+++ b/js/modelViewerFallback.js
@@ -11,11 +11,10 @@ function ensureModelViewerLoaded() {
 
   return new Promise((resolve, reject) => {
     const finalize = () => {
-      if (window.customElements?.get("model-viewer")) {
-        resolve();
-      } else {
-        reject(new Error("model-viewer failed to load"));
+      if (!window.customElements?.get("model-viewer")) {
+        console.error("model-viewer custom element is not registered");
       }
+      resolve();
     };
 
     const s = document.createElement("script");


### PR DESCRIPTION
## Summary
- avoid rejecting when model-viewer custom element is missing and always resolve after script load

## Testing
- `npm run format` *(fails: 403 Forbidden - GET https://registry.npmjs.org/npm; SyntaxError: Unexpected token (110:1) in tests/frontend/modelViewerLoader.test.js)*
- `npm test`
- `node scripts/run-jest.js tests/frontend/modelViewerLoader.test.js` *(fails: Jest is not installed)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff; Lockfile mismatch detected)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68bebd616bb0832dbb6b461b19d0efa8