### PR TITLE
fix: resize and reposition colour palette

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -127,8 +127,8 @@
                 <!-- colour palette (purely visual; closed by default) -->
                 <div
                   id="single-color-menu"
-                  class="absolute top-1/2 left-1/2 grid grid-cols-8 place-items-center gap-2 p-2 bg-[#2A2A2E] border border-white/20 rounded-3xl w-80 h-24 z-20 hidden"
-                  style="transform: translate(-50%, -60%);"
+                  class="absolute top-1/2 left-1/2 grid grid-cols-4 place-items-center gap-2 p-2 bg-[#2A2A2E] border border-white/20 rounded-3xl w-40 h-40 z-20 hidden"
+                  style="transform: translate(-75%, -25%);"
                 >
                   <button type="button" class="w-8 h-8 rounded-full border border-white/20" style="background-color: #ff0000" data-color="#ff0000"></button>
                   <button type="button" class="w-8 h-8 rounded-full border border-white/20" style="background-color: #ff5500" data-color="#ff5500"></button>


### PR DESCRIPTION
## Summary
- convert checkout single-colour palette to 4x4 grid and shift overlay down-left

## Testing
- `npm run format` (backend)
- `npm test` (backend)
- `npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `npm run smoke` *(skipped in offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_68c1488db9d0832dbd9ec669c524324c