### PR TITLE
fix: reposition checkout layout

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -46,7 +46,7 @@
     </header>
 
     <!-- MAIN -->
-    <main class="flex-1 flex flex-col items-center justify-center px-4 space-y-8">
+    <main class="flex-1 flex flex-col items-center px-4 space-y-8">
       <div class="relative flex flex-col md:flex-row items-start justify-center w-full max-w-4xl gap-8">
 
         <!-- LEFT: Preview card -->


### PR DESCRIPTION
## Summary
- remove vertical centering from payment layout to return checkout elements to the top

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npx prettier --check payment.html`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68c04facce90832db45fa738f4b13b0b