### PR TITLE
refactor: remove leftover model viewer code from payment

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -125,7 +125,6 @@
       }
       #pay-summary.visible { display: block; }
 
-      /* Hide model-viewer’s built-in progress bar */
     </style>
   </head>
 
@@ -413,7 +412,6 @@
     </div>
 
     <!-- Init scripts (SAFE SET — none touch <model-viewer>) -->
-    <!-- REMOVED: service worker registration/prefetch -->
 
     <script type="module" src="js/wizard.js" defer></script>
     <script type="module" src="js/print-slots.js" defer></script>


### PR DESCRIPTION
## Summary
- drop obsolete progress-bar and service worker comments from payment page

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format`
- `npm test`
- `npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff; Lockfile mismatch detected)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68bffc08b2b0832db4b02ea7b63ee489