### PR TITLE
fix: remove LFS skip smudge setting

### DIFF
--- a/.lfsconfig
+++ b/.lfsconfig
@@ -1,2 +1,1 @@
 [lfs]
-    skipsmudge = true


### PR DESCRIPTION
## Summary
- remove `skipsmudge` from `.lfsconfig`

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup` *(fails: hung, interrupted)*
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Lockfile mismatch / 403)*
- `SKIP_PW_DEPS=1 npm run smoke`
- `git lfs push --all origin main` *(fails: Invalid remote name "origin")*

------
https://chatgpt.com/codex/tasks/task_e_68c0104444fc832dad56c790bb1658b6