### PR TITLE
test: update checkout endpoint tests

### DIFF
--- a/backend/tests/checkout.edgecases.test.ts
+++ b/backend/tests/checkout.edgecases.test.ts
@@ -25,14 +25,16 @@ afterEach(() => {
 
 describe("checkout edge cases", () => {
   test("missing email returns 400", async () => {
-    const res = await request(app).post("/api/checkout").send({ slug: "m1" });
+    const res = await request(app)
+      .post("/api/checkout/create")
+      .send({ slug: "m1" });
     expect(res.status).toBe(400);
     expect(orders.size).toBe(0);
   });
 
   test("missing slug returns 400", async () => {
     const res = await request(app)
-      .post("/api/checkout")
+      .post("/api/checkout/create")
       .send({ email: "a@a.com" });
     expect(res.status).toBe(400);
     expect(orders.size).toBe(0);
@@ -43,7 +45,7 @@ describe("checkout edge cases", () => {
       new Error("invalid"),
     );
     const res = await request(app)
-      .post("/api/checkout")
+      .post("/api/checkout/create")
       .send({ slug: "m1", email: "a@a.com" });
     expect(res.status).toBe(500);
   });
@@ -53,7 +55,7 @@ describe("checkout edge cases", () => {
       new Error("timeout"),
     );
     const res = await request(app)
-      .post("/api/checkout")
+      .post("/api/checkout/create")
       .send({ slug: "m1", email: "a@a.com" });
     expect(res.status).toBe(500);
   });
@@ -65,7 +67,7 @@ describe("checkout edge cases", () => {
     });
     const setSpy = jest.spyOn(orders, "set");
     const res = await request(app)
-      .post("/api/checkout")
+      .post("/api/checkout/create")
       .send({ slug: "m1", email: "a@a.com" });
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ checkoutUrl: "http://ok" });

--- a/backend/tests/checkout.test.ts
+++ b/backend/tests/checkout.test.ts
@@ -28,9 +28,9 @@ afterEach(() => {
   jest.clearAllMocks();
 });
 
-test("POST /api/checkout creates session", async () => {
+test("POST /api/checkout/create creates session", async () => {
   const res = await request(app)
-    .post("/api/checkout")
+    .post("/api/checkout/create")
     .send({ slug: "m1", email: "a@a.com" });
   expect(res.status).toBe(200);
   expect(stripeMock.checkout.sessions.create).toHaveBeenCalled();
@@ -55,8 +55,10 @@ test("POST /stripe/webhook marks paid and emails", async () => {
   expect(sendMail).toHaveBeenCalled();
 });
 
-test("POST /api/checkout validates required fields", async () => {
-  const res = await request(app).post("/api/checkout").send({ slug: "m1" });
+test("POST /api/checkout/create validates required fields", async () => {
+  const res = await request(app)
+    .post("/api/checkout/create")
+    .send({ slug: "m1" });
   expect(res.status).toBe(400);
   expect(orders.size).toBe(0);
 });

--- a/backend/tests/routes.app.refactor.e2e.b7d9e2a.spec.ts
+++ b/backend/tests/routes.app.refactor.e2e.b7d9e2a.spec.ts
@@ -23,7 +23,7 @@ let app: express.Express;
 let orders: Map<string, any>;
 
 beforeAll(async () => {
-  process.env.STRIPE_SECRET_KEY = "sk_test";
+  process.env.STRIPE_TEST_KEY = "sk_test";
   process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
   process.env.FRONTEND_SUCCESS_URL = "https://example.com/success";
   process.env.FRONTEND_CANCEL_URL = "https://example.com/cancel";
@@ -45,10 +45,9 @@ const requestJson = (
   url: string,
   body?: any,
 ) => {
-  let req = (request(app) as any)[method](url).set(
-    "Content-Type",
-    "application/json",
-  );
+  let req = (request(app) as any)
+    [method](url)
+    .set("Content-Type", "application/json");
   if (body !== undefined) {
     req = req.send(body);
   }
@@ -107,7 +106,7 @@ describe("items router", () => {
     const res = await request(app)
       .post("/api/items")
       .set("Content-Type", "text/plain")
-      .send("{\"name\":\"a\",\"priceCents\":1}");
+      .send('{"name":"a","priceCents":1}');
     expect(res.status).toBeGreaterThanOrEqual(400);
     expect(res.status).toBeLessThan(500);
   });
@@ -166,13 +165,16 @@ describe("items router", () => {
 });
 
 describe("checkout router", () => {
-  test("POST /api/checkout missing fields returns 400", async () => {
-    const res = await requestJson("post", "/api/checkout", {});
+  test("POST /api/checkout/create missing fields returns 400", async () => {
+    const res = await requestJson("post", "/api/checkout/create", {});
     expect(res.status).toBe(400);
   });
 
   test("uses env success and cancel URLs", async () => {
-    mockStripeSessionCreate.mockResolvedValueOnce({ id: "cs_test_123", url: "u" });
+    mockStripeSessionCreate.mockResolvedValueOnce({
+      id: "cs_test_123",
+      url: "u",
+    });
     const prevSuccess = process.env.FRONTEND_SUCCESS_URL;
     const prevCancel = process.env.FRONTEND_CANCEL_URL;
     process.env.FRONTEND_SUCCESS_URL = "https://env/success";
@@ -191,7 +193,10 @@ describe("checkout router", () => {
   });
 
   test("returns session id", async () => {
-    mockStripeSessionCreate.mockResolvedValueOnce({ id: "cs_test_456", url: "u" });
+    mockStripeSessionCreate.mockResolvedValueOnce({
+      id: "cs_test_456",
+      url: "u",
+    });
     const res = await requestJson("post", "/api/checkout/create", {
       items: [{ price: "p1", quantity: 1 }],
     });
@@ -234,7 +239,11 @@ describe("stripe webhook router", () => {
   });
 
   test("checkout.session.completed triggers side effects", async () => {
-    orders.set("sess123", { slug: "model", email: "user@example.com", paid: false });
+    orders.set("sess123", {
+      slug: "model",
+      email: "user@example.com",
+      paid: false,
+    });
     mockStripeConstructEvent.mockReturnValueOnce({
       type: "checkout.session.completed",
       data: { object: { id: "sess123" } },

--- a/backend/tests/stripe.paymentIntent.create.spec.ts
+++ b/backend/tests/stripe.paymentIntent.create.spec.ts
@@ -1,4 +1,4 @@
-process.env.STRIPE_SECRET_KEY = "sk_test";
+process.env.STRIPE_TEST_KEY = "sk_test";
 
 jest.mock("../db", () => ({ query: jest.fn() }));
 const db = require("../db");

--- a/backend/tests/stripe/checkout.session.errors.spec.ts
+++ b/backend/tests/stripe/checkout.session.errors.spec.ts
@@ -6,10 +6,15 @@ const mockStripe = jest.fn().mockImplementation(() => ({
   checkout: { sessions: { create: mockCreate } },
 }));
 jest.mock("stripe", () => mockStripe);
-jest.mock("../../src/db.js", () => ({ query: jest.fn().mockResolvedValue({ rows: [] }) }), { virtual: true });
+jest.mock(
+  "../../src/db.js",
+  () => ({ query: jest.fn().mockResolvedValue({ rows: [] }) }),
+  { virtual: true },
+);
 
 const buildApp = () => {
-  const router = require("../../src/routes/stripe/create-checkout-session").default;
+  const router =
+    require("../../src/routes/stripe/create-checkout-session").default;
   const app = express();
   app.use(express.json());
   app.use(router);
@@ -27,23 +32,21 @@ describe("create checkout session errors", () => {
     process.env.FRONTEND_CANCEL_URL = "https://example.com/cancel";
   });
 
-  test("missing STRIPE_SECRET_KEY returns 500", async () => {
-    delete process.env.STRIPE_SECRET_KEY;
-    delete process.env.STRIPE_KEY;
+  test("missing STRIPE_TEST_KEY returns 500", async () => {
+    delete process.env.STRIPE_TEST_KEY;
     mockCreate.mockImplementation(() => {
-      throw new Error("STRIPE_SECRET_KEY missing");
+      throw new Error("STRIPE_TEST_KEY missing");
     });
     const app = buildApp();
     const res = await request(app)
-      .post("/api/create-checkout-session")
+      .post("/api/checkout/create")
       .send({ price: 100 });
     expect(res.status).toBe(500);
-    expect(res.body.error).toMatch(/STRIPE_SECRET_KEY missing/);
+    expect(res.body.error).toMatch(/STRIPE_TEST_KEY missing/);
   });
 
   test("Stripe SDK throws surfaces 500 and log", async () => {
-    process.env.STRIPE_SECRET_KEY = "sk_test";
-    process.env.STRIPE_KEY = "sk_test";
+    process.env.STRIPE_TEST_KEY = "sk_test";
     const error = new Error("boom");
     mockCreate.mockImplementation(() => {
       throw error;
@@ -51,7 +54,7 @@ describe("create checkout session errors", () => {
     const app = buildApp();
     const spy = jest.spyOn(console, "error").mockImplementation(() => {});
     const res = await request(app)
-      .post("/api/create-checkout-session")
+      .post("/api/checkout/create")
       .send({ price: 100 });
     expect(res.status).toBe(500);
     expect(spy).toHaveBeenCalled();

--- a/backend/tests/stripe/checkout.session.success.spec.ts
+++ b/backend/tests/stripe/checkout.session.success.spec.ts
@@ -1,16 +1,23 @@
 import request from "supertest";
 import express from "express";
 
-const mockCreate = jest.fn().mockResolvedValue({ id: "sess_123", url: "https://pay" });
+const mockCreate = jest
+  .fn()
+  .mockResolvedValue({ id: "sess_123", url: "https://pay" });
 jest.mock("stripe", () => {
   return jest.fn().mockImplementation(() => ({
     checkout: { sessions: { create: mockCreate } },
   }));
 });
-jest.mock("../../src/db.js", () => ({ query: jest.fn().mockResolvedValue({ rows: [] }) }), { virtual: true });
+jest.mock(
+  "../../src/db.js",
+  () => ({ query: jest.fn().mockResolvedValue({ rows: [] }) }),
+  { virtual: true },
+);
 
 const buildApp = () => {
-  const router = require("../../src/routes/stripe/create-checkout-session").default;
+  const router =
+    require("../../src/routes/stripe/create-checkout-session").default;
   const app = express();
   app.use(express.json());
   app.use(router);
@@ -24,7 +31,7 @@ const buildApp = () => {
 describe("create checkout session success", () => {
   beforeEach(() => {
     mockCreate.mockClear();
-    process.env.STRIPE_KEY = "sk_test";
+    process.env.STRIPE_TEST_KEY = "sk_test";
     process.env.FRONTEND_SUCCESS_URL = "https://example.com/success";
     process.env.FRONTEND_CANCEL_URL = "https://example.com/cancel";
   });
@@ -32,7 +39,7 @@ describe("create checkout session success", () => {
   test("returns id and uses env URLs", async () => {
     const app = buildApp();
     const res = await request(app)
-      .post("/api/create-checkout-session")
+      .post("/api/checkout/create")
       .send({ price: 100 });
     expect(res.status).toBe(200);
     expect(res.body).toHaveProperty("id", "sess_123");


### PR DESCRIPTION
## Summary
- switch checkout-related tests to `POST /api/checkout/create`
- use `STRIPE_TEST_KEY` in test setups instead of old secret keys

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npx prettier --write tests/checkout.test.ts tests/checkout.edgecases.test.ts tests/routes.app.refactor.e2e.b7d9e2a.spec.ts tests/stripe.paymentIntent.create.spec.ts tests/stripe/checkout.session.errors.spec.ts tests/stripe/checkout.session.success.spec.ts`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` (fails: lockfile mismatch / registry access 403)
- `SKIP_PW_DEPS=1 npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_68c1f2a1c99c832dbf1863e7b5843445