### PR TITLE
fix: remove name etching field

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -169,14 +169,6 @@
             <!-- Address / details (static) -->
             <div><input class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10" placeholder="Name" autocomplete="name" /></div>
 
-            <div class="relative">
-              <input class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10" placeholder="Name for etching (optional)" maxlength="20" disabled />
-              <div class="pointer-events-none absolute inset-y-0 left-0 flex items-center gap-2 pl-2 hidden">
-                <div class="border-t-2 border-[#30D5C8] w-[20ch]"></div>
-                <span class="text-sm text-[#30D5C8] whitespace-nowrap">Multi-colour required</span>
-              </div>
-            </div>
-
             <div><input type="email" class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10" placeholder="Email" autocomplete="email" /></div>
 
             <div class="space-y-[0.33rem]">


### PR DESCRIPTION
## Summary
- remove unused "name for etching" text field from payment page

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup` (command hung; aborted after `Skipping Playwright/apt deps`)
- `npm run format` (backend)
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` (failed to fetch `lockfile-diff`)
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c07660745c832d8d736944e1786649