### PR TITLE
fix: reposition single color menu

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -127,8 +127,8 @@
                 <!-- colour palette (purely visual; closed by default) -->
                 <div
                   id="single-color-menu"
-                  class="absolute bottom-0 left-1/2 grid grid-cols-8 place-items-center gap-2 p-2 bg-[#2A2A2E] border border-white/20 rounded-3xl w-80 h-24 z-20 hidden"
-                  style="transform: translateX(-50%) translateY(8%);"
+                  class="absolute top-1/2 left-1/2 grid grid-cols-8 place-items-center gap-2 p-2 bg-[#2A2A2E] border border-white/20 rounded-3xl w-80 h-24 z-20 hidden"
+                  style="transform: translate(-50%, -60%);"
                 >
                   <button type="button" class="w-8 h-8 rounded-full border border-white/20" style="background-color: #ff0000" data-color="#ff0000"></button>
                   <button type="button" class="w-8 h-8 rounded-full border border-white/20" style="background-color: #ff5500" data-color="#ff5500"></button>


### PR DESCRIPTION
## Summary
- move 16-color palette so it overlays the single-color option button and price

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` (failed: 403 Forbidden - GET https://registry.npmjs.org/npm)
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` (failed: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)
- `SKIP_PW_DEPS=1 npm run smoke`
- `npm run diagnose` (failed: Missing script "diagnose")

------
https://chatgpt.com/codex/tasks/task_e_68c0b820e71c832da472ef910b8c7dc7