### PR TITLE
fix: adjust checkout form spacing

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -95,7 +95,7 @@
         <div class="relative w-full md:w-1/2 max-w-md bg-[#2A2A2E] border border-white/10 rounded-3xl p-6">
           <h2 class="text-2xl font-semibold mb-4 text-center">Checkout</h2>
 
-          <form class="space-y-[0.33rem]">
+          <form>
             <!-- Material/price options (static) -->
             <fieldset id="material-options" class="flex w-full justify-between">
               <label class="text-center flex flex-col items-center w-1/3 opacity-50 cursor-not-allowed group">
@@ -182,11 +182,11 @@
             </div>
 
             <!-- Address / details (static) -->
-            <div><input class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10" placeholder="Name" autocomplete="name" /></div>
+            <div class="mt-2"><input class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10" placeholder="Name" autocomplete="name" /></div>
 
-            <div><input type="email" class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10" placeholder="Email" autocomplete="email" /></div>
+            <div class="mt-2"><input type="email" class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10" placeholder="Email" autocomplete="email" /></div>
 
-            <div class="space-y-[0.33rem]">
+            <div class="space-y-[0.33rem] mt-2">
               <div class="space-y-[0.33rem]">
                 <div><input class="w-full p-2 rounded-md bg-[#1A1A1D] border border-white/10" placeholder="Address" autocomplete="address-line1" /></div>
                 <div class="flex gap-2">


### PR DESCRIPTION
## Summary
- remove `space-y` from payment form and add explicit `mt` classes
- preserve large margin before Pay button

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup` *(hangs after skipping Playwright deps)*
- `npm run format`
- `npm test --silent`
- `npm run ci` *(fails: Lockfile mismatch, unable to fetch lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke`
- `npm run build` *(fails: ASTRONAUT_GLB_URL not set)*

------
https://chatgpt.com/codex/tasks/task_e_68c0b73b2ba8832d9d817ccbdbc4252a