### PR TITLE
fix: trim whitespace when locating test files

### DIFF
--- a/scripts/__tests__/run-jest-trim-b3n5p9x2k7s1d4f6.test.ts
+++ b/scripts/__tests__/run-jest-trim-b3n5p9x2k7s1d4f6.test.ts
@@ -1,0 +1,33 @@
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const vm = require("vm");
+
+function getVerifyFiles() {
+  const src = fs.readFileSync(
+    path.join(__dirname, "..", "run-jest.js"),
+    "utf8",
+  );
+  const sandbox = {
+    module: { exports: {} },
+    require,
+    __dirname: path.join(__dirname, ".."),
+    process,
+    console,
+  };
+  vm.runInNewContext(src, sandbox);
+  return sandbox.verifyFiles;
+}
+
+test("trims whitespace from test file paths", () => {
+  const verifyFiles = getVerifyFiles();
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "rj-"));
+  const file = path.join(dir, "one.test.js");
+  fs.writeFileSync(file, "");
+  try {
+    const result = verifyFiles([`  ${file}  `]);
+    expect(result).toContain(file);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -35,7 +35,8 @@ function resolveFromPaths(mod) {
 function verifyFiles(args) {
   let checking = false;
   const normalized = new Set();
-  for (const arg of args) {
+  for (const raw of args) {
+    const arg = raw.trim();
     if (arg === "--runTestsByPath") {
       checking = true;
       normalized.add(arg);
@@ -191,25 +192,18 @@ async function run(args) {
     const env = { ...process.env };
     delete env.JEST_WORKER_ID;
     const port = 3000;
-    const server = spawn(
-      "npx",
-      ["http-server", repoRoot, "-p", String(port)],
-      { stdio: "ignore" },
-    );
+    const server = spawn("npx", ["http-server", repoRoot, "-p", String(port)], {
+      stdio: "ignore",
+    });
     try {
       await waitOn({
         resources: [`http://localhost:${port}`],
         timeout: 30000,
       });
-      const res = spawnSync(
-        "npx",
-        [
-          "playwright",
-          "test",
-          ...relPwTests,
-        ],
-        { stdio: "inherit", env },
-      );
+      const res = spawnSync("npx", ["playwright", "test", ...relPwTests], {
+        stdio: "inherit",
+        env,
+      });
       exitCode = res.status ?? 1;
     } finally {
       server.kill();


### PR DESCRIPTION
## Summary
- trim whitespace from test paths in test runner
- add regression test for trimming behavior

## Testing
- `npx prettier -w scripts/run-jest.js scripts/__tests__/run-jest-trim-b3n5p9x2k7s1d4f6.test.ts`
- `npm test -- --runTestsByPath scripts/__tests__/run-jest-trim-b3n5p9x2k7s1d4f6.test.ts` *(fails: Cannot find module 'wait-on')*


------
https://chatgpt.com/codex/tasks/task_e_68c1d1a08c74832d8a25759f4714b91e