### PR TITLE
fix: ensure discount banner always visible

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -770,23 +770,21 @@ refs.submitBtn.addEventListener("click", async () => {
 });
 
 function initDiscountDeliveryBanner(bannerEl) {
+  if (!bannerEl) return;
+  const discountMsg = "24% off when you order 3 prints";
   let countdownText = "";
   let showDiscount = true;
   bannerEl.style.opacity = "1";
   bannerEl.style.transition = "opacity 1s";
-  bannerEl.textContent = "24% off when you order 3 prints";
+  bannerEl.textContent = discountMsg;
 
   function getCountdownText() {
     const now = new Date();
     const day = now.getDay();
-    if (day === 0 || day === 6) {
-      bannerEl.classList.add("hidden");
-      return null;
-    }
     const friday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
     friday.setDate(friday.getDate() + ((5 - day + 7) % 7));
     const diff = friday - now;
-    if (diff > 0 && diff < 7 * 86400000) {
+    if (day !== 0 && day !== 6 && diff > 0 && diff < 7 * 86400000) {
       const hoursTotal = Math.floor(diff / 3600000);
       const days = Math.floor(hoursTotal / 24);
       const hours = hoursTotal % 24;
@@ -799,25 +797,26 @@ function initDiscountDeliveryBanner(bannerEl) {
       parts.push(`${seconds.toString().padStart(2, "0")}s`);
       return `${parts.join(" ")} left for weekend delivery`;
     }
-    bannerEl.classList.add("hidden");
-    return null;
+    return "";
   }
 
   function refresh() {
-    const text = getCountdownText();
-    if (!text) return;
-    countdownText = text;
+    countdownText = getCountdownText();
     bannerEl.classList.remove("hidden");
-    if (!showDiscount) bannerEl.textContent = countdownText;
+    if (!countdownText) {
+      showDiscount = true;
+      bannerEl.textContent = discountMsg;
+    } else if (!showDiscount) {
+      bannerEl.textContent = countdownText;
+    }
   }
 
   function cycle() {
+    if (!countdownText) return;
     bannerEl.style.opacity = "0";
     setTimeout(() => {
       showDiscount = !showDiscount;
-      bannerEl.textContent = showDiscount
-        ? "24% off when you order 3 prints"
-        : countdownText;
+      bannerEl.textContent = showDiscount ? discountMsg : countdownText;
       bannerEl.style.opacity = "1";
     }, 1000);
   }

--- a/tests/frontend/discount-delivery-banner.k1m2n3b4v5c6x7z8.test.js
+++ b/tests/frontend/discount-delivery-banner.k1m2n3b4v5c6x7z8.test.js
@@ -64,15 +64,19 @@ describe("Discount/delivery banner", () => {
     expect(() => initDiscountDeliveryBanner(null)).not.toThrow();
   });
 
-  test("hides banner on weekend", () => {
+  test("shows discount only on weekend", () => {
     jest.useRealTimers();
     jest.useFakeTimers();
     now = new Date("2024-01-06T12:00:00Z"); // Saturday
     jest.setSystemTime(now);
-    document.body.innerHTML = '<div id="theme-banner"></div>';
+    document.body.innerHTML = '<div id="theme-banner" class="hidden"></div>';
     const weekendBanner = document.getElementById("theme-banner");
     initDiscountDeliveryBanner(weekendBanner);
-    expect(weekendBanner.classList.contains("hidden")).toBe(true);
+    expect(weekendBanner.classList.contains("hidden")).toBe(false);
+    expect(weekendBanner.textContent).toBe("24% off when you order 3 prints");
+    advance(7000);
+    advance(1000);
+    expect(weekendBanner.textContent).toBe("24% off when you order 3 prints");
   });
 
   test("countdown updates over time", () => {


### PR DESCRIPTION
## Summary
- always show 24% discount banner and rotate to countdown only when weekday
- keep banner visible with static discount on weekends

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` (backend)
- `npm test` (backend)
- `node scripts/run-jest.js tests/frontend/discount-delivery-banner*.test.js` *(fails: Cannot find module 'wait-on')*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: lockfile-diff 403)*
- `SKIP_PW_DEPS=1 npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_68c0b8568c68832d8e9ce2c7b4c1a95a