### PR TITLE
fix: restore bulk discount message

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -139,11 +139,32 @@
             <div class="flex items-center gap-2 mt-2 text-white text-sm">
               <span>Quantity:</span>
               <div class="flex items-center bg-[#2A2A2E] border border-white/20 rounded-full overflow-hidden p-1">
-                <button type="button" class="w-[2.1rem] h-[2.1rem] flex items-center justify-center text-[1.05rem] select-none">−</button>
-                <input id="print-qty" type="number" min="1" value="2" class="w-[2.1rem] text-center bg-transparent" />
-                <button type="button" class="w-[2.1rem] h-[2.1rem] flex items-center justify-center text-[1.05rem] select-none">+</button>
+                <button
+                  type="button"
+                  id="qty-decrement"
+                  class="w-[2.1rem] h-[2.1rem] flex items-center justify-center text-[1.05rem] select-none"
+                >
+                  −
+                </button>
+                <input
+                  id="print-qty"
+                  type="number"
+                  min="1"
+                  value="2"
+                  class="w-[2.1rem] text-center bg-transparent"
+                />
+                <button
+                  type="button"
+                  id="qty-increment"
+                  class="w-[2.1rem] h-[2.1rem] flex items-center justify-center text-[1.05rem] select-none"
+                >
+                  +
+                </button>
               </div>
-              <p class="text-xs whitespace-nowrap ml-2 text-gray-400">Popular: keep one, gift one</p>
+              <p
+                id="bulk-discount-msg"
+                class="text-xs whitespace-nowrap ml-2 text-gray-400"
+              ></p>
             </div>
 
             <!-- Address / details (static) -->
@@ -226,6 +247,9 @@
       <div class="flex-1 text-center py-2">Building model</div>
       <div class="flex-1 text-center py-2">Purchase model</div>
     </div>
+
+    <!-- Init scripts -->
+    <script type="module" src="js/payment.js" defer></script>
 
   </body>
 </html>


### PR DESCRIPTION
## Summary
- restore dynamic bulk discount messaging on checkout page with "gift two" savings and price highlights
- hook up payment script to populate messaging automatically

## Testing
- `npm run format` *(fails: 403 Forbidden to registry)*
- `npm test`
- `npm run ci` *(fails: 403 Forbidden to registry)*
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c0515fe630832d860ca450ec3d79ed