### PR TITLE
refactor: clean payment viewer

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -12,7 +12,6 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
     <link rel="preconnect" href="https://modelviewer.dev" crossorigin />
 
-    <!-- REMOVED: data-model-href preload (boombox.glb) -->
     <!-- Keep HDRI preload (useful & harmless) -->
     <link
       rel="preload"
@@ -45,7 +44,6 @@
       src="https://cdn.jsdelivr.net/npm/@google/model-viewer@1.12.0/dist/model-viewer-legacy.js"
     ></script>
 
-    <!-- REMOVED: js/modelLoader.js -->
 
     <style>
       /* --- existing UI styles, unchanged --- */
@@ -220,9 +218,6 @@
               <span class="sr-only">Next model</span>
             </button>
 
-            <div id="loader" class="absolute inset-0 flex items-center justify-center bg-[#2A2A2E]/80" style="display: none">
-              <div class="h-10 w-10 border-4 border-white border-t-transparent rounded-full animate-spin"></div>
-            </div>
           </section>
 
           <div id="trust-badge" class="mt-4 text-center text-sm text-gray-400">
@@ -432,10 +427,6 @@
     </div>
 
     <!-- Init scripts (SAFE SET — none touch <model-viewer>) -->
-    <!-- REMOVED: js/model-ready-hook.js block -->
-    <!-- REMOVED: js/modelViewerTouchFix.js -->
-    <!-- REMOVED: js/modelViewerFallback.js -->
-    <!-- REMOVED: service worker registration/prefetch -->
 
     <script type="module" src="js/wizard.js" defer></script>
     <script type="module" src="js/print-slots.js" defer></script>
@@ -487,6 +478,5 @@
     <script type="module" src="js/saveList.js" defer></script>
     <script type="module" src="js/trackingPixel.js"></script>
 
-    <!-- REMOVED: bottom IIFE that mutated [data-model-href] -->
   </body>
 </html>


### PR DESCRIPTION
## Summary
- remove legacy model viewer scripts and progress elements from payment checkout

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` *(fails: tests/frontend/modelViewerLoader.test.js: SyntaxError)*
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Lockfile mismatch detected)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68bf5944c9bc832d815ba5b9bd0fdff1