### PR TITLE
fix: remove optional name etching text

### DIFF
--- a/luckybox-payment.html
+++ b/luckybox-payment.html
@@ -296,10 +296,6 @@
                 >
                   <span class="font-semibold">£29.99</span>
                   <span class="text-xs">multi-colour</span>
-                  <span
-                    class="text-[10px] leading-tight text-center mt-2 text-[#30D5C8]"
-                    >+ (optional) name<br />etching</span
-                  >
                 </span>
                 <span
                   class="absolute -top-2 left-1/2 -translate-x-16 text-base line-through whitespace-nowrap pointer-events-none z-10 no-transform"

--- a/payment.html
+++ b/payment.html
@@ -110,7 +110,6 @@
                 <span class="relative w-28 h-28 flex flex-col items-center justify-center rounded-full border-4 border-white/20 shadow-xl transition-transform duration-200 group-hover:scale-105">
                   <span class="font-semibold">£59.99</span>
                   <span class="text-xs">multi-colour</span>
-                  <span class="text-[10px] leading-tight text-center mt-2 text-[#30D5C8]">+ (optional) name<br />etching</span>
                 </span>
                 <span class="block text-xs mt-1 text-red-300 w-28">Only coloured prints left</span>
                 <span class="block text-xs mt-1 text-white w-28">(most popular)</span>


### PR DESCRIPTION
## Summary
- remove optional name etching text from multicolour option on checkout pages

## Testing
- `npx prettier -w payment.html luckybox-payment.html`
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68c09645bacc832da80cff0226e31150