### PR TITLE
test: start backend server for Playwright tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   timeout: 30 * 1000,
   use: {
     browserName: "chromium",
-    baseURL: "http://localhost:3000",
+    // Point Playwright to the backend server so API routes are available
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || "http://localhost:3001",
   },
 });

--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -4,22 +4,33 @@ const path = require("path");
 const { spawnSync, spawn } = require("child_process");
 const waitOn = require("wait-on");
 
-let pwServer;
+let staticServer;
+let backendServer;
 
-async function stopPwServer() {
-  if (pwServer && !pwServer.killed) {
-    const proc = pwServer;
-    pwServer = null;
-    proc.kill();
-    await new Promise((resolve) => proc.once("exit", resolve));
-  } else {
-    pwServer = null;
-  }
+async function stopServers() {
+  const toStop = [staticServer, backendServer];
+  staticServer = null;
+  backendServer = null;
+  await Promise.all(
+    toStop.map(
+      (srv) =>
+        new Promise((resolve) => {
+          if (srv && !srv.killed) {
+            srv.kill();
+            srv.once("exit", resolve);
+          } else {
+            resolve();
+          }
+        }),
+    ),
+  );
 }
 
 for (const sig of ["exit", "SIGINT", "SIGTERM"]) {
   process.on(sig, () => {
-    if (pwServer && !pwServer.killed) pwServer.kill();
+    for (const srv of [staticServer, backendServer]) {
+      if (srv && !srv.killed) srv.kill();
+    }
   });
 }
 
@@ -209,24 +220,40 @@ async function run(args) {
     const relPwTests = pwTests.map((p) => path.relative(repoRoot, p));
     const env = { ...process.env };
     delete env.JEST_WORKER_ID;
-    const port = 3000;
-    await stopPwServer();
-    pwServer = spawn("npx", ["http-server", repoRoot, "-p", String(port)], {
+    const staticPort = 3000;
+    const backendPort = 3001;
+    await stopServers();
+    backendServer = spawn("npm", ["start"], {
+      cwd: backendRoot,
+      env: { ...env, PORT: String(backendPort) },
+      stdio: "ignore",
+    });
+    staticServer = spawn("npx", ["http-server", repoRoot, "-p", String(staticPort)], {
       stdio: "ignore",
     });
     try {
       await waitOn({
-        resources: [`http://localhost:${port}`],
+        resources: [
+          `http://localhost:${staticPort}/index.html`,
+          `http://localhost:${backendPort}/healthz`,
+        ],
         timeout: 30000,
       });
       const res = spawnSync(
         "npx",
         ["playwright", "test", ...relPwTests],
-        { stdio: "inherit", env },
+        {
+          stdio: "inherit",
+          env: {
+            ...env,
+            PLAYWRIGHT_BASE_URL: `http://localhost:${backendPort}`,
+            STATIC_SERVER_URL: `http://localhost:${staticPort}`,
+          },
+        },
       );
       exitCode = res.status ?? 1;
     } finally {
-      await stopPwServer();
+      await stopServers();
     }
   }
   process.exit(exitCode);

--- a/scripts/run-playwright.js
+++ b/scripts/run-playwright.js
@@ -1,43 +1,78 @@
 #!/usr/bin/env node
+const path = require("path");
 const { spawn, spawnSync } = require("child_process");
 const waitOn = require("wait-on");
 
-let server;
+let staticServer;
+let backendServer;
 
-async function stopServer() {
-  if (server && !server.killed) {
-    const proc = server;
-    server = null;
-    proc.kill();
-    await new Promise((resolve) => proc.once("exit", resolve));
-  } else {
-    server = null;
-  }
+async function stopServers() {
+  const toStop = [staticServer, backendServer];
+  staticServer = null;
+  backendServer = null;
+  await Promise.all(
+    toStop.map(
+      (srv) =>
+        new Promise((resolve) => {
+          if (srv && !srv.killed) {
+            srv.kill();
+            srv.once("exit", resolve);
+          } else {
+            resolve();
+          }
+        }),
+    ),
+  );
 }
 
 async function run() {
-  server = spawn("npx", ["http-server", ".", "-p", "3000"], {
+  const repoRoot = path.resolve(__dirname, "..");
+  const backendRoot = path.join(repoRoot, "backend");
+  const staticPort = 3000;
+  const backendPort = 3001;
+
+  backendServer = spawn("npm", ["start"], {
+    cwd: backendRoot,
+    env: { ...process.env, PORT: String(backendPort) },
+    stdio: "ignore",
+  });
+  staticServer = spawn("npx", ["http-server", repoRoot, "-p", String(staticPort)], {
     stdio: "ignore",
   });
 
   try {
-    await waitOn({ resources: ["http://localhost:3000"], timeout: 30000 });
+    await waitOn({
+      resources: [
+        `http://localhost:${staticPort}/index.html`,
+        `http://localhost:${backendPort}/healthz`,
+      ],
+      timeout: 30000,
+    });
     const res = spawnSync(
       "npx",
       ["playwright", "test", ...process.argv.slice(2)],
-      { stdio: "inherit" },
+      {
+        stdio: "inherit",
+        env: {
+          ...process.env,
+          PLAYWRIGHT_BASE_URL: `http://localhost:${backendPort}`,
+          STATIC_SERVER_URL: `http://localhost:${staticPort}`,
+        },
+      },
     );
-    await stopServer();
+    await stopServers();
     process.exit(res.status ?? 1);
   } catch (err) {
-    await stopServer();
+    await stopServers();
     throw err;
   }
 }
 
 for (const sig of ["SIGINT", "SIGTERM", "exit"]) {
   process.on(sig, () => {
-    if (server && !server.killed) server.kill();
+    for (const srv of [staticServer, backendServer]) {
+      if (srv && !srv.killed) srv.kill();
+    }
   });
 }
 

--- a/tests/astronaut-fallback/astronaut-fallback.e2e.spec.ts
+++ b/tests/astronaut-fallback/astronaut-fallback.e2e.spec.ts
@@ -1,6 +1,8 @@
 import { test, expect } from "@playwright/test";
 import { waitForModelViewer, intercept } from "./utils";
 
+const STATIC_BASE = process.env.STATIC_SERVER_URL || "http://localhost:3000";
+
 test.beforeEach(async ({ page }) => {
   // Forward browser console and failed network requests to the test logs
   page.on("console", (msg) => console.log("PAGE LOG:", msg.text()));
@@ -13,7 +15,7 @@ test.describe("Basic rendering", () => {
   test("Index loads model-viewer and astronaut model", async ({ page }) => {
     const modelReq = await intercept(page, "Astronaut.glb");
     const envReq = await intercept(page, "neutral.hdr");
-    await page.goto("/index.html");
+    await page.goto(`${STATIC_BASE}/index.html`);
     await waitForModelViewer(page);
     expect(modelReq.length).toBeGreaterThan(0);
     expect(modelReq[0].url()).toMatch(/Astronaut\.glb$/);
@@ -26,7 +28,7 @@ test.describe("Basic rendering", () => {
   }) => {
     const modelReq = await intercept(page, "Astronaut.glb");
     const envReq = await intercept(page, "neutral.hdr");
-    await page.goto("/payment.html");
+    await page.goto(`${STATIC_BASE}/payment.html`);
     await waitForModelViewer(page);
     expect(modelReq.length).toBeGreaterThan(0);
     expect(envReq.length).toBeGreaterThan(0);
@@ -36,7 +38,7 @@ test.describe("Basic rendering", () => {
 test.describe("Custom src parameter", () => {
   test("modelLoader.js applies custom ?model url", async ({ page }) => {
     const custom = "https://example.com/a.glb";
-    await page.goto(`/index.html?model=${encodeURIComponent(custom)}`);
+    await page.goto(`${STATIC_BASE}/index.html?model=${encodeURIComponent(custom)}`);
     await waitForModelViewer(page);
     await expect(page.locator("model-viewer")).toHaveAttribute("src", custom);
   });
@@ -44,7 +46,7 @@ test.describe("Custom src parameter", () => {
   const invalid = ["", "null", "undefined", "0", "false"];
   for (const val of invalid) {
     test(`Fallback to default for ?model=${val}`, async ({ page }) => {
-      await page.goto(`/index.html?model=${val}`);
+      await page.goto(`${STATIC_BASE}/index.html?model=${val}`);
       await waitForModelViewer(page);
       await expect(page.locator("model-viewer")).toHaveAttribute(
         "src",
@@ -56,7 +58,7 @@ test.describe("Custom src parameter", () => {
 
 test.describe("Script loading behaviour", () => {
   test("Remote CDN script success path", async ({ page }) => {
-    await page.goto("/index.html");
+    await page.goto(`${STATIC_BASE}/index.html`);
     await waitForModelViewer(page);
     const scripts = page.locator('script[src*="model-viewer"]');
     await expect(scripts).toHaveCount(1);
@@ -75,7 +77,7 @@ test.describe("Script loading behaviour", () => {
       (route) => route.abort(),
     );
     const localReqs = await intercept(page, "js/model-viewer.min.js");
-    await page.goto("/index.html");
+    await page.goto(`${STATIC_BASE}/index.html`);
     await waitForModelViewer(page);
     expect(localReqs.length).toBeGreaterThan(0);
     expect(
@@ -89,8 +91,8 @@ test.describe("Multiple model-viewers", () => {
     const content = `
       <html>
       <head>
-        <script type="module" src="/js/modelLoader.js"></script>
-        <script type="module" src="/js/modelViewerFallback.js"></script>
+        <script type="module" src="${STATIC_BASE}/js/modelLoader.js"></script>
+        <script type="module" src="${STATIC_BASE}/js/modelViewerFallback.js"></script>
       </head>
       <body>
         ${"<model-viewer></model-viewer>".repeat(5)}
@@ -120,8 +122,8 @@ test.describe("Removal of element", () => {
     await page.setContent(`
       <html>
       <head>
-        <script type="module" src="/js/modelLoader.js"></script>
-        <script type="module" src="/js/modelViewerFallback.js"></script>
+        <script type="module" src="${STATIC_BASE}/js/modelLoader.js"></script>
+        <script type="module" src="${STATIC_BASE}/js/modelViewerFallback.js"></script>
       </head>
       <body></body>
       </html>
@@ -140,7 +142,7 @@ test.describe("Network edge cases", () => {
     await page.route("**/neutral.hdr", (route) =>
       route.fulfill({ status: 404 }),
     );
-    await page.goto("/index.html");
+    await page.goto(`${STATIC_BASE}/index.html`);
     await waitForModelViewer(page);
     expect(errors.some((e) => e.includes("neutral.hdr"))).toBe(true);
     await expect(page.locator("model-viewer")).not.toHaveAttribute(
@@ -159,7 +161,7 @@ test.describe("Network edge cases", () => {
     await page.route("**/Astronaut.glb", (route) =>
       route.fulfill({ status: 404 }),
     );
-    await page.goto("/index.html");
+    await page.goto(`${STATIC_BASE}/index.html`);
     await page.waitForLoadState("load");
     const expectedError =
       "GET https://modelviewer.dev/shared-assets/models/Astronaut.glb 404 (Not Found)";
@@ -170,7 +172,7 @@ test.describe("Network edge cases", () => {
 test.describe("Timing conditions", () => {
   test("DOMContentLoaded triggers load only once", async ({ page }) => {
     const modelReq = await intercept(page, "Astronaut.glb");
-    await page.goto("/index.html");
+    await page.goto(`${STATIC_BASE}/index.html`);
     await waitForModelViewer(page);
     expect(modelReq.length).toBe(1);
     await page.reload();
@@ -180,7 +182,7 @@ test.describe("Timing conditions", () => {
 
 test.describe("Visual sanity snapshot", () => {
   test("captures screenshot of model-viewer", async ({ page }) => {
-    await page.goto("/index.html");
+    await page.goto(`${STATIC_BASE}/index.html`);
     await waitForModelViewer(page);
     const buf = await page.locator("model-viewer").screenshot();
     expect(buf.length).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary
- start backend and static servers together when running Playwright
- point Playwright baseURL at backend server
- load static assets via STATIC_SERVER_URL in Playwright tests

## Testing
- `npm --prefix backend run format`
- `npm --prefix backend test`
- `npm test` *(fails: Cannot find module 'wait-on')*


------
https://chatgpt.com/codex/tasks/task_e_68bf2c2587a4832db6949aea7d150d84