### PR TITLE
fix: correct wizard paint image path

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -299,7 +299,7 @@
                   class="w-full sm:w-1/2 h-64 object-cover rounded-xl"
                 />
                 <img
-                  src="images/wizard-paint.png"
+                  src="./images/wizard-paint.png"
                   alt="Wizard paint"
                   loading="lazy"
                   class="w-full sm:w-1/2 h-64 object-cover rounded-xl"


### PR DESCRIPTION
## Summary
- fix wizard paint image path in CommunityCreations section so the image loads

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` (backend)
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: skipping smoke)*


------
https://chatgpt.com/codex/tasks/task_e_68c18e652ab0832db58aec8d756d76dc