### PR TITLE
test: assert full astronaut 404 error

### DIFF
--- a/tests/astronaut-fallback/astronaut-fallback.e2e.spec.ts
+++ b/tests/astronaut-fallback/astronaut-fallback.e2e.spec.ts
@@ -160,7 +160,9 @@ test.describe("Network edge cases", () => {
     );
     await page.goto("/index.html");
     await page.waitForLoadState("load");
-    expect(errors.some((e) => e.includes("Astronaut"))).toBe(true);
+    const expectedError =
+      "GET https://modelviewer.dev/shared-assets/models/Astronaut.glb 404 (Not Found)";
+    expect(errors).toContain(expectedError);
   });
 });
 


### PR DESCRIPTION
## Summary
- assert the exact console error string for missing Astronaut.glb in the fallback Playwright test

## Testing
- `npm run format --prefix backend` *(fails: SyntaxError in tests/frontend/modelViewerLoader.test.js)*
- `npm run ci` *(fails: 403 Forbidden from registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68bef54d1c14832d9afeb2fb33a81da3