### PR TITLE
fix: show checkout trust badges

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -219,7 +219,7 @@
           <!-- side badge -->
           <div
             id="money-back-badge"
-            style="position: absolute; left: calc(100% + 0.55cm); top: 85%; transform: translateY(-72%); visibility: hidden;"
+            style="position: absolute; left: calc(100% + 0.55cm); top: 50%; transform: translateY(-50%);"
             class="whitespace-nowrap text-sm pointer-events-none"
           >
             <p>🔒 Secure Checkout</p>


### PR DESCRIPTION
## Summary
- restore checkout trust badge next to payment button
- vertically center badge on the pay button

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_68c09708121c832d83bb93fef7785ae1