### PR TITLE
fix: display remaining print slots in wizard banner

### DIFF
--- a/js/wizard.js
+++ b/js/wizard.js
@@ -51,6 +51,12 @@ document.addEventListener("DOMContentLoaded", updateWizard);
 window.setWizardStage = setWizardStage;
 export function setWizardSlotCount(n) {
   const el = document.getElementById("wizard-slots");
-  if (el) el.textContent = `Only ${n} print slots left`;
+  if (el) {
+    el.textContent = `Only ${n} print slots left`;
+    const stage = localStorage.getItem(STAGE_KEY);
+    if (stage === "purchase" || stage === "print") {
+      el.classList.remove("hidden");
+    }
+  }
 }
 window.setWizardSlotCount = setWizardSlotCount;


### PR DESCRIPTION
## Summary
- unhide wizard slot count when the wizard reaches the purchase stage so remaining prints text appears

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0ad394f18832d8f02a5085d08245a