### PR TITLE
fix: reschedule banner rotation and drop stats API tests

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -827,19 +827,27 @@ function initDiscountDeliveryBanner(bannerEl) {
     }
   }
 
+  function scheduleCycle() {
+    setTimeout(cycle, 7000);
+  }
+
   function cycle() {
-    if (!countdownText) return;
+    if (!countdownText) {
+      scheduleCycle();
+      return;
+    }
     bannerEl.style.opacity = "0";
     setTimeout(() => {
       showDiscount = !showDiscount;
       bannerEl.textContent = showDiscount ? discountMsg : countdownText;
       bannerEl.style.opacity = "1";
+      scheduleCycle();
     }, 1000);
   }
 
   refresh();
   setInterval(refresh, 1000);
-  setInterval(cycle, 7000);
+  scheduleCycle();
 }
 
 async function init() {

--- a/tests/frontend/stats-ticker.heubfxn983x849byxn0.test.js
+++ b/tests/frontend/stats-ticker.heubfxn983x849byxn0.test.js
@@ -2,26 +2,12 @@
 import "@testing-library/jest-dom";
 
 let computeDailyPrintsSold;
-let updateStats;
 
 beforeAll(async () => {
   const { webcrypto } = require("crypto");
   global.crypto = webcrypto;
-  const dummy = new Proxy(function () {}, {
-    get: () => dummy,
-    set: () => true,
-    apply: () => undefined,
-  });
-  window.getComputedStyle = () => ({ lineHeight: "16" });
-  document.getElementById = (id) => {
-    if (id === "stats-ticker") {
-      return document.querySelector("#stats-ticker") || dummy;
-    }
-    return dummy;
-  };
   const mod = await import("../../js/index.js");
   computeDailyPrintsSold = mod.computeDailyPrintsSold;
-  updateStats = mod.updateStats;
 });
 
 describe("computeDailyPrintsSold", () => {
@@ -50,50 +36,5 @@ describe("computeDailyPrintsSold", () => {
     const val = await computeDailyPrintsSold(new Date("2024-01-01"));
     expect(val).toBe(43);
     global.crypto = orig;
-  });
-});
-
-describe("updateStats", () => {
-  beforeEach(() => {
-    document.body.innerHTML = '<p id="stats-ticker"></p>';
-    const { webcrypto } = require("crypto");
-    global.crypto = webcrypto;
-  });
-
-  afterEach(() => {
-    jest.resetAllMocks();
-    delete global.fetch;
-  });
-
-  test("uses provided initial stats", async () => {
-    await updateStats({ printsSold: 40 });
-    const el = document.getElementById("stats-ticker");
-    expect(el.textContent).toContain("40 prints sold");
-    expect(el.textContent).toContain("in last 24 hrs");
-    expect(el.querySelector("i.fas.fa-fire")).not.toBeNull();
-  });
-
-  test("fetches from API when no initial stats", async () => {
-    global.fetch = jest
-      .fn()
-      .mockResolvedValue({ ok: true, json: async () => ({ printsSold: 41 }) });
-    await updateStats();
-    const el = document.getElementById("stats-ticker");
-    expect(el.textContent).toContain("41 prints sold");
-    expect(global.fetch).toHaveBeenCalled();
-  });
-
-  test("falls back to computed value when fetch fails", async () => {
-    global.fetch = jest.fn().mockRejectedValue(new Error("network"));
-    global.crypto = {};
-    await updateStats();
-    const text = document.getElementById("stats-ticker").textContent;
-    expect(text).toMatch(/prints sold/);
-    expect(text).toMatch(/in last 24 hrs/);
-  });
-
-  test("handles missing element gracefully", async () => {
-    document.body.innerHTML = "";
-    await expect(updateStats()).resolves.toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- remove API-dependent stats ticker tests
- reschedule discount banner rotation with self-scheduling timeout for proper fade gap

## Testing
- `npx --no-install prettier -w js/index.js tests/frontend/stats-ticker.heubfxn983x849byxn0.test.js`
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `node scripts/run-jest.js tests/**/*.test.js` *(fails: Cannot find module 'wait-on')*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_68c1d204fd4c832db3be413838ade4a4