### PR TITLE
fix: validate stored model url

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -39,6 +39,11 @@ import {
   }
 })();
 
+const _migratedModel = localStorage.getItem("print2Model");
+if (_migratedModel !== null && !sanitizeUrl(_migratedModel)) {
+  localStorage.removeItem("print2Model");
+}
+
 // Initialize Stripe after the library loads to avoid breaking the rest of the
 // page if the network request for Stripe fails. This variable will be assigned
 // once the DOM content is ready.
@@ -96,8 +101,10 @@ let checkoutItems = [];
 let currentIndex = 0;
 
 function sanitizeUrl(url) {
+  if (!url || url === "null" || url === "undefined") return "";
   try {
-    return new URL(url, window.location.origin).href;
+    const href = new URL(url, window.location.origin).href;
+    return href.endsWith(".glb") ? href : "";
   } catch {
     return "";
   }
@@ -261,8 +268,7 @@ function ensureModelViewerLoaded() {
       fallback.type = "module";
       fallback.src = localUrl;
       fallback.onload = resolve;
-      fallback.onerror = () =>
-        reject(new Error("model-viewer failed to load"));
+      fallback.onerror = () => reject(new Error("model-viewer failed to load"));
       document.head.appendChild(fallback);
     };
 


### PR DESCRIPTION
## Summary
- remove invalid stored model URLs after localStorage migration
- validate model URLs and require .glb extension before use

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup` *(fails: 403 Forbidden to registry.npmjs.org)*
- `npx prettier -w js/payment.js`
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm test` *(fails: Cannot find module 'wait-on')*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden to registry.npmjs.org)*
- `SKIP_PW_DEPS=1 npm run smoke`
- `node -e "const { JSDOM } = require('./backend/node_modules/jsdom'); const FALLBACK_GLB='https://modelviewer.dev/shared-assets/models/Astronaut.glb'; function sanitizeUrl(url){ if (!url||url==='null'||url==='undefined') return ''; try { const href = new URL(url, 'https://example.com').href; return href.endsWith('.glb')?href:'';} catch { return '';} } let dom=new JSDOM('<model-viewer id=\"viewer\"></model-viewer>', {url:'https://example.com'}); dom.window.localStorage.clear(); let stored=sanitizeUrl(dom.window.localStorage.getItem('print2Model')); let viewer=dom.window.document.getElementById('viewer'); viewer.src=stored||FALLBACK_GLB; console.log('absent', viewer.src); dom.window.localStorage.setItem('print2Model','null'); stored=sanitizeUrl(dom.window.localStorage.getItem('print2Model')); viewer.src=stored||FALLBACK_GLB; console.log('null', viewer.src); let valid='https://example.com/model.glb'; dom.window.localStorage.setItem('print2Model', valid); stored=sanitizeUrl(dom.window.localStorage.getItem('print2Model')); viewer.src=stored||FALLBACK_GLB; console.log('valid', viewer.src);"`

------
https://chatgpt.com/codex/tasks/task_e_68c0ac712d2c832d8c36e024ccddac54