### PR TITLE
fix: import model-viewer from CDN

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,6 +84,10 @@
       crossorigin
     />
 
+    <script
+      type="module"
+      src="https://cdn.jsdelivr.net/npm/@google/model-viewer@1.12.0/dist/model-viewer.min.js"
+    ></script>
     <script type="module" src="js/modelLoader.js"></script>
 
     <style>

--- a/payment.html
+++ b/payment.html
@@ -35,7 +35,10 @@
 
     <!-- Font Awesome (back-arrow icon) -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" referrerpolicy="no-referrer">
-
+    <script
+      type="module"
+      src="https://cdn.jsdelivr.net/npm/@google/model-viewer@1.12.0/dist/model-viewer.min.js"
+    ></script>
     <script type="module" src="js/modelLoader.js"></script>
     <style>
       /* Add rainbow shimmer effect used on the index submit arrow */


### PR DESCRIPTION
## Summary
- load @google/model-viewer directly from jsdelivr on index and payment pages
- retain existing modelViewerFallback.js fallback

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run setup` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest-runner)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Lockfile mismatch detected; 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke` *(skipped: offline mode)*
- `curl -I https://modelviewer.dev/shared-assets/models/Astronaut.glb` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bf3969b954832daa1af2f29c9189ca