### PR TITLE
fix: wait for model viewer load before enabling basket

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1038,9 +1038,7 @@ async function init() {
         new Promise((resolve) => {
           if (!refs.viewer) return resolve();
           if (refs.viewer.modelIsVisible) return resolve();
-          const onLoad = () => resolve();
-          refs.viewer.addEventListener("load", onLoad, { once: true });
-          setTimeout(onLoad, 100);
+          refs.viewer.addEventListener("load", () => resolve(), { once: true });
         }),
     );
 


### PR DESCRIPTION
## Summary
- wait for `<model-viewer>` to emit `load` before enabling add-to-basket button

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup` *(fails: registry 403)*
- `(cd backend && npm run format)` *(fails: registry 403)*
- `(cd backend && npm test)` *(fails: missing jest)
- `SKIP_PW_DEPS=1 npm run ci` *(fails: registry 403)*
- `SKIP_PW_DEPS=1 npm run smoke` *(skipped: offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_68c2d586ddd4832dafbd511e53ff2929