### PR TITLE
fix: thin premium and multicolour tier borders

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -100,7 +100,7 @@
             <fieldset id="material-options" class="flex w-full justify-between">
               <label class="text-center flex flex-col items-center w-1/3 opacity-50 cursor-not-allowed group">
                 <input type="radio" name="material" value="premium" class="sr-only" disabled />
-                <span class="w-24 h-24 flex flex-col items-center justify-center rounded-full border-4 border-white/20 pt-0 transition-transform duration-200 group-hover:scale-105">
+                <span class="w-24 h-24 flex flex-col items-center justify-center rounded-full border-2 border-white/20 pt-0 transition-transform duration-200 group-hover:scale-105">
                   <span class="font-semibold">£79.99</span>
                   <span class="text-xs">premium</span>
                 </span>
@@ -109,7 +109,7 @@
 
               <label class="text-center relative flex flex-col items-center w-1/3 group">
                 <input type="radio" name="material" value="multi" class="sr-only" checked />
-                <span class="relative w-28 h-28 flex flex-col items-center justify-center rounded-full border-4 border-white/20 shadow-xl transition-transform duration-200 group-hover:scale-105">
+                <span class="relative w-28 h-28 flex flex-col items-center justify-center rounded-full border-2 border-white/20 shadow-xl transition-transform duration-200 group-hover:scale-105">
                   <span class="font-semibold">£59.99</span>
                   <span class="text-xs">multi-colour</span>
                 </span>


### PR DESCRIPTION
## Summary
- reduce border width for premium and multicolour material options on payment page

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` (backend)
- `npm test` (backend)
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c0ab90d728832d85c5b8fe0c9abeb5