### PR TITLE
fix: restore dynamic pricing on checkout

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -195,13 +195,17 @@
               </div>
             </div>
 
-            <!-- Payment CTA (static) -->
-            <button type="button" class="w-full bg-[#30D5C8] text-[#1A1A1D] py-3 rounded-xl font-semibold mt-2">
-              Pay £39.99
+            <!-- Payment CTA (dynamic) -->
+            <button
+              id="submit-payment"
+              type="button"
+              class="w-full bg-[#30D5C8] text-[#1A1A1D] py-3 rounded-xl font-semibold mt-2"
+            >
+              Pay
             </button>
 
             <div class="flex justify-between mt-2 mb-2 text-xs h-8">
-              <pre class="whitespace-pre-wrap text-right"></pre>
+              <pre id="price-breakdown" class="whitespace-pre-wrap text-right"></pre>
             </div>
           </form>
 


### PR DESCRIPTION
## Summary
- restore dynamic pricing by adding missing ID on payment button
- reinstate price breakdown display beneath payment button

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke`
- `SKIP_PW_DEPS=1 npm run diagnose` *(fails: Missing script "diagnose")*


------
https://chatgpt.com/codex/tasks/task_e_68c076932aa8832db9a5586035cc9915