### PR TITLE
fix: disable multicolour and premium tiers

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -591,7 +591,7 @@
           }
         });
 
-        setTier("silver");
+        setTier("bronze");
         init();
         restoreOpenModel();
         loadReferralLink();

--- a/competitions.html
+++ b/competitions.html
@@ -396,10 +396,11 @@
                 : "multi";
           localStorage.setItem("print3Material", material);
         }
+        window.setTier = setTier;
 
         tierToggle?.addEventListener("click", (ev) => {
           const btn = ev.target.closest("button[data-tier]");
-          if (btn) setTier(btn.dataset.tier);
+          if (btn && !btn.disabled) setTier(btn.dataset.tier);
         });
 
         function close() {
@@ -484,7 +485,7 @@
         document.addEventListener("keydown", (e) => {
           if (e.key === "Escape") close();
         });
-        setTier("silver");
+        setTier("bronze");
       });
     </script>
     <script type="module" src="js/printclub.js"></script>

--- a/js/competitions.js
+++ b/js/competitions.js
@@ -316,6 +316,7 @@ function openModelModal(url, jobId, snapshot) {
   const checkoutBtn = document.getElementById("modal-checkout");
   const addBasketBtn = document.getElementById("modal-add-basket");
   const copyBtn = document.getElementById("modal-copy-link");
+  const tierToggle = document.getElementById("tier-toggle");
   viewer.setAttribute("poster", snapshot || "");
   viewer.setAttribute("fetchpriority", "high");
   viewer.setAttribute("loading", "eager");
@@ -331,6 +332,14 @@ function openModelModal(url, jobId, snapshot) {
   }
   if (copyBtn) {
     copyBtn.dataset.id = jobId;
+  }
+  window.setTier?.("bronze");
+  if (tierToggle) {
+    tierToggle.querySelectorAll("button[data-tier]").forEach((btn) => {
+      const isBronze = btn.dataset.tier === "bronze";
+      btn.disabled = !isBronze;
+      btn.classList.toggle("cursor-not-allowed", !isBronze);
+    });
   }
   modalEl.classList.remove("hidden");
   document.body.classList.add("overflow-hidden");


### PR DESCRIPTION
## Summary
- disable multicolour and premium tiers for competition entries
- default community creations to single-colour tier
- ensure tier buttons are greyed out and inactive

## Testing
- `npx prettier js/competitions.js -w --log-level=debug`
- `cd backend && npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68c17884d520832db6ae255eb3788ac6