### PR TITLE
fix: emphasize limited print slots

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,7 +149,7 @@
           <p class="whitespace-nowrap" style="margin-left: 0.5cm">"This feels like magic"<br />– email from an <span class="text-white">r/DnD</span> user</p>
         </div>
         <div id="print-run-info" class="absolute text-right text-sm text-red-400 leading-snug invisible">
-          <p class="whitespace-nowrap" style="margin-right: 0.5cm"><span id="print-run-slots"></span> print slots left for next <span id="print-run-hours">6</span> <span id="print-run-hours-label">hours</span></p>
+          <p class="whitespace-nowrap" style="margin-right: 0.5cm">Only <span id="print-run-slots"></span> print slots left for next <span id="print-run-hours">6</span> <span id="print-run-hours-label">hours</span></p>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- prepend "Only" to print slot availability message

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup` *(fails: network timeout)*
- `cd backend && npm run format`
- `cd backend && npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 fetching lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_68c07c63a1b4832db3eaa7dfc7ce07fb