### PR TITLE
test: wait for basket async handler

### DIFF
--- a/tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js
+++ b/tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js
@@ -1,5 +1,6 @@
 /** @jest-environment jsdom */
 import "@testing-library/jest-dom";
+import { waitFor } from "@testing-library/dom";
 
 let getBasket;
 let addToBasket;
@@ -146,5 +147,5 @@ test("index add-basket button adds to basket", async () => {
   viewer.modelIsVisible = true;
   viewer.dispatchEvent(new Event("load"));
   document.getElementById("add-basket-button").click();
-  expect(getBasket()).toHaveLength(1);
+  await waitFor(() => expect(getBasket()).toHaveLength(1));
 });


### PR DESCRIPTION
## Summary
- ensure basket button test waits for asynchronous handler

## Testing
- `npx prettier tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js -w`
- `node scripts/run-jest.js tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js` *(fails: Cannot find module 'wait-on')*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_68c2b9e72804832d889b5b39f8a1b34d