### PR TITLE
test: add viewer smoke test

### DIFF
--- a/tests/smoke-viewer.spec.ts
+++ b/tests/smoke-viewer.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from "@playwright/test";
+
+const pages = ["/index.html", "/payment.html"];
+const forbidden = [
+  "modelLoader.js",
+  "modelViewerTouchFix.js",
+  "modelViewerFallback.js",
+  "model-ready-hook.js",
+];
+
+for (const path of pages) {
+  test(`model-viewer smoke test for ${path}`, async ({ page }) => {
+    await page.addInitScript(() => {
+      if ("serviceWorker" in navigator) {
+        navigator.serviceWorker.addEventListener("message", (event) => {
+          (window as any).__swMessages = (window as any).__swMessages || [];
+          (window as any).__swMessages.push(event.data);
+        });
+      }
+    });
+
+    await page.goto(path);
+
+    const viewer = page.locator("model-viewer");
+    await expect(viewer).toHaveCount(1);
+    await expect(viewer).toHaveAttribute("src", /Astronaut\.glb/);
+
+    for (const name of forbidden) {
+      await expect(page.locator(`script[src*="${name}"]`)).toHaveCount(0);
+    }
+
+    const swMessages = await page.evaluate(
+      () => (window as any).__swMessages || [],
+    );
+    expect(
+      swMessages.some((m: any) => m && m.type === "prefetch-models"),
+    ).toBeFalsy();
+  });
+}


### PR DESCRIPTION
## Summary
- add Playwright smoke test ensuring model-viewer loads the Astronaut model and no legacy scripts are present

## Testing
- `npm run validate-env` *(fails: 403 Forbidden - GET https://registry.npmjs.org/npm)*
- `SKIP_PW_DEPS=1 npm run setup` *(terminated due to hang)*
- `npm --prefix backend run format` *(fails: tests/frontend/modelViewerLoader.test.js syntax error)*
- `npm test` *(fails: Cannot find module 'wait-on')*
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `npm run smoke` *(offline mode: skipping smoke)*
- `npx playwright test tests/smoke-viewer.spec.ts` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68bf59b41bec832da54e23ddc8063df1