### PR TITLE
chore: drop astronaut test scaffolding

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,8 +57,7 @@
     "prepush": "echo \"(pre-push) no checks\"",
     "test:fresh": "npm test",
     "test:banner": "node scripts/run-jest.js tests/frontend/discount-delivery-banner*.test.js",
-    "serve": "node scripts/serve.js",
-    "test:astronaut-fallback:playwright": "playwright test tests/astronaut-fallback/astronaut-fallback.e2e.spec.q4h7c2n5r9k1m8s6.ts"
+    "serve": "node scripts/serve.js"
   },
   "babel": {
     "presets": [

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "@playwright/test";
 
 export default defineConfig({
-  testDir: "./tests/astronaut-fallback",
+  testDir: "./tests/e2e",
   timeout: 30 * 1000,
   webServer: {
     command: "npx http-server . -p 3000",

--- a/scripts/ci.mjs
+++ b/scripts/ci.mjs
@@ -31,4 +31,4 @@ try {
 execSync("node scripts/run-npm-ci.js", { stdio: "inherit" });
 execSync("npm run build --workspaces=false", { stdio: "inherit" });
 execSync("npm test", { stdio: "inherit" });
-execSync("npm run test:astronaut-fallback:playwright", { stdio: "inherit" });
+


### PR DESCRIPTION
## Summary
- remove astronaut fallback Playwright script
- drop astronaut fallback Playwright test from CI
- point Playwright config at e2e tests

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68c043e7879c832d95935c748b811a5e