### PR TITLE
fix: enlarge multicolour option on hover

### DIFF
--- a/luckybox-payment.html
+++ b/luckybox-payment.html
@@ -93,6 +93,9 @@
           0 0 10px rgba(48, 213, 200, 0.6),
           0 6px 10px rgba(0, 0, 0, 0.6);
       }
+      #material-options label:hover input:checked + span {
+        transform: scale(1.08);
+      }
 
       #material-options label:hover span.no-transform,
       #material-options input:active + span.no-transform,

--- a/minis-checkout.html
+++ b/minis-checkout.html
@@ -118,6 +118,9 @@
           0 0 10px rgba(48, 213, 200, 0.6),
           0 6px 10px rgba(0, 0, 0, 0.6);
       }
+      #material-options label:hover input:checked + span {
+        transform: scale(1.08);
+      }
 
       #material-options label:hover span.no-transform,
       #material-options input:active + span.no-transform,


### PR DESCRIPTION
## Summary
- enlarge checked material option when hovered on minis and luckybox checkout pages

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` (fails: Lockfile mismatch detected)
- `SKIP_PW_DEPS=1 npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_68c165d396a4832db5c48abba86c8288