### PR TITLE
feat: add model viewer fallbacks

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -14,7 +14,7 @@
       property="og:description"
       content="Browse and share 3D models created by the print3 community."
     />
-      <meta property="og:image" content="images/box%20logo.png" />
+    <meta property="og:image" content="images/box%20logo.png" />
     <script src="js/applyColorScheme.js"></script>
     <link rel="preconnect" href="https://modelviewer.dev" crossorigin />
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
@@ -225,6 +225,7 @@
                 class="carousel-slide flex-none p-4 flex items-center justify-center"
               >
                 <model-viewer
+                  poster="images/astro-image.png"
                   src="https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoomBox/glTF-Binary/BoomBox.glb"
                   alt="BoomBox model"
                   environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
@@ -270,13 +271,14 @@
               <div
                 class="carousel-slide flex-none p-4 flex flex-col sm:flex-row items-center justify-center gap-4"
               >
-                  <img
-                    src="images/astro-image.png"
-                    alt="Real-life print"
-                    loading="lazy"
-                    class="w-full sm:w-1/2 h-64 object-cover rounded-xl"
-                  />
+                <img
+                  src="images/astro-image.png"
+                  alt="Real-life print"
+                  loading="lazy"
+                  class="w-full sm:w-1/2 h-64 object-cover rounded-xl"
+                />
                 <model-viewer
+                  poster="images/astro-image.png"
                   src="https://modelviewer.dev/shared-assets/models/Astronaut.glb"
                   alt="3D model preview"
                   environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
@@ -346,6 +348,7 @@
           <span class="sr-only">Close</span>
         </button>
         <model-viewer
+          poster="images/astro-image.png"
           src="about:blank"
           alt="3D model preview"
           environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"

--- a/competitions.html
+++ b/competitions.html
@@ -114,12 +114,13 @@
         class="bg-[#2A2A2E] p-4 rounded-xl flex items-center space-x-4 border border-white/10"
       >
         <div data-testid="primary-model">
-          <model-viewer
-            src="https://modelviewer.dev/shared-assets/models/Astronaut.glb"
-            alt="Contest winner"
-            environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
-            camera-controls
-            auto-rotate
+        <model-viewer
+          poster="images/astro-image.png"
+          src="https://modelviewer.dev/shared-assets/models/Astronaut.glb"
+          alt="Contest winner"
+          environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
+          camera-controls
+          auto-rotate
             class="w-24 h-24 rounded-full"
             data-testid="model-viewer"
             role="img"
@@ -284,15 +285,16 @@
             <line x1="6" y1="18" x2="18" y2="6" />
           </svg>
           <span class="sr-only">Close</span>
-        </button>
-        <model-viewer
-          src="about:blank"
-          alt="3D model preview"
-          environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
-          camera-controls
-          auto-rotate
-          class="w-full h-96 bg-[#2A2A2E] rounded-xl"
-        ></model-viewer>
+      </button>
+      <model-viewer
+        poster="images/astro-image.png"
+        src="about:blank"
+        alt="3D model preview"
+        environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
+        camera-controls
+        auto-rotate
+        class="w-full h-96 bg-[#2A2A2E] rounded-xl"
+      ></model-viewer>
         <div
           id="modal-action-panel"
           class="absolute bottom-4 left-4 right-4 flex justify-between items-end"

--- a/index.html
+++ b/index.html
@@ -119,15 +119,16 @@
           class="relative w-full max-w-lg bg-[#2A2A2E] border border-white/10 rounded-3xl overflow-hidden"
           style="height: calc(18rem + 1cm)"
         >
-          <!-- Minimal, hard-coded viewer. 
-           DO NOT attach custom loaders, swap src via JS, or register SW prefetch for .glb/.hdr here. 
-           If future enhancements are needed, create a dedicated viewer module in /js/viewer/ with strict interfaces. -->
-          <model-viewer
-            id="glb-viewer"
-            src="https://modelviewer.dev/shared-assets/models/Astronaut.glb"
-            environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
-            camera-controls
-            auto-rotate
+        <!-- Minimal, hard-coded viewer.
+         DO NOT attach custom loaders, swap src via JS, or register SW prefetch for .glb/.hdr here.
+         If future enhancements are needed, create a dedicated viewer module in /js/viewer/ with strict interfaces. -->
+        <model-viewer
+          id="glb-viewer"
+          poster="images/astro-image.png"
+          src="https://modelviewer.dev/shared-assets/models/Astronaut.glb"
+          environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
+          camera-controls
+          auto-rotate
             loading="eager"
             alt="3D astronaut"
             style="width: 100%; height: 100%; display: block"

