### PR TITLE
fix: wait for model before enabling basket

### DIFF
--- a/index.html
+++ b/index.html
@@ -201,6 +201,7 @@
          (left) your unrelated app scripts below -->
     <script type="module" src="js/wizard.js" defer></script>
     <script type="module" src="js/print-slots.js" defer></script>
+    <script type="module" src="js/basket.js" defer></script>
     <script type="module" src="js/index.js" defer></script>
     <script src="js/stats-ticker.js" defer></script>
     <script type="module" src="js/subredditLanding.js" defer></script>
@@ -256,7 +257,6 @@
 
     <script type="module" src="js/printclub.js"></script>
     <script type="module" src="js/rewardBadge.js"></script>
-    <script type="module" src="js/basket.js" defer></script>
 
     <div id="purchase-popups" class="fixed bottom-28 left-4 bg-black/80 text-white px-3 py-1 rounded hidden opacity-0 text-sm flex flex-col items-center space-y-2"></div>
     <svg xmlns="http://www.w3.org/2000/svg" class="hidden">

--- a/js/index.js
+++ b/js/index.js
@@ -6,6 +6,7 @@ import {
   adjustedSlots,
   updatePrintRunInfo,
 } from "./print-slots.js";
+import { addToBasket } from "./basket.js";
 
 (() => {
   try {
@@ -1001,46 +1002,66 @@ async function init() {
     if (window.setWizardStage) window.setWizardStage("purchase");
   });
 
-  refs.addBasketBtn?.addEventListener("click", async () => {
-    if (!window.addToBasket || !refs.viewer.src) return;
-    let snapshot = refs.previewImg?.src;
-    const host = (() => {
-      try {
-        return snapshot ? new URL(snapshot).hostname : "";
-      } catch {
-        return "";
+  if (refs.addBasketBtn) {
+    refs.addBasketBtn.disabled = true;
+    const viewerReadyPromise = new Promise((resolve) => {
+      if (refs.viewer?.src) return resolve();
+      if (!refs.viewer) return resolve();
+      const obs = new MutationObserver(() => {
+        if (refs.viewer.src) {
+          obs.disconnect();
+          resolve();
+        }
+      });
+      obs.observe(refs.viewer, { attributes: true, attributeFilter: ["src"] });
+    });
+
+    viewerReadyPromise.then(() => {
+      refs.addBasketBtn.disabled = false;
+    });
+
+    refs.addBasketBtn.addEventListener("click", async () => {
+      await viewerReadyPromise;
+      if (!refs.viewer.src) return;
+      let snapshot = refs.previewImg?.src;
+      const host = (() => {
+        try {
+          return snapshot ? new URL(snapshot).hostname : "";
+        } catch {
+          return "";
+        }
+      })();
+      if (
+        !snapshot ||
+        snapshot.includes("placehold.co") ||
+        host === "images.unsplash.com"
+      ) {
+        snapshot = await captureModelSnapshot(refs.viewer.src);
       }
-    })();
-    if (
-      !snapshot ||
-      snapshot.includes("placehold.co") ||
-      host === "images.unsplash.com"
-    ) {
-      snapshot = await captureModelSnapshot(refs.viewer.src);
-    }
-    lastSnapshot = snapshot;
-    const item = { jobId: lastJobId, modelUrl: refs.viewer.src, snapshot };
-    if (
-      window.manualizeItem &&
-      window
-        .getBasket?.()
-        .some((it) => it.auto && it.modelUrl === item.modelUrl)
-    ) {
-      window.manualizeItem((it) => it.modelUrl === item.modelUrl);
-    } else {
-      window.addToBasket(item);
-    }
-    const sessionId = localStorage.getItem("adSessionId");
-    const subreddit = localStorage.getItem("adSubreddit");
-    if (sessionId && subreddit && item.jobId) {
-      track("cart", {
-        sessionId,
-        modelId: item.jobId,
-        subreddit,
-      }).catch(() => {});
-    }
-    // Animation and sound handled in basket.js
-  });
+      lastSnapshot = snapshot;
+      const item = { jobId: lastJobId, modelUrl: refs.viewer.src, snapshot };
+      if (
+        window.manualizeItem &&
+        window
+          .getBasket?.()
+          .some((it) => it.auto && it.modelUrl === item.modelUrl)
+      ) {
+        window.manualizeItem((it) => it.modelUrl === item.modelUrl);
+      } else {
+        addToBasket(item);
+      }
+      const sessionId = localStorage.getItem("adSessionId");
+      const subreddit = localStorage.getItem("adSubreddit");
+      if (sessionId && subreddit && item.jobId) {
+        track("cart", {
+          sessionId,
+          modelId: item.jobId,
+          subreddit,
+        }).catch(() => {});
+      }
+      // Animation and sound handled in basket.js
+    });
+  }
 
   setInterval(updateStats, 3600000);
 


### PR DESCRIPTION
## Summary
- ensure `basket.js` loads before `index.js` so basket helpers are available
- import `addToBasket` directly and wait for model viewer before enabling basket button

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npx prettier js/index.js -w`
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c139a55d1c832daec5b284ace0c17f