### PR TITLE
feat: show remaining slots in payment viewer

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -67,6 +67,16 @@
               alt="3D astronaut"
               style="width: 100%; height: 100%; display: block"
             ></model-viewer>
+            <div
+              id="print-run-info"
+              class="absolute top-2 left-2 text-left text-sm text-red-400 leading-snug invisible"
+            >
+              <p class="whitespace-nowrap" style="margin-left: 0.5cm">
+                Only <span id="print-run-slots"></span> print slots left for next
+                <span id="print-run-hours">6</span>
+                <span id="print-run-hours-label">hours</span>
+              </p>
+            </div>
           </section>
 
           <!-- Trust badge (static) -->


### PR DESCRIPTION
## Summary
- show remaining print slots in the payment viewer

## Testing
- `npx prettier payment.html -w`
- `cd backend && npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68c086d8ec14832dac795dd0a41101bd