### PR TITLE
fix: handle missing wait-on dependency in run-jest

### DIFF
--- a/scripts/__tests__/run-jest-missing-wait-on-4r8s2k1n9p5w7q3v.test.ts
+++ b/scripts/__tests__/run-jest-missing-wait-on-4r8s2k1n9p5w7q3v.test.ts
@@ -1,0 +1,28 @@
+const fs = require("fs");
+const path = require("path");
+const vm = require("vm");
+
+test("fails with helpful message when wait-on is missing", () => {
+  const src = fs.readFileSync(
+    path.join(__dirname, "..", "run-jest.js"),
+    "utf8",
+  );
+  const errors: string[] = [];
+  const sandbox: any = {
+    module: { exports: {} },
+    require: (mod: string) => {
+      if (mod === "wait-on") {
+        const err: any = new Error("Cannot find module 'wait-on'");
+        err.code = "MODULE_NOT_FOUND";
+        throw err;
+      }
+      return require(mod);
+    },
+    console: { error: (msg: unknown) => errors.push(String(msg)) },
+    process: { exit: (code: number) => (sandbox.exitCode = code) },
+    __dirname: path.join(__dirname, ".."),
+  };
+  vm.runInNewContext(src, sandbox);
+  expect(sandbox.exitCode).toBe(1);
+  expect(errors.join(" ")).toContain("wait-on is not installed");
+});

--- a/scripts/run-jest.js
+++ b/scripts/run-jest.js
@@ -2,7 +2,15 @@
 const fs = require("fs");
 const path = require("path");
 const { spawnSync, spawn } = require("child_process");
-const waitOn = require("wait-on");
+let waitOn;
+try {
+  waitOn = require("wait-on");
+} catch {
+  console.error(
+    "wait-on is not installed. Run `npm run setup` to install dependencies.",
+  );
+  process.exit(1);
+}
 
 const repoRoot = path.resolve(__dirname, "..");
 const backendRoot = path.join(repoRoot, "backend");


### PR DESCRIPTION
## Summary
- handle missing `wait-on` gracefully in run-jest
- add regression test for missing `wait-on`

## Testing
- `npx prettier -w scripts/run-jest.js scripts/__tests__/run-jest-missing-wait-on-4r8s2k1n9p5w7q3v.test.ts`
- `node scripts/run-jest.js scripts/__tests__/run-jest-missing-wait-on-4r8s2k1n9p5w7q3v.test.ts` *(fails: wait-on is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c2dc4d6b10832da3048d354a5b523b