### PR TITLE
feat: require luckybox selections before checkout

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -261,7 +261,17 @@
               </div>
             </label>
           </fieldset>
-          <a href="luckybox-payment.html" class="absolute bottom-4 right-4 font-bold py-2 px-5 rounded-full shadow-md transition border-2 border-black" style="background-color: #30d5c8; color: #1a1a1d" onmouseover="this.style.opacity='0.85'" onmouseout="this.style.opacity='1'">
+          <p
+            id="luckybox-error"
+            class="hidden absolute bottom-16 right-4 text-red-500 text-sm"
+          ></p>
+          <a
+            href="luckybox-payment.html"
+            class="absolute bottom-4 right-4 font-bold py-2 px-5 rounded-full shadow-md transition border-2 border-black"
+            style="background-color: #30d5c8; color: #1a1a1d"
+            onmouseover="this.style.opacity='0.85'"
+            onmouseout="this.style.opacity='1'"
+          >
             Buy →
           </a>
         </div>

--- a/js/addons.js
+++ b/js/addons.js
@@ -130,3 +130,40 @@ function initLuckyboxOptions() {
 }
 
 document.addEventListener("DOMContentLoaded", initLuckyboxOptions);
+
+function initLuckyboxValidation() {
+  const buyLink = document.querySelector(
+    '#luckybox a[href="luckybox-payment.html"]',
+  );
+  const error = document.getElementById("luckybox-error");
+  if (!buyLink || !error) return;
+  function hideError() {
+    if (
+      document.querySelector(
+        '#luckybox-tiers input[name="luckybox-tier"]:checked',
+      ) &&
+      document.querySelector('input[name="luckybox"]:checked')
+    ) {
+      error.classList.add("hidden");
+    }
+  }
+  buyLink.addEventListener("click", (e) => {
+    const tier = document.querySelector(
+      '#luckybox-tiers input[name="luckybox-tier"]:checked',
+    );
+    const choice = document.querySelector('input[name="luckybox"]:checked');
+    if (!tier || !choice) {
+      e.preventDefault();
+      error.textContent =
+        "Please choose a tier and a Luckybox option before continuing.";
+      error.classList.remove("hidden");
+    }
+  });
+  document
+    .querySelectorAll(
+      '#luckybox-tiers input[name="luckybox-tier"], input[name="luckybox"]',
+    )
+    .forEach((input) => input.addEventListener("change", hideError));
+}
+
+document.addEventListener("DOMContentLoaded", initLuckyboxValidation);


### PR DESCRIPTION
## Summary
- warn users to pick a tier and Luckybox option before buying

## Testing
- `npm run format` *(backend)*
- `npx prettier -w addons.html js/addons.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c18d0e53d8832db531ad21a1f13aab