### PR TITLE
fix: contain community modal buttons

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -347,6 +347,7 @@
           </svg>
           <span class="sr-only">Close</span>
         </button>
+          <div class="relative">
         <model-viewer
           poster="images/box logo.png"
           src="about:blank"
@@ -420,6 +421,7 @@
             </a>
           </div>
         </div>
+          </div>
         <div class="p-4">
           <ul
             id="comments-list"


### PR DESCRIPTION
## Summary
- ensure Community Creations modal action buttons render within the model viewer by wrapping viewer and controls in a relative container

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_68c14e35996c832d94e04a0b3ad04e44