### PR TITLE
fix: show discount before countdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -189,7 +189,7 @@
       id="theme-banner"
       class="bg-[#30D5C8] text-black text-center py-1 hidden"
     >
-      2d 07h 00m left for weekend delivery
+      24% off when you order 3 prints
     </div>
 
     <!-- ▸▸▸ HEADER ------------------------------------------------------- -->

--- a/js/index.js
+++ b/js/index.js
@@ -849,9 +849,10 @@ refs.submitBtn.addEventListener("click", async () => {
 
 function initDiscountDeliveryBanner(bannerEl) {
   let countdownText = "";
-  let showDiscount = false;
+  let showDiscount = true;
   bannerEl.style.opacity = "1";
   bannerEl.style.transition = "opacity 1s";
+  bannerEl.textContent = "24% off when you order 3 prints";
 
   function getCountdownText() {
     const now = new Date();

--- a/tests/frontend/discount-delivery-banner.k1m2n3b4v5c6x7z8.test.js
+++ b/tests/frontend/discount-delivery-banner.k1m2n3b4v5c6x7z8.test.js
@@ -24,11 +24,13 @@ describe("Discount/delivery banner", () => {
     jest.advanceTimersByTime(ms);
   }
 
-  test("shows countdown on init", () => {
-    expect(banner.textContent).toMatch(/left for weekend delivery/);
+  test("shows discount on init", () => {
+    expect(banner.textContent).toBe("24% off when you order 3 prints");
   });
 
   test("countdown includes phrase", () => {
+    advance(7000);
+    advance(1000);
     expect(banner.textContent).toContain("left for weekend delivery");
   });
 
@@ -37,19 +39,19 @@ describe("Discount/delivery banner", () => {
     expect(banner.style.opacity).toBe("0");
   });
 
-  test("discount message appears after rotation", () => {
+  test("countdown message appears after rotation", () => {
     advance(7000);
     advance(1000);
-    expect(banner.textContent).toBe("24% off when you order 3 prints");
+    expect(banner.textContent).toMatch(/left for weekend delivery/);
   });
 
-  test("returns to countdown after second rotation", () => {
+  test("returns to discount after second rotation", () => {
     advance(7000);
     advance(1000);
     advance(7000);
     expect(banner.style.opacity).toBe("0");
     advance(1000);
-    expect(banner.textContent).toMatch(/left for weekend delivery/);
+    expect(banner.textContent).toBe("24% off when you order 3 prints");
   });
 
   test("opacity resets after transition", () => {
@@ -74,6 +76,8 @@ describe("Discount/delivery banner", () => {
   });
 
   test("countdown updates over time", () => {
+    advance(7000);
+    advance(1000);
     const first = banner.textContent;
     advance(1000);
     const second = banner.textContent;
@@ -81,8 +85,6 @@ describe("Discount/delivery banner", () => {
   });
 
   test("banner remains visible during discount", () => {
-    advance(7000);
-    advance(1000);
     expect(banner.classList.contains("hidden")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- start index page banner with discount message before countdown
- update banner rotation logic and tests for new order

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup` *(fails: 403 Forbidden - GET https://registry.npmjs.org/npm)*
- `npm run format` *(fails: SyntaxError in tests/frontend/modelViewerLoader.test.js)*
- `npm test` in `backend/`
- `node scripts/run-jest.js tests/frontend/discount-delivery-banner.k1m2n3b4v5c6x7z8.test.js` *(fails: Cannot find module 'wait-on')*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68bef06cb940832dabc56d94698acaba