### PR TITLE
fix: update luckybox placeholder

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -478,7 +478,7 @@ async function initPaymentPage() {
   viewer?.addEventListener("error", () => {
     const img = document.getElementById("preview-img");
     if (img) {
-      img.src = "images/astro-image.png";
+      img.src = viewer?.dataset.fallback || "images/astro-image.png";
       img.style.display = "block";
     }
     if (viewer) viewer.style.display = "none";

--- a/luckybox-payment.html
+++ b/luckybox-payment.html
@@ -235,6 +235,7 @@
               src="images/luckybox-preview.png"
               alt="Luckybox preview"
               class="object-cover h-full w-full rounded-3xl"
+              data-fallback="images/luckybox-preview.png"
             />
           </section>
           <div id="trust-badge" class="mt-4 text-center text-sm text-gray-400">


### PR DESCRIPTION
## Summary
- ensure Luckybox payment fallback uses its preview image
- allow pages to specify fallback image via `data-fallback`

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup` *(failed: Skipping Playwright/apt deps; minimal output)*
- `npm --prefix backend test`
- `SKIP_PW_DEPS=1 npm run ci` *(failed: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke` *(skipped: offline mode)*
- `npx prettier -w js/payment.js luckybox-payment.html`


------
https://chatgpt.com/codex/tasks/task_e_68c1690867c0832da9a7272c3da7b9ca