### PR TITLE
fix: use color wizard image

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -301,8 +301,8 @@
                   class="w-full sm:w-1/2 h-64 object-cover rounded-xl"
                 />
                 <img
-                  src="./images/wizard-paint.png"
-                  alt="Wizard paint"
+                  src="./images/wizardcolour.png"
+                  alt="Wizard colour"
                   loading="lazy"
                   class="w-full sm:w-1/2 h-64 object-cover rounded-xl"
                 />


### PR DESCRIPTION
## Summary
- switch community page wizard image to `wizardcolour.png`

## Testing
- `npm run format` (fails: 403 Forbidden - GET https://registry.npmjs.org/npm)
- `npm test`
- `npm run ci` (fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)
- `npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_68c1a54b4aa4832dae14e08bd878e591