### PR TITLE
ci: use ASTRONAUT_GLB_URL in workflows

### DIFF
--- a/.github/workflows/api-removal-safety.yml
+++ b/.github/workflows/api-removal-safety.yml
@@ -40,7 +40,7 @@ jobs:
           fi
       - run: npm run build --if-present
         env:
-          ASTRONAUT_MODEL_URL: ${{ secrets.ASTRONAUT_MODEL_URL }}
+          ASTRONAUT_GLB_URL: ${{ secrets.ASTRONAUT_GLB_URL }}
       - run: node scripts/ci-doctor.mjs
         env:
           STRIPE_SECRET_KEY: sk_test
@@ -73,7 +73,7 @@ jobs:
           fi
       - run: npm run build --if-present
         env:
-          ASTRONAUT_MODEL_URL: ${{ secrets.ASTRONAUT_MODEL_URL }}
+          ASTRONAUT_GLB_URL: ${{ secrets.ASTRONAUT_GLB_URL }}
       - run: node scripts/ci-doctor.mjs
         env:
           STRIPE_SECRET_KEY: sk_test
@@ -112,7 +112,7 @@ jobs:
           fi
       - run: npm run build --if-present
         env:
-          ASTRONAUT_MODEL_URL: ${{ secrets.ASTRONAUT_MODEL_URL }}
+          ASTRONAUT_GLB_URL: ${{ secrets.ASTRONAUT_GLB_URL }}
       - run: node scripts/ci-doctor.mjs
         env:
           STRIPE_SECRET_KEY: sk_test
@@ -148,7 +148,7 @@ jobs:
           fi
       - run: npm run build --if-present
         env:
-          ASTRONAUT_MODEL_URL: ${{ secrets.ASTRONAUT_MODEL_URL }}
+          ASTRONAUT_GLB_URL: ${{ secrets.ASTRONAUT_GLB_URL }}
       - run: node scripts/ci-doctor.mjs
         env:
           STRIPE_SECRET_KEY: sk_test
@@ -182,7 +182,7 @@ jobs:
           fi
       - run: npm run build --if-present
         env:
-          ASTRONAUT_MODEL_URL: ${{ secrets.ASTRONAUT_MODEL_URL }}
+          ASTRONAUT_GLB_URL: ${{ secrets.ASTRONAUT_GLB_URL }}
       - run: node scripts/ci-doctor.mjs
         env:
           STRIPE_SECRET_KEY: sk_test

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -59,7 +59,7 @@ jobs:
       - run: npm ci --prefix backend
       - run: npm run build --if-present
         env:
-          ASTRONAUT_MODEL_URL: ${{ secrets.ASTRONAUT_MODEL_URL }}
+          ASTRONAUT_GLB_URL: ${{ secrets.ASTRONAUT_GLB_URL }}
       - run: node scripts/ci-doctor.mjs
         env:
           STRIPE_SECRET_KEY: sk_test

--- a/.github/workflows/ci-minimal.yml
+++ b/.github/workflows/ci-minimal.yml
@@ -21,7 +21,7 @@ jobs:
       # Build
       - run: npm run build --if-present
         env:
-          ASTRONAUT_MODEL_URL: ${{ secrets.ASTRONAUT_MODEL_URL }}
+          ASTRONAUT_GLB_URL: ${{ secrets.ASTRONAUT_GLB_URL }}
       - run: node scripts/ci-doctor.mjs
         env:
           STRIPE_SECRET_KEY: sk_test
@@ -46,7 +46,7 @@ jobs:
       # Build
       - run: npm run build --if-present
         env:
-          ASTRONAUT_MODEL_URL: ${{ secrets.ASTRONAUT_MODEL_URL }}
+          ASTRONAUT_GLB_URL: ${{ secrets.ASTRONAUT_GLB_URL }}
       - run: node scripts/ci-doctor.mjs
         env:
           STRIPE_SECRET_KEY: sk_test

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,7 +48,7 @@ jobs:
 
       - run: npm run build --if-present
         env:
-          ASTRONAUT_MODEL_URL: ${{ secrets.ASTRONAUT_MODEL_URL }}
+          ASTRONAUT_GLB_URL: ${{ secrets.ASTRONAUT_GLB_URL }}
 
       - run: node scripts/ci-doctor.mjs
         env:

--- a/.github/workflows/model-e2e.yml
+++ b/.github/workflows/model-e2e.yml
@@ -34,7 +34,7 @@ jobs:
       - run: npx playwright install --with-deps chromium
       - run: npm run build --if-present
         env:
