### PR TITLE
test: update stripe webhook tests

### DIFF
--- a/backend/tests/stripe/webhook.event-types.spec.ts
+++ b/backend/tests/stripe/webhook.event-types.spec.ts
@@ -1,20 +1,27 @@
 import request from "supertest";
 import express from "express";
-import router, { orders } from "../../src/routes/checkout";
 import { sign } from "./helpers/stripe-signing";
 
-jest.mock("../../mail.js", () => ({ sendMail: jest.fn() }));
-const mockMail = require("../../mail.js").sendMail as jest.Mock;
+jest.mock("../../src/db", () => ({ query: jest.fn() }));
+jest.mock("../../src/queue/printQueue", () => ({ enqueuePrint: jest.fn() }));
+jest.mock("../../src/queue/dbPrintQueue", () => ({ enqueuePrint: jest.fn() }));
+
+process.env.STRIPE_KEY = "sk_test_valid";
+process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
+
+const router = require("../../src/routes/stripe/webhook").default;
+const db = require("../../src/db");
+const { enqueuePrint } = require("../../src/queue/printQueue");
+const {
+  enqueuePrint: enqueueDbPrint,
+} = require("../../src/queue/dbPrintQueue");
 
 const app = express();
 app.use(router);
 
 describe("webhook event types", () => {
   beforeEach(() => {
-    orders.clear();
-    mockMail.mockClear();
-    process.env.STRIPE_SECRET_KEY = "sk_test_valid";
-    process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
+    jest.clearAllMocks();
   });
 
   test("unhandled event acknowledged without side effects", async () => {
@@ -25,37 +32,51 @@ describe("webhook event types", () => {
     });
     const { header } = sign(payload, process.env.STRIPE_WEBHOOK_SECRET!);
     const res = await request(app)
-      .post("/stripe/webhook")
+      .post("/api/webhook/stripe")
       .set("stripe-signature", header)
       .set("Content-Type", "application/json")
       .send(payload);
     expect(res.status).toBe(200);
-    expect(mockMail).not.toHaveBeenCalled();
+    expect(db.query).not.toHaveBeenCalled();
+    expect(enqueueDbPrint).not.toHaveBeenCalled();
+    expect(enqueuePrint).not.toHaveBeenCalled();
   });
 
-  test("payment_intent.succeeded with valid signature returns 200", async () => {
+  test("checkout.session.completed with valid signature updates db and queues", async () => {
     const payload = JSON.stringify({
       id: "evt2",
-      type: "payment_intent.succeeded",
-      data: { object: { id: "pi" } },
+      type: "checkout.session.completed",
+      data: { object: { id: "sess1", metadata: { jobId: "job1" } } },
     });
     const { header } = sign(payload, process.env.STRIPE_WEBHOOK_SECRET!);
     const res = await request(app)
-      .post("/stripe/webhook")
+      .post("/api/webhook/stripe")
       .set("stripe-signature", header)
       .set("Content-Type", "application/json")
       .send(payload);
     expect(res.status).toBe(200);
+    expect(db.query).toHaveBeenCalledWith(
+      "UPDATE orders SET status=$1 WHERE session_id=$2",
+      ["paid", "sess1"],
+    );
+    expect(enqueueDbPrint).toHaveBeenCalledWith(
+      "job1",
+      "sess1",
+      {},
+      null,
+      null,
+    );
+    expect(enqueuePrint).toHaveBeenCalledWith("job1");
   });
 
-  test("malformed payload with matching signature returns 500", async () => {
+  test("malformed payload with matching signature returns 400", async () => {
     const payload = '{"id":"evt3"';
     const { header } = sign(payload, process.env.STRIPE_WEBHOOK_SECRET!);
     const res = await request(app)
-      .post("/stripe/webhook")
+      .post("/api/webhook/stripe")
       .set("stripe-signature", header)
       .set("Content-Type", "application/json")
       .send(payload);
-    expect(res.status).toBe(500);
+    expect(res.status).toBe(400);
   });
 });

--- a/backend/tests/stripe/webhook.idempotency.spec.ts
+++ b/backend/tests/stripe/webhook.idempotency.spec.ts
@@ -1,82 +1,91 @@
 import request from "supertest";
 import express from "express";
-import router, { orders } from "../../src/routes/checkout";
 import { sign } from "./helpers/stripe-signing";
 
-jest.mock("../../mail.js", () => ({ sendMail: jest.fn() }));
-const mockMail = require("../../mail.js").sendMail as jest.Mock;
+jest.mock("../../src/db", () => ({ query: jest.fn() }));
+jest.mock("../../src/queue/printQueue", () => ({ enqueuePrint: jest.fn() }));
+jest.mock("../../src/queue/dbPrintQueue", () => ({ enqueuePrint: jest.fn() }));
+
+process.env.STRIPE_KEY = "sk_test_valid";
+process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
+
+const router = require("../../src/routes/stripe/webhook").default;
+const db = require("../../src/db");
+const { enqueuePrint } = require("../../src/queue/printQueue");
+const {
+  enqueuePrint: enqueueDbPrint,
+} = require("../../src/queue/dbPrintQueue");
 
 const app = express();
 app.use(router);
 
 describe("webhook idempotency", () => {
   beforeEach(() => {
-    orders.clear();
-    mockMail.mockClear();
-    process.env.STRIPE_SECRET_KEY = "sk_test_valid";
-    process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
+    jest.clearAllMocks();
   });
 
-  const makePayload = (id: string, session: string) =>
+  const makePayload = (id: string, session: string, job = "job") =>
     JSON.stringify({
       id,
       type: "checkout.session.completed",
-      data: { object: { id: session } },
+      data: { object: { id: session, metadata: { jobId: job } } },
     });
 
   test("same event delivered twice processed once", async () => {
-    orders.set("sess1", { slug: "a", email: "a@b.com", paid: false });
-    const payload = makePayload("evt1", "sess1");
+    const payload = makePayload("evt1", "sess1", "job1");
     const { header } = sign(payload, process.env.STRIPE_WEBHOOK_SECRET!);
     await request(app)
-      .post("/stripe/webhook")
+      .post("/api/webhook/stripe")
       .set("stripe-signature", header)
       .set("Content-Type", "application/json")
       .send(payload);
     await request(app)
-      .post("/stripe/webhook")
+      .post("/api/webhook/stripe")
       .set("stripe-signature", header)
       .set("Content-Type", "application/json")
       .send(payload);
-    expect(mockMail.mock.calls.length).toBe(1);
+    expect(db.query).toHaveBeenCalledTimes(1);
+    expect(enqueueDbPrint).toHaveBeenCalledTimes(1);
+    expect(enqueuePrint).toHaveBeenCalledTimes(1);
   });
 
   test("out-of-order duplicate ignored", async () => {
-    orders.set("sess2", { slug: "b", email: "b@c.com", paid: false });
-    const payload1 = makePayload("evt2", "sess2");
+    const payload1 = makePayload("evt2", "sess2", "job2");
     const { header: h1 } = sign(payload1, process.env.STRIPE_WEBHOOK_SECRET!);
     await request(app)
-      .post("/stripe/webhook")
+      .post("/api/webhook/stripe")
       .set("stripe-signature", h1)
       .set("Content-Type", "application/json")
       .send(payload1);
-    const payload2 = makePayload("evt1", "sess2");
+    const payload2 = makePayload("evt1", "sess2", "job2");
     const { header: h2 } = sign(payload2, process.env.STRIPE_WEBHOOK_SECRET!);
     await request(app)
-      .post("/stripe/webhook")
+      .post("/api/webhook/stripe")
       .set("stripe-signature", h2)
       .set("Content-Type", "application/json")
       .send(payload2);
-    expect(mockMail.mock.calls.length).toBe(1);
+    expect(db.query).toHaveBeenCalledTimes(1);
+    expect(enqueueDbPrint).toHaveBeenCalledTimes(1);
+    expect(enqueuePrint).toHaveBeenCalledTimes(1);
   });
 
   test("different events processed each once", async () => {
-    orders.set("sess3", { slug: "c", email: "c@d.com", paid: false });
-    orders.set("sess4", { slug: "d", email: "d@e.com", paid: false });
-    const p1 = makePayload("evt3", "sess3");
-    const p2 = makePayload("evt4", "sess4");
+    const p1 = makePayload("evt3", "sess3", "job3");
+    const p2 = makePayload("evt4", "sess4", "job4");
     const { header: h1 } = sign(p1, process.env.STRIPE_WEBHOOK_SECRET!);
     const { header: h2 } = sign(p2, process.env.STRIPE_WEBHOOK_SECRET!);
     await request(app)
-      .post("/stripe/webhook")
+      .post("/api/webhook/stripe")
       .set("stripe-signature", h1)
       .set("Content-Type", "application/json")
       .send(p1);
     await request(app)
-      .post("/stripe/webhook")
+      .post("/api/webhook/stripe")
       .set("stripe-signature", h2)
       .set("Content-Type", "application/json")
       .send(p2);
-    expect(mockMail.mock.calls.length).toBe(2);
+    expect(db.query).toHaveBeenCalledTimes(2);
+    expect(enqueueDbPrint).toHaveBeenCalledTimes(2);
+    expect(enqueuePrint).toHaveBeenCalledTimes(2);
   });
 });

--- a/backend/tests/stripe/webhook.invalid-signature.spec.ts
+++ b/backend/tests/stripe/webhook.invalid-signature.spec.ts
@@ -1,20 +1,27 @@
 import request from "supertest";
 import express from "express";
-import router, { orders } from "../../src/routes/checkout";
 import { sign } from "./helpers/stripe-signing";
 
-jest.mock("../../mail.js", () => ({
-  sendMail: jest.fn(),
-}));
+jest.mock("../../src/db", () => ({ query: jest.fn() }));
+jest.mock("../../src/queue/printQueue", () => ({ enqueuePrint: jest.fn() }));
+jest.mock("../../src/queue/dbPrintQueue", () => ({ enqueuePrint: jest.fn() }));
+
+process.env.STRIPE_KEY = "sk_test_valid";
+process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
+
+const router = require("../../src/routes/stripe/webhook").default;
+const db = require("../../src/db");
+const { enqueuePrint } = require("../../src/queue/printQueue");
+const {
+  enqueuePrint: enqueueDbPrint,
+} = require("../../src/queue/dbPrintQueue");
 
 const app = express();
 app.use(router);
 
 describe("webhook invalid signature", () => {
   beforeEach(() => {
-    orders.clear();
-    process.env.STRIPE_SECRET_KEY = "sk_test_valid";
-    process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
+    jest.clearAllMocks();
   });
 
   const payload = JSON.stringify({
@@ -23,21 +30,27 @@ describe("webhook invalid signature", () => {
     data: { object: { id: "sess_1" } },
   });
 
-  test("missing signature header returns 500", async () => {
+  test("missing signature header returns 400", async () => {
     const res = await request(app)
-      .post("/stripe/webhook")
+      .post("/api/webhook/stripe")
       .set("Content-Type", "application/json")
       .send(payload);
-    expect(res.status).toBe(500);
+    expect(res.status).toBe(400);
+    expect(db.query).not.toHaveBeenCalled();
+    expect(enqueueDbPrint).not.toHaveBeenCalled();
+    expect(enqueuePrint).not.toHaveBeenCalled();
   });
 
-  test("wrong secret signature returns 500", async () => {
+  test("wrong secret signature returns 400", async () => {
     const { header } = sign(payload, "wrong");
     const res = await request(app)
-      .post("/stripe/webhook")
+      .post("/api/webhook/stripe")
       .set("stripe-signature", header)
       .set("Content-Type", "application/json")
       .send(payload);
-    expect(res.status).toBe(500);
+    expect(res.status).toBe(400);
+    expect(db.query).not.toHaveBeenCalled();
+    expect(enqueueDbPrint).not.toHaveBeenCalled();
+    expect(enqueuePrint).not.toHaveBeenCalled();
   });
 });

--- a/backend/tests/stripe/webhook.logging.spec.ts
+++ b/backend/tests/stripe/webhook.logging.spec.ts
@@ -1,42 +1,47 @@
 import request from "supertest";
 import express from "express";
-import router, { orders } from "../../src/routes/checkout";
 import { sign } from "./helpers/stripe-signing";
 
-let currentEvent: any;
-jest.mock("../../mail.js", () => ({ sendMail: jest.fn() }));
-const mockMail = require("../../mail.js").sendMail as jest.Mock;
-mockMail.mockImplementation(async () => {
-  console.log(currentEvent.id, currentEvent.type);
-});
+jest.mock("../../src/db", () => ({ query: jest.fn() }));
+jest.mock("../../src/queue/printQueue", () => ({ enqueuePrint: jest.fn() }));
+jest.mock("../../src/queue/dbPrintQueue", () => ({ enqueuePrint: jest.fn() }));
+jest.mock("../../src/logger", () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+process.env.STRIPE_KEY = "sk_test_valid";
+process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
+
+const router = require("../../src/routes/stripe/webhook").default;
+const logger = require("../../src/logger");
 
 const app = express();
 app.use(router);
 
 describe("webhook logging", () => {
   beforeEach(() => {
-    orders.clear();
-    mockMail.mockClear();
-    process.env.STRIPE_SECRET_KEY = "sk_test_valid";
-    process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
+    jest.clearAllMocks();
   });
 
-  test("logs include event id and type", async () => {
-    currentEvent = {
+  test("logs include event type and session id", async () => {
+    const payload = JSON.stringify({
       id: "evt1",
       type: "checkout.session.completed",
-      data: { object: { id: "sess1" } },
-    };
-    orders.set("sess1", { slug: "a", email: "a@b.com", paid: false });
-    const payload = JSON.stringify(currentEvent);
+      data: { object: { id: "sess1", metadata: { jobId: "job1" } } },
+    });
     const { header } = sign(payload, process.env.STRIPE_WEBHOOK_SECRET!);
-    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
     await request(app)
-      .post("/stripe/webhook")
+      .post("/api/webhook/stripe")
       .set("stripe-signature", header)
       .set("Content-Type", "application/json")
       .send(payload);
-    expect(logSpy).toHaveBeenCalledWith("evt1", "checkout.session.completed");
-    logSpy.mockRestore();
+    expect(logger.info).toHaveBeenCalledWith("stripe_webhook_received", {
+      type: "checkout.session.completed",
+    });
+    expect(logger.info).toHaveBeenCalledWith("order_paid", {
+      sessionId: "sess1",
+    });
   });
 });

--- a/backend/tests/stripe/webhook.performance.spec.ts
+++ b/backend/tests/stripe/webhook.performance.spec.ts
@@ -1,34 +1,35 @@
 import request from "supertest";
 import express from "express";
-import router, { orders } from "../../src/routes/checkout";
 import { sign } from "./helpers/stripe-signing";
 
-jest.mock("../../mail.js", () => ({
-  sendMail: jest.fn().mockResolvedValue(undefined),
-}));
+jest.mock("../../src/db", () => ({ query: jest.fn() }));
+jest.mock("../../src/queue/printQueue", () => ({ enqueuePrint: jest.fn() }));
+jest.mock("../../src/queue/dbPrintQueue", () => ({ enqueuePrint: jest.fn() }));
+
+process.env.STRIPE_KEY = "sk_test_valid";
+process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
+
+const router = require("../../src/routes/stripe/webhook").default;
 
 const app = express();
 app.use(router);
 
 describe("webhook performance", () => {
   beforeEach(() => {
-    orders.clear();
-    process.env.STRIPE_SECRET_KEY = "sk_test_valid";
-    process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
+    jest.clearAllMocks();
   });
 
   test("valid event completes under budget", async () => {
     const budget = Number(process.env.STRIPE_TEST_BUDGET_MS || "500");
-    orders.set("sess1", { slug: "a", email: "a@b.com", paid: false });
     const payload = JSON.stringify({
       id: "evt1",
       type: "checkout.session.completed",
-      data: { object: { id: "sess1" } },
+      data: { object: { id: "sess1", metadata: { jobId: "job1" } } },
     });
     const { header } = sign(payload, process.env.STRIPE_WEBHOOK_SECRET!);
     const start = Date.now();
     const res = await request(app)
-      .post("/stripe/webhook")
+      .post("/api/webhook/stripe")
       .set("stripe-signature", header)
       .set("Content-Type", "application/json")
       .send(payload);

--- a/backend/tests/stripe/webhook.signature.spec.ts
+++ b/backend/tests/stripe/webhook.signature.spec.ts
@@ -1,9 +1,11 @@
 const request = require("supertest");
+process.env.STRIPE_KEY = "sk_test_valid";
+process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
 const app = require("../../src/app");
 
 test("unsigned webhook returns 400", async () => {
   await request(app)
-    .post("/stripe/webhook")
+    .post("/api/webhook/stripe")
     .set("Content-Type", "application/json")
     .send("{}")
     .expect(400);

--- a/backend/tests/stripe/webhook.valid-signature.spec.ts
+++ b/backend/tests/stripe/webhook.valid-signature.spec.ts
@@ -1,52 +1,68 @@
 import request from "supertest";
 import express from "express";
-import router, { orders } from "../../src/routes/checkout";
 import { sign } from "./helpers/stripe-signing";
 
-jest.mock("../../mail.js", () => ({
-  sendMail: jest.fn().mockResolvedValue(undefined),
-}));
+jest.mock("../../src/db", () => ({ query: jest.fn() }));
+jest.mock("../../src/queue/printQueue", () => ({ enqueuePrint: jest.fn() }));
+jest.mock("../../src/queue/dbPrintQueue", () => ({ enqueuePrint: jest.fn() }));
+
+process.env.STRIPE_KEY = "sk_test_valid";
+process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
+
+const router = require("../../src/routes/stripe/webhook").default;
+const db = require("../../src/db");
+const { enqueuePrint } = require("../../src/queue/printQueue");
+const {
+  enqueuePrint: enqueueDbPrint,
+} = require("../../src/queue/dbPrintQueue");
 
 const app = express();
 app.use(router);
 
 describe("webhook valid signature", () => {
   beforeEach(() => {
-    orders.clear();
-    process.env.STRIPE_SECRET_KEY = "sk_test_valid";
-    process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
+    jest.clearAllMocks();
   });
 
   test("valid checkout.session.completed returns 200", async () => {
-    orders.set("sess_1", { slug: "x", email: "a@b.com", paid: false });
     const payload = JSON.stringify({
       id: "evt_1",
       type: "checkout.session.completed",
-      data: { object: { id: "sess_1" } },
+      data: { object: { id: "sess_1", metadata: { jobId: "job1" } } },
     });
     const { header } = sign(payload, process.env.STRIPE_WEBHOOK_SECRET!);
     const res = await request(app)
-      .post("/stripe/webhook")
+      .post("/api/webhook/stripe")
       .set("stripe-signature", header)
       .set("Content-Type", "application/json")
       .send(payload);
     expect(res.status).toBe(200);
-    expect(res.text).toBe("OK");
+    expect(res.body).toEqual({ received: true });
   });
 
-  test("handler extracts session id", async () => {
-    orders.set("sess_2", { slug: "y", email: "c@d.com", paid: false });
+  test("handler updates order and enqueues print", async () => {
     const payload = JSON.stringify({
       id: "evt_2",
       type: "checkout.session.completed",
-      data: { object: { id: "sess_2" } },
+      data: { object: { id: "sess_2", metadata: { jobId: "job2" } } },
     });
     const { header } = sign(payload, process.env.STRIPE_WEBHOOK_SECRET!);
     await request(app)
-      .post("/stripe/webhook")
+      .post("/api/webhook/stripe")
       .set("stripe-signature", header)
       .set("Content-Type", "application/json")
       .send(payload);
-    expect(orders.get("sess_2")?.paid).toBe(true);
+    expect(db.query).toHaveBeenCalledWith(
+      "UPDATE orders SET status=$1 WHERE session_id=$2",
+      ["paid", "sess_2"],
+    );
+    expect(enqueueDbPrint).toHaveBeenCalledWith(
+      "job2",
+      "sess_2",
+      {},
+      null,
+      null,
+    );
+    expect(enqueuePrint).toHaveBeenCalledWith("job2");
   });
 });


### PR DESCRIPTION
## Summary
- refactor stripe webhook tests to use new router and /api/webhook/stripe path
- assert database and print queues instead of legacy order/mail mocks

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` (failed: Lockfile mismatch / npm 403)
- `SKIP_PW_DEPS=1 npm run smoke` (offline mode: skipping smoke)


------
https://chatgpt.com/codex/tasks/task_e_68c1f297d178832d9c5185c9d7408b90