### PR TITLE
fix: ensure basket script loads on index

### DIFF
--- a/index.html
+++ b/index.html
@@ -201,7 +201,7 @@
          (left) your unrelated app scripts below -->
     <script type="module" src="js/wizard.js" defer></script>
     <script type="module" src="js/print-slots.js" defer></script>
-    <script type="module" src="js/basket.js" defer></script>
+    <script type="module" src="js/basket.js"></script>
     <script type="module" src="js/index.js" defer></script>
     <script src="js/stats-ticker.js" defer></script>
     <script type="module" src="js/subredditLanding.js" defer></script>


### PR DESCRIPTION
## Summary
- ensure `basket.js` loads before other modules on index page so add-to-basket works

## Testing
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run validate-env`
- `npm run format` (backend)
- `npm test` (backend)
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Lockfile mismatch / registry 403)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c17815ee7c832d8a674622e067c6e3