### PR TITLE
fix: throw on missing stripe env vars

### DIFF
--- a/backend/src/routes/stripe/create-checkout-session.ts
+++ b/backend/src/routes/stripe/create-checkout-session.ts
@@ -31,7 +31,7 @@ try {
   cancelUrl = getEnvVar("FRONTEND_CANCEL_URL", { required: true })!;
 } catch (err) {
   logger.error((err as Error).message);
-  process.exit(1);
+  throw err;
 }
 
 const realStripe = new Stripe(stripeKey, {

--- a/backend/tests/stripe/create-checkout-session.missing-env.test.p8r7s6t5u4v3w2x1.ts
+++ b/backend/tests/stripe/create-checkout-session.missing-env.test.p8r7s6t5u4v3w2x1.ts
@@ -1,0 +1,23 @@
+const modulePath = "../../src/routes/stripe/create-checkout-session";
+
+const envKeys = [
+  "STRIPE_TEST_KEY",
+  "FRONTEND_SUCCESS_URL",
+  "FRONTEND_CANCEL_URL",
+];
+
+const originalEnv = { ...process.env };
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+  jest.resetModules();
+});
+
+describe("create-checkout-session env requirements", () => {
+  test("throws when required env vars are missing", () => {
+    for (const key of envKeys) {
+      delete process.env[key];
+    }
+    expect(() => require(modulePath)).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- avoid exiting process when stripe env vars are missing
- add unit test for missing stripe env vars

## Testing
- `npm run format`
- `npm test tests/stripe/create-checkout-session.missing-env.test.p8r7s6t5u4v3w2x1.ts`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Lockfile mismatch detected. Run 'npm install' to regenerate package-lock.json.)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c2a77f2bac832d9ab0abfd7d62bcc4