### PR TITLE
fix: show referral link box in recent community section

### DIFF
--- a/js/community.js
+++ b/js/community.js
@@ -324,16 +324,17 @@ async function loadReferralLink() {
     });
     if (res.ok) {
       const { code } = await res.json();
-      const input = document.getElementById("referral-link");
-      if (input) input.value = `${window.location.origin}?ref=${code}`;
+      document.querySelectorAll(".referral-link").forEach((input) => {
+        input.value = `${window.location.origin}?ref=${code}`;
+      });
     }
   } catch (err) {
     console.error("Failed to fetch referral link", err);
   }
 }
 
-function copyReferralLink() {
-  const input = document.getElementById("referral-link");
+function copyReferralLink(e) {
+  const input = e?.currentTarget?.previousElementSibling;
   input?.select();
   document.execCommand("copy");
 }
@@ -576,45 +577,35 @@ function renderGrid(type, filters = getFilters()) {
     const advert = document.createElement("div");
     advert.className =
       type === "recent"
-        ? "w-full min-h-32 bg-[#2A2A2E] border border-dashed border-white/40 rounded-xl flex flex-col items-center justify-center text-sm row-start-1 sm:col-start-2 md:col-start-3 pt-4 pb-14 relative"
+        ? "w-full min-h-32 bg-[#2A2A2E] border border-dashed border-white/40 rounded-xl flex items-center justify-center text-sm p-2 row-start-1 sm:col-start-2 md:col-start-3"
         : "w-full min-h-32 bg-[#2A2A2E] border border-dashed border-white/40 rounded-xl flex items-center justify-center text-sm p-2 row-start-3 sm:col-start-2 md:col-start-2";
-    if (type === "popular") {
-      advert.classList.add("flex-col");
-      const loggedIn = !!localStorage.getItem("token");
-      const inputClass =
-        "flex-1 bg-[#1A1A1D] border border-white/10 rounded-l-xl px-3 py-2 text-white placeholder-gray-500" +
-        (loggedIn ? "" : " cursor-default pointer-events-none");
-      const btnClass =
-        "bg-[#30D5C8] text-[#1A1A1D] px-4 rounded-r-xl" +
-        (loggedIn ? "" : " opacity-50 cursor-default pointer-events-none");
-      const btnHandler = loggedIn ? ' onclick="copyReferralLink()"' : "";
-      advert.innerHTML =
-        '<p class="mb-2 text-center text-white">Earn <span class="text-[#30D5C8]">£5 credit</span> when someone buys with your link.</p>' +
-        '<div class="space-y-1 w-full max-w-xs">' +
-        '<label for="referral-link" class="block text-sm">Your referral link:</label>' +
-        '<div class="flex">' +
-        `<input id="referral-link" aria-label="Referral link" class="${inputClass}" placeholder="Log in to get your link" readonly />` +
-        `<button aria-label="Copy referral link" class="${btnClass}"${btnHandler}>Copy</button>` +
-        "</div></div>";
-    } else {
-      advert.classList.add("text-center");
-
-      if (type === "recent") {
-        const loggedIn = !!localStorage.getItem("token");
-        const msg = loggedIn
-          ? '<p class="text-white">Earn <span class="text-[#30D5C8]">free prints</span></p>'
-          : '<p class="text-white">Sign up to earn <span class="text-[#30D5C8]">free prints</span>.</p>';
-        const link = loggedIn ? "earn-rewards.html" : "signup.html";
-        const btnText = loggedIn ? "Earn Rewards" : "Sign Up";
-        advert.innerHTML =
-          msg +
-          `<a href="${link}" class="absolute bottom-4 left-1/2 font-bold text-lg py-1.5 px-4 rounded-full shadow-md transition border-2 border-black inline-block" style="background-color: #30D5C8; color: #1A1A1D; transform: translateX(-50%) scale(0.78);" onmouseover="this.style.opacity='0.85'" onmouseout="this.style.opacity='1'">${btnText}</a>`;
-      } else {
-        advert.innerHTML =
-          '<p class="text-white"><span class="text-[#30D5C8]">£7 off</span> your 2nd and <span class="text-[#30D5C8]">£15 off</span> 3rd item you buy from this page.</p>' +
-          '<a href="payment.html" class="absolute bottom-4 left-1/2 font-bold text-lg py-1.5 px-4 rounded-full shadow-md transition border-2 border-black inline-block" style="background-color: #30D5C8; color: #1A1A1D; transform: translateX(-50%) scale(0.78);" onmouseover="this.style.opacity=\'0.85\'" onmouseout="this.style.opacity=\'1\'">Buy Current Basket →</a>';
-      }
-    }
+    advert.classList.add("flex-col");
+    const loggedIn = !!localStorage.getItem("token");
+    const inputClass =
+      "flex-1 bg-[#1A1A1D] border border-white/10 rounded-l-xl px-3 py-2 text-white placeholder-gray-500" +
+      (loggedIn ? "" : " cursor-default pointer-events-none");
+    const btnClass =
+      "bg-[#30D5C8] text-[#1A1A1D] px-4 rounded-r-xl" +
+      (loggedIn ? "" : " opacity-50 cursor-default pointer-events-none");
+    const btnHandler = loggedIn ? ' onclick="copyReferralLink(event)"' : "";
+    const inputId = type === "recent" ? "referral-link-recent" : "referral-link";
+    advert.innerHTML =
+      '<p class="mb-2 text-center text-white">Earn <span class="text-[#30D5C8]">£5 credit</span> when someone buys with your link.</p>' +
+      '<div class="space-y-1 w-full max-w-xs">' +
+      `<label for="${inputId}" class="block text-sm">Your referral link:</label>` +
+      '<div class="flex">' +
+      `<input id="${inputId}" aria-label="Referral link" class="referral-link ${inputClass}" placeholder="Log in to get your link" readonly />` +
+      `<button aria-label="Copy referral link" class="${btnClass}"${btnHandler}>Copy</button>` +
+      "</div></div>";
+    grid.appendChild(advert);
+  } else {
+    const advert = document.createElement("div");
+    advert.className =
+      "w-full min-h-32 bg-[#2A2A2E] border border-dashed border-white/40 rounded-xl flex flex-col items-center justify-center text-sm row-start-3 sm:col-start-2 md:col-start-2";
+    advert.classList.add("text-center");
+    advert.innerHTML =
+      '<p class="text-white"><span class="text-[#30D5C8]">£7 off</span> your 2nd and <span class="text-[#30D5C8]">£15 off</span> 3rd item you buy from this page.</p>' +
+      '<a href="payment.html" class="absolute bottom-4 left-1/2 font-bold text-lg py-1.5 px-4 rounded-full shadow-md transition border-2 border-black inline-block" style="background-color: #30D5C8; color: #1A1A1D; transform: translateX(-50%) scale(0.78);" onmouseover="this.style.opacity=\'0.85\'" onmouseout="this.style.opacity=\'1\'">Buy Current Basket →</a>';
     grid.appendChild(advert);
   }
   let state = window.communityState[type][key];


### PR DESCRIPTION
## Summary
- show referral-link input in recent section instead of duplicate sign-up card
- support multiple referral link inputs and button-triggered copying

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup` *(fails: command hung due to registry access issues)*
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: lockfile-diff fetch 403)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c1a3852950832da0007d96f93a02a8