### PR TITLE
fix: validate path arguments in run-jest

### DIFF
--- a/scripts/__tests__/run-jest-missing-dir-m9t4p6k7w2s8d1h5.test.ts
+++ b/scripts/__tests__/run-jest-missing-dir-m9t4p6k7w2s8d1h5.test.ts
@@ -1,0 +1,16 @@
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+const script = path.join(__dirname, "..", "run-jest.js");
+const env = { ...process.env, SKIP_ROOT_DEPS_CHECK: "1" };
+
+test("fails on nonexistent directory", () => {
+  const missing = "definitely-missing-dir";
+  const result = spawnSync(process.execPath, [script, missing], {
+    encoding: "utf8",
+    env,
+  });
+  expect(result.status).toBe(1);
+  const output = result.stdout + result.stderr;
+  expect(output).toContain(`Directory or file not found: ${missing}`);
+});

--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -42,6 +42,10 @@ function verifyFiles(args) {
       normalized.add(arg);
       continue;
     }
+    if (arg.startsWith("-")) {
+      normalized.add(arg);
+      continue;
+    }
     const candidates = [
       path.resolve(process.cwd(), arg),
       path.resolve(repoRoot, arg),
@@ -64,11 +68,12 @@ function verifyFiles(args) {
       }
       continue;
     }
-    if (isTestArg) {
-      console.error(`Test file not found: ${arg}`);
-      process.exit(1);
-    }
-    normalized.add(arg);
+    console.error(
+      isTestArg
+        ? `Test file not found: ${arg}`
+        : `Directory or file not found: ${arg}`,
+    );
+    process.exit(1);
   }
   return Array.from(normalized);
 }


### PR DESCRIPTION
## Summary
- fail fast when run-jest receives a non-existent path and show `Directory or file not found`
- add test covering missing directory behavior

## Testing
- `npx prettier -w scripts/run-jest.js scripts/__tests__/run-jest-missing-dir-m9t4p6k7w2s8d1h5.test.ts`
- `npm run format --prefix backend`
- `npm test` *(fails: Cannot find module 'wait-on')*
- `npm test --prefix backend` *(fails: Missing jest; run `npm run setup` before testing.)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden fetching lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c1f286a93c832d999e90b204a7323a