### PR TITLE
ci: run image pipeline tests

### DIFF
--- a/scripts/test-image-pipeline.js
+++ b/scripts/test-image-pipeline.js
@@ -22,7 +22,7 @@ try {
   execSync("npm ls aws-sdk-client-mock --silent", { stdio: "pipe" });
 } catch {
   console.warn(
-    "aws-sdk-client-mock may be extraneous or mismatched; run npm install"
+    "aws-sdk-client-mock may be extraneous or mismatched; run npm install",
   );
 }
 
@@ -52,5 +52,5 @@ if (networkOk) {
   }
 }
 
-// Force tests to run even when offline
-run("CI_FORCE=1 node scripts/run-jest.js --testPathPattern tests/assets");
+// Force tests to run even when offline using a real test directory
+run("CI_FORCE=1 node scripts/run-jest.js tests/frontend");


### PR DESCRIPTION
## Summary
- use existing frontend tests when running image pipeline

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup` *(fails: await step never completed)*
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: lockfile mismatch)*
- `SKIP_PW_DEPS=1 npm run smoke`
- `node scripts/run-jest.js tests/frontend` *(fails: Cannot find module 'wait-on')*

------
https://chatgpt.com/codex/tasks/task_e_68c1d24bf6d8832dbcccca6efdee7e38