### PR TITLE
fix: load extra models for popular grid

### DIFF
--- a/js/community.js
+++ b/js/community.js
@@ -515,7 +515,12 @@ async function loadMore(type, filters = getFilters()) {
   if (!cache[key]) cache[key] = { offset: 0, models: [] };
   const state = cache[key];
   const offsetBefore = state.offset;
-  const limit = type === "recent" && offsetBefore === 0 ? 8 : 9;
+  const limit =
+    type === "recent" && offsetBefore === 0
+      ? 8
+      : type === "popular" && offsetBefore === 0
+        ? 11
+        : 9;
   let models = await fetchCreations(
     type,
     state.offset,
@@ -528,9 +533,6 @@ async function loadMore(type, filters = getFilters()) {
     models = getFallbackModels(limit, state.offset);
   }
   const fetchedCount = models.length;
-  if (type === "popular" && offsetBefore === 0 && models.length) {
-    models = models.slice(1);
-  }
   models = models.filter(
     (m) => m && (m.placeholder || (m.model_url && m.snapshot)),
   );


### PR DESCRIPTION
## Summary
- ensure popular grid loads enough models so all 12 slots fill

## Testing
- `npx prettier -w js/community.js`
- `npm test` *(fails: Cannot find module 'wait-on')*
- `npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68c18e270ad4832d8f4501a7686ea497