### PR TITLE
fix: increase spacing between promo code and pay button

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -205,7 +205,7 @@
             <button
               id="submit-payment"
               type="button"
-              class="w-full bg-[#30D5C8] text-[#1A1A1D] py-3 rounded-xl font-semibold mt-4"
+              class="w-full bg-[#30D5C8] text-[#1A1A1D] py-3 rounded-xl font-semibold mt-6"
             >
               Pay
             </button>


### PR DESCRIPTION
## Summary
- increase top margin for the Pay button on payment page to create more space below the promo code input

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` (backend)
- `npm test` (backend)
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: skipping smoke)*
- `npm run diagnose` *(fails: Missing script "diagnose")*


------
https://chatgpt.com/codex/tasks/task_e_68c0aced03e0832dac9b709e0154f885