### PR TITLE
fix: update payment pricing

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -98,11 +98,10 @@
               <label class="text-center relative flex flex-col items-center w-1/3 group">
                 <input type="radio" name="material" class="sr-only" checked />
                 <span class="relative w-28 h-28 flex flex-col items-center justify-center rounded-full border-4 border-white/20 shadow-xl transition-transform duration-200 group-hover:scale-105">
-                  <span class="font-semibold">£39.99</span>
+                  <span class="font-semibold">£59.99</span>
                   <span class="text-xs">multi-colour</span>
                   <span class="text-[10px] leading-tight text-center mt-2 text-[#30D5C8]">+ (optional) name<br />etching</span>
                 </span>
-                <span class="absolute -top-2 left-1/2 -translate-x-16 text-base line-through whitespace-nowrap pointer-events-none">£54.99</span>
                 <span class="block text-xs mt-1 text-red-300 w-28">Only coloured prints left</span>
                 <span class="block text-xs mt-1 text-white w-28">(most popular)</span>
               </label>
@@ -113,6 +112,7 @@
                   <span class="font-semibold">£29.99</span>
                   <span class="text-xs">single-colour</span>
                 </span>
+                <span class="absolute -top-2 left-1/2 -translate-x-16 text-base line-through whitespace-nowrap pointer-events-none">£45.00</span>
 
                 <!-- colour palette (purely visual; closed by default) -->
                 <div
@@ -197,7 +197,7 @@
 
             <!-- Payment CTA (static) -->
             <button type="button" class="w-full bg-[#30D5C8] text-[#1A1A1D] py-3 rounded-xl font-semibold mt-2">
-              Pay £39.99
+              Pay £59.99
             </button>
 
             <div class="flex justify-between mt-2 mb-2 text-xs h-8">


### PR DESCRIPTION
## Summary
- move crossed-out price to single colour option and update to £45.00
- update multicolour option and pay button to £59.99

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` (fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)
- `SKIP_PW_DEPS=1 npm run smoke`
- `SKIP_PW_DEPS=1 npm run setup` (fails: process stalled)


------
https://chatgpt.com/codex/tasks/task_e_68c07a9685a4832d9aac3a04e77cf3ae