### PR TITLE
fix: remove unsupported base url flag

### DIFF
--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -203,8 +203,6 @@ async function run(args) {
         [
           "playwright",
           "test",
-          "--base-url",
-          env.PLAYWRIGHT_BASE_URL,
           ...relPwTests,
         ],
         { stdio: "inherit", env },


### PR DESCRIPTION
## Summary
- remove unsupported `--base-url` flag from custom jest runner

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup` *(hangs, terminated)*
- `npm run format` *(fails: SyntaxError in tests/frontend/modelViewerLoader.test.js)*
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Lockfile mismatch)*
- `SKIP_PW_DEPS=1 npm run smoke`
- `node scripts/run-jest.js tests/astronaut-fallback` *(fails: Cannot find module 'wait-on')*

------
https://chatgpt.com/codex/tasks/task_e_68beeb697cd8832daa13e5b2f2831639