### PR TITLE
test: wait for discount banner fade

### DIFF
--- a/tests/frontend/discount-delivery-banner.k1m2n3b4v5c6x7z8.test.js
+++ b/tests/frontend/discount-delivery-banner.k1m2n3b4v5c6x7z8.test.js
@@ -49,6 +49,7 @@ describe("Discount/delivery banner", () => {
     advance(7000);
     advance(1000);
     advance(7000);
+    advance(1000);
     expect(banner.textContent).toBe("24% off when you order 3 prints");
     expect(banner.style.opacity).toBe("1");
   });


### PR DESCRIPTION
## Summary
- allow discount banner test to wait for fade transition completion

## Testing
- `npm run validate-env`
- `npm run format` (backend)
- `npm test` (backend)
- `node scripts/run-jest.js tests/frontend/discount-delivery-banner.k1m2n3b4v5c6x7z8.test.js` *(fails: Cannot find module 'wait-on')*


------
https://chatgpt.com/codex/tasks/task_e_68c1f1f4bfe0832d825c6db30b288816