### PR TITLE
feat: add hover grow effect to price buttons

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -86,18 +86,18 @@
           <form class="space-y-[0.33rem]">
             <!-- Material/price options (static) -->
             <fieldset id="material-options" class="flex w-full justify-between">
-              <label class="text-center flex flex-col items-center w-1/3 opacity-50 cursor-not-allowed">
+              <label class="text-center flex flex-col items-center w-1/3 opacity-50 cursor-not-allowed group">
                 <input type="radio" name="material" class="sr-only" disabled />
-                <span class="w-24 h-24 flex flex-col items-center justify-center rounded-full border border-white/20 pt-0">
+                <span class="w-24 h-24 flex flex-col items-center justify-center rounded-full border border-white/20 pt-0 transition-transform duration-200 group-hover:scale-105">
                   <span class="font-semibold">£79.99</span>
                   <span class="text-xs">premium</span>
                 </span>
                 <span class="block text-xs mt-1">coming soon</span>
               </label>
 
-              <label class="text-center relative flex flex-col items-center w-1/3">
+              <label class="text-center relative flex flex-col items-center w-1/3 group">
                 <input type="radio" name="material" class="sr-only" checked />
-                <span class="relative w-28 h-28 flex flex-col items-center justify-center rounded-full border-4 border-white/20 shadow-xl">
+                <span class="relative w-28 h-28 flex flex-col items-center justify-center rounded-full border-4 border-white/20 shadow-xl transition-transform duration-200 group-hover:scale-105">
                   <span class="font-semibold">£39.99</span>
                   <span class="text-xs">multi-colour</span>
                   <span class="text-[10px] leading-tight text-center mt-2 text-[#30D5C8]">+ (optional) name<br />etching</span>
@@ -107,9 +107,9 @@
                 <span class="block text-xs mt-1 text-white w-28">(most popular)</span>
               </label>
 
-              <label class="text-center relative flex flex-col items-center self-start w-1/3">
+              <label class="text-center relative flex flex-col items-center self-start w-1/3 group">
                 <input type="radio" name="material" class="sr-only" />
-                <span class="w-24 h-24 flex flex-col items-center justify-center rounded-full border border-white/20 pt-0">
+                <span class="w-24 h-24 flex flex-col items-center justify-center rounded-full border border-white/20 pt-0 transition-transform duration-200 group-hover:scale-105">
                   <span class="font-semibold">£29.99</span>
                   <span class="text-xs">single-colour</span>
                 </span>


### PR DESCRIPTION
## Summary
- restore hover grow animation on price option circles in `payment.html`

## Testing
- `npm run validate-env`
- `npm run format` (backend)
- `npm test` (backend)
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke`
- `node scripts/run-jest.js` *(fails: Cannot find module 'wait-on')*


------
https://chatgpt.com/codex/tasks/task_e_68c0505153dc832dbd197c9a972f233f