--- a/js/basket.js
+++ b/js/basket.js
@@ -383,7 +383,7 @@ export function setupBasketUI() {
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="w-10 h-10" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"><line x1="6" y1="6" x2="18" y2="18" /><line x1="6" y1="18" x2="18" y2="6" /></svg>
         <span class="sr-only">Close</span>
       </button>
-      <model-viewer src="" alt="3D model preview" environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr" camera-controls auto-rotate crossOrigin="anonymous" class="w-full h-96 bg-[#2A2A2E] rounded-xl"></model-viewer>
+      <model-viewer src="" alt="3D model preview" poster="images/astro-image.png" environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr" camera-controls auto-rotate crossOrigin="anonymous" class="w-full h-96 bg-[#2A2A2E] rounded-xl"></model-viewer>
       <div id="basket-checkout-container" class="absolute bottom-4 right-4 flex flex-col items-center">
         <div id="basket-tier-toggle" class="flex gap-1 mb-2 text-xs">
           <button type="button" data-tier="bronze" class="basket-tier-option px-2 py-1 rounded-full border border-white/20 opacity-50 text-black" style="background-color: #cd7f32">1 colour</button>
@@ -396,6 +396,14 @@ export function setupBasketUI() {
   document.body.appendChild(viewerOverlay);
   viewerModal = viewerOverlay;
   viewerEl = viewerOverlay.querySelector("model-viewer");
+  const fallbackModelError = (e) => {
+    const img = document.createElement("img");
+    img.src = "images/astro-image.png";
+    img.alt = "3D model preview unavailable";
+    img.className = e.target.className;
+    e.target.replaceWith(img);
+  };
+  viewerEl.addEventListener("error", fallbackModelError);
   viewerCheckoutBtn = viewerOverlay.querySelector("#basket-model-checkout");
   viewerTierToggle = viewerOverlay.querySelector("#basket-tier-toggle");
   viewerOverlay

--- a/js/community.js
+++ b/js/community.js
@@ -37,7 +37,16 @@ import { captureSnapshots } from "./snapshot.js";
 const API_BASE = (window.API_ORIGIN || "") + "/api";
 
 const OPEN_KEY = "print2CommunityOpen";
-const FALLBACK_GLB = "https://modelviewer.dev/shared-assets/models/Astronaut.glb";
+const FALLBACK_GLB =
+  "https://modelviewer.dev/shared-assets/models/Astronaut.glb";
+
+function handleModelError(e) {
+  const img = document.createElement("img");
+  img.src = "images/astro-image.png";
+  img.alt = "3D model preview unavailable";
+  img.className = e.target.className;
+  e.target.replaceWith(img);
+}
 
 function addBasketModel(model) {
   if (window.addToBasket) {
@@ -213,6 +222,7 @@ function prefetchModel(url) {
 function openModel(model) {
   const modal = document.getElementById("model-modal");
   const viewer = modal.querySelector("model-viewer");
+  viewer?.addEventListener("error", handleModelError);
   const checkoutBtn = document.getElementById("modal-checkout");
   const addBasketBtn = document.getElementById("modal-add-basket");
   const submitBtn = document.getElementById("comment-submit");
@@ -382,7 +392,10 @@ function createViewerCard(modelUrl) {
     "viewer-card model-card relative bg-[#2A2A2E] border border-white/10 rounded-xl flex items-center justify-center cursor-pointer";
 
   div.dataset.model = modelUrl;
-  div.innerHTML = `<model-viewer src="${modelUrl}" alt="3D model preview" environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr" camera-controls auto-rotate loading="lazy" class="w-full h-full bg-[#2A2A2E] rounded-xl"></model-viewer>\n    <button class="purchase absolute bottom-1 right-1 font-bold text-lg py-1.5 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]" style="transform: scale(0.78); transform-origin: right bottom;">Buy from £29.99</button>`;
+  div.innerHTML = `<model-viewer src="${modelUrl}" alt="3D model preview" poster="images/astro-image.png" environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr" camera-controls auto-rotate loading="lazy" class="w-full h-full bg-[#2A2A2E] rounded-xl"></model-viewer>\n    <button class="purchase absolute bottom-1 right-1 font-bold text-lg py-1.5 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]" style="transform: scale(0.78); transform-origin: right bottom;">Buy from £29.99</button>`;
+  div
+    .querySelector("model-viewer")
+    ?.addEventListener("error", handleModelError);
   div.addEventListener("pointerenter", () => prefetchModel(modelUrl));
   div.addEventListener("click", (e) => {
     // Avoid opening the modal when rotating the model preview

--- a/js/marketplace.js
+++ b/js/marketplace.js
@@ -34,11 +34,22 @@
 
 const API_BASE = (window.API_ORIGIN || "") + "/api";
 
+function handleModelError(e) {
+  const img = document.createElement("img");
+  img.src = "images/astro-image.png";
+  img.alt = "3D model preview unavailable";
+  img.className = e.target.className;
+  e.target.replaceWith(img);
+}
+
 function createCard(item) {
   const div = document.createElement("div");
   div.className =
     "model-card relative h-32 bg-[#2A2A2E] border border-white/10 rounded-xl flex items-center justify-center";
-  div.innerHTML = `<model-viewer src="${item.file_path}" alt="Model" environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr" camera-controls auto-rotate loading="lazy" crossOrigin="anonymous" class="w-full h-full bg-[#2A2A2E] rounded-xl"></model-viewer>\n<progress max="100" value="${item.royalty_percent || 0}" class="absolute left-1 bottom-1 w-16 h-2"></progress>\n<button class="buy absolute bottom-1 right-1 font-bold text-lg py-1.5 px-4 rounded-full shadow-md transition border-2 border-black" style="background-color:#30D5C8;color:#1A1A1D;transform:scale(0.78);transform-origin:right bottom;">Buy</button>`;
+  div.innerHTML = `<model-viewer src="${item.file_path}" alt="Model" poster="images/astro-image.png" environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr" camera-controls auto-rotate loading="lazy" crossOrigin="anonymous" class="w-full h-full bg-[#2A2A2E] rounded-xl"></model-viewer>\n<progress max="100" value="${item.royalty_percent || 0}" class="absolute left-1 bottom-1 w-16 h-2"></progress>\n<button class="buy absolute bottom-1 right-1 font-bold text-lg py-1.5 px-4 rounded-full shadow-md transition border-2 border-black" style="background-color:#30D5C8;color:#1A1A1D;transform:scale(0.78);transform-origin:right bottom;">Buy</button>`;
+  div
+    .querySelector("model-viewer")
+    ?.addEventListener("error", handleModelError);
   div.querySelector(".buy").addEventListener("click", () => {
     localStorage.setItem("print2Model", item.file_path);
     if (item.job_id) localStorage.setItem("print2JobId", item.job_id);

--- a/js/payment.js
+++ b/js/payment.js
@@ -247,17 +247,17 @@ function ensureModelViewerLoaded() {
   ) {
     return Promise.resolve();
   }
-    const cdnUrl =
-      "https://cdn.jsdelivr.net/npm/@google/model-viewer@1.12.0/dist/model-viewer.min.js";
-    return new Promise((resolve) => {
-      const s = document.createElement("script");
-      s.type = "module";
-      s.src = cdnUrl;
-      s.onload = resolve;
-      s.onerror = resolve;
-      document.head.appendChild(s);
-    });
-  }
+  const cdnUrl =
+    "https://cdn.jsdelivr.net/npm/@google/model-viewer@1.12.0/dist/model-viewer.min.js";
+  return new Promise((resolve) => {
+    const s = document.createElement("script");
+    s.type = "module";
+    s.src = cdnUrl;
+    s.onload = resolve;
+    s.onerror = resolve;
+    document.head.appendChild(s);
+  });
+}
 
 function computeColorSlotsByTime() {
   const dtf = new Intl.DateTimeFormat("en-US", {
@@ -458,6 +458,14 @@ async function initPaymentPage() {
   const promoToggle = document.querySelector(".promo-toggle");
   const promoBox = document.querySelector(".promo-input");
   const surpriseToggle = document.getElementById("surprise-toggle");
+  viewer?.addEventListener("error", () => {
+    const img = document.getElementById("preview-img");
+    if (img) {
+      img.src = "images/astro-image.png";
+      img.style.display = "block";
+    }
+    if (viewer) viewer.style.display = "none";
+  });
   const recipientFields = document.getElementById("recipient-fields");
   const qtySelect = document.getElementById("print-qty");
   const qtyDec = document.getElementById("qty-decrement");

--- a/library.html
+++ b/library.html
@@ -132,6 +132,7 @@
         </button>
         <div data-testid="primary-model">
           <model-viewer
+            poster="images/astro-image.png"
             src="about:blank"
             alt="3D model preview"
             environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
@@ -146,8 +147,7 @@
       </div>
     </div>
     <script>
-      document
-        .querySelector('[data-testid="model-viewer"]')
+      document.querySelector('[data-testid="model-viewer"]');
     </script>
     <script type="module" src="js/library.js"></script>
     <script type="module" src="js/basket.js"></script>

--- a/marketplace.html
+++ b/marketplace.html
@@ -140,6 +140,7 @@
           </p>
           <div data-testid="primary-model">
             <model-viewer
+              poster="images/astro-image.png"
               src="https://modelviewer.dev/shared-assets/models/Astronaut.glb"
               alt="Shopping bag model"
               environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
@@ -155,8 +156,7 @@
           </div>
           <input id="glbUpload" type="file" accept=".glb" class="hidden" />
           <script>
-            document
-              .querySelector('[data-testid="model-viewer"]')
+            document.querySelector('[data-testid="model-viewer"]');
           </script>
         </div>
         <div

--- a/minis-checkout.html
+++ b/minis-checkout.html
@@ -257,6 +257,7 @@
             />
             <model-viewer
               id="viewer"
+              poster="images/astro-image.png"
               alt="3D astronaut"
               environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
               camera-controls

--- a/my_creations.html
+++ b/my_creations.html
@@ -85,6 +85,7 @@
           <span class="sr-only">Close</span>
         </button>
         <model-viewer
+          poster="images/astro-image.png"
           src="about:blank"
           alt="3D model preview"
           environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"

--- a/my_profile.html
+++ b/my_profile.html
@@ -135,6 +135,7 @@
         />
         <model-viewer
           id="avatar-model-preview"
+          poster="images/astro-image.png"
           src="about:blank"
           alt="3D avatar preview"
           environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
@@ -224,12 +225,12 @@
         <h2 class="text-lg font-semibold mb-2">print2 Pro Usage</h2>
         <div class="w-full bg-white/20 rounded h-4">
           <div
-              id="usage-bar"
+            id="usage-bar"
             class="bg-blue-600 h-full rounded"
             style="width: 0%"
           ></div>
         </div>
-          <p id="usage-text" class="text-sm mt-2"></p>
+        <p id="usage-text" class="text-sm mt-2"></p>
         <p id="loyalty-info" class="text-sm mt-1"></p>
 
         <button
@@ -355,6 +356,7 @@
           <span class="sr-only">Close</span>
         </button>
         <model-viewer
+          poster="images/astro-image.png"
           src="about:blank"
           alt="3D model preview"
           environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"

--- a/payment.html
+++ b/payment.html
@@ -190,6 +190,7 @@
              If future enhancements are needed, create a dedicated viewer module in /js/viewer/ with strict interfaces. -->
             <model-viewer
               id="viewer"
+              poster="images/astro-image.png"
               src="https://modelviewer.dev/shared-assets/models/Astronaut.glb"
               environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
               camera-controls

--- a/profile.html
+++ b/profile.html
@@ -129,6 +129,7 @@
         />
         <model-viewer
           id="profile-avatar-model"
+          poster="images/astro-image.png"
           src="about:blank"
           alt="Profile 3D avatar"
           environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
@@ -216,6 +217,7 @@
           <span class="sr-only">Close</span>
         </button>
         <model-viewer
+          poster="images/astro-image.png"
           src="about:blank"
           alt="3D model preview"
           environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"

--- a/share.html
+++ b/share.html
@@ -91,6 +91,7 @@
       <div class="w-full max-w-md h-80 relative">
         <model-viewer
           id="viewer"
+          poster="images/astro-image.png"
           src="about:blank"
           environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
           camera-controls


### PR DESCRIPTION
## Summary
- show a static poster while 3D models load
- replace model viewer with fallback image when loading fails

## Testing
- `npm run format`
- `npm test` *(fails: Cannot find module 'wait-on')*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68bfff6c1dd8832daf601ad0f333d5df