### PR TITLE
fix: align etch box with model viewer size

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -258,7 +258,7 @@
                 <p class="max-w-md italic">"I love using print2!" – Anna J.</p>
               </div>
               <div
-                class="carousel-slide flex-none p-4 flex flex-col items-center justify-center text-center space-y-4 bg-[#2A2A2E] border border-white/10 rounded-xl"
+                class="carousel-slide flex-none p-4 flex flex-col items-center justify-center text-center space-y-4 bg-[#2A2A2E] border border-white/10 rounded-xl w-full h-64"
               >
                 <i class="fas fa-pen-fancy text-4xl text-[#30D5C8]"></i>
                 <p class="max-w-md">Etch your name on your print:</p>


### PR DESCRIPTION
## Summary
- match "Etch your name on your print" card dimensions to boombox viewer in community carousel

## Testing
- `npm run format` (backend)
- `npm test` (backend)
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke` *(skipped in offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_68c17aea0338832daa908c3e97ec0a0e