### PR TITLE
fix: add coming soon text to multi-colour tier

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -113,6 +113,7 @@
                   <span class="font-semibold">£59.99</span>
                   <span class="text-xs">multi-colour</span>
                 </span>
+                <span class="block text-xs mt-1">coming soon</span>
               </label>
 
               <label id="single-label" class="text-center relative flex flex-col items-center self-start w-1/3 group">


### PR DESCRIPTION
## Summary
- show "coming soon" text under the multi-colour tier button on the payment page

## Testing
- `npx prettier -w payment.html --log-level debug`
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden for lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68c0ac081034832d9c6408634bacae6d