### PR TITLE
fix: show remaining slots earlier

### DIFF
--- a/js/wizard.js
+++ b/js/wizard.js
@@ -42,7 +42,7 @@ export function updateWizard() {
 
   const slots = document.getElementById("wizard-slots");
   if (slots) {
-    if (idx >= 2) slots.classList.remove("hidden");
+    if (idx >= 1) slots.classList.remove("hidden");
     else slots.classList.add("hidden");
   }
 }
@@ -54,7 +54,7 @@ export function setWizardSlotCount(n) {
   if (el) {
     el.textContent = `Only ${n} print slots left`;
     const stage = localStorage.getItem(STAGE_KEY);
-    if (stage === "purchase" || stage === "print") {
+    if (stage === "building" || stage === "purchase" || stage === "print") {
       el.classList.remove("hidden");
     }
   }


### PR DESCRIPTION
## Summary
- show remaining print slots once user reaches building stage
- reveal slot message when slot count is set during building or later

## Testing
- `npm run format` (backend)
- `npm test` (backend)
- `npm run ci` *(fails: Lockfile mismatch detected. Run 'npm install' to regenerate package-lock.json.)*
- `npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68c17c046530832db02d1227d778c605