### PR TITLE
fix: persist selected model to payment page

### DIFF
--- a/js/basket.js
+++ b/js/basket.js
@@ -323,13 +323,13 @@ export function setupBasketUI() {
   overlay.querySelector("#basket-close").addEventListener("click", closeBasket);
   overlay.querySelector("#basket-checkout").addEventListener("click", () => {
     const items = getBasket();
-    if (items.length === 1) {
-      const item = items[0];
-      if (item.modelUrl) {
-        localStorage.setItem("print2Model", item.modelUrl);
+    if (items.length) {
+      const first = items[0];
+      if (first.modelUrl) {
+        localStorage.setItem("print2Model", first.modelUrl);
       }
-      if (item.jobId) {
-        localStorage.setItem("print2JobId", item.jobId);
+      if (first.jobId) {
+        localStorage.setItem("print2JobId", first.jobId);
       } else {
         localStorage.removeItem("print2JobId");
       }

--- a/js/payment.js
+++ b/js/payment.js
@@ -1102,7 +1102,6 @@ async function initPaymentPage() {
     }
   }
   const storedModel = sanitizeUrl(localStorage.getItem("print2Model"));
-  viewer.src = storedModel || FALLBACK_GLB;
 
   // Load saved basket items unless this is the Luckybox page
   if (!window.location.pathname.endsWith("luckybox-payment.html")) {
@@ -1125,6 +1124,11 @@ async function initPaymentPage() {
   } else {
     localStorage.removeItem("print2CheckoutItems");
   }
+
+  viewer.src =
+    (checkoutItems[0] && sanitizeUrl(checkoutItems[0].modelUrl)) ||
+    storedModel ||
+    FALLBACK_GLB;
 
   // Sync checkout items with the current basket in case this page was
   // opened directly and the stored list is stale.


### PR DESCRIPTION
## Summary
- ensure checkout from basket uses first item's model
- preload payment viewer with stored basket model or previously viewed model

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npx --no-install prettier -w js/basket.js js/payment.js`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c1799d5bd8832da1edcffd4b9a6348