### PR TITLE
fix: wait for model-viewer load event before enabling basket button

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1037,8 +1037,12 @@ async function init() {
       () =>
         new Promise((resolve) => {
           if (!refs.viewer) return resolve();
-          if (refs.viewer.modelIsVisible) return resolve();
-          refs.viewer.addEventListener("load", () => resolve(), { once: true });
+          const onLoad = () => resolve();
+          if (refs.viewer.loaded || refs.viewer.modelIsVisible) {
+            onLoad();
+          } else {
+            refs.viewer.addEventListener("load", onLoad, { once: true });
+          }
         }),
     );
 

--- a/tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js
+++ b/tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js
@@ -144,8 +144,8 @@ test("index add-basket button adds to basket", async () => {
   await window.initIndexPage();
   const viewer = document.getElementById("glb-viewer");
   viewer.src = "model.glb";
-  viewer.modelIsVisible = true;
   viewer.dispatchEvent(new Event("load"));
+  await Promise.resolve();
   document.getElementById("add-basket-button").click();
   await waitFor(() => expect(getBasket()).toHaveLength(1));
 });
@@ -366,7 +366,7 @@ test("index viewer load enables add-basket button", async () => {
   await window.initIndexPage();
   const viewer = document.getElementById("glb-viewer");
   viewer.src = "model.glb";
-  viewer.modelIsVisible = true;
   viewer.dispatchEvent(new Event("load"));
+  await Promise.resolve();
   expect(document.getElementById("add-basket-button").disabled).toBe(false);
 });


### PR DESCRIPTION
## Summary
- ensure Add to Basket button only enables after `<model-viewer>` fires its load event
- adjust basket pipeline tests to simulate a load event

## Testing
- `npm run format`
- `node scripts/run-jest.js` *(fails: wait-on is not installed. Run `npm run setup` to install dependencies.)*

------
https://chatgpt.com/codex/tasks/task_e_68c2efbcc2d4832dbf519458e11f3593