### PR TITLE
fix: tweak print run label offset

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -69,7 +69,7 @@
             ></model-viewer>
             <div
               id="print-run-info"
-              class="absolute top-2 left-2 text-left text-sm text-red-400 leading-snug invisible"
+              class="absolute top-2 left-3 text-left text-sm text-red-400 leading-snug invisible"
             >
               <p class="whitespace-nowrap m-0">
                 Only <span id="print-run-slots"></span> prints left


### PR DESCRIPTION
## Summary
- adjust payment page "Only prints left" label to sit slightly further from the viewer's edge

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup` *(fails: skipping Playwright/apt deps and hangs due to network)*
- `npm run format --prefix backend`
- `npx prettier -w payment.html`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68c0b669de64832db9abc43e9c5260a3