### PR TITLE
fix: display gift two discount consistently

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -844,9 +844,7 @@ async function initPaymentPage() {
     if (!bulkMsg) return;
     const path = window.location.pathname;
     const amount = path.endsWith("minis-checkout.html") ? "£5.00" : "£7.00";
-    const qty = Math.max(1, parseInt(qtySelect?.value || "1", 10));
     const showGiftTwo =
-      qty >= 3 &&
       !path.endsWith("minis-checkout.html") &&
       !path.endsWith("luckybox-payment.html");
     bulkMsg.textContent = "";


### PR DESCRIPTION
## Summary
- always show the "gift two – save £22.00" line on the checkout page, independent of quantity

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup` *(fails: missing registry access)*
- `npm run format` (backend)
- `npx prettier js/payment.js -w`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden from npm registry)*
- `SKIP_PW_DEPS=1 npm run smoke` *(skipped: offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_68c1aeef2ecc832d87abadd7fb2d7b1a