### PR TITLE
feat: add genre panel for luckybox B

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -112,15 +112,6 @@
         border-color: #30d5c8;
         box-shadow: 0 0 0 3px rgba(48, 213, 200, 0.5);
       }
-      .genre-input {
-        margin-top: 0.5rem;
-        padding: 0.125rem 0.25rem;
-        color: #000;
-        border-radius: 0.25rem;
-      }
-      .is-hidden {
-        display: none;
-      }
     </style>
   </head>
 
@@ -224,7 +215,7 @@
               </label>
             </fieldset>
           </div>
-          <fieldset id="luckybox-options" class="luckybox-options">
+          <fieldset id="luckybox-options" class="luckybox-options" data-addons="luckybox-options">
             <legend>Choose your Luckybox</legend>
             <label class="lucky-card">
               <input type="radio" name="luckybox" id="opt-a" value="A" class="lucky-input" checked />
@@ -235,14 +226,40 @@
               </span>
             </label>
             <label class="lucky-card">
-              <input type="radio" name="luckybox" id="opt-b" value="B" class="lucky-input" />
+              <input
+                type="radio"
+                name="luckybox"
+                id="opt-b"
+                value="B"
+                class="lucky-input"
+                aria-controls="genre-panel"
+              />
               <img src="images/luckybox-preview.png" alt="" />
               <span class="lucky-text">
                 <span class="lucky-title">Luckybox B</span>
                 <span class="lucky-subtitle">Random print in your chosen genre</span>
               </span>
+              <div id="genre-panel" hidden>
+                <div class="flex gap-2 mb-2">
+                  <button type="button" class="px-2 py-1 rounded-full bg-[#444] text-xs">Abstract</button>
+                  <button type="button" class="px-2 py-1 rounded-full bg-[#444] text-xs">Nature</button>
+                  <button type="button" class="px-2 py-1 rounded-full bg-[#444] text-xs">Retro</button>
+                  <button type="button" class="px-2 py-1 rounded-full bg-[#444] text-xs">Minimal</button>
+                </div>
+                <input
+                  id="genre"
+                  name="genre"
+                  type="text"
+                  placeholder="Type a genre (e.g., Surreal, Cyberpunk)"
+                  minlength="2"
+                  maxlength="30"
+                  disabled
+                  aria-disabled="true"
+                  class="mt-2 p-1 rounded text-black"
+                />
+                <p class="text-xs mt-1">Pick a chip or type your own genre. 2–30 characters.</p>
+              </div>
             </label>
-            <input id="genre-input" type="text" placeholder="Genre" class="genre-input is-hidden" />
           </fieldset>
           <a href="luckybox-payment.html" class="absolute bottom-4 right-4 font-bold py-2 px-5 rounded-full shadow-md transition border-2 border-black" style="background-color: #30d5c8; color: #1a1a1d" onmouseover="this.style.opacity='0.85'" onmouseout="this.style.opacity='1'">
             Buy →

--- a/js/addons.js
+++ b/js/addons.js
@@ -115,15 +115,15 @@ document.addEventListener("DOMContentLoaded", initLuckybox);
 
 function initLuckyboxOptions() {
   const optionRadios = document.querySelectorAll('input[name="luckybox"]');
-  const genreInput = document.getElementById("genre-input");
-  if (!optionRadios.length || !genreInput) return;
+  const genrePanel = document.getElementById("genre-panel");
+  const genreInput = document.getElementById("genre");
+  if (!optionRadios.length || !genrePanel || !genreInput) return;
   function update() {
     const selected = document.querySelector('input[name="luckybox"]:checked');
-    if (selected && selected.value === "B") {
-      genreInput.classList.remove("is-hidden");
-    } else {
-      genreInput.classList.add("is-hidden");
-    }
+    const show = selected && selected.value === "B";
+    genrePanel.hidden = !show;
+    genreInput.disabled = !show;
+    genreInput.setAttribute("aria-disabled", (!show).toString());
   }
   optionRadios.forEach((r) => r.addEventListener("change", update));
   update();


### PR DESCRIPTION
## Summary
- add collapsible genre panel for Luckybox option B
- toggle genre panel visibility and input state via script

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npx prettier -w addons.html js/addons.js`
- `cd backend && npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c178dab8a0832d98222121670449f5