### PR TITLE
fix: ensure model viewer readiness before enabling basket button

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1012,17 +1012,14 @@ async function init() {
 
   if (refs.addBasketBtn) {
     refs.addBasketBtn.disabled = true;
-    const viewerReadyPromise = new Promise((resolve) => {
-      if (refs.viewer?.src) return resolve();
-      if (!refs.viewer) return resolve();
-      const obs = new MutationObserver(() => {
-        if (refs.viewer.src) {
-          obs.disconnect();
-          resolve();
-        }
-      });
-      obs.observe(refs.viewer, { attributes: true, attributeFilter: ["src"] });
-    });
+    const viewerReadyPromise = customElements.whenDefined("model-viewer").then(
+      () =>
+        new Promise((resolve) => {
+          if (!refs.viewer) return resolve();
+          if (refs.viewer.modelIsVisible) return resolve();
+          refs.viewer.addEventListener("load", resolve, { once: true });
+        }),
+    );
 
     viewerReadyPromise.then(() => {
       refs.addBasketBtn.disabled = false;


### PR DESCRIPTION
## Summary
- use `customElements.whenDefined('model-viewer')` and load event to await viewer readiness
- enable add-to-basket button once model viewer is loaded

## Testing
- `npm run validate-env` *(fails: 403 Forbidden - GET https://registry.npmjs.org/npm)*
- `npm run setup` *(fails: 403 Forbidden - GET https://registry.npmjs.org/npm)*
- `npx prettier -w js/index.js`
- `npm run format` (backend)
- `npm test` (backend)
- `npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `npm run smoke` *(offline mode: skipping smoke)*
- `npm test` *(fails: Cannot find module 'wait-on')*


------
https://chatgpt.com/codex/tasks/task_e_68c1bd2f178c832d95591cae5d84690f