### PR TITLE
fix: enable basket button after viewer ready

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1042,9 +1042,8 @@ async function init() {
         }),
     );
 
-    viewerReadyPromise.then(() => {
-      refs.addBasketBtn.disabled = false;
-    });
+    await viewerReadyPromise;
+    refs.addBasketBtn.disabled = false;
 
     refs.addBasketBtn.addEventListener("click", async () => {
       await viewerReadyPromise;


### PR DESCRIPTION
## Summary
- ensure Add to Basket button is enabled only after the model viewer finishes loading

## Testing
- `npm run validate-env`
- `npx prettier js/index.js -w`
- `node scripts/run-jest.js tests/frontend/basket-pipeline.*.test.js --runInBand --verbose` *(fails: wait-on is not installed)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden from registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68c2ef9be63c832d8e5879345291451b