### PR TITLE
feat: improve luckybox option accessibility

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -130,11 +130,16 @@
       [data-addons="luckybox-options"] #genre-panel {
         border-top: 1px solid #23272e;
         margin-top: 10px;
-        padding: 10px;
-        animation: genre-slide 180ms ease-out;
+        padding: 0 10px;
+        overflow: hidden;
+        max-height: 0;
+        opacity: 0;
+        transition: max-height 180ms ease-out, opacity 180ms ease-out,
+          padding 180ms ease-out;
       }
-      [data-addons="luckybox-options"] #genre-panel[hidden] {
-        display: none;
+      [data-addons="luckybox-options"] #genre-panel.is-open {
+        padding: 10px;
+        opacity: 1;
       }
       [data-addons="luckybox-options"] .genre-chips {
         display: flex;
@@ -170,16 +175,7 @@
         opacity: 0.8;
         margin-top: 4px;
       }
-      @keyframes genre-slide {
-        from {
-          opacity: 0;
-          transform: translateY(-4px);
-        }
-        to {
-          opacity: 1;
-          transform: translateY(0);
-        }
-      }
+      /* genre-slide animation removed; handled via max-height transition */
     </style>
   </head>
 
@@ -301,6 +297,7 @@
                 value="B"
                 class="lucky-input"
                 aria-controls="genre-panel"
+                aria-expanded="false"
               />
               <img src="images/luckybox-preview.png" alt="" />
               <span class="lucky-text">

--- a/js/addons.js
+++ b/js/addons.js
@@ -122,14 +122,49 @@ function initLuckyboxOptions() {
   const genreInput = container.querySelector("#genre");
   const chips = container.querySelectorAll(".chip");
   const cards = container.querySelectorAll(".lucky-card");
-  const bLabel = b ? b.closest("label") : null;
   const form = container.closest("form");
   if (!a || !b || !panel || !genreInput) return;
 
+  function showPanel() {
+    panel.hidden = false;
+    panel.classList.add("is-open");
+    panel.style.maxHeight = "0";
+    requestAnimationFrame(() => {
+      panel.style.maxHeight = panel.scrollHeight + "px";
+    });
+    panel.addEventListener(
+      "transitionend",
+      () => {
+        panel.style.maxHeight = "";
+      },
+      { once: true },
+    );
+  }
+
+  function hidePanel() {
+    panel.style.maxHeight = panel.scrollHeight + "px";
+    requestAnimationFrame(() => {
+      panel.classList.remove("is-open");
+      panel.style.maxHeight = "0";
+    });
+    panel.addEventListener(
+      "transitionend",
+      () => {
+        panel.hidden = true;
+        panel.style.maxHeight = "";
+      },
+      { once: true },
+    );
+  }
+
   function updateGenreVisibility() {
     const show = b.checked;
-    panel.hidden = !show;
-    if (bLabel) bLabel.setAttribute("aria-expanded", show ? "true" : "false");
+    if (show) {
+      showPanel();
+    } else if (!panel.hidden) {
+      hidePanel();
+    }
+    b.setAttribute("aria-expanded", show ? "true" : "false");
     genreInput.disabled = !show;
     genreInput.setAttribute("aria-disabled", String(!show));
     const selected = container.querySelector('input[name="luckybox"]:checked');
@@ -140,6 +175,14 @@ function initLuckyboxOptions() {
   }
 
   [a, b].forEach((r) => r.addEventListener("change", updateGenreVisibility));
+  [a, b].forEach((r) =>
+    r.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") {
+        r.checked = true;
+        r.dispatchEvent(new Event("change", { bubbles: true }));
+      }
+    }),
+  );
 
   chips.forEach((chip) =>
     chip.addEventListener("click", () => {


### PR DESCRIPTION
## Summary
- animate Luckybox genre panel and expose expanded state via aria attributes
- handle Enter key selection and chip clicks for Luckybox options

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` (backend)
- `npm test` (backend)
- `SKIP_PW_DEPS=1 npm run ci` *(fails: lockfile mismatch/403 fetching lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode skipped)*
- `npx prettier addons.html js/addons.js -w`


------
https://chatgpt.com/codex/tasks/task_e_68c1a1160fd0832d86a938cf9279df62