### PR TITLE
fix: add hover effect for multicolour option

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -109,7 +109,7 @@
 
               <label class="text-center flex flex-col items-center w-1/3 opacity-50 cursor-not-allowed group">
                 <input type="radio" name="material" value="multi" class="sr-only" disabled />
-                <span class="relative w-28 h-28 flex flex-col items-center justify-center rounded-full border-2 border-white/20 shadow-xl transition-transform duration-200">
+                <span class="relative w-28 h-28 flex flex-col items-center justify-center rounded-full border-2 border-white/20 shadow-xl transition-transform duration-200 group-hover:scale-105">
                   <span class="font-semibold">£59.99</span>
                   <span class="text-xs">multi-colour</span>
                 </span>


### PR DESCRIPTION
## Summary
- add hover scaling effect to multicolour option on payment page so it matches other materials

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c18c501f04832d940dd681f2f5e495