### PR TITLE
fix: update prompt placeholder text

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,7 +161,7 @@
 
           <div class="flex items-center w-full gap-4">
             <div id="prompt-wrapper" class="flex-1 bg-[#2A2A2E] border border-white/10 rounded-3xl px-5 py-2 flex items-center">
-              <textarea id="promptInput" rows="1" maxlength="200" placeholder="Text, image, or both — we’ll 3D print it…" aria-label="Prompt" class="prompt-textarea w-full bg-transparent resize-none text-lg placeholder-gray-500 focus:outline-none"></textarea>
+              <textarea id="promptInput" rows="1" maxlength="200" placeholder="Text or image — we’ll 3D print it…" aria-label="Prompt" class="prompt-textarea w-full bg-transparent resize-none text-lg placeholder-gray-500 focus:outline-none"></textarea>
             </div>
             <button id="submit-button" aria-label="Generate model" class="flex items-center justify-center gap-2 bg-white rounded-full px-4 py-2 transition-shape">
               <span class="text-[#1A1A1D] font-semibold">Generate model</span>


### PR DESCRIPTION
## Summary
- replace "Text, image, or both" with "Text or image" in the prompt placeholder

## Testing
- `npm run format`
- `npm test` *(fails: Missing jest; run `npm run setup` before testing)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68c0b8fa4480832daf9da3d829ea4f7d