### PR TITLE
fix: widen prompt UI elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,7 +156,7 @@
       </div>
 
       <!-- PROMPT / UPLOAD AREA (unchanged UI) -->
-      <section id="prompt-section" class="w-full max-w-xl">
+      <section id="prompt-section" class="w-full max-w-2xl">
         <div class="flex flex-col items-center text-center">
           <img src="images/box%20logo.png" alt="print2 cube" class="w-32 h-auto mb-4" />
           <h1 class="text-2xl font-semibold mb-4">Design &amp; Print in 30&nbsp;Seconds. 3-day delivery. :)))))<h1>
@@ -165,7 +165,7 @@
             <div id="prompt-wrapper" class="flex-1 bg-[#2A2A2E] border border-white/10 rounded-3xl px-5 py-2 flex items-center">
               <textarea id="promptInput" rows="1" maxlength="200" placeholder="Describe with text/image, we'll build it" aria-label="Prompt" class="prompt-textarea w-full bg-transparent resize-none text-lg placeholder-gray-500 focus:outline-none"></textarea>
             </div>
-            <button id="submit-button" aria-label="Generate model" class="flex items-center justify-center gap-2 bg-white rounded-full px-4 py-2 transition-shape">
+            <button id="submit-button" aria-label="Generate model" class="flex items-center justify-center gap-2 bg-white rounded-full px-6 py-2 transition-shape">
               <span class="text-[#1A1A1D] font-semibold">Generate model</span>
               <i id="submit-icon" class="fas fa-arrow-up text-xl text-[#1A1A1D]"></i>
             </button>


### PR DESCRIPTION
## Summary
- widen prompt section max width to match previous layout
- expand generate button padding for a broader appearance

## Testing
- `npm run format`
- `npm test` *(fails: Cannot find module '../queue/printQueue')*
- `npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `npm run smoke` *(skipped: offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_68c2b5de2c84832daabf357d2cac2f26