### PR TITLE
fix: resize colour palette container

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -127,7 +127,7 @@
                 <!-- colour palette (purely visual; closed by default) -->
                 <div
                   id="single-color-menu"
-                  class="absolute top-1/2 left-1/2 grid grid-cols-4 place-items-center gap-2 p-2 bg-[#2A2A2E] border border-white/20 rounded-3xl w-42 h-42 z-20 hidden"
+                  class="absolute top-1/2 left-1/2 grid grid-cols-4 place-items-center gap-2 p-2 bg-[#2A2A2E] border border-white/20 rounded-3xl w-44 h-44 z-20 hidden"
                   style="transform: translate(-75%, -25%) translate(0.5cm, -0.5cm);"
                 >
                   <button type="button" class="w-8 h-8 rounded-full border border-white/20" style="background-color: #ff0000" data-color="#ff0000"></button>


### PR DESCRIPTION
## Summary
- expand single-colour palette container to w-44 h-44 so 16 swatches fit without overlap

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup` *(failed: process hung due to missing dependencies/network)*
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(failed: registry access forbidden)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c1a2b6a314832db9f642b9d9a34e9c