### PR TITLE
fix: simplify print run message

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -72,9 +72,11 @@
               class="absolute top-2 left-2 text-left text-sm text-red-400 leading-snug invisible"
             >
               <p class="whitespace-nowrap" style="margin-left: 0.5cm">
-                Only <span id="print-run-slots"></span> print slots left for next
-                <span id="print-run-hours">6</span>
-                <span id="print-run-hours-label">hours</span>
+                Only <span id="print-run-slots"></span> prints left
+                <span hidden>
+                  for next <span id="print-run-hours">6</span>
+                  <span id="print-run-hours-label">hours</span>
+                </span>
               </p>
             </div>
           </section>

--- a/tests/frontend/print-run-info.4hb2oxnb2c7nx14by7.spec.js
+++ b/tests/frontend/print-run-info.4hb2oxnb2c7nx14by7.spec.js
@@ -13,9 +13,11 @@ describe("print run info", () => {
     originalStorage = window.localStorage;
     document.body.innerHTML = `
       <div id="print-run-info" class="invisible">
-        <span id="print-run-slots"></span> print slots left for next
-        <span id="print-run-hours"></span>
-        <span id="print-run-hours-label"></span>
+        Only <span id="print-run-slots"></span> prints left
+        <span hidden>
+          for next <span id="print-run-hours"></span>
+          <span id="print-run-hours-label"></span>
+        </span>
       </div>`;
     global.fetch = undefined;
     localStorage.clear();


### PR DESCRIPTION
## Summary
- streamline print run banner wording
- adjust test fixture for updated banner

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` in backend
- `npm test` (backend) *(fails: Missing jest)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Lockfile mismatch / registry access)*
- `SKIP_PW_DEPS=1 npm run smoke`
- `node scripts/run-jest.js tests/frontend/print-run-info.4hb2oxnb2c7nx14by7.spec.js` *(fails: Cannot find module 'wait-on')*


------
https://chatgpt.com/codex/tasks/task_e_68c096043b30832d840f87d65642573b