### PR TITLE
style: shift r/DnD quote further right

### DIFF
--- a/index.html
+++ b/index.html
@@ -146,7 +146,7 @@
 
         <!-- (kept) quote + info UI -->
         <div id="subreddit-quote" class="absolute text-left text-sm text-gray-400 leading-snug invisible">
-          <p class="whitespace-nowrap" style="margin-left: 0.5cm">"This feels like magic"<br />&emsp;&emsp;– email from an <span class="text-white">r/DnD</span> user</p>
+          <p class="whitespace-nowrap" style="margin-left: 0.5cm">"This feels like magic"<br />&emsp;&emsp;&emsp;&emsp;– email from an <span class="text-white">r/DnD</span> user</p>
         </div>
         <div id="print-run-info" class="absolute text-right text-sm text-red-400 leading-snug invisible">
           <p class="whitespace-nowrap" style="margin-right: 0.5cm">Only <span id="print-run-slots"></span> print slots left for next <span id="print-run-hours">6</span> <span id="print-run-hours-label">hours</span></p>


### PR DESCRIPTION
## Summary
- double the indentation of the "email from r/DnD" quote on the homepage

## Testing
- `npm run format`
- `npm test`
- `npm run setup` *(fails: tunnel error: unsuccessful)*
- `npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c13d83d1a0832da293dbeff0bfe708