### PR TITLE
fix: shrink quantity buttons

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -143,7 +143,7 @@
                   type="button"
                   id="qty-decrement"
                   aria-label="Decrease quantity"
-                  class="w-[2.1rem] h-[2.1rem] flex items-center justify-center text-[1.05rem]"
+                  class="w-8 h-8 flex items-center justify-center text-[1.05rem]"
                 >
                   &minus;
                 </button>
@@ -152,13 +152,13 @@
                   type="number"
                   min="1"
                   value="2"
-                  class="w-[2.1rem] text-center bg-transparent appearance-none"
+                  class="w-8 text-center bg-transparent appearance-none"
                 />
                 <button
                   type="button"
                   id="qty-increment"
                   aria-label="Increase quantity"
-                  class="w-[2.1rem] h-[2.1rem] flex items-center justify-center text-[1.05rem]"
+                  class="w-8 h-8 flex items-center justify-center text-[1.05rem]"
                 >
                   +
                 </button>


### PR DESCRIPTION
## Summary
- shrink quantity stepper buttons on payment page for tighter spacing

## Testing
- `npm run format` (backend)
- `npm test` (backend)
- `node scripts/run-jest.js` *(fails: Cannot find module 'wait-on')*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68c07b42961c832db5d11148ec908a75