### PR TITLE
fix: add aria label to model viewer

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,6 +132,8 @@
             auto-rotate
             loading="eager"
             alt="3D astronaut"
+            role="img"
+            aria-label="3D astronaut"
             style="width: 100%; height: 100%; display: block"
           ></model-viewer>
 


### PR DESCRIPTION
## Summary
- ensure the `<model-viewer>` on the landing page exposes an accessible name by adding `role="img"` and `aria-label`

## Testing
- `npx prettier -w index.html`
- `npm run format` (backend)
- `npm test` (backend)
- `npm test` *(fails: Cannot find module 'wait-on')*
- `npm run ci` *(fails: lockfile-diff 403)*
- `npm run smoke` *(skipped: offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f26308b0832d9f174b1dac9ad281