### PR TITLE
fix: show fixed saving for four-plus orders

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -786,8 +786,11 @@ async function initPaymentPage() {
       text += ` - £${saved.toFixed(2)} = £${total.toFixed(2)}`;
       if (!window.location.pathname.endsWith("luckybox-payment.html")) {
         const indent = text.lastIndexOf("£");
-        const pct = totalQty > 3 ? "" : "%";
-        text += `\n${" ".repeat(indent)}(${percent}${pct} saving)`;
+        if (totalQty > 3) {
+          text += `\n${" ".repeat(indent)}(£22 saving)`;
+        } else {
+          text += `\n${" ".repeat(indent)}(${percent}% saving)`;
+        }
       }
     } else {
       text += ` = £${total.toFixed(2)}`;


### PR DESCRIPTION
## Summary
- display a fixed "£22 saving" when four or more items are purchased

## Testing
- `npm run format`
- `npm test`
- `npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68c148128908832db1bc941cbf750f97