### PR TITLE
test: broaden Playwright testMatch for hashed specs

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "@playwright/test";
 
 export default defineConfig({
   testDir: "./tests/e2e",
+  testMatch: /.*\.(spec|test)(\.[^.]+)?\.ts/,
   timeout: 30 * 1000,
   webServer: {
     command: "npx http-server . -p 3000",


### PR DESCRIPTION
## Summary
- expand Playwright testMatch to include hashed suffix after `.spec`/`.test`

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68c1907e8f44832d8d04512627866b0d