### PR TITLE
fix: disable multicolour option

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -90,7 +90,7 @@ const ANNUAL_DISCOUNT = 0.9;
 const PRINT_CLUB_ANNUAL_PRICE = Math.round(
   PRINT_CLUB_PRICE * 12 * ANNUAL_DISCOUNT,
 );
-let selectedPrice = PRICES.multi;
+let selectedPrice = PRICES.single;
 const SINGLE_BORDER_COLOR = "#60a5fa";
 const API_BASE = (window.API_ORIGIN || "") + "/api";
 // Time zone used to reset local purchase counts at 1 AM Eastern
@@ -170,13 +170,13 @@ async function fetchPaymentInit() {
 }
 
 // Restore previously selected material option and colour
-let storedMaterial = localStorage.getItem("print2Material");
+let storedMaterial = localStorage.getItem("print2Material") || "single";
 let storedColor = localStorage.getItem("print2Color");
 const personalise = qs("personalise");
 if (personalise !== null) {
   storedMaterial = "multi";
-  localStorage.setItem("print2Material", storedMaterial);
 }
+localStorage.setItem("print2Material", storedMaterial);
 if (storedMaterial && PRICES[storedMaterial]) {
   selectedPrice = PRICES[storedMaterial];
 }

--- a/payment.html
+++ b/payment.html
@@ -107,9 +107,9 @@
                 <span class="block text-xs mt-1">coming soon</span>
               </label>
 
-              <label class="text-center relative flex flex-col items-center w-1/3 group">
-                <input type="radio" name="material" value="multi" class="sr-only" checked />
-                <span class="relative w-28 h-28 flex flex-col items-center justify-center rounded-full border-2 border-white/20 shadow-xl transition-transform duration-200 group-hover:scale-105">
+              <label class="text-center flex flex-col items-center w-1/3 opacity-50 cursor-not-allowed group">
+                <input type="radio" name="material" value="multi" class="sr-only" disabled />
+                <span class="relative w-28 h-28 flex flex-col items-center justify-center rounded-full border-2 border-white/20 shadow-xl transition-transform duration-200">
                   <span class="font-semibold">£59.99</span>
                   <span class="text-xs">multi-colour</span>
                 </span>
@@ -117,7 +117,7 @@
               </label>
 
               <label id="single-label" class="text-center relative flex flex-col items-center self-start w-1/3 group">
-                <input type="radio" name="material" value="single" id="opt-single" class="sr-only" />
+                <input type="radio" name="material" value="single" id="opt-single" class="sr-only" checked />
                 <span class="w-24 h-24 flex flex-col items-center justify-center rounded-full border-4 border-white/20 pt-0 transition-transform duration-200 group-hover:scale-105">
                   <span class="font-semibold">£29.99</span>
                   <span class="text-xs">single-colour</span>


### PR DESCRIPTION
## Summary
- disable multicolour material on checkout and default to single colour
- default pricing logic to the single colour option

## Testing
- `npm run format` (backend)
- `npm test` (backend)
- `npm run ci` *(fails: Lockfile mismatch and npm registry 403)*
- `npm run smoke`
- `npx prettier -w payment.html js/payment.js`


------
https://chatgpt.com/codex/tasks/task_e_68c0b767d894832d973784d4cb143de3