### PR TITLE
fix: update wizard image on community page

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -301,8 +301,8 @@
                   class="w-full sm:w-1/2 h-64 object-cover rounded-xl"
                 />
                 <img
-                  src="./images/wizard-paint.png"
-                  alt="Wizard paint"
+                  src="./images/wizardcolour.png"
+                  alt="Wizard colour"
                   loading="lazy"
                   class="w-full sm:w-1/2 h-64 object-cover rounded-xl"
                 />


### PR DESCRIPTION
## Summary
- replace wizard-paint.png with wizardcolour.png on community creations page

## Testing
- `npm run setup`
- `npm run format`
- `npm test` *(fails: Missing jest; run `npm run setup` before testing)*
- `npm run ci` *(fails: Lockfile mismatch; registry access forbidden)*
- `npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68c1a54b4aa4832dae14e08bd878e591