### PR TITLE
fix: schedule discount banner rotation correctly

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -841,8 +841,8 @@ function initDiscountDeliveryBanner(bannerEl) {
       showDiscount = !showDiscount;
       bannerEl.textContent = showDiscount ? discountMsg : countdownText;
       bannerEl.style.opacity = "1";
-      scheduleCycle();
     }, 1000);
+    scheduleCycle();
   }
 
   refresh();


### PR DESCRIPTION
## Summary
- ensure discount banner scheduling isn't delayed by the fade transition so it rotates back to the discount message on time

## Testing
- `npm run validate-env`
- `npx prettier -w js/index.js tests/frontend/discount-delivery-banner.k1m2n3b4v5c6x7z8.test.js`
- `npm run test:banner` *(fails: Cannot find module 'wait-on')*


------
https://chatgpt.com/codex/tasks/task_e_68c1f17784d8832da9d195ab6a4995dd