### PR TITLE
fix: allow missing astronaut url

### DIFF
--- a/scripts/fetch-assets.cjs
+++ b/scripts/fetch-assets.cjs
@@ -57,8 +57,11 @@ async function fetchAstronaut() {
   const url = process.env.ASTRONAUT_GLB_URL;
 
   if (!url) {
-    await unlink(dest).catch(() => {});
-    throw new Error("ASTRONAUT_GLB_URL not set");
+    console.warn("ASTRONAUT_GLB_URL not set; creating placeholder file");
+    await ensureDir(dest);
+    await writeFile(dest, "");
+    lastAstronautUrl = undefined;
+    return dest;
   }
 
   try {


### PR DESCRIPTION
## Summary
- allow fetch-assets to create placeholder when ASTRONAUT_GLB_URL is missing

## Testing
- `npm run validate-env`
- `npm run format`
- `npm test` (fails: Missing jest; run `npm run setup` before testing.)
- `npm run ci` (fails: 403 Forbidden from registry)


------
https://chatgpt.com/codex/tasks/task_e_68c1c9552c18832d9aa058372cd56774