### PR TITLE
fix: show wizard paint image on community page

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -299,7 +299,7 @@
                   class="w-full sm:w-1/2 h-64 object-cover rounded-xl"
                 />
                 <img
-                  src="images/wizard-paint.psd"
+                  src="images/wizard-paint.png"
                   alt="Wizard paint"
                   loading="lazy"
                   class="w-full sm:w-1/2 h-64 object-cover rounded-xl"


### PR DESCRIPTION
## Summary
- fix the "What people are talking about" carousel to load `wizard-paint.png` instead of a fallback

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68c17a7d0c40832dabc3205f5011eeac