### PR TITLE
fix: use astro image with astronaut model

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -272,13 +272,13 @@
                 class="carousel-slide flex-none p-4 flex flex-col sm:flex-row items-center justify-center gap-4"
               >
                 <img
-                  src="images/box logo.png"
-                  alt="Real-life print"
+                  src="images/astro-image.png"
+                  alt="Astronaut print"
                   loading="lazy"
                   class="w-full sm:w-1/2 h-64 object-cover rounded-xl"
                 />
                 <model-viewer
-                  poster="images/box logo.png"
+                  poster="images/astro-image.png"
                   src="https://modelviewer.dev/shared-assets/models/Astronaut.glb"
                   alt="3D model preview"
                   environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"


### PR DESCRIPTION
## Summary
- use astronaut promotional image with Astronaut.glb slide on Community Creations page

## Testing
- `npm run format`
- `npm test`
- `npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `npm run smoke` *(skipped: offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_68c088740a0c832d8b690e5f578a1595