### PR TITLE
fix: align personalization carousel slide

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -257,16 +257,18 @@
                 />
                 <p class="max-w-md italic">"I love using print2!" – Anna J.</p>
               </div>
-              <div
-                class="carousel-slide flex-none p-4 flex flex-col items-center justify-center text-center space-y-4 bg-[#2A2A2E] border border-white/10 rounded-xl w-full h-64"
-              >
-                <i class="fas fa-pen-fancy text-4xl text-[#30D5C8]"></i>
-                <p class="max-w-md">Etch your name on your print:</p>
-                <a
-                  href="payment.html?personalise=1"
-                  class="px-4 py-2 bg-[#30D5C8] text-[#1A1A1D] rounded-xl font-semibold hover:bg-[#28b7a8] transition"
-                  >Personalise now</a
+              <div class="carousel-slide flex-none p-4">
+                <div
+                  class="flex flex-col items-center justify-center text-center space-y-4 bg-[#2A2A2E] border border-white/10 rounded-xl w-full h-64"
                 >
+                  <i class="fas fa-pen-fancy text-4xl text-[#30D5C8]"></i>
+                  <p class="max-w-md">Etch your name on your print:</p>
+                  <a
+                    href="payment.html?personalise=1"
+                    class="px-4 py-2 bg-[#30D5C8] text-[#1A1A1D] rounded-xl font-semibold hover:bg-[#28b7a8] transition"
+                    >Personalise now</a
+                  >
+                </div>
               </div>
               <div
                 class="carousel-slide flex-none p-4 flex flex-col sm:flex-row items-center justify-center gap-4"


### PR DESCRIPTION
## Summary
- move personalization promo slide inside its own padded container so its top aligns with neighboring astronaut content in carousel

## Testing
- `npm run validate-env`
- `npm run setup`
- `npm run format` (backend)
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68c18ec8be80832db7db04c33c58f6d5