### PR TITLE
fix: restore quantity controls

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -139,9 +139,29 @@
             <div class="flex items-center gap-2 mt-2 text-white text-sm">
               <span>Quantity:</span>
               <div class="flex items-center bg-[#2A2A2E] border border-white/20 rounded-full overflow-hidden p-1">
-                <button type="button" class="w-[2.1rem] h-[2.1rem] flex items-center justify-center text-[1.05rem] select-none">−</button>
-                <input id="print-qty" type="number" min="1" value="2" class="w-[2.1rem] text-center bg-transparent" />
-                <button type="button" class="w-[2.1rem] h-[2.1rem] flex items-center justify-center text-[1.05rem] select-none">+</button>
+                <button
+                  type="button"
+                  id="qty-decrement"
+                  aria-label="Decrease quantity"
+                  class="w-[2.1rem] h-[2.1rem] flex items-center justify-center text-[1.05rem]"
+                >
+                  &minus;
+                </button>
+                <input
+                  id="print-qty"
+                  type="number"
+                  min="1"
+                  value="2"
+                  class="w-[2.1rem] text-center bg-transparent appearance-none"
+                />
+                <button
+                  type="button"
+                  id="qty-increment"
+                  aria-label="Increase quantity"
+                  class="w-[2.1rem] h-[2.1rem] flex items-center justify-center text-[1.05rem]"
+                >
+                  +
+                </button>
               </div>
               <p class="text-xs whitespace-nowrap ml-2 text-gray-400">Popular: keep one, gift one</p>
             </div>
@@ -227,5 +247,6 @@
       <div class="flex-1 text-center py-2">Purchase model</div>
     </div>
 
+    <script type="module" src="js/payment.js" defer></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- restore plus/minus quantity controls on checkout page
- load payment script to enable quantity changes

## Testing
- `npm run validate-env`
- `npm run setup` *(fails: Skipping Playwright/apt deps)*
- `cd backend && npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c05078ec24832dae21018416019385