### PR TITLE
fix: enforce minimum checkout quantity

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -1188,6 +1188,12 @@ async function initPaymentPage() {
     } catch {}
   }
 
+  // Ensure a minimum quantity of 2 when arriving on the payment page
+  if (checkoutItems.length === 1 && checkoutItems[0].qty === 1) {
+    checkoutItems[0].qty = 2;
+    saveCheckoutItems();
+  }
+
   if (!checkoutItems.length) {
     if (viewer && viewer.tagName.toLowerCase() !== "img") {
       viewer.addEventListener("load", applyStoredColorIfNeeded, { once: true });


### PR DESCRIPTION
## Summary
- increase single-item checkout quantity to 2 when landing on payment page

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` (fails: Lockfile mismatch detected. Run 'npm install' to regenerate package-lock.json.)
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c1f3035274832db6a02534e067ad7a