### PR TITLE
fix: reuse server in Playwright tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,7 +7,8 @@ export default defineConfig({
   webServer: {
     command: "npx http-server . -p 3000",
     port: 3000,
-    reuseExistingServer: !process.env.CI,
+    // Always reuse an existing server to avoid port-in-use errors during CI runs
+    reuseExistingServer: true,
   },
   use: {
     browserName: "chromium",


### PR DESCRIPTION
## Summary
- always reuse existing server in Playwright config to avoid port conflicts

## Testing
- `npm run format`
- `npm test`
- `npm run smoke` *(offline mode: skipping smoke)*
- `npx playwright test tests/e2e/model-loading.hf.spec.ts tests/e2e/model-fallbacks.spec.ts tests/e2e/a11y-model.spec.ts --pass-with-no-tests` *(fails: npm error 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d28891f4832d80c40fd0ae5c79c8