### PR TITLE
fix: avoid Playwright server port conflicts

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   webServer: {
     command: "npx http-server . -p 3000",
     port: 3000,
-    reuseExistingServer: !process.env.CI,
+    reuseExistingServer: true,
   },
   use: {
     browserName: "chromium",

--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -4,6 +4,25 @@ const path = require("path");
 const { spawnSync, spawn } = require("child_process");
 const waitOn = require("wait-on");
 
+let pwServer;
+
+async function stopPwServer() {
+  if (pwServer && !pwServer.killed) {
+    const proc = pwServer;
+    pwServer = null;
+    proc.kill();
+    await new Promise((resolve) => proc.once("exit", resolve));
+  } else {
+    pwServer = null;
+  }
+}
+
+for (const sig of ["exit", "SIGINT", "SIGTERM"]) {
+  process.on(sig, () => {
+    if (pwServer && !pwServer.killed) pwServer.kill();
+  });
+}
+
 const repoRoot = path.resolve(__dirname, "..");
 const backendRoot = path.join(repoRoot, "backend");
 
@@ -191,7 +210,8 @@ async function run(args) {
     const env = { ...process.env };
     delete env.JEST_WORKER_ID;
     const port = 3000;
-    const server = spawn(
+    await stopPwServer();
+    pwServer = spawn(
       "npx",
       ["http-server", repoRoot, "-p", String(port)],
       { stdio: "ignore" },
@@ -212,7 +232,7 @@ async function run(args) {
       );
       exitCode = res.status ?? 1;
     } finally {
-      server.kill();
+      await stopPwServer();
     }
   }
   process.exit(exitCode);


### PR DESCRIPTION
## Summary
- ensure `run-jest` cleans up any lingering http-server before running Playwright
- always reuse an existing server in Playwright config to avoid port clashes

## Testing
- `npm run smoke` *(fails: offline mode: skipping smoke)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: lockfile mismatch and registry 403)*
- `npm test` *(fails: Missing jest; run `npm run setup` before testing)*
- `node scripts/run-jest.js tests/astronaut-fallback/astronaut-fallback.e2e.spec.ts` *(fails: Cannot find module 'wait-on')*

------
https://chatgpt.com/codex/tasks/task_e_68bf1436c7d4832dac9c37075956f173