### PR TITLE
ci: add basket button checks

### DIFF
--- a/.github/workflows/basket-button.yml
+++ b/.github/workflows/basket-button.yml
@@ -1,4 +1,4 @@
-name: Checks for the button in bottom RHS
+name: Checks for the Basket button in bottom RHS
 
 on:
   push:

--- a/.github/workflows/basket-button.yml
+++ b/.github/workflows/basket-button.yml
@@ -1,0 +1,21 @@
+name: Checks for the button in bottom RHS
+
+on:
+  push:
+    branches: [dev, "00000production"]
+  pull_request:
+    branches: [dev, "00000production"]
+
+jobs:
+  basket-button:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - name: Run basket button tests
+        run: npx playwright test tests/e2e/basket-button.spec.*.ts

--- a/tests/e2e/basket-button.spec.r8k2m5n7b3v1c6x9.ts
+++ b/tests/e2e/basket-button.spec.r8k2m5n7b3v1c6x9.ts
@@ -1,0 +1,35 @@
+import { test, expect } from "@playwright/test";
+import fs from "fs";
+import path from "path";
+
+const root = path.resolve(__dirname, "../../");
+const basketPages = fs
+  .readdirSync(root)
+  .filter((f) => f.endsWith(".html"))
+  .filter((f) =>
+    fs.readFileSync(path.join(root, f), "utf8").includes("js/basket.js"),
+  );
+
+for (const file of basketPages) {
+  test.describe(`basket button on ${file}`, () => {
+    test("shows count when items exist", async ({ page }) => {
+      await page.addInitScript(() => {
+        localStorage.setItem("print2Basket", JSON.stringify([{ modelUrl: "m" }]));
+      });
+      await page.goto(`/${file}`);
+      await expect(page.locator("#basket-button")).toBeVisible();
+      await expect(page.locator("#basket-count")).toHaveText("1");
+    });
+
+    test("hides count when empty", async ({ page }) => {
+      await page.goto(`/${file}`);
+      await expect(page.locator("#basket-count")).toBeHidden();
+    });
+
+    test("includes font awesome", async ({ page }) => {
+      await page.goto(`/${file}`);
+      const links = page.locator('head link[href*="font-awesome"]');
+      await expect(links).not.toHaveCount(0);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add Playwright tests ensuring basket button appears, displays item count, and pages include Font Awesome
- run checks on dev and 00000production via GitHub Actions

## Testing
- `npm run validate-env` (passes)
- `SKIP_PW_DEPS=1 npm run setup` (passes)
- `npm run format` (passes)
- `npm test` (fails: Cannot find module '../queue/printQueue')
- `SKIP_PW_DEPS=1 npm run ci` (fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)
- `SKIP_PW_DEPS=1 npm run smoke` (skipped: offline mode)
- `npx playwright test tests/e2e/basket-button.spec.r8k2m5n7b3v1c6x9.ts` (fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)


------
https://chatgpt.com/codex/tasks/task_e_68c2c21ec06c832d94c115c90defad70