### PR TITLE
test: log E2E console and network failures

### DIFF
--- a/tests/astronaut-fallback/astronaut-fallback.e2e.spec.ts
+++ b/tests/astronaut-fallback/astronaut-fallback.e2e.spec.ts
@@ -1,6 +1,13 @@
 import { test, expect } from "@playwright/test";
 import { waitForModelViewer, intercept } from "./utils";
 
+test.beforeEach(async ({ page }) => {
+  page.on("console", (msg) => console.log("PAGE LOG:", msg.text()));
+  page.on("requestfailed", (req) =>
+    console.log("REQUEST FAIL:", req.url(), req.failure()),
+  );
+});
+
 test.describe("Basic rendering", () => {
   test("Index loads model-viewer and astronaut model", async ({ page }) => {
     const modelReq = await intercept(page, "Astronaut.glb");


### PR DESCRIPTION
## Summary
- log console messages and failed requests in astronaut fallback Playwright spec for easier troubleshooting

## Testing
- `npx prettier tests/astronaut-fallback/astronaut-fallback.e2e.spec.ts -w`
- `npm run format --prefix backend` *(fails: SyntaxError in tests/frontend/modelViewerLoader.test.js)*
- `npm test --prefix backend`
- `DEBUG=pw:api npm run test:astronaut-fallback:playwright` *(fails: playwright not found)*
- `SKIP_PW_DEPS=1 npm run smoke` *(skipped: offline mode)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: lockfile mismatch / npm 403)*

------
https://chatgpt.com/codex/tasks/task_e_68beeb864c40832d9fe2a82ba80ebf93