### PR TITLE
fix: expand luckybox genre panel

### DIFF
--- a/addons.html
+++ b/addons.html
@@ -83,6 +83,7 @@
         display: flex;
         align-items: center;
         gap: 14px;
+        flex-wrap: wrap;
         padding: 14px;
         border: 1px solid #2a2f36;
         border-radius: 14px;
@@ -134,6 +135,8 @@
         overflow: hidden;
         max-height: 0;
         opacity: 0;
+        flex-basis: 100%;
+        width: 100%;
         transition: max-height 180ms ease-out, opacity 180ms ease-out,
           padding 180ms ease-out;
       }


### PR DESCRIPTION
## Summary
- allow luckybox option card to wrap its content so the genre field can appear
- ensure the genre panel spans the full width when Luckybox B is selected

## Testing
- `npm run validate-env`
- `prettier addons.html -w --log-level debug`
- `npm test --prefix backend`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c1aff741d4832da669c08b1315329f