### PR TITLE
ci: update image pipeline test path

### DIFF
--- a/.github/workflows/image-pipeline.yml
+++ b/.github/workflows/image-pipeline.yml
@@ -19,4 +19,4 @@ jobs:
       - name: install
         run: npm ci
       - name: run image pipeline tests
-        run: node scripts/run-jest.js tests/assets
+        run: node scripts/run-jest.js tests/fetch-assets.test.h3k9f2s8p1t6w4y5.js


### PR DESCRIPTION
## Summary
- adjust image pipeline workflow to target fetch-assets test

## Testing
- `npm test` (backend)
- `node scripts/run-jest.js tests/fetch-assets.test.h3k9f2s8p1t6w4y5.js` *(fails: Cannot find module 'wait-on')*
- `node --test tests/fetch-assets.test.h3k9f2s8p1t6w4y5.js`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*


------
https://chatgpt.com/codex/tasks/task_e_68c1f27a5a3c832d8770a1968c33398e