### PR TITLE
refactor: remove unused viewer elements

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -272,11 +272,7 @@ async function updateStats() {
 const $ = (id) => document.getElementById(id);
 const refs = {
   previewImg: $("preview-img"),
-  loader: $("loader"),
   viewer: document.getElementById("viewer"),
-  progressBar: $("progress-bar"),
-  progressWrapper: $("progress-wrapper"),
-  progressText: $("progress-text"),
   demoNote: $("demo-note"),
   demoClose: $("demo-note-close"),
   promptInput: $("promptInput"),
@@ -321,9 +317,6 @@ let userProfile = null;
 // Track when the prompt or images have been modified after a generation
 let editsPending = false;
 
-let progressInterval = null;
-let progressStart = null;
-let usingViewerProgress = false;
 let lastSnapshot = null;
 let errorFadeTimeout = null;
 let errorClearTimeout = null;
@@ -410,39 +403,8 @@ async function captureModelSnapshot(url) {
   return result;
 }
 
-function startProgress(estimateMs = 20000) {
-  if (!refs.progressWrapper) return;
-  progressStart = Date.now();
-  usingViewerProgress = false;
-  refs.progressBar.style.width = "0%";
-  refs.progressWrapper.style.display = "block";
-  const tick = () => {
-    if (usingViewerProgress) return;
-    const elapsed = Date.now() - progressStart;
-    const pct = Math.min((elapsed / estimateMs) * 100, 99);
-    refs.progressBar.style.width = pct + "%";
-    const remaining = Math.max(estimateMs - elapsed, 0);
-    refs.progressText.textContent = `~${Math.ceil(remaining / 1000)}s remaining`;
-  };
-  tick();
-  clearInterval(progressInterval);
-  progressInterval = setInterval(tick, 500);
-}
-
-function stopProgress() {
-  if (!refs.progressWrapper) return;
-  clearInterval(progressInterval);
-  usingViewerProgress = false;
-  refs.progressBar.style.width = "100%";
-  refs.progressText.textContent = "";
-  setTimeout(() => {
-    refs.progressWrapper.style.display = "none";
-  }, 300);
-}
-
 const hideAll = () => {
   refs.previewImg.style.display = "none";
-  refs.loader.style.display = "none";
 
   refs.viewer.style.opacity = "0";
   refs.viewer.style.pointerEvents = "none";
@@ -453,18 +415,16 @@ const hideAll = () => {
     delete document.body.dataset.viewerReady;
   }
 };
-const showLoader = (withProgress = true) => {
-  // Keep the viewer visible while showing the loader so the fallback model
-  // remains on screen during generation and on failures.
+const showLoader = () => {
+  // Keep the viewer visible so the fallback model remains on screen during
+  // generation and on failures.
   refs.previewImg.style.display = "none";
-  refs.loader.style.display = "flex";
   refs.viewer.style.display = "block";
   refs.viewer.style.opacity = "1";
   refs.viewer.style.pointerEvents = "auto";
   if (typeof refs.viewer.play === "function") {
     refs.viewer.play();
   }
-  if (withProgress) startProgress();
 };
 const showModel = () => {
   hideAll();
@@ -480,7 +440,6 @@ const showModel = () => {
     document.body.dataset.viewerReady = "true";
   }
 
-  stopProgress();
   // Force a render in case Safari paused the canvas while hidden
   if (typeof refs.viewer.requestUpdate === "function") {
     refs.viewer.requestUpdate();
@@ -989,19 +948,6 @@ async function init() {
       { once: true },
     );
   }
-  refs.viewer.addEventListener("progress", (e) => {
-    if (!progressStart) progressStart = Date.now();
-    usingViewerProgress = true;
-    const pct = Math.round(e.detail.totalProgress * 100);
-    refs.progressBar.style.width = pct + "%";
-    const elapsed = Date.now() - progressStart;
-    if (pct < 100) {
-      const remaining = pct > 0 ? (elapsed * (100 - pct)) / pct : 0;
-      refs.progressText.textContent = `~${Math.ceil(remaining / 1000)}s remaining`;
-    } else {
-      stopProgress();
-    }
-  });
   refs.viewer.addEventListener("load", showModel, { once: true });
   refs.viewer.addEventListener(
     "error",

--- a/js/payment.js
+++ b/js/payment.js
@@ -455,7 +455,6 @@ async function initPaymentPage() {
     } catch {}
   }
 
-  const loader = document.getElementById("loader");
   const viewer = document.getElementById("viewer");
   const optOut = document.getElementById("opt-out");
   const emailEl = document.getElementById("checkout-email");
@@ -923,21 +922,6 @@ async function initPaymentPage() {
   }
   updatePayButton();
   updatePopularMessage();
-  const prevBtn = document.getElementById("prev-model");
-  const nextBtn = document.getElementById("next-model");
-  const removeBtn = document.getElementById("remove-model");
-
-  function updateNavButtons() {
-    if (!prevBtn || !nextBtn) return;
-    if (checkoutItems.length > 1) {
-      prevBtn.classList.remove("hidden");
-      nextBtn.classList.remove("hidden");
-    } else {
-      prevBtn.classList.add("hidden");
-      nextBtn.classList.add("hidden");
-    }
-  }
-
   function showItem(idx) {
     if (!checkoutItems.length) return;
     currentIndex = (idx + checkoutItems.length) % checkoutItems.length;
@@ -997,48 +981,10 @@ async function initPaymentPage() {
     if (qtySelect) {
       qtySelect.value = String(item.qty || 1);
     }
-    const counter = document.getElementById("model-counter");
-    if (counter) {
-      if (checkoutItems.length > 1) {
-        counter.textContent = `${currentIndex + 1} / ${checkoutItems.length}`;
-        counter.classList.remove("hidden");
-      } else {
-        counter.classList.add("hidden");
-      }
-    }
-    if (removeBtn) {
-      if (checkoutItems.length > 1) {
-        removeBtn.classList.remove("hidden");
-      } else {
-        removeBtn.classList.add("hidden");
-      }
-    }
-    updateNavButtons();
     applyStoredColorIfNeeded();
     updatePayButton();
     updateFlashSaleBanner();
   }
-
-  prevBtn?.addEventListener("click", () => showItem(currentIndex - 1));
-  nextBtn?.addEventListener("click", () => showItem(currentIndex + 1));
-  removeBtn?.addEventListener("click", () => {
-    if (!checkoutItems.length) return;
-    const idx = currentIndex;
-    checkoutItems.splice(idx, 1);
-    saveCheckoutItems();
-    try {
-      const basket = JSON.parse(localStorage.getItem("print2Basket")) || [];
-      if (idx >= 0 && idx < basket.length) {
-        basket.splice(idx, 1);
-        localStorage.setItem("print2Basket", JSON.stringify(basket));
-      }
-    } catch {}
-    if (checkoutItems.length) {
-      if (currentIndex >= checkoutItems.length) currentIndex = 0;
-      showItem(currentIndex);
-    }
-    window.dispatchEvent(new CustomEvent("basket-change"));
-  });
   const sessionId = qs("session_id");
   if (sessionId) {
     recordPurchase();
@@ -1132,19 +1078,6 @@ async function initPaymentPage() {
     });
   }
 
-  const hideLoader = () => (loader.hidden = true);
-
-  // Attach events immediately so we don't miss the "load" event even if the
-  // <model-viewer> element upgrades while this script is still loading. If the
-  // library fails to load, the "error" handler falls back to the astronaut
-  // model and hides the loader overlay.
-  if (viewer && viewer.tagName.toLowerCase() !== "img") {
-    viewer.addEventListener("load", hideLoader);
-    viewer.addEventListener("error", () => {
-      hideLoader();
-    });
-  }
-
   // Wait for the <model-viewer> definition before assigning the model source.
   // Some browsers won't process the "src" attribute on a custom element until
   // after it's upgraded, so we guard against that here.
@@ -1158,13 +1091,6 @@ async function initPaymentPage() {
   const storedModel = sanitizeUrl(localStorage.getItem("print2Model"));
   setModelSrc(storedModel || FALLBACK_GLB);
 
-  if (viewer && viewer.tagName.toLowerCase() === "img") {
-    // The Luckybox page uses a static <img> preview, so skip the loading
-    // overlay entirely to avoid covering the image.
-    loader.hidden = true;
-  } else {
-    loader.hidden = false;
-  }
   // Load saved basket items unless this is the Luckybox page
   if (!window.location.pathname.endsWith("luckybox-payment.html")) {
     try {
@@ -1253,11 +1179,9 @@ async function initPaymentPage() {
   }
 
   if (!checkoutItems.length) {
-    if (removeBtn) removeBtn.classList.add("hidden");
     if (viewer && viewer.tagName.toLowerCase() !== "img") {
       viewer.addEventListener("load", applyStoredColorIfNeeded, { once: true });
     }
-    updateNavButtons();
   } else {
     const first = checkoutItems[0];
     if (first.jobId) localStorage.setItem("print2JobId", first.jobId);
@@ -1265,11 +1189,6 @@ async function initPaymentPage() {
     storedMaterial = first.material || storedMaterial;
     localStorage.setItem("print2Material", storedMaterial);
     showItem(0);
-    if (removeBtn) {
-      if (checkoutItems.length > 1) removeBtn.classList.remove("hidden");
-      else removeBtn.classList.add("hidden");
-    }
-    updateNavButtons();
   }
 
   if (!checkoutItems.length && qtySelect) {
@@ -1278,7 +1197,6 @@ async function initPaymentPage() {
   }
 
   // Hide the overlay if nothing happens after a short delay
-  setTimeout(hideLoader, 7000);
 
   if (sessionId) {
     successMsg.hidden = false;

--- a/luckybox-payment.html
+++ b/luckybox-payment.html
@@ -230,49 +230,12 @@
               style="display: none"
               alt="Preview image"
             />
-              <img
-                id="viewer"
-                src="images/luckybox-preview.png"
-                alt="Luckybox preview"
-                class="object-cover h-full w-full rounded-3xl"
-              />
-            <button
-              id="remove-model"
-              type="button"
-              class="absolute top-2 right-2 w-6 h-6 rounded-full bg-white text-black border border-black flex items-center justify-center z-20 hidden"
-            >
-              <i class="fas fa-times"></i>
-              <span class="sr-only">Remove from basket</span>
-            </button>
-            <p
-              id="model-counter"
-              class="absolute top-10 right-2 text-white text-xs hidden"
-            ></p>
-            <button
-              id="prev-model"
-              type="button"
-              class="absolute left-2 top-1/2 -translate-y-1/2 bg-[#2A2A2E] border border-white/20 rounded-full p-2 hidden"
-            >
-              <i class="fas fa-chevron-left"></i>
-              <span class="sr-only">Previous model</span>
-            </button>
-            <button
-              id="next-model"
-              type="button"
-              class="absolute right-2 top-1/2 -translate-y-1/2 bg-[#2A2A2E] border border-white/20 rounded-full p-2 hidden"
-            >
-              <i class="fas fa-chevron-right"></i>
-              <span class="sr-only">Next model</span>
-            </button>
-            <div
-              id="loader"
-              class="absolute inset-0 flex items-center justify-center bg-[#2A2A2E]/80"
-              style="display: none"
-            >
-              <div
-                class="h-10 w-10 border-4 border-white border-t-transparent rounded-full animate-spin"
-              ></div>
-            </div>
+            <img
+              id="viewer"
+              src="images/luckybox-preview.png"
+              alt="Luckybox preview"
+              class="object-cover h-full w-full rounded-3xl"
+            />
           </section>
           <div id="trust-badge" class="mt-4 text-center text-sm text-gray-400">
             <p class="mb-1">
@@ -848,8 +811,8 @@
     <script type="module" src="js/trackingPixel.js"></script>
     <script>
       document.addEventListener("DOMContentLoaded", () => {
-          const img = document.getElementById("viewer");
-          if (img) img.src = "images/luckybox-preview.png";
+        const img = document.getElementById("viewer");
+        if (img) img.src = "images/luckybox-preview.png";
       });
     </script>
   </body>

--- a/minis-checkout.html
+++ b/minis-checkout.html
@@ -13,7 +13,12 @@
     <link rel="preconnect" href="https://modelviewer.dev" crossorigin />
 
     <!-- Preload 3D assets -->
-    <link rel="preload" href="https://modelviewer.dev/shared-assets/models/Astronaut.glb" as="fetch" fetchpriority="high" />
+    <link
+      rel="preload"
+      href="https://modelviewer.dev/shared-assets/models/Astronaut.glb"
+      as="fetch"
+      fetchpriority="high"
+    />
     <link
       rel="preload"
       href="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
@@ -242,68 +247,32 @@
       >
         <!-- Model Preview -->
         <div class="w-full md:w-1/2 max-w-lg flex flex-col items-center">
-        <section
-          id="preview-wrapper"
-          class="relative w-full h-80 bg-[#2A2A2E] border border-white/10 rounded-3xl overflow-visible"
-        >
-          <img
-            id="preview-img"
-            src="https://placehold.co/600x400/2A2A2E/2A2A2E?text="
-            class="object-contain h-full w-full"
-            style="display: none"
-            alt="Preview image"
-          />
-          <model-viewer
-            id="viewer"
-            alt="3D astronaut"
-            environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
-            camera-controls
-            auto-rotate
-            style="width: 100%; height: 100%; display: block"
-          ></model-viewer>
-          <p class="absolute top-2 left-2 text-red-300 text-xs">
-            Only <span id="slot-count" style="visibility: hidden"></span> print
-            slots remaining
-          </p>
-          <button
-            id="remove-model"
-            type="button"
-            class="absolute top-2 right-2 w-6 h-6 rounded-full bg-white text-black border border-black flex items-center justify-center z-20 hidden"
+          <section
+            id="preview-wrapper"
+            class="relative w-full h-80 bg-[#2A2A2E] border border-white/10 rounded-3xl overflow-visible"
           >
-            <i class="fas fa-times"></i>
-            <span class="sr-only">Remove from basket</span>
-          </button>
-          <p
-            id="model-counter"
-            class="absolute top-10 right-2 text-white text-xs hidden"
-          ></p>
-          <button
-            id="prev-model"
-            type="button"
-            class="absolute left-2 top-1/2 -translate-y-1/2 bg-[#2A2A2E] border border-white/20 rounded-full p-2 hidden"
-          >
-            <i class="fas fa-chevron-left"></i>
-            <span class="sr-only">Previous model</span>
-          </button>
-          <button
-            id="next-model"
-            type="button"
-            class="absolute right-2 top-1/2 -translate-y-1/2 bg-[#2A2A2E] border border-white/20 rounded-full p-2 hidden"
-          >
-            <i class="fas fa-chevron-right"></i>
-            <span class="sr-only">Next model</span>
-          </button>
-          <div
-            id="loader"
-            class="absolute inset-0 flex items-center justify-center bg-[#2A2A2E]/80"
-            style="display: none"
-          >
-            <div
-              class="h-10 w-10 border-4 border-white border-t-transparent rounded-full animate-spin"
-            ></div>
-          </div>
-        </section>
-        <div id="trust-badge" class="mt-4 text-center text-sm text-gray-400">
+            <img
+              id="preview-img"
+              src="https://placehold.co/600x400/2A2A2E/2A2A2E?text="
+              class="object-contain h-full w-full"
+              style="display: none"
+              alt="Preview image"
+            />
+            <model-viewer
+              id="viewer"
+              alt="3D astronaut"
+              environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
+              camera-controls
+              auto-rotate
+              style="width: 100%; height: 100%; display: block"
+            ></model-viewer>
+            <p class="absolute top-2 left-2 text-red-300 text-xs">
+              Only
+              <span id="slot-count" style="visibility: hidden"></span> print
+              slots remaining
+            </p>
+          </section>
+          <div id="trust-badge" class="mt-4 text-center text-sm text-gray-400">
             <p class="mb-1">
               Trusted by <span class="text-white">thousands of makers:</span>
             </p>
@@ -312,7 +281,7 @@
               questions asked:
               <span class="text-white">enquiries@domain.com</span>
             </p>
-        </div>
+          </div>
         </div>
 
         <!-- Checkout Form -->

--- a/payment.html
+++ b/payment.html
@@ -205,24 +205,6 @@
               Only <span id="slot-count" style="visibility: hidden"></span> print slots remaining
             </p>
 
-            <!-- Unused UI retained (not wired) -->
-            <button id="remove-model" type="button" class="absolute top-2 right-2 w-6 h-6 rounded-full bg-white text-black border border-black flex items-center justify-center z-20 hidden">
-              <i class="fas fa-times"></i>
-              <span class="sr-only">Remove from basket</span>
-            </button>
-            <p id="model-counter" class="absolute top-10 right-2 text-white text-xs hidden"></p>
-            <button id="prev-model" type="button" class="absolute left-2 top-1/2 -translate-y-1/2 bg-[#2A2A2E] border border-white/20 rounded-full p-2 hidden">
-              <i class="fas fa-chevron-left"></i>
-              <span class="sr-only">Previous model</span>
-            </button>
-            <button id="next-model" type="button" class="absolute right-2 top-1/2 -translate-y-1/2 bg-[#2A2A2E] border border-white/20 rounded-full p-2 hidden">
-              <i class="fas fa-chevron-right"></i>
-              <span class="sr-only">Next model</span>
-            </button>
-
-            <div id="loader" class="absolute inset-0 flex items-center justify-center bg-[#2A2A2E]/80" style="display: none">
-              <div class="h-10 w-10 border-4 border-white border-t-transparent rounded-full animate-spin"></div>
-            </div>
           </section>
 
           <div id="trust-badge" class="mt-4 text-center text-sm text-gray-400">


### PR DESCRIPTION
## Summary
- clean up viewer scripts by removing loader/progress handling
- strip unused navigation buttons from checkout previews
- keep preview boxes with just the model viewer and slot labels

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` *(fails: Unexpected token in backend/tests/frontend/modelViewerLoader.test.js)*
- `npm test` *(fails: Missing jest; run `npm run setup` before testing)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Lockfile mismatch detected)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68bf59678694832dafa827b4bf0171b7