### PR TITLE
fix: unblock basket button when viewer load missing

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1037,7 +1037,9 @@ async function init() {
         new Promise((resolve) => {
           if (!refs.viewer) return resolve();
           if (refs.viewer.modelIsVisible) return resolve();
-          refs.viewer.addEventListener("load", resolve, { once: true });
+          const onLoad = () => resolve();
+          refs.viewer.addEventListener("load", onLoad, { once: true });
+          setTimeout(onLoad, 100);
         }),
     );
 

--- a/tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js
+++ b/tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js
@@ -133,15 +133,18 @@ test("index add-basket button adds to basket", async () => {
     '<button id="add-basket-button"></button>' +
     '<img id="preview-img" src="http://example.com/s.png" />' +
     '<div id="glb-viewer"></div>';
-  const viewer = document.getElementById("glb-viewer");
-  viewer.src = "model.glb";
-  viewer.modelIsVisible = true;
   global.fetch = jest
     .fn()
     .mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
   const { webcrypto } = require("crypto");
   global.crypto = webcrypto;
+  window.customElements.whenDefined = () => Promise.resolve();
   await import("../../js/index.js");
+  await window.initIndexPage();
+  const viewer = document.getElementById("glb-viewer");
+  viewer.src = "model.glb";
+  viewer.modelIsVisible = true;
+  viewer.dispatchEvent(new Event("load"));
   document.getElementById("add-basket-button").click();
   expect(getBasket()).toHaveLength(1);
 });


### PR DESCRIPTION
## Summary
- ensure add-basket button enables if model viewer load never fires
- trigger model viewer load in basket pipeline test

## Testing
- `npx prettier -w js/index.js tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js`
- `npm test` in `backend/`
- `node scripts/run-jest.js tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js tests/frontend/discount-delivery-banner.k1m2n3b4v5c6x7z8.test.js tests/frontend/stats-ticker.heubfxn983x849byxn0.test.js` *(fails: Cannot find module 'wait-on')*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c2a7089cf8832d97f0f53be8656806