### PR TITLE
fix: update prompt placeholder text

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,7 +161,7 @@
 
           <div class="flex items-center w-full gap-4">
             <div id="prompt-wrapper" class="flex-1 bg-[#2A2A2E] border border-white/10 rounded-3xl px-5 py-2 flex items-center">
-              <textarea id="promptInput" rows="1" maxlength="200" placeholder="Describe object with text or image — we’ll build it…" aria-label="Prompt" class="prompt-textarea w-full bg-transparent resize-none text-lg placeholder-gray-500 focus:outline-none"></textarea>
+              <textarea id="promptInput" rows="1" maxlength="200" placeholder="Describe with text/image, we built it" aria-label="Prompt" class="prompt-textarea w-full bg-transparent resize-none text-lg placeholder-gray-500 focus:outline-none"></textarea>
             </div>
             <button id="submit-button" aria-label="Generate model" class="flex items-center justify-center gap-2 bg-white rounded-full px-4 py-2 transition-shape">
               <span class="text-[#1A1A1D] font-semibold">Generate model</span>


### PR DESCRIPTION
## Summary
- update homepage prompt placeholder to "Describe with text/image, we built it"

## Testing
- `npm run format`
- `npm test`
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup` *(fails: hang/interrupt)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68c147534690832d9e86db2fe82f7e82