### PR TITLE
fix: expose model fallback test id

### DIFF
--- a/src/js/loadModel.js
+++ b/src/js/loadModel.js
@@ -21,6 +21,7 @@ export async function loadModel(url, containerId, key = "default") {
   } catch (err) {
     console.error("Three.js failed to load", err);
     container.textContent = "model not available";
+    container.setAttribute("data-testid", "model-fallback");
     return;
   }
 
@@ -48,7 +49,7 @@ export async function loadModel(url, containerId, key = "default") {
         url,
         (gltf) => {
           scene.add(gltf.scene);
-            resolve();
+          resolve();
         },
         undefined,
         reject,
@@ -57,6 +58,7 @@ export async function loadModel(url, containerId, key = "default") {
   } catch (err) {
     console.error("GLTF load failed", err);
     container.textContent = "model not available";
+    container.setAttribute("data-testid", "model-fallback");
     return;
   }
 

--- a/tests/e2e/model-fallbacks.spec.ts
+++ b/tests/e2e/model-fallbacks.spec.ts
@@ -3,8 +3,8 @@ import { test, expect } from "@playwright/test";
 test("index: missing model shows fallback UI", async ({ page }) => {
   await page.route(/\.glb(\?|$)/i, (r) => r.abort()); // simulate failure
   await page.goto("/index.html");
-  const fallback = page.locator(
-    '[data-testid="model-fallback"], text=/model not available/i',
-  );
+  const fallback = page
+    .getByTestId("model-fallback")
+    .or(page.getByText(/model not available/i));
   await expect(fallback).toBeVisible();
 });


### PR DESCRIPTION
## Summary
- tag model fallback container with a data-testid so tests can identify fallback UI
- use Playwright's text selector API for the model fallback test

## Testing
- `npm run format` (backend)
- `npm test` (backend)
- `npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `npm run smoke` *(offline mode: skipping smoke)*
- `npm test` *(fails: Cannot find module 'wait-on')*


------
https://chatgpt.com/codex/tasks/task_e_68c1f245e498832d9bee685a52b44896