### PR TITLE
fix: sync payment viewer id

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -58,7 +58,7 @@
           >
             <!-- the .glb viewer built on the box (EXACT from index sample) -->
             <model-viewer
-              id="glb-viewer"
+              id="viewer"
               src="https://modelviewer.dev/shared-assets/models/Astronaut.glb"
               environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
               camera-controls


### PR DESCRIPTION
## Summary
- hook payment page model viewer to existing viewer logic by renaming its id

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup` *(fails: process interrupted)*
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c09731f5b8832d93bd286363e760b1