### PR TITLE
fix: await basket server id

### DIFF
--- a/js/basket.js
+++ b/js/basket.js
@@ -49,7 +49,7 @@ let reserveInterval;
 function notifyBasketChange() {
   window.dispatchEvent(new CustomEvent("basket-change"));
 }
-export function addToBasket(item, opts = {}) {
+export async function addToBasket(item, opts = {}) {
   const items = getBasket();
   const expire = Date.now() + RESERVE_MINS * 60 * 1000;
   const entry = { ...item, auto: !!opts.auto, reserveUntil: expire };
@@ -58,7 +58,7 @@ export function addToBasket(item, opts = {}) {
   const token = localStorage.getItem("token");
   if (token && item.jobId && typeof fetch === "function") {
     try {
-      const res = fetch(`${API_BASE}/cart/items`, {
+      const res = await fetch(`${API_BASE}/cart/items`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -66,17 +66,10 @@ export function addToBasket(item, opts = {}) {
         },
         body: JSON.stringify({ jobId: item.jobId, quantity: 1 }),
       });
-      if (res && typeof res.then === "function") {
-        res
-          .then((r) => r.json())
-          .then((d) => {
-            if (d.id) {
-              const list = getBasket();
-              list[list.length - 1].serverId = d.id;
-              saveBasket(list);
-            }
-          })
-          .catch(() => {});
+      const d = await res.json();
+      if (d.id) {
+        entry.serverId = d.id;
+        saveBasket(items);
       }
     } catch {
       /* ignore network errors */
@@ -99,6 +92,7 @@ export function addToBasket(item, opts = {}) {
     }
   }
   notifyBasketChange();
+  return entry.serverId;
 }
 
 export function addAutoItem(item) {

--- a/tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js
+++ b/tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js
@@ -172,8 +172,7 @@ test("addToBasket stores serverId from response", async () => {
   global.fetch.mockResolvedValueOnce({
     json: () => Promise.resolve({ id: 9 }),
   });
-  addToBasket({ modelUrl: "m", jobId: "j2" });
-  await Promise.resolve();
+  await addToBasket({ modelUrl: "m", jobId: "j2" });
   expect(getBasket()[0].serverId).toBe(9);
 });
 


### PR DESCRIPTION
## Summary
- make `addToBasket` async and persist server id once fetch resolves
- await `addToBasket` in server id test

## Testing
- `prettier -w js/basket.js tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js`
- `prettier -w .` (backend)
- `node scripts/run-jest.js tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js` *(fails: wait-on is not installed)*
- `npm test` *(fails: Missing jest)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: lockfile-diff 403)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68c2efa8f010832d9dad80bb69d8cd84