### PR TITLE
fix: replace astro placeholder on community page

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -225,7 +225,7 @@
                 class="carousel-slide flex-none p-4 flex items-center justify-center"
               >
                 <model-viewer
-                  poster="images/astro-image.png"
+                  poster="images/box logo.png"
                   src="https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoomBox/glTF-Binary/BoomBox.glb"
                   alt="BoomBox model"
                   environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
@@ -272,13 +272,13 @@
                 class="carousel-slide flex-none p-4 flex flex-col sm:flex-row items-center justify-center gap-4"
               >
                 <img
-                  src="images/astro-image.png"
+                  src="images/box logo.png"
                   alt="Real-life print"
                   loading="lazy"
                   class="w-full sm:w-1/2 h-64 object-cover rounded-xl"
                 />
                 <model-viewer
-                  poster="images/astro-image.png"
+                  poster="images/box logo.png"
                   src="https://modelviewer.dev/shared-assets/models/Astronaut.glb"
                   alt="3D model preview"
                   environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
@@ -348,7 +348,7 @@
           <span class="sr-only">Close</span>
         </button>
         <model-viewer
-          poster="images/astro-image.png"
+          poster="images/box logo.png"
           src="about:blank"
           alt="3D model preview"
           environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"

--- a/js/community.js
+++ b/js/community.js
@@ -42,7 +42,7 @@ const FALLBACK_GLB =
 
 function handleModelError(e) {
   const img = document.createElement("img");
-  img.src = "images/astro-image.png";
+  img.src = "images/box logo.png";
   img.alt = "3D model preview unavailable";
   img.className = e.target.className;
   e.target.replaceWith(img);
@@ -392,7 +392,7 @@ function createViewerCard(modelUrl) {
     "viewer-card model-card relative bg-[#2A2A2E] border border-white/10 rounded-xl flex items-center justify-center cursor-pointer";
 
   div.dataset.model = modelUrl;
-  div.innerHTML = `<model-viewer src="${modelUrl}" alt="3D model preview" poster="images/astro-image.png" environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr" camera-controls auto-rotate loading="lazy" class="w-full h-full bg-[#2A2A2E] rounded-xl"></model-viewer>\n    <button class="purchase absolute bottom-1 right-1 font-bold text-lg py-1.5 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]" style="transform: scale(0.78); transform-origin: right bottom;">Buy from £29.99</button>`;
+  div.innerHTML = `<model-viewer src="${modelUrl}" alt="3D model preview" poster="images/box logo.png" environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr" camera-controls auto-rotate loading="lazy" class="w-full h-full bg-[#2A2A2E] rounded-xl"></model-viewer>\n    <button class="purchase absolute bottom-1 right-1 font-bold text-lg py-1.5 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]" style="transform: scale(0.78); transform-origin: right bottom;">Buy from £29.99</button>`;
   div
     .querySelector("model-viewer")
     ?.addEventListener("error", handleModelError);


### PR DESCRIPTION
## Summary
- use print2 box logo as poster and fallback image on community page

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68c051e66778832dbeb7768cddb2b750