### PR TITLE
fix: disable premium tiers in community viewer

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -488,9 +488,11 @@
           localStorage.setItem("print3Material", material);
         }
 
+        window.setTier = setTier;
+
         tierToggle?.addEventListener("click", (ev) => {
           const btn = ev.target.closest("button[data-tier]");
-          if (btn) setTier(btn.dataset.tier);
+          if (btn && !btn.disabled) setTier(btn.dataset.tier);
         });
 
         const close = closeModel;

--- a/js/community.js
+++ b/js/community.js
@@ -249,6 +249,15 @@ function openModel(model) {
     input.value = "";
     renderComments(model.id);
   }
+  window.setTier?.("bronze");
+  const tierToggle = document.getElementById("tier-toggle");
+  if (tierToggle) {
+    tierToggle.querySelectorAll("button[data-tier]").forEach((btn) => {
+      const isBronze = btn.dataset.tier === "bronze";
+      btn.disabled = !isBronze;
+      btn.classList.toggle("cursor-not-allowed", !isBronze);
+    });
+  }
   modal.classList.remove("hidden");
   const closeBtn = document.getElementById("close-modal");
   const svg = closeBtn?.querySelector("svg");


### PR DESCRIPTION
## Summary
- disable multicolour and premium tiers when viewing community models
- expose `setTier` and ignore clicks on disabled tier buttons

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c14d465c7c832d8c140e0c25ffbef6