### PR TITLE
fix: remove model prefetch from service worker

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -47,18 +47,3 @@ self.addEventListener("fetch", (event) => {
   }
 });
 
-self.addEventListener("message", (event) => {
-  if (event.data && event.data.type === "prefetch-models") {
-    event.waitUntil(
-      caches
-        .open(CACHE_NAME)
-        .then((cache) =>
-          Promise.all(
-            ASSETS.map((url) =>
-              fetch(url).then((resp) => cache.put(url, resp.clone())),
-            ),
-          ),
-        ),
-    );
-  }
-});


### PR DESCRIPTION
## Summary
- remove prefetch-models message handler from service worker

## Testing
- `npm run format` (failed: tests/frontend/modelViewerLoader.test.js: SyntaxError: Unexpected token (110:1))
- `npm test` (failed: Missing jest; run `npm run setup` before testing.)
- `SKIP_PW_DEPS=1 npm run ci` (failed: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)


------
https://chatgpt.com/codex/tasks/task_e_68bf59494090832d96aca1874ead26f4