### PR TITLE
fix: balance colour palette spacing

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -127,7 +127,7 @@
                 <!-- colour palette (purely visual; closed by default) -->
                 <div
                   id="single-color-menu"
-                  class="absolute top-1/2 left-1/2 grid grid-cols-4 place-items-center gap-2 p-2 bg-[#2A2A2E] border border-white/20 rounded-3xl w-40 h-40 z-20 hidden"
+                  class="absolute top-1/2 left-1/2 grid grid-cols-4 place-items-center gap-2 p-2 bg-[#2A2A2E] border border-white/20 rounded-3xl w-42 h-42 z-20 hidden"
                   style="transform: translate(-75%, -25%) translate(0.5cm, -0.5cm);"
                 >
                   <button type="button" class="w-8 h-8 rounded-full border border-white/20" style="background-color: #ff0000" data-color="#ff0000"></button>


### PR DESCRIPTION
## Summary
- expand single-color palette container to evenly space top and bottom rows

## Testing
- `npm run format` (backend)
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff; Lockfile mismatch detected)*
- `SKIP_PW_DEPS=1 npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_68c178cd0cd4832da7210dd665e148c6