### PR TITLE
fix: clarify loyalty rewards formatting

### DIFF
--- a/printclub.html
+++ b/printclub.html
@@ -108,16 +108,16 @@
             <h3 class="text-lg underline mb-1 text-center">Loyalty Rewards</h3>
             <ul class="list-disc list-inside space-y-1 inline-block text-left">
               <li>
-                3 months – (2 + <span class="text-[#30D5C8]">1 extra</span> = 3)
+                3 months: (2 + <span class="text-[#30D5C8]">1 extra</span> = 3)
                 prints each week
               </li>
               <li>
-                6 months – (2 + <span class="text-[#30D5C8]">2 extra</span> = 4)
+                6 months: (2 + <span class="text-[#30D5C8]">2 extra</span> = 4)
                 prints each week
               </li>
               <li>
-                12 months – (2 + <span class="text-[#30D5C8]">4 extra</span> =
-                6) prints each week
+                12 months: (2 + <span class="text-[#30D5C8]">4 extra</span> = 6)
+                prints each week
               </li>
             </ul>
           </div>


### PR DESCRIPTION
## Summary
- replace dashes with colons in loyalty rewards durations on Print Club page

## Testing
- `npm run format`
- `npm test`
- `npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68c09916c18c832d99ba318860f5ee5c