### PR TITLE
ci: fix debug workflow test path

### DIFF
--- a/.github/workflows/debug-astronaut-download.yml
+++ b/.github/workflows/debug-astronaut-download.yml
@@ -1,6 +1,5 @@
 name: "Debugging 'incomplete response' (at the 'Run npm run build' step) when downloading astronaut .glb for tests"
 
-
 on:
   push:
     branches: [dev, "00000production"]
@@ -15,4 +14,4 @@ jobs:
       - uses: actions/setup-node@v4.0.2
         with:
           node-version: 20
-      - run: node --test tests/fetch-assets.test.x9dh37as6fk9p4b2.js
+      - run: node --test tests/fetch-assets.test.h3k9f2s8p1t6w4y5.js

--- a/tests/fetch-assets.test.h3k9f2s8p1t6w4y5.js
+++ b/tests/fetch-assets.test.h3k9f2s8p1t6w4y5.js
@@ -1,0 +1,9 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { resolve } = require("node:path");
+const fs = require("node:fs");
+
+test("fetch-assets script exists", () => {
+  const script = resolve(__dirname, "../scripts/fetch-assets.cjs");
+  assert.ok(fs.existsSync(script), "fetch-assets.cjs should exist");
+});


### PR DESCRIPTION
## Summary
- fix debug workflow to run new fetch-assets test
- add minimal test ensuring fetch-assets script exists

## Testing
- `npm run format`
- `npm test` *(fails: Cannot find module 'wait-on')*

------
https://chatgpt.com/codex/tasks/task_e_68c1d1e97178832d86e83cefb0984b1a