### PR TITLE
fix: align print run text

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -71,7 +71,7 @@
               id="print-run-info"
               class="absolute top-2 left-2 text-left text-sm text-red-400 leading-snug invisible"
             >
-              <p class="whitespace-nowrap" style="margin-left: 0.5cm">
+              <p class="whitespace-nowrap m-0">
                 Only <span id="print-run-slots"></span> prints left
                 <span hidden>
                   for next <span id="print-run-hours">6</span>


### PR DESCRIPTION
## Summary
- Align print run indicator with viewer's top edge

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` (backend)
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Lockfile mismatch: cannot reach npm registry)*
- `SKIP_PW_DEPS=1 npm run smoke`
- `npm run diagnose` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68c0abdfe4bc832da540e9e49a9d1727