### PR TITLE
test: stub DB and queue in webhook tests

### DIFF
--- a/backend/tests/stripe/webhook.idempotency.spec.ts
+++ b/backend/tests/stripe/webhook.idempotency.spec.ts
@@ -1,82 +1,106 @@
+process.env.STRIPE_KEY = "sk_test_valid";
+process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
+
+jest.mock("../../src/db", () => ({ query: jest.fn() }));
+jest.mock("../../src/queue/dbPrintQueue", () => ({ enqueuePrint: jest.fn() }));
+jest.mock("../../src/queue/printQueue", () => ({ enqueuePrint: jest.fn() }));
+jest.mock("../../src/logger", () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
 import request from "supertest";
 import express from "express";
-import router, { orders } from "../../src/routes/checkout";
+import router from "../../src/routes/stripe/webhook";
 import { sign } from "./helpers/stripe-signing";
 
-jest.mock("../../mail.js", () => ({ sendMail: jest.fn() }));
-const mockMail = require("../../mail.js").sendMail as jest.Mock;
+const db = require("../../src/db");
+const { enqueuePrint: enqueueDbPrint } = require("../../src/queue/dbPrintQueue");
+const { enqueuePrint } = require("../../src/queue/printQueue");
+const logger = require("../../src/logger");
 
 const app = express();
 app.use(router);
 
 describe("webhook idempotency", () => {
   beforeEach(() => {
-    orders.clear();
-    mockMail.mockClear();
-    process.env.STRIPE_SECRET_KEY = "sk_test_valid";
-    process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
+    jest.clearAllMocks();
   });
 
   const makePayload = (id: string, session: string) =>
     JSON.stringify({
       id,
       type: "checkout.session.completed",
-      data: { object: { id: session } },
+      data: {
+        object: { id: session, metadata: { jobId: `job-${session}` } },
+      },
     });
 
   test("same event delivered twice processed once", async () => {
-    orders.set("sess1", { slug: "a", email: "a@b.com", paid: false });
     const payload = makePayload("evt1", "sess1");
     const { header } = sign(payload, process.env.STRIPE_WEBHOOK_SECRET!);
     await request(app)
-      .post("/stripe/webhook")
+      .post("/api/webhook/stripe")
       .set("stripe-signature", header)
       .set("Content-Type", "application/json")
       .send(payload);
     await request(app)
-      .post("/stripe/webhook")
+      .post("/api/webhook/stripe")
       .set("stripe-signature", header)
       .set("Content-Type", "application/json")
       .send(payload);
-    expect(mockMail.mock.calls.length).toBe(1);
+    expect(db.query).toHaveBeenCalledTimes(1);
+    expect(enqueueDbPrint).toHaveBeenCalledTimes(1);
+    expect(enqueuePrint).toHaveBeenCalledTimes(1);
+    const orderPaidLogs = logger.info.mock.calls.filter(
+      ([msg]: any[]) => msg === "order_paid",
+    );
+    expect(orderPaidLogs.length).toBe(1);
   });
 
   test("out-of-order duplicate ignored", async () => {
-    orders.set("sess2", { slug: "b", email: "b@c.com", paid: false });
     const payload1 = makePayload("evt2", "sess2");
     const { header: h1 } = sign(payload1, process.env.STRIPE_WEBHOOK_SECRET!);
     await request(app)
-      .post("/stripe/webhook")
+      .post("/api/webhook/stripe")
       .set("stripe-signature", h1)
       .set("Content-Type", "application/json")
       .send(payload1);
     const payload2 = makePayload("evt1", "sess2");
     const { header: h2 } = sign(payload2, process.env.STRIPE_WEBHOOK_SECRET!);
     await request(app)
-      .post("/stripe/webhook")
+      .post("/api/webhook/stripe")
       .set("stripe-signature", h2)
       .set("Content-Type", "application/json")
       .send(payload2);
-    expect(mockMail.mock.calls.length).toBe(1);
+    expect(db.query).toHaveBeenCalledTimes(1);
+    const orderPaidLogs = logger.info.mock.calls.filter(
+      ([msg]: any[]) => msg === "order_paid",
+    );
+    expect(orderPaidLogs.length).toBe(1);
   });
 
   test("different events processed each once", async () => {
-    orders.set("sess3", { slug: "c", email: "c@d.com", paid: false });
-    orders.set("sess4", { slug: "d", email: "d@e.com", paid: false });
     const p1 = makePayload("evt3", "sess3");
     const p2 = makePayload("evt4", "sess4");
     const { header: h1 } = sign(p1, process.env.STRIPE_WEBHOOK_SECRET!);
     const { header: h2 } = sign(p2, process.env.STRIPE_WEBHOOK_SECRET!);
     await request(app)
-      .post("/stripe/webhook")
+      .post("/api/webhook/stripe")
       .set("stripe-signature", h1)
       .set("Content-Type", "application/json")
       .send(p1);
     await request(app)
-      .post("/stripe/webhook")
+      .post("/api/webhook/stripe")
       .set("stripe-signature", h2)
       .set("Content-Type", "application/json")
       .send(p2);
-    expect(mockMail.mock.calls.length).toBe(2);
+    expect(db.query).toHaveBeenCalledTimes(2);
+    const orderPaidLogs = logger.info.mock.calls.filter(
+      ([msg]: any[]) => msg === "order_paid",
+    );
+    expect(orderPaidLogs.length).toBe(2);
   });
 });
+

--- a/backend/tests/stripe/webhook.logging.spec.ts
+++ b/backend/tests/stripe/webhook.logging.spec.ts
@@ -1,42 +1,53 @@
-import request from "supertest";
-import express from "express";
-import router, { orders } from "../../src/routes/checkout";
-import { sign } from "./helpers/stripe-signing";
+process.env.STRIPE_KEY = "sk_test_valid";
+process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
 
 let currentEvent: any;
-jest.mock("../../mail.js", () => ({ sendMail: jest.fn() }));
-const mockMail = require("../../mail.js").sendMail as jest.Mock;
-mockMail.mockImplementation(async () => {
-  console.log(currentEvent.id, currentEvent.type);
-});
+
+jest.mock("../../src/db", () => ({ query: jest.fn() }));
+jest.mock("../../src/queue/dbPrintQueue", () => ({
+  enqueuePrint: jest.fn(async () => {
+    console.log(currentEvent.id, currentEvent.type);
+  }),
+}));
+jest.mock("../../src/queue/printQueue", () => ({ enqueuePrint: jest.fn() }));
+jest.mock("../../src/logger", () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+}));
+
+import request from "supertest";
+import express from "express";
+import router from "../../src/routes/stripe/webhook";
+import { sign } from "./helpers/stripe-signing";
+
+const db = require("../../src/db");
 
 const app = express();
 app.use(router);
 
 describe("webhook logging", () => {
   beforeEach(() => {
-    orders.clear();
-    mockMail.mockClear();
-    process.env.STRIPE_SECRET_KEY = "sk_test_valid";
-    process.env.STRIPE_WEBHOOK_SECRET = "whsec_test";
+    jest.clearAllMocks();
   });
 
   test("logs include event id and type", async () => {
     currentEvent = {
       id: "evt1",
       type: "checkout.session.completed",
-      data: { object: { id: "sess1" } },
+      data: { object: { id: "sess1", metadata: { jobId: "job-sess1" } } },
     };
-    orders.set("sess1", { slug: "a", email: "a@b.com", paid: false });
     const payload = JSON.stringify(currentEvent);
     const { header } = sign(payload, process.env.STRIPE_WEBHOOK_SECRET!);
     const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
     await request(app)
-      .post("/stripe/webhook")
+      .post("/api/webhook/stripe")
       .set("stripe-signature", header)
       .set("Content-Type", "application/json")
       .send(payload);
+    expect(db.query).toHaveBeenCalledTimes(1);
     expect(logSpy).toHaveBeenCalledWith("evt1", "checkout.session.completed");
     logSpy.mockRestore();
   });
 });
+


### PR DESCRIPTION
## Summary
- replace in-memory order/mail mocks with DB and queue stubs in Stripe webhook tests
- assert idempotent processing and logging of Stripe events without duplication

## Testing
- `npm run format` *(fails: 403 Forbidden - GET https://registry.npmjs.org/npm)*
- `npm test`
- `npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/npm)*
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c1f2b155dc832d9225eebd3670118d