### PR TITLE
fix: restore rotating banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@
   </head>
 
   <body class="bg-[#1A1A1D] text-white font-sans flex flex-col">
-    <div id="theme-banner" class="bg-[#30D5C8] text-black text-center py-1 hidden">2d 07h 00m left for weekend delivery</div>
+    <div id="theme-banner" class="bg-[#30D5C8] text-black text-center py-1 hidden">24% off when you order 3 prints</div>
 
     <!-- HEADER (unchanged UI) -->
     <header class="relative flex items-center justify-between py-4 px-6">

--- a/js/index.js
+++ b/js/index.js
@@ -198,23 +198,9 @@ const EXAMPLES = [
   "geometric flower vase",
 ];
 const TRENDING = ["dragon statue", "space rover", "anime character"];
-const THEME_CAMPAIGNS = [
-  { name: "Sci-fi Month", tagline: "Explore out-of-this-world designs!" },
-  { name: "D&D Drop", tagline: "Epic minis all month long!" },
-  { name: "Fantasy February", tagline: "Dragons and castles galore!" },
-];
 const PRINTS_MIN = 30;
 const PRINTS_MAX = 50;
 const UINT32_MAX = 0xffffffff;
-
-function showThemeBanner() {
-  const banner = document.getElementById("theme-banner");
-  if (!banner) return;
-  const idx = new Date().getMonth() % THEME_CAMPAIGNS.length;
-  const theme = THEME_CAMPAIGNS[idx];
-  banner.textContent = `${theme.name} – ${theme.tagline}`;
-  banner.hidden = false;
-}
 
 async function computeDailyPrintsSold(date = new Date()) {
   const eastern = new Date(date.toLocaleString("en-US", { timeZone: TZ }));
@@ -874,7 +860,6 @@ async function init() {
       }
     }
     await updateStats();
-    showThemeBanner();
     updatePrintRunInfo();
     setInterval(updatePrintRunInfo, 60000);
   } else {
@@ -886,7 +871,6 @@ async function init() {
       }
     });
     await updateStats();
-    showThemeBanner();
     updatePrintRunInfo();
     setInterval(updatePrintRunInfo, 60000);
   }


### PR DESCRIPTION
## Summary
- restore discount/weekend delivery banner rotation on index page
- remove theme campaign banner logic

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup` *(fails: 403 Forbidden)*
- `npm run format` *(backend)*
- `npm test` *(backend)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Lockfile mismatch / 403 Forbidden)*
- `SKIP_PW_DEPS=1 npm run smoke`
- `node scripts/run-jest.js tests/frontend/discount-delivery-banner.k1m2n3b4v5c6x7z8.test.js` *(missing module 'wait-on')*


------
https://chatgpt.com/codex/tasks/task_e_68c087869244832dbc11ce94c1987f41