### PR TITLE
feat: preload local model assets

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,8 +40,17 @@
 
     <link
       rel="preload"
-      href="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
+      href="models/astronaut.glb"
       as="fetch"
+      type="model/gltf-binary"
+      fetchpriority="high"
+      crossorigin
+    />
+    <link
+      rel="preload"
+      href="models/neutral.hdr"
+      as="fetch"
+      type="model/gltf-binary"
       fetchpriority="high"
       crossorigin
     />
@@ -124,8 +133,8 @@
            If future enhancements are needed, create a dedicated viewer module in /js/viewer/ with strict interfaces. -->
           <model-viewer
             id="glb-viewer"
-            src="https://modelviewer.dev/shared-assets/models/Astronaut.glb"
-            environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
+            src="models/astronaut.glb"
+            environment-image="models/neutral.hdr"
             camera-controls
             auto-rotate
             loading="eager"

--- a/payment.html
+++ b/payment.html
@@ -12,11 +12,19 @@
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
     <link rel="preconnect" href="https://modelviewer.dev" crossorigin />
 
-    <!-- Keep HDRI preload (useful & harmless) -->
     <link
       rel="preload"
-      href="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
+      href="models/astronaut.glb"
       as="fetch"
+      type="model/gltf-binary"
+      fetchpriority="high"
+      crossorigin
+    />
+    <link
+      rel="preload"
+      href="models/neutral.hdr"
+      as="fetch"
+      type="model/gltf-binary"
       fetchpriority="high"
       crossorigin
     />
@@ -190,8 +198,8 @@
              If future enhancements are needed, create a dedicated viewer module in /js/viewer/ with strict interfaces. -->
             <model-viewer
               id="viewer"
-              src="https://modelviewer.dev/shared-assets/models/Astronaut.glb"
-              environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
+              src="models/astronaut.glb"
+              environment-image="models/neutral.hdr"
               camera-controls
               auto-rotate
               loading="eager"

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "model-cache-v4";
+const CACHE_NAME = "model-cache-v5";
 // Cache only same-origin assets. Remote resources can fail to load when served
 // from the service worker cache, breaking the 3D viewer.
 const ASSETS = [
@@ -6,6 +6,8 @@ const ASSETS = [
   "js/rewardBadge.js",
   "js/basket.js",
   "js/trackingPixel.js",
+  "models/astronaut.glb",
+  "models/neutral.hdr",
 ];
 
 self.addEventListener("install", (event) => {


### PR DESCRIPTION
## Summary
- preload local GLB and HDR assets in index and payment pages
- cache model assets via service worker

## Testing
- `npm run format`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68bfff71897c832d84c49cf5579c9f99