### PR TITLE
test: broaden basket pipeline coverage

### DIFF
--- a/tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js
+++ b/tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js
@@ -148,3 +148,224 @@ test("index add-basket button adds to basket", async () => {
   document.getElementById("add-basket-button").click();
   expect(getBasket()).toHaveLength(1);
 });
+
+test("addToBasket skips server call without token", () => {
+  addToBasket({ modelUrl: "m", jobId: "j" });
+  expect(global.fetch).not.toHaveBeenCalled();
+});
+
+test("addToBasket posts to server when token and jobId", () => {
+  localStorage.setItem("token", "t");
+  addToBasket({ modelUrl: "m", jobId: "j1" });
+  expect(global.fetch).toHaveBeenCalledWith(
+    expect.stringMatching(/\/api\/cart\/items$/),
+    expect.objectContaining({
+      method: "POST",
+      body: JSON.stringify({ jobId: "j1", quantity: 1 }),
+    }),
+  );
+});
+
+test("addToBasket stores serverId from response", async () => {
+  localStorage.setItem("token", "t");
+  global.fetch.mockResolvedValueOnce({
+    json: () => Promise.resolve({ id: 9 }),
+  });
+  addToBasket({ modelUrl: "m", jobId: "j2" });
+  await Promise.resolve();
+  expect(getBasket()[0].serverId).toBe(9);
+});
+
+test("addToBasket handles fetch rejection", () => {
+  localStorage.setItem("token", "t");
+  global.fetch.mockRejectedValueOnce(new Error("fail"));
+  expect(() => addToBasket({ modelUrl: "m", jobId: "j3" })).not.toThrow();
+});
+
+test("addAutoItem updates badge count", () => {
+  const badge = document.getElementById("basket-count");
+  addAutoItem({ modelUrl: "a" });
+  expect(badge).toHaveTextContent("1");
+});
+
+test("addAutoItem dispatches event", () => {
+  const spy = jest.fn();
+  window.addEventListener("basket-change", spy);
+  addAutoItem({ modelUrl: "a" });
+  expect(spy).toHaveBeenCalled();
+});
+
+test("manualizeItem no-op when predicate fails", () => {
+  addAutoItem({ modelUrl: "a" });
+  manualizeItem(() => false);
+  expect(getBasket()[0].auto).toBe(true);
+});
+
+test("removeFromBasket dispatches basket-change", () => {
+  const spy = jest.fn();
+  window.addEventListener("basket-change", spy);
+  addToBasket({ modelUrl: "a" });
+  removeFromBasket(0);
+  expect(spy).toHaveBeenCalled();
+});
+
+test("removeFromBasket calls server when token and serverId", () => {
+  localStorage.setItem("token", "t");
+  addToBasket({ modelUrl: "a" });
+  getBasket()[0].serverId = 5;
+  global.fetch.mockClear();
+  removeFromBasket(0);
+  expect(global.fetch).toHaveBeenCalledWith(
+    expect.stringMatching(/\/api\/cart\/items\/5$/),
+    expect.objectContaining({ method: "DELETE" }),
+  );
+});
+
+test("removeFromBasket trims checkout items", () => {
+  addToBasket({ modelUrl: "a" });
+  localStorage.setItem(
+    "print2CheckoutItems",
+    JSON.stringify([{ id: 1 }, { id: 2 }]),
+  );
+  removeFromBasket(0);
+  expect(localStorage.getItem("print2CheckoutItems")).toBe(
+    JSON.stringify([{ id: 2 }]),
+  );
+});
+
+test("clearBasket calls server delete when token", () => {
+  localStorage.setItem("token", "t");
+  clearBasket();
+  expect(global.fetch).toHaveBeenCalledWith(
+    expect.stringMatching(/\/api\/cart$/),
+    expect.objectContaining({ method: "DELETE" }),
+  );
+});
+
+test("clearBasket dispatches basket-change", () => {
+  const spy = jest.fn();
+  window.addEventListener("basket-change", spy);
+  addToBasket({ modelUrl: "a" });
+  clearBasket();
+  expect(spy).toHaveBeenCalled();
+});
+
+test("badge shows when items exist", () => {
+  const badge = document.getElementById("basket-count");
+  addToBasket({ modelUrl: "a" });
+  expect(badge.hidden).toBe(false);
+});
+
+test("renderList populates basket list", () => {
+  addToBasket({ modelUrl: "a" });
+  document.getElementById("basket-button").click();
+  const list = document.querySelectorAll("#basket-list .remove");
+  expect(list).toHaveLength(1);
+});
+
+test("renderList remove button deletes item", () => {
+  addToBasket({ modelUrl: "a" });
+  document.getElementById("basket-button").click();
+  document.querySelector("#basket-list .remove").click();
+  expect(getBasket()).toHaveLength(0);
+});
+
+test("basket button opens overlay", () => {
+  document.getElementById("basket-button").click();
+  expect(document.getElementById("basket-overlay").classList).not.toContain(
+    "hidden",
+  );
+});
+
+test("basket close button hides overlay", () => {
+  document.getElementById("basket-button").click();
+  document.getElementById("basket-close").click();
+  expect(document.getElementById("basket-overlay").classList).toContain(
+    "hidden",
+  );
+});
+
+test("startReservationTimer shows queue label", () => {
+  jest.useFakeTimers();
+  addToBasket({ modelUrl: "a" });
+  jest.runOnlyPendingTimers();
+  const label = document.getElementById("basket-reserve");
+  expect(label.hidden).toBe(false);
+  expect(label.textContent).toMatch(/Queue position: 1/);
+  jest.useRealTimers();
+});
+
+test("clicking item image opens model modal", () => {
+  addToBasket({ modelUrl: "m", snapshot: "s" });
+  document.getElementById("basket-button").click();
+  document.querySelector("#basket-list img").click();
+  expect(
+    document.getElementById("basket-model-modal").classList.contains("hidden"),
+  ).toBe(false);
+});
+
+test("model modal close hides modal", () => {
+  addToBasket({ modelUrl: "m", snapshot: "s" });
+  document.getElementById("basket-button").click();
+  document.querySelector("#basket-list img").click();
+  document.getElementById("basket-model-close").click();
+  expect(
+    document.getElementById("basket-model-modal").classList.contains("hidden"),
+  ).toBe(true);
+});
+
+test("tier toggle sets material and price", () => {
+  addToBasket({ modelUrl: "m", snapshot: "s" });
+  document.getElementById("basket-button").click();
+  document.querySelector("#basket-list img").click();
+  const goldBtn = document.querySelector(
+    '#basket-tier-toggle button[data-tier="gold"]',
+  );
+  goldBtn.click();
+  expect(localStorage.getItem("print2Material")).toBe("premium");
+  expect(document.getElementById("basket-model-checkout")).toHaveTextContent(
+    "£59.99",
+  );
+});
+
+test("checkout button saves model and job id", () => {
+  addToBasket({ modelUrl: "m", jobId: "j", snapshot: "s" });
+  document.getElementById("basket-button").click();
+  document.querySelector("#basket-list img").click();
+  const btn = document.getElementById("basket-model-checkout");
+  btn.dataset.model = "m";
+  btn.dataset.job = "j";
+  btn.click();
+  expect(localStorage.getItem("print2Model")).toBe("m");
+  expect(localStorage.getItem("print2JobId")).toBe("j");
+});
+
+test("index add-basket button disabled until viewer ready", async () => {
+  document.body.innerHTML +=
+    '<button id="add-basket-button"></button>' +
+    '<img id="preview-img" src="http://example.com/s.png" />' +
+    '<div id="glb-viewer"></div>';
+  const { webcrypto } = require("crypto");
+  global.crypto = webcrypto;
+  window.customElements.whenDefined = () => Promise.resolve();
+  await import("../../js/index.js");
+  await window.initIndexPage();
+  expect(document.getElementById("add-basket-button").disabled).toBe(true);
+});
+
+test("index viewer load enables add-basket button", async () => {
+  document.body.innerHTML +=
+    '<button id="add-basket-button"></button>' +
+    '<img id="preview-img" src="http://example.com/s.png" />' +
+    '<div id="glb-viewer"></div>';
+  const { webcrypto } = require("crypto");
+  global.crypto = webcrypto;
+  window.customElements.whenDefined = () => Promise.resolve();
+  await import("../../js/index.js");
+  await window.initIndexPage();
+  const viewer = document.getElementById("glb-viewer");
+  viewer.src = "model.glb";
+  viewer.modelIsVisible = true;
+  viewer.dispatchEvent(new Event("load"));
+  expect(document.getElementById("add-basket-button").disabled).toBe(false);
+});


### PR DESCRIPTION
## Summary
- expand basket pipeline suite with 24 additional atomic tests covering server sync, UI overlays, modal flow, and index page integration

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: Cannot find module '../queue/printQueue')*
- `node scripts/run-jest.js tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js` *(fails: Cannot find module 'wait-on')*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c2b87886ec832d94ec257a29eddc54