### PR TITLE
fix: restore single-colour palette

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -87,7 +87,7 @@
             <!-- Material/price options (static) -->
             <fieldset id="material-options" class="flex w-full justify-between">
               <label class="text-center flex flex-col items-center w-1/3 opacity-50 cursor-not-allowed group">
-                <input type="radio" name="material" class="sr-only" disabled />
+                <input type="radio" name="material" value="premium" class="sr-only" disabled />
                 <span class="w-24 h-24 flex flex-col items-center justify-center rounded-full border border-white/20 pt-0 transition-transform duration-200 group-hover:scale-105">
                   <span class="font-semibold">£79.99</span>
                   <span class="text-xs">premium</span>
@@ -96,7 +96,7 @@
               </label>
 
               <label class="text-center relative flex flex-col items-center w-1/3 group">
-                <input type="radio" name="material" class="sr-only" checked />
+                <input type="radio" name="material" value="multi" class="sr-only" checked />
                 <span class="relative w-28 h-28 flex flex-col items-center justify-center rounded-full border-4 border-white/20 shadow-xl transition-transform duration-200 group-hover:scale-105">
                   <span class="font-semibold">£39.99</span>
                   <span class="text-xs">multi-colour</span>
@@ -107,8 +107,8 @@
                 <span class="block text-xs mt-1 text-white w-28">(most popular)</span>
               </label>
 
-              <label class="text-center relative flex flex-col items-center self-start w-1/3 group">
-                <input type="radio" name="material" class="sr-only" />
+              <label id="single-label" class="text-center relative flex flex-col items-center self-start w-1/3 group">
+                <input type="radio" name="material" value="single" id="opt-single" class="sr-only" />
                 <span class="w-24 h-24 flex flex-col items-center justify-center rounded-full border border-white/20 pt-0 transition-transform duration-200 group-hover:scale-105">
                   <span class="font-semibold">£29.99</span>
                   <span class="text-xs">single-colour</span>
@@ -116,21 +116,26 @@
 
                 <!-- colour palette (purely visual; closed by default) -->
                 <div
-                  class="absolute bottom-0 left-1/2 grid grid-cols-6 place-items-center gap-2 p-2 bg-[#2A2A2E] border border-white/20 rounded-3xl w-60 h-28 z-20 hidden"
-                  style="transform: translateX(-3.5rem) translateY(8%);"
+                  id="single-color-menu"
+                  class="absolute bottom-0 left-1/2 grid grid-cols-8 place-items-center gap-2 p-2 bg-[#2A2A2E] border border-white/20 rounded-3xl w-80 h-24 z-20 hidden"
+                  style="transform: translateX(-50%) translateY(8%);"
                 >
-                  <span class="w-8 h-8 rounded-full border border-white/20" style="background:#ff0000"></span>
-                  <span class="w-8 h-8 rounded-full border border-white/20" style="background:#ff5500"></span>
-                  <span class="w-8 h-8 rounded-full border border-white/20" style="background:#fbbf24"></span>
-                  <span class="w-8 h-8 rounded-full border border-white/20" style="background:#34d399"></span>
-                  <span class="w-8 h-8 rounded-full border border-white/20" style="background:#60a5fa"></span>
-                  <span class="w-8 h-8 rounded-full border border-white/20" style="background:#7c3aed"></span>
-                  <span class="w-8 h-8 rounded-full border border-white/20" style="background:#ff1493"></span>
-                  <span class="w-8 h-8 rounded-full border border-white/20" style="background:#00ffff"></span>
-                  <span class="w-8 h-8 rounded-full border border-white/20" style="background:#008080"></span>
-                  <span class="w-8 h-8 rounded-full border border-white/20" style="background:#000000"></span>
-                  <span class="w-8 h-8 rounded-full border border-white/20" style="background:#606060"></span>
-                  <span class="w-8 h-8 rounded-full border border-white/20" style="background:#ffffff"></span>
+                  <button type="button" class="w-8 h-8 rounded-full border border-white/20" style="background-color: #ff0000" data-color="#ff0000"></button>
+                  <button type="button" class="w-8 h-8 rounded-full border border-white/20" style="background-color: #ff5500" data-color="#ff5500"></button>
+                  <button type="button" class="w-8 h-8 rounded-full border border-white/20" style="background-color: #fbbf24" data-color="#ffcc00"></button>
+                  <button type="button" class="w-8 h-8 rounded-full border border-white/20" style="background-color: #34d399" data-color="#00cc00"></button>
+                  <button type="button" class="w-8 h-8 rounded-full border border-white/20" style="background-color: #60a5fa" data-color="#0000ff"></button>
+                  <button type="button" class="w-8 h-8 rounded-full border border-white/20" style="background-color: #7c3aed" data-color="#5b2ddf"></button>
+                  <button type="button" class="w-8 h-8 rounded-full border border-white/20" style="background-color: #ff1493" data-color="#ff1493"></button>
+                  <button type="button" class="w-8 h-8 rounded-full border border-white/20" style="background-color: #00ffff" data-color="#00ffff"></button>
+                  <button type="button" class="w-8 h-8 rounded-full border border-white/20" style="background-color: #008080" data-color="#008080"></button>
+                  <button type="button" class="w-8 h-8 rounded-full border border-white/20" style="background-color: #000000" data-color="#000000"></button>
+                  <button type="button" class="w-8 h-8 rounded-full border border-white/20" style="background-color: #606060" data-color="#606060"></button>
+                  <button type="button" class="w-8 h-8 rounded-full border border-white/20" style="background-color: #ffffff" data-color="#ffffff"></button>
+                  <button type="button" class="w-8 h-8 rounded-full border border-white/20" style="background-color: #f97316" data-color="#ff6600"></button>
+                  <button type="button" class="w-8 h-8 rounded-full border border-white/20" style="background-color: #fde047" data-color="#ffff00"></button>
+                  <button type="button" class="w-8 h-8 rounded-full border border-white/20" style="background-color: #4ade80" data-color="#00ff00"></button>
+                  <button type="button" class="w-8 h-8 rounded-full border border-white/20" style="background-color: #818cf8" data-color="#4b4bff"></button>
                 </div>
               </label>
             </fieldset>


### PR DESCRIPTION
## Summary
- reconnect single-colour option to reveal a 2x8 grid of colour buttons

## Testing
- `npm run format`
- `npm test` *(fails: Missing jest; run `npm run setup` before testing)*
- `npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68c08739c7f4832d8c17843623e52bcf