### PR TITLE
fix: show remaining slots message

### DIFF
--- a/js/wizard.js
+++ b/js/wizard.js
@@ -51,6 +51,6 @@ document.addEventListener("DOMContentLoaded", updateWizard);
 window.setWizardStage = setWizardStage;
 export function setWizardSlotCount(n) {
   const el = document.getElementById("wizard-slots");
-  if (el) el.textContent = `Only ${n} print slots remaining:`;
+  if (el) el.textContent = `Only ${n} print slots left`;
 }
 window.setWizardSlotCount = setWizardSlotCount;


### PR DESCRIPTION
## Summary
- display "Only X print slots left" in the wizard bar when reaching the purchase step

## Testing
- `npm run validate-env`
- `npm run setup`
- `npm run format` (backend)
- `npm test` (backend)
- `node scripts/run-jest.js` *(fails: Cannot find module 'wait-on')*
- `npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_68c097958768832db32b454416edba1e