### PR TITLE
test: update banner rotation expectation

### DIFF
--- a/tests/frontend/discount-delivery-banner.k1m2n3b4v5c6x7z8.test.js
+++ b/tests/frontend/discount-delivery-banner.k1m2n3b4v5c6x7z8.test.js
@@ -49,9 +49,8 @@ describe("Discount/delivery banner", () => {
     advance(7000);
     advance(1000);
     advance(7000);
-    expect(banner.style.opacity).toBe("0");
-    advance(1000);
     expect(banner.textContent).toBe("24% off when you order 3 prints");
+    expect(banner.style.opacity).toBe("1");
   });
 
   test("opacity resets after transition", () => {


### PR DESCRIPTION
## Summary
- adjust discount banner test to expect opacity restored after second rotation

## Testing
- `npm run format tests/frontend/discount-delivery-banner.k1m2n3b4v5c6x7z8.test.js`
- `npm --offline run format` (backend)
- `npm run test:banner` *(fails: Cannot find module 'wait-on')*
- `npm test` (backend) *(fails: Missing jest; run `npm run setup` before testing)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Lockfile mismatch detected)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d16e2a60832d98d8be906937ab3d