### PR TITLE
fix: remove extra text under multi colour option

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -112,8 +112,6 @@
                   <span class="text-xs">multi-colour</span>
                   <span class="text-[10px] leading-tight text-center mt-2 text-[#30D5C8]">+ (optional) name<br />etching</span>
                 </span>
-                <span class="block text-xs mt-1 text-red-300 w-28">Only coloured prints left</span>
-                <span class="block text-xs mt-1 text-white w-28">(most popular)</span>
               </label>
 
               <label id="single-label" class="text-center relative flex flex-col items-center self-start w-1/3 group">


### PR DESCRIPTION
## Summary
- remove marketing labels under multi colour option

## Testing
- `npm run format` (backend)
- `npm test` (backend)
- `npm run validate-env`
- `npm run setup` *(fails: network error when fetching packages)*
- `npm run ci` *(fails: 403 Forbidden when fetching lockfile-diff)*
- `npm run smoke` *(skipped: offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_68c096325b60832db09c31c4ed856f0b