### PR TITLE
fix: filter invalid community models

### DIFF
--- a/js/community.js
+++ b/js/community.js
@@ -531,9 +531,11 @@ async function loadMore(type, filters = getFilters()) {
   const fetchedCount = models.length;
   if (type === "popular" && offsetBefore === 0 && models.length) {
     models = models.slice(1);
-    state.offset += 1;
   }
-  state.offset += models.length;
+  models = models.filter(
+    (m) => m && (m.placeholder || (m.model_url && m.snapshot)),
+  );
+  state.offset += fetchedCount;
   state.models = state.models.concat(models);
   const grid = document.getElementById(`${type}-grid`);
   models.forEach((m) => grid.appendChild(createCard(m)));


### PR DESCRIPTION
## Summary
- sanitize community models before rendering to avoid blank cards

## Testing
- `npm run validate-env`
- `npx prettier js/community.js --write`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff; Lockfile mismatch detected)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68c17446fe24832d89b07cbb5466b424