### PR TITLE
fix: run Playwright tests after Jest

### DIFF
--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -186,7 +186,8 @@ async function run(args) {
     exitCode = results.success ? 0 : 1;
   }
   if (!exitCode && pwTests.length) {
-    const res = spawnSync("npx", ["playwright", "test", ...pwTests], {
+    const relPwTests = pwTests.map((p) => path.relative(repoRoot, p));
+    const res = spawnSync("npx", ["playwright", "test", ...relPwTests], {
       stdio: "inherit",
     });
     exitCode = res.status || 1;


### PR DESCRIPTION
## Summary
- ensure Playwright tests run after Jest by passing repo-relative paths

## Testing
- `npm run format`
- `node scripts/run-jest.js tests/astronaut-fallback` *(fails: Jest is not installed)*
- `npm test` in `backend/`
- `npm run ci` *(fails: lockfile mismatch / registry 403)*
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68bedab60a4c832d868d82055a74f036