### PR TITLE
test: start static server for playwright

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,6 +3,11 @@ import { defineConfig } from "@playwright/test";
 export default defineConfig({
   testDir: "./tests/astronaut-fallback",
   timeout: 30 * 1000,
+  webServer: {
+    command: "npx http-server . -p 3000",
+    port: 3000,
+    reuseExistingServer: !process.env.CI,
+  },
   use: {
     browserName: "chromium",
     baseURL: "http://localhost:3000",


### PR DESCRIPTION
## Summary
- start `http-server` on port 3000 before Playwright runs
- set baseURL to `http://localhost:3000` for relative `page.goto` calls

## Testing
- `npm run validate-env`
- `npm run format` *(fails: Unexpected token in tests/frontend/modelViewerLoader.test.js)*
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke`
- `npm run test:astronaut-fallback:playwright` *(fails: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf03e5685c832d9a993a534256e550