### PR TITLE
fix: adjust colour palette position in checkout

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -128,7 +128,7 @@
                 <div
                   id="single-color-menu"
                   class="absolute top-1/2 left-1/2 grid grid-cols-4 place-items-center gap-2 p-2 bg-[#2A2A2E] border border-white/20 rounded-3xl w-40 h-40 z-20 hidden"
-                  style="transform: translate(-75%, -25%);"
+                  style="transform: translate(-75%, -25%) translate(0.5cm, -0.5cm);"
                 >
                   <button type="button" class="w-8 h-8 rounded-full border border-white/20" style="background-color: #ff0000" data-color="#ff0000"></button>
                   <button type="button" class="w-8 h-8 rounded-full border border-white/20" style="background-color: #ff5500" data-color="#ff5500"></button>


### PR DESCRIPTION
## Summary
- move single-colour palette 0.5cm up and to the right on the checkout page

## Testing
- `npm run validate-env`
- `npm run setup` *(partial: hangs after skipping Playwright dependencies)*
- `npm run format` *(backend)*
- `npm test`
- `npm run ci` *(fails: 403 Forbidden to registry.npmjs.org)*
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c1661c0060832da6c06a210f2aa643