### PR TITLE
test: start static server for playwright tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,10 +3,8 @@ import { defineConfig } from "@playwright/test";
 export default defineConfig({
   testDir: "./tests/astronaut-fallback",
   timeout: 30 * 1000,
-  use: { browserName: "chromium", baseURL: "http://localhost:3000" },
-  webServer: {
-    command: "npm run serve",
-    port: 3000,
-    reuseExistingServer: !process.env.CI,
+  use: {
+    browserName: "chromium",
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || "http://localhost:3000",
   },
 });

--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 const fs = require("fs");
 const path = require("path");
-const { spawnSync } = require("child_process");
+const { spawnSync, spawn } = require("child_process");
+const waitOn = require("wait-on");
 
 const repoRoot = path.resolve(__dirname, "..");
 const backendRoot = path.join(repoRoot, "backend");
@@ -189,11 +190,29 @@ async function run(args) {
     const relPwTests = pwTests.map((p) => path.relative(repoRoot, p));
     const env = { ...process.env };
     delete env.JEST_WORKER_ID;
-    const res = spawnSync("npx", ["playwright", "test", ...relPwTests], {
-      stdio: "inherit",
-      env,
+    const port = 3000;
+    env.PLAYWRIGHT_BASE_URL = `http://localhost:${port}`;
+    const server = spawn("node", [path.join(__dirname, "serve.js")], {
+      stdio: "ignore",
+      env: { ...env, PORT: port },
     });
-    exitCode = res.status ?? 1;
+    try {
+      await waitOn({ resources: [env.PLAYWRIGHT_BASE_URL], timeout: 30000 });
+      const res = spawnSync(
+        "npx",
+        [
+          "playwright",
+          "test",
+          "--base-url",
+          env.PLAYWRIGHT_BASE_URL,
+          ...relPwTests,
+        ],
+        { stdio: "inherit", env },
+      );
+      exitCode = res.status ?? 1;
+    } finally {
+      server.kill();
+    }
   }
   process.exit(exitCode);
 }


### PR DESCRIPTION
## Summary
- start a local static server in run-jest before Playwright tests and shut it down afterward
- allow Playwright to receive the server URL through `PLAYWRIGHT_BASE_URL`

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npx prettier scripts/run-jest.js playwright.config.ts -w`
- `npm run format` *(fails: Unexpected token in tests/frontend/modelViewerLoader.test.js)*
- `npm test` *(fails: Cannot find module 'wait-on')*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_68bee623a978832d9d49ea2269c7f56e