### PR TITLE
test: launch static server for Playwright

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,6 +5,6 @@ export default defineConfig({
   timeout: 30 * 1000,
   use: {
     browserName: "chromium",
-    baseURL: process.env.PLAYWRIGHT_BASE_URL || "http://localhost:3000",
+    baseURL: "http://localhost:3000",
   },
 });

--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -191,13 +191,16 @@ async function run(args) {
     const env = { ...process.env };
     delete env.JEST_WORKER_ID;
     const port = 3000;
-    env.PLAYWRIGHT_BASE_URL = `http://localhost:${port}`;
-    const server = spawn("node", [path.join(__dirname, "serve.js")], {
-      stdio: "ignore",
-      env: { ...env, PORT: port },
-    });
+    const server = spawn(
+      "npx",
+      ["http-server", repoRoot, "-p", String(port)],
+      { stdio: "ignore" },
+    );
     try {
-      await waitOn({ resources: [env.PLAYWRIGHT_BASE_URL], timeout: 30000 });
+      await waitOn({
+        resources: [`http://localhost:${port}`],
+        timeout: 30000,
+      });
       const res = spawnSync(
         "npx",
         [


### PR DESCRIPTION
## Summary
- start http-server before Playwright tests and ensure it's terminated
- configure Playwright baseURL for local static pages

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup` *(hangs after skipping Playwright/apt deps)*
- `npm run format` *(failed: SyntaxError in tests/frontend/modelViewerLoader.test.js)*
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(failed: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68bef4b6eaf4832d80df481cdf97d1c6