### PR TITLE
fix: thicken border for payment tiers

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -98,7 +98,7 @@
             <fieldset id="material-options" class="flex w-full justify-between">
               <label class="text-center flex flex-col items-center w-1/3 opacity-50 cursor-not-allowed group">
                 <input type="radio" name="material" value="premium" class="sr-only" disabled />
-                <span class="w-24 h-24 flex flex-col items-center justify-center rounded-full border border-white/20 pt-0 transition-transform duration-200 group-hover:scale-105">
+                <span class="w-24 h-24 flex flex-col items-center justify-center rounded-full border-4 border-white/20 pt-0 transition-transform duration-200 group-hover:scale-105">
                   <span class="font-semibold">£79.99</span>
                   <span class="text-xs">premium</span>
                 </span>
@@ -118,7 +118,7 @@
 
               <label id="single-label" class="text-center relative flex flex-col items-center self-start w-1/3 group">
                 <input type="radio" name="material" value="single" id="opt-single" class="sr-only" />
-                <span class="w-24 h-24 flex flex-col items-center justify-center rounded-full border border-white/20 pt-0 transition-transform duration-200 group-hover:scale-105">
+                <span class="w-24 h-24 flex flex-col items-center justify-center rounded-full border-4 border-white/20 pt-0 transition-transform duration-200 group-hover:scale-105">
                   <span class="font-semibold">£29.99</span>
                   <span class="text-xs">single-colour</span>
                 </span>


### PR DESCRIPTION
## Summary
- align premium and single-colour option ring border thickness with multicolour tier

## Testing
- `npm run validate-env`
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 from registry)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68c096700048832d8464a7754c342058