-          ASTRONAUT_MODEL_URL: ${{ secrets.ASTRONAUT_MODEL_URL }}
+          ASTRONAUT_GLB_URL: ${{ secrets.ASTRONAUT_GLB_URL }}
       - run: node scripts/ci-doctor.mjs
         env:
           STRIPE_SECRET_KEY: sk_test
@@ -44,7 +44,7 @@ jobs:
           nohup npm run start > /tmp/app.log 2>&1 &
           npx wait-on http://localhost:3000 --timeout 180000
         env:
-          ASTRONAUT_MODEL_URL: ${{ secrets.ASTRONAUT_MODEL_URL }}
+          ASTRONAUT_GLB_URL: ${{ secrets.ASTRONAUT_GLB_URL }}
       - name: Run Playwright model tests (skip if specs are missing)
         shell: bash
         run: |

--- a/.github/workflows/no-lfs-in-tests.yml
+++ b/.github/workflows/no-lfs-in-tests.yml
@@ -13,7 +13,7 @@ jobs:
       - run: npm ci
       - run: npm run build --if-present
         env:
-          ASTRONAUT_MODEL_URL: ${{ secrets.ASTRONAUT_MODEL_URL }}
+          ASTRONAUT_GLB_URL: ${{ secrets.ASTRONAUT_GLB_URL }}
       - run: node scripts/ci-doctor.mjs
         env:
           STRIPE_SECRET_KEY: sk_test

--- a/.github/workflows/node-version-guard.yml
+++ b/.github/workflows/node-version-guard.yml
@@ -12,7 +12,7 @@ jobs:
       - run: npm ci
       - run: npm run build --if-present
         env:
-          ASTRONAUT_MODEL_URL: ${{ secrets.ASTRONAUT_MODEL_URL }}
+          ASTRONAUT_GLB_URL: ${{ secrets.ASTRONAUT_GLB_URL }}
       - run: node scripts/ci-doctor.mjs
         env:
           STRIPE_SECRET_KEY: sk_test

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -24,7 +24,7 @@ jobs:
       - run: npm ci
       - run: npm run build
         env:
-          ASTRONAUT_MODEL_URL: ${{ secrets.ASTRONAUT_MODEL_URL }}
+          ASTRONAUT_GLB_URL: ${{ secrets.ASTRONAUT_GLB_URL }}
       - name: Copy static site files
         run: |
           cp -a *.html frontend/dist/

--- a/.github/workflows/playwright-deps-and-e2e.yml
+++ b/.github/workflows/playwright-deps-and-e2e.yml
@@ -38,7 +38,7 @@ jobs:
         run: npx playwright install chromium
       - run: npm run build --if-present
         env:
-          ASTRONAUT_MODEL_URL: ${{ secrets.ASTRONAUT_MODEL_URL }}
+          ASTRONAUT_GLB_URL: ${{ secrets.ASTRONAUT_GLB_URL }}
       - run: node scripts/ci-doctor.mjs
         env:
           STRIPE_SECRET_KEY: sk_test

--- a/.github/workflows/root-ci.yml
+++ b/.github/workflows/root-ci.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Build
         run: npm run build --workspaces=false
         env:
-          ASTRONAUT_MODEL_URL: ${{ secrets.ASTRONAUT_MODEL_URL }}
+          ASTRONAUT_GLB_URL: ${{ secrets.ASTRONAUT_GLB_URL }}
 
       - name: CI doctor
         run: node scripts/ci-doctor.mjs

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -34,7 +34,7 @@ jobs:
           fi
       - run: npm run build --if-present
         env:
-          ASTRONAUT_MODEL_URL: ${{ secrets.ASTRONAUT_MODEL_URL }}
+          ASTRONAUT_GLB_URL: ${{ secrets.ASTRONAUT_GLB_URL }}
       - run: node scripts/ci-doctor.mjs
         env:
           STRIPE_SECRET_KEY: sk_test

--- a/.github/workflows/stripe-tests.yml
+++ b/.github/workflows/stripe-tests.yml
@@ -30,7 +30,7 @@ jobs:
           fi
       - run: npm run build --if-present
         env:
-          ASTRONAUT_MODEL_URL: ${{ secrets.ASTRONAUT_MODEL_URL }}
+          ASTRONAUT_GLB_URL: ${{ secrets.ASTRONAUT_GLB_URL }}
       - run: node scripts/ci-doctor.mjs
         env:
           STRIPE_SECRET_KEY: sk_test_dummy


### PR DESCRIPTION
## Summary
- switch workflows to ASTRONAUT_GLB_URL secret

## Testing
- `npm run validate-env`
- `npm run format` (backend)
- `npm test` (backend)
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke`
- `ASTRONAUT_GLB_URL=https://example.com/astronaut.glb npm run build` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c196924ef8832da8e76c4684fe5e38