### PR TITLE
Add wizard progress bar test suite

### DIFF
--- a/.github/workflows/wizard-progress-bar.yml
+++ b/.github/workflows/wizard-progress-bar.yml
@@ -1,0 +1,21 @@
+name: Wizard progress bar - test suite
+
+on:
+  push:
+    branches: [dev, "00000production"]
+  pull_request:
+    branches: [dev, "00000production"]
+
+jobs:
+  wizard-progress-bar:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - name: Run wizard progress bar tests
+        run: npx playwright test tests/e2e/wizard-progress-bar.spec.*.ts

--- a/tests/e2e/wizard-progress-bar.spec.x3h7p9k2d6s4f8l0.ts
+++ b/tests/e2e/wizard-progress-bar.spec.x3h7p9k2d6s4f8l0.ts
@@ -1,0 +1,28 @@
+import { test, expect } from "@playwright/test";
+
+async function reachPurchaseStage(page: import("@playwright/test").Page) {
+  await page.evaluate(() => {
+    // @ts-ignore - exposed for tests
+    window.setWizardStage("purchase");
+    // @ts-ignore - exposed for tests
+    window.setWizardSlotCount(2);
+  });
+}
+
+for (const path of ["/index.html", "/payment.html"]) {
+  test(`shows print counter after progress on ${path}`, async ({ page }) => {
+    await page.goto(path);
+    await reachPurchaseStage(page);
+    await expect(page.locator("#wizard-step-prompt")).toHaveCSS(
+      "background-color",
+      "rgb(48, 213, 200)",
+    );
+    await expect(page.locator("#wizard-step-building")).toHaveCSS(
+      "background-color",
+      "rgb(48, 213, 200)",
+    );
+    const slots = page.locator("#wizard-slots");
+    await expect(slots).toBeVisible();
+    await expect(slots).toHaveText("Only 2 print slots left");
+  });
+}


### PR DESCRIPTION
## Summary
- add Playwright tests covering wizard progress bar on index and payment pages
- run wizard progress bar tests in dedicated GitHub Action workflow

## Testing
- `npm test` *(fails: Cannot find module 'wait-on')*
- `npx playwright test tests/e2e/wizard-progress-bar.spec.x3h7p9k2d6s4f8l0.ts` *(fails: 403 Forbidden from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68c13c6da53c832da67b6adeb322fbe8