### PR TITLE
feat: add luckybox option genre script

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -309,10 +309,10 @@
               </span>
               <div id="genre-panel" hidden>
                 <div class="genre-chips">
-                  <button type="button" class="genre-chip">Abstract</button>
-                  <button type="button" class="genre-chip">Nature</button>
-                  <button type="button" class="genre-chip">Retro</button>
-                  <button type="button" class="genre-chip">Minimal</button>
+                  <button type="button" class="genre-chip chip">Abstract</button>
+                  <button type="button" class="genre-chip chip">Nature</button>
+                  <button type="button" class="genre-chip chip">Retro</button>
+                  <button type="button" class="genre-chip chip">Minimal</button>
                 </div>
                 <input
                   id="genre"

--- a/js/addons.js
+++ b/js/addons.js
@@ -114,19 +114,57 @@ function initLuckybox() {
 document.addEventListener("DOMContentLoaded", initLuckybox);
 
 function initLuckyboxOptions() {
-  const optionRadios = document.querySelectorAll('input[name="luckybox"]');
-  const genrePanel = document.getElementById("genre-panel");
-  const genreInput = document.getElementById("genre");
-  if (!optionRadios.length || !genrePanel || !genreInput) return;
-  function update() {
-    const selected = document.querySelector('input[name="luckybox"]:checked');
-    const show = selected && selected.value === "B";
-    genrePanel.hidden = !show;
+  const container = document.querySelector('[data-addons="luckybox-options"]');
+  if (!container) return;
+  const a = container.querySelector("#opt-a");
+  const b = container.querySelector("#opt-b");
+  const panel = container.querySelector("#genre-panel");
+  const genreInput = container.querySelector("#genre");
+  const chips = container.querySelectorAll(".chip");
+  const cards = container.querySelectorAll(".lucky-card");
+  const bLabel = b ? b.closest("label") : null;
+  const form = container.closest("form");
+  if (!a || !b || !panel || !genreInput) return;
+
+  function updateGenreVisibility() {
+    const show = b.checked;
+    panel.hidden = !show;
+    if (bLabel) bLabel.setAttribute("aria-expanded", show ? "true" : "false");
     genreInput.disabled = !show;
-    genreInput.setAttribute("aria-disabled", (!show).toString());
+    genreInput.setAttribute("aria-disabled", String(!show));
+    const selected = container.querySelector('input[name="luckybox"]:checked');
+    cards.forEach((card) =>
+      card.classList.toggle("is-selected", card.contains(selected)),
+    );
+    if (show) genreInput.focus({ preventScroll: true });
   }
-  optionRadios.forEach((r) => r.addEventListener("change", update));
-  update();
+
+  [a, b].forEach((r) => r.addEventListener("change", updateGenreVisibility));
+
+  chips.forEach((chip) =>
+    chip.addEventListener("click", () => {
+      genreInput.value = chip.dataset.genre || chip.textContent.trim();
+      genreInput.focus();
+    }),
+  );
+
+  if (form) {
+    form.addEventListener("submit", (e) => {
+      if (a.checked) {
+        genreInput.disabled = true;
+        genreInput.setAttribute("aria-disabled", "true");
+      } else {
+        genreInput.disabled = false;
+        genreInput.setAttribute("aria-disabled", "false");
+        if (!genreInput.checkValidity()) {
+          e.preventDefault();
+          genreInput.reportValidity();
+        }
+      }
+    });
+  }
+
+  updateGenreVisibility();
 }
 
 document.addEventListener("DOMContentLoaded", initLuckyboxOptions);


### PR DESCRIPTION
## Summary
- add chips and genre field toggling for Luckybox B option
- wire chips to input and validate genre on submit

## Testing
- `npm run validate-env`
- `npm run setup`
- `npx prettier addons.html js/addons.js --write`
- `npm test` *(fails: Missing jest; run `npm run setup` before testing)*
- `npm run ci` *(fails: Lockfile mismatch)*
- `npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68c197426dd8832db6e5912a758ab88b