### PR TITLE
fix: disable multicolour luckybox tier

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -149,16 +149,17 @@
                 <span class="block text-xs mt-1">coming soon</span>
               </label>
               <!-- multicolour -->
-              <label class="cursor-pointer flex flex-col items-center text-center">
-                <input type="radio" name="luckybox-tier" value="multicolour" class="sr-only peer" checked />
-                <span id="luckybox-multi" class="w-36 h-36 flex flex-col items-center justify-center rounded-full border-4 border-white/20 shadow-xl peer-checked:border-[#30D5C8]">
+              <label class="cursor-not-allowed flex flex-col items-center text-center opacity-50">
+                <input type="radio" name="luckybox-tier" value="multicolour" class="sr-only peer" disabled />
+                <span id="luckybox-multi" class="w-36 h-36 flex flex-col items-center justify-center rounded-full border-4 border-white/20 shadow-xl">
                   <span class="font-semibold">£29.99</span>
                   <span class="text-xs">multicolour</span>
                 </span>
+                <span class="block text-xs mt-1">coming soon</span>
               </label>
               <!-- single colour -->
               <label class="cursor-pointer flex flex-col items-center text-center">
-                <input type="radio" name="luckybox-tier" value="basic" class="sr-only peer" />
+                <input type="radio" name="luckybox-tier" value="basic" class="sr-only peer" checked />
                 <span class="w-28 h-28 flex flex-col items-center justify-center rounded-full border border-white/20 peer-checked:border-2 peer-checked:border-[#30D5C8]">
                   <span class="font-semibold">£19.99</span>
                   <span class="text-xs">single colour</span>

--- a/js/addons.js
+++ b/js/addons.js
@@ -86,10 +86,10 @@ function initLuckybox() {
     premium: "£59.99 print + 10 print points (usually £79.99)",
   };
   const defaultRadio = document.querySelector(
-    '#luckybox-tiers input[value="multicolour"]',
+    '#luckybox-tiers input[value="basic"]',
   );
   if (defaultRadio) defaultRadio.checked = true;
-  localStorage.setItem("print2Material", "multi");
+  localStorage.setItem("print2Material", "single");
   function selectedTier() {
     const checked = document.querySelector(
       '#luckybox-tiers input[name="luckybox-tier"]:checked',


### PR DESCRIPTION
## Summary
- disable multicolour Luckybox tier and label it coming soon
- default Luckybox selection to single colour

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: E403 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c167d36358832da4a124cc0954451b