### PR TITLE
fix: unify stripe secret env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,18 +69,18 @@ Set the following environment variables so the build can download model assets:
 
    Set `DB_URL` to point at your server before continuing.
 
-- `STRIPE_TEST_KEY` – test secret key for Stripe.
-- `STRIPE_LIVE_KEY` – live secret key for Stripe.
-- `STRIPE_PUBLISHABLE_KEY` – publishable key for Stripe.js on the frontend.
-- `STRIPE_WEBHOOK_SECRET` – signing secret for Stripe webhooks.
-- `HUNYUAN_API_KEY` – key for the Sparc3D API.
-- `HF_TOKEN` – Hugging Face access token used by scripts like `setup_space.sh`.
-- `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` – credentials for S3 uploads.
+ - `STRIPE_SECRET_KEY` – secret key for Stripe.
+ - `STRIPE_PUBLISHABLE_KEY` – publishable key for Stripe.js on the frontend.
+ - `STRIPE_WEBHOOK_SECRET` – signing secret for Stripe webhooks.
+ - `HUNYUAN_API_KEY` – key for the Sparc3D API.
+ - `HF_TOKEN` – Hugging Face access token used by scripts like `setup_space.sh`.
+ - `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` – credentials for S3 uploads.
 
-The server uses `STRIPE_LIVE_KEY` when `NODE_ENV=production`; otherwise `STRIPE_TEST_KEY` is used.
+ Set `STRIPE_SECRET_KEY` to your Stripe secret key. Use a test key for development
+ and a live key in production.
 
-- If `STRIPE_TEST_KEY` isn't set, `npm run setup` generates a temporary dummy key
-  so local installs don't fail.
+ - If `STRIPE_SECRET_KEY` isn't set, `npm run setup` generates a temporary dummy key
+   so local installs don't fail.
 - The repository uses `mise` for toolchain management. The included `.mise.toml` enables
   automatic Node version detection via `.nvmrc`. If you don't have `mise` installed,
   run `bash scripts/install-mise.sh` before continuing. After cloning, run `mise trust`

