### PR TITLE
fix: display checkout trust badge

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -205,9 +205,9 @@
             </div>
           </form>
 
-          <!-- side badge (kept static; hidden as before) -->
+          <!-- side badge -->
           <div
-            style="position: absolute; left: calc(100% + 0.55cm); top: 85%; transform: translateY(-72%); visibility: hidden;"
+            style="position: absolute; left: calc(100% + 0.55cm); top: 85%; transform: translateY(-72%);"
             class="whitespace-nowrap text-sm pointer-events-none"
           >
             <p>🔒 Secure Checkout</p>


### PR DESCRIPTION
## Summary
- Restore checkout trust badge to the right of the Buy button

## Testing
- `npm run format`
- `npm test`
- `npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68c07bc97668832d81f5c27391cf7eb0