### PR TITLE
fix: restore basket button on payment page

### DIFF
--- a/payment.html
+++ b/payment.html
@@ -277,6 +277,7 @@
     </div>
 
     <script type="module" src="js/wizard.js" defer></script>
+    <script type="module" src="js/basket.js"></script>
     <script type="module" src="js/payment.js" defer></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- restore bottom-right basket button on payment page by loading basket.js

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` (backend)
- `npm test` (backend)
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c1ffd8d7b8832db5f2a81b14f3a409