### PR TITLE
feat: add wizard paint slide

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -289,6 +289,22 @@
                   class="w-full sm:w-1/2 h-64 bg-[#2A2A2E] border border-white/10 rounded-xl"
                 ></model-viewer>
               </div>
+              <div
+                class="carousel-slide flex-none p-4 flex flex-col sm:flex-row items-center justify-center gap-4"
+              >
+                <img
+                  src="images/pre-paint.png"
+                  alt="Pre-painted model"
+                  loading="lazy"
+                  class="w-full sm:w-1/2 h-64 object-cover rounded-xl"
+                />
+                <img
+                  src="images/wizard-paint.psd"
+                  alt="Wizard paint"
+                  loading="lazy"
+                  class="w-full sm:w-1/2 h-64 object-cover rounded-xl"
+                />
+              </div>
             </div>
           </div>
           <button


### PR DESCRIPTION
## Summary
- extend Community Creations carousel with a new slide featuring a pre-painted model and wizard paint image

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup` *(failed: tunnel error: unsuccessful)*
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(failed: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke` *(skipped: offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_68c16c75bbc4832d9c74540dab15dc0f