### PR TITLE
fix: guard model snapshot capture

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -361,6 +361,7 @@ async function captureModelSnapshot(url) {
     document.body.appendChild(mv);
     try {
       await mv.updateComplete;
+      if (typeof mv.toDataURL !== "function") return null;
       return await mv.toDataURL("image/png");
     } catch (err) {
       console.error("Failed to capture snapshot", err);


### PR DESCRIPTION
## Summary
- guard `captureModelSnapshot` against missing `toDataURL` implementation

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npx prettier js/index.js -w`
- `npm run format` (backend)
- `npm test` *(fails: Cannot find module 'wait-on')*
- `npm test` (backend) *(fails: Cannot find module '../queue/printQueue')*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68c2b9e3bac0832da8f0d59e1bd65d84