### PR TITLE
fix: show luckybox preview image

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -1121,10 +1121,12 @@ async function initPaymentPage() {
     localStorage.removeItem("print2CheckoutItems");
   }
 
-  viewer.src =
-    (checkoutItems[0] && sanitizeUrl(checkoutItems[0].modelUrl)) ||
-    storedModel ||
-    FALLBACK_GLB;
+  if (viewer && viewer.tagName.toLowerCase() !== "img") {
+    viewer.src =
+      (checkoutItems[0] && sanitizeUrl(checkoutItems[0].modelUrl)) ||
+      storedModel ||
+      FALLBACK_GLB;
+  }
 
   // Sync checkout items with the current basket in case this page was
   // opened directly and the stored list is stale.


### PR DESCRIPTION
## Summary
- avoid overwriting <img> preview source so Luckybox page uses its preview image

## Testing
- `npm run validate-env`
- `npm run setup` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `npx prettier --check js/payment.js`
- `npm test` *(backend)*
- `npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c18c8a6838832d982256394db8dcc2