### PR TITLE
fix: restore gift two savings line

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -163,7 +163,7 @@
                   +
                 </button>
               </div>
-              <p class="text-xs whitespace-nowrap ml-2 text-gray-400">Popular: keep one, gift one</p>
+              <p id="bulk-discount-msg" class="text-xs whitespace-nowrap ml-2 text-gray-400"></p>
             </div>
 
             <!-- Address / details (static) -->


### PR DESCRIPTION
## Summary
- restore dynamic bulk discount message on payment page

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format`
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke`
- `npm test` *(fails: Cannot find module 'wait-on')*


------
https://chatgpt.com/codex/tasks/task_e_68c0762b29c8832dbf7b52fc5ababb3e