--- a/backend/__tests__/runSmokeWarn.test.js
+++ b/backend/__tests__/runSmokeWarn.test.js
@@ -8,13 +8,13 @@ test("does not warn when env vars are missing", () => {
   console.warn = (msg) => warnings.push(msg);
 
   jest.isolateModules(() => {
-    const originalStripe = process.env.STRIPE_TEST_KEY;
+    const originalStripe = process.env.STRIPE_SECRET_KEY;
     const originalDomain = process.env.CLOUDFRONT_MODEL_DOMAIN;
-    delete process.env.STRIPE_TEST_KEY;
+    delete process.env.STRIPE_SECRET_KEY;
     delete process.env.CLOUDFRONT_MODEL_DOMAIN;
     require("../../scripts/run-smoke.js");
     if (originalStripe !== undefined)
-      process.env.STRIPE_TEST_KEY = originalStripe;
+      process.env.STRIPE_SECRET_KEY = originalStripe;
     if (originalDomain !== undefined)
       process.env.CLOUDFRONT_MODEL_DOMAIN = originalDomain;
   });

--- a/backend/src/__tests__/app.test.js
+++ b/backend/src/__tests__/app.test.js
@@ -1,6 +1,6 @@
 process.env.DB_URL = "postgres://user:pass@localhost/db";
 process.env.CLOUDFRONT_DOMAIN = "cloud.test";
-process.env.STRIPE_TEST_KEY = "sk_test_dummy";
+process.env.STRIPE_SECRET_KEY = "sk_test_dummy";
 
 jest.mock("pg");
 const { Pool } = require("pg");

--- a/backend/src/__tests__/models.test.js
+++ b/backend/src/__tests__/models.test.js
@@ -1,6 +1,6 @@
 process.env.DB_URL = "postgres://user:pass@localhost/db";
 process.env.CLOUDFRONT_DOMAIN = "cdn.example.com";
-process.env.STRIPE_TEST_KEY = "sk_test_dummy";
+process.env.STRIPE_SECRET_KEY = "sk_test_dummy";
 
 jest.mock("pg");
 const { Pool } = require("pg");

--- a/backend/src/routes/checkout.ts
+++ b/backend/src/routes/checkout.ts
@@ -13,8 +13,7 @@ const router = Router();
 
 router.post("/checkout/create", async (req, res) => {
   try {
-    const secretKey =
-      process.env.STRIPE_SECRET_KEY || process.env.STRIPE_TEST_KEY || "";
+      const secretKey = process.env.STRIPE_SECRET_KEY || "";
     const successUrl = process.env.FRONTEND_SUCCESS_URL;
     const cancelUrl = process.env.FRONTEND_CANCEL_URL;
 

--- a/backend/src/routes/stripe/create-checkout-session.ts
+++ b/backend/src/routes/stripe/create-checkout-session.ts
@@ -26,7 +26,7 @@ let stripeKey: string;
 let successUrl: string;
 let cancelUrl: string;
 try {
-  stripeKey = getEnvVar("STRIPE_TEST_KEY", { required: true })!;
+  stripeKey = getEnvVar("STRIPE_SECRET_KEY", { required: true })!;
   successUrl = getEnvVar("FRONTEND_SUCCESS_URL", { required: true })!;
   cancelUrl = getEnvVar("FRONTEND_CANCEL_URL", { required: true })!;
 } catch (err) {

--- a/backend/src/routes/stripe/webhook.ts
+++ b/backend/src/routes/stripe/webhook.ts
@@ -12,7 +12,7 @@ const router = Router();
 let stripeKey: string;
 let stripeWebhookSecret: string;
 try {
-  stripeKey = getEnvVar("STRIPE_KEY", { required: true })!;
+  stripeKey = getEnvVar("STRIPE_SECRET_KEY", { required: true })!;
   stripeWebhookSecret = getEnvVar("STRIPE_WEBHOOK_SECRET", { required: true })!;
 } catch (err) {
   logger.error((err as Error).message);

--- a/backend/tests/checkout.edgecases.test.ts
+++ b/backend/tests/checkout.edgecases.test.ts
@@ -1,8 +1,7 @@
 const request = require("supertest");
 const Stripe = require("stripe");
 
-process.env.STRIPE_TEST_KEY = "sk_test";
-process.env.STRIPE_LIVE_KEY = "sk_live";
+process.env.STRIPE_SECRET_KEY = "sk_test";
 process.env.STRIPE_WEBHOOK_SECRET = "whsec";
 
 jest.mock("stripe");

--- a/backend/tests/checkout.env.test.js
+++ b/backend/tests/checkout.env.test.js
@@ -1,27 +1,22 @@
 jest.mock("stripe");
 
 describe("checkout env validation", () => {
-  const originalTestKey = process.env.STRIPE_TEST_KEY;
-  const originalLiveKey = process.env.STRIPE_LIVE_KEY;
+  const originalTestKey = process.env.STRIPE_SECRET_KEY;
   beforeEach(() => {
     jest.resetModules();
     jest.clearAllMocks();
   });
   afterEach(() => {
-    process.env.STRIPE_TEST_KEY = originalTestKey;
-    process.env.STRIPE_LIVE_KEY = originalLiveKey;
+    process.env.STRIPE_SECRET_KEY = originalTestKey;
   });
   test("module loads with default key when env missing", () => {
-    delete process.env.STRIPE_TEST_KEY;
-    delete process.env.STRIPE_LIVE_KEY;
+    delete process.env.STRIPE_SECRET_KEY;
     expect(() => {
       jest.isolateModules(() => require("../src/routes/checkout"));
     }).not.toThrow();
   });
   test("does not throw when all stripe keys are missing", () => {
     const secret = process.env.STRIPE_SECRET_KEY;
-    delete process.env.STRIPE_TEST_KEY;
-    delete process.env.STRIPE_LIVE_KEY;
     delete process.env.STRIPE_SECRET_KEY;
     expect(() => {
       jest.isolateModules(() => require("../src/routes/checkout"));
@@ -29,7 +24,7 @@ describe("checkout env validation", () => {
     process.env.STRIPE_SECRET_KEY = secret;
   });
   test("router exposes orders map", () => {
-    process.env.STRIPE_TEST_KEY = "sk_test";
+    process.env.STRIPE_SECRET_KEY = "sk_test";
     jest.isolateModules(() => {
       const module = require("../src/routes/checkout");
       expect(module.default.orders).toBe(module.orders);

--- a/backend/tests/checkout.shared.test.ts
+++ b/backend/tests/checkout.shared.test.ts
@@ -1,15 +1,13 @@
 const { expect, test } = require("@jest/globals");
 
 beforeEach(() => {
-  process.env.STRIPE_TEST_KEY = "sk_test";
-  process.env.STRIPE_LIVE_KEY = "sk_live";
+  process.env.STRIPE_SECRET_KEY = "sk_test";
   process.env.STRIPE_WEBHOOK_SECRET = "whsec";
   jest.resetModules();
 });
 
 afterEach(() => {
-  delete process.env.STRIPE_TEST_KEY;
-  delete process.env.STRIPE_LIVE_KEY;
+  delete process.env.STRIPE_SECRET_KEY;
   delete process.env.STRIPE_WEBHOOK_SECRET;
 });
 

--- a/backend/tests/checkout.test.ts
+++ b/backend/tests/checkout.test.ts
@@ -1,5 +1,4 @@
-process.env.STRIPE_TEST_KEY = "sk_test";
-process.env.STRIPE_LIVE_KEY = "sk_live";
+process.env.STRIPE_SECRET_KEY = "sk_test";
 process.env.STRIPE_WEBHOOK_SECRET = "whsec";
 
 jest.mock("../mail", () => ({ sendMail: jest.fn() }));

--- a/backend/tests/envValidation.test.js
+++ b/backend/tests/envValidation.test.js
@@ -18,22 +18,9 @@ describe("validate-env script", () => {
     npm_config_https_proxy: "",
   };
 
-  test("passes with STRIPE_TEST_KEY set", () => {
+  test("passes with STRIPE_SECRET_KEY set", () => {
     const { status } = spawnSync("bash", [script], {
-      env: { ...process.env, ...baseEnv, STRIPE_TEST_KEY: "sk_test" },
-      stdio: "pipe",
-    });
-    expect(status).toBe(0);
-  });
-
-  test("passes with STRIPE_LIVE_KEY set", () => {
-    const { status } = spawnSync("bash", [script], {
-      env: {
-        ...process.env,
-        ...baseEnv,
-        STRIPE_LIVE_KEY: "sk_live",
-        STRIPE_TEST_KEY: "",
-      },
+      env: { ...process.env, ...baseEnv, STRIPE_SECRET_KEY: "sk_test" },
       stdio: "pipe",
     });
     expect(status).toBe(0);
@@ -44,8 +31,7 @@ describe("validate-env script", () => {
       env: {
         ...process.env,
         ...baseEnv,
-        STRIPE_TEST_KEY: "",
-        STRIPE_LIVE_KEY: "",
+        STRIPE_SECRET_KEY: "",
       },
       stdio: "pipe",
     });
@@ -57,7 +43,7 @@ describe("validate-env script", () => {
       env: {
         ...process.env,
         ...baseEnv,
-        STRIPE_TEST_KEY: "sk_test",
+        STRIPE_SECRET_KEY: "sk_test",
         npm_config_http_proxy: "http://proxy",
       },
       stdio: "pipe",

--- a/backend/tests/routes/models.spec.ts
+++ b/backend/tests/routes/models.spec.ts
@@ -1,6 +1,6 @@
 process.env.DB_URL = "postgres://user:pass@localhost/db";
 process.env.CLOUDFRONT_DOMAIN = "cdn.example.com";
-process.env.STRIPE_TEST_KEY = "sk_test_dummy";
+process.env.STRIPE_SECRET_KEY = "sk_test_dummy";
 
 import request from "supertest";
 import type { Express } from "express";

--- a/backend/tests/setupGlobals.js
+++ b/backend/tests/setupGlobals.js
@@ -84,8 +84,8 @@ const stripeKey =
   process.env.STRIPE_SECRET_KEY || mockSecrets.STRIPE_SECRET_KEY;
 const webhook =
   process.env.STRIPE_WEBHOOK_SECRET || mockSecrets.STRIPE_WEBHOOK_SECRET;
-if (!process.env.STRIPE_TEST_KEY) {
-  process.env.STRIPE_TEST_KEY = stripeKey;
+if (!process.env.STRIPE_SECRET_KEY) {
+  process.env.STRIPE_SECRET_KEY = stripeKey;
 }
 if (!process.env.STRIPE_PUBLISHABLE_KEY) {
   process.env.STRIPE_PUBLISHABLE_KEY = "pk_live";

--- a/backend/tests/stripe/checkout.session.errors.spec.ts
+++ b/backend/tests/stripe/checkout.session.errors.spec.ts
@@ -29,7 +29,6 @@ describe("create checkout session errors", () => {
 
   test("missing STRIPE_SECRET_KEY returns 500", async () => {
     delete process.env.STRIPE_SECRET_KEY;
-    delete process.env.STRIPE_KEY;
     mockCreate.mockImplementation(() => {
       throw new Error("STRIPE_SECRET_KEY missing");
     });
@@ -43,7 +42,6 @@ describe("create checkout session errors", () => {
 
   test("Stripe SDK throws surfaces 500 and log", async () => {
     process.env.STRIPE_SECRET_KEY = "sk_test";
-    process.env.STRIPE_KEY = "sk_test";
     const error = new Error("boom");
     mockCreate.mockImplementation(() => {
       throw error;

--- a/backend/tests/stripe/checkout.session.spec.ts
+++ b/backend/tests/stripe/checkout.session.spec.ts
@@ -9,7 +9,7 @@ describe("POST /api/checkout/create", () => {
   beforeEach(() => {
     process.env.FRONTEND_SUCCESS_URL = "https://success";
     process.env.FRONTEND_CANCEL_URL = "https://cancel";
-    process.env.STRIPE_TEST_KEY = "sk_test_X";
+    process.env.STRIPE_SECRET_KEY = "sk_test_X";
     (Stripe as any).__mocks.createMock.mockClear();
     (db.query as jest.Mock).mockClear();
   });

--- a/backend/tests/stripe/checkout.session.success.spec.ts
+++ b/backend/tests/stripe/checkout.session.success.spec.ts
@@ -24,7 +24,7 @@ const buildApp = () => {
 describe("create checkout session success", () => {
   beforeEach(() => {
     mockCreate.mockClear();
-    process.env.STRIPE_KEY = "sk_test";
+    process.env.STRIPE_SECRET_KEY = "sk_test";
     process.env.FRONTEND_SUCCESS_URL = "https://example.com/success";
     process.env.FRONTEND_CANCEL_URL = "https://example.com/cancel";
   });

--- a/backend/tests/validateEnv.test.ts
+++ b/backend/tests/validateEnv.test.ts
@@ -38,12 +38,11 @@ function runGetHFAPIKey(env) {
 describe("validate-env script", () => {
   test("succeeds when required vars set and proxies unset", () => {
     const output = run({
-      STRIPE_TEST_KEY: "test",
+      STRIPE_SECRET_KEY: "sk_test_dummy",
       HF_TOKEN: "token",
       AWS_ACCESS_KEY_ID: "id",
       AWS_SECRET_ACCESS_KEY: "secret",
       DB_URL: "postgres://user:pass@localhost/db",
-      STRIPE_SECRET_KEY: "sk_test_dummy",
       SKIP_DB_CHECK: "1",
     });
     expect(output).toContain("environment OK");
@@ -53,7 +52,7 @@ describe("validate-env script", () => {
     expect(() =>
       run(
         {
-          STRIPE_TEST_KEY: "test",
+          STRIPE_SECRET_KEY: "test",
           HF_TOKEN: "token",
           AWS_ACCESS_KEY_ID: "id",
           AWS_SECRET_ACCESS_KEY: "secret",
@@ -66,7 +65,7 @@ describe("validate-env script", () => {
 
   test("succeeds when HF_TOKEN is missing", () => {
     const output = run({
-      STRIPE_TEST_KEY: "test",
+      STRIPE_SECRET_KEY: "test",
       HF_TOKEN: "",
       HF_API_KEY: "",
       AWS_ACCESS_KEY_ID: "id",
@@ -79,13 +78,12 @@ describe("validate-env script", () => {
 
   test("exports HF_API_KEY when absent", () => {
     const key = runGetHFAPIKey({
-      STRIPE_TEST_KEY: "test",
+      STRIPE_SECRET_KEY: "sk_test_dummy",
       HF_TOKEN: "",
       HF_API_KEY: "",
       AWS_ACCESS_KEY_ID: "id",
       AWS_SECRET_ACCESS_KEY: "secret",
       DB_URL: "postgres://user:pass@localhost/db",
-      STRIPE_SECRET_KEY: "sk_test_dummy",
       SKIP_DB_CHECK: "1",
     });
     expect(key).toMatch(/^hf_dummy_/);
@@ -93,7 +91,7 @@ describe("validate-env script", () => {
 
   test("falls back when database unreachable", () => {
     const output = run({
-      STRIPE_TEST_KEY: "test",
+      STRIPE_SECRET_KEY: "test",
       HF_TOKEN: "token",
       AWS_ACCESS_KEY_ID: "id",
       AWS_SECRET_ACCESS_KEY: "secret",

--- a/scripts/check-env.sh
+++ b/scripts/check-env.sh
@@ -46,10 +46,6 @@ for kv in \
   fi
 done
 
-if [[ -z "${STRIPE_TEST_KEY:-}" && -z "${STRIPE_LIVE_KEY:-}" ]]; then
-  echo "Using dummy STRIPE_TEST_KEY" >&2
-  export STRIPE_TEST_KEY="sk_test_dummy_$(date +%s)"
-fi
 if [[ -z "${HF_TOKEN:-}" && -z "${HF_API_KEY:-}" ]]; then
   echo "Using dummy HF_TOKEN and HF_API_KEY" >&2
   export HF_TOKEN="hf_dummy_$(date +%s)"

--- a/scripts/run-smoke.js
+++ b/scripts/run-smoke.js
@@ -50,20 +50,18 @@ function initEnv(baseEnv = process.env) {
   ensureDefault("AWS_ACCESS_KEY_ID", "dummy");
   ensureDefault("AWS_SECRET_ACCESS_KEY", "dummy");
   ensureDefault("DB_URL", "postgres://user:pass@localhost/db");
-  ensureDefault("STRIPE_SECRET_KEY", "sk_test_dummy");
-  ensureDefault("STRIPE_WEBHOOK_SECRET", `whsec_dummy_${Date.now()}`);
-  ensureDefault("STRIPE_TEST_KEY", `sk_test_dummy_${Date.now()}`);
-  ensureDefault("SKIP_DB_CHECK", "1");
-  ensureDefault("CLOUDFRONT_MODEL_DOMAIN", "cdn.test");
+    ensureDefault("STRIPE_SECRET_KEY", "sk_test_dummy");
+    ensureDefault("STRIPE_WEBHOOK_SECRET", `whsec_dummy_${Date.now()}`);
+    ensureDefault("SKIP_DB_CHECK", "1");
+    ensureDefault("CLOUDFRONT_MODEL_DOMAIN", "cdn.test");
 
-  const required = [
-    "STRIPE_TEST_KEY",
-    "CLOUDFRONT_MODEL_DOMAIN",
-    "AWS_ACCESS_KEY_ID",
-    "AWS_SECRET_ACCESS_KEY",
-    "DB_URL",
-    "STRIPE_SECRET_KEY",
-  ];
+    const required = [
+      "CLOUDFRONT_MODEL_DOMAIN",
+      "AWS_ACCESS_KEY_ID",
+      "AWS_SECRET_ACCESS_KEY",
+      "DB_URL",
+      "STRIPE_SECRET_KEY",
+    ];
   for (const key of required) {
     if (!env[key]) {
       console.warn(`Missing env var ${key}`);

--- a/scripts/validate-env.sh
+++ b/scripts/validate-env.sh
@@ -78,10 +78,6 @@ fi
 # Disable HTTP/2 for local testing to avoid client errors
 export HTTP2=false
 
-if [[ -z "${STRIPE_TEST_KEY:-}" && -z "${STRIPE_LIVE_KEY:-}" ]]; then
-  echo "Using dummy STRIPE_TEST_KEY" >&2
-  export STRIPE_TEST_KEY="sk_test_dummy_$(date +%s)"
-fi
 if [[ -z "${HF_TOKEN:-}" && -z "${HF_API_KEY:-}" ]]; then
   echo "Using dummy HF_TOKEN and HF_API_KEY" >&2
   export HF_TOKEN="hf_dummy_$(date +%s)"


### PR DESCRIPTION
## Summary
- standardize on STRIPE_SECRET_KEY for all Stripe secret usage
- update documentation and scripts for new variable name
- adjust tests to reference STRIPE_SECRET_KEY

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_68c1f2bdf65c832dbfaa2da112af9c59