### PR TITLE
fix: persist basket item updates

### DIFF
--- a/js/basket.js
+++ b/js/basket.js
@@ -34,15 +34,20 @@
 
 const KEY = "print2Basket";
 const API_BASE = (window.API_ORIGIN || "") + "/api";
+let basket;
 export function getBasket() {
-  try {
-    return JSON.parse(localStorage.getItem(KEY)) || [];
-  } catch {
-    return [];
+  if (!basket) {
+    try {
+      basket = JSON.parse(localStorage.getItem(KEY)) || [];
+    } catch {
+      basket = [];
+    }
   }
+  return basket;
 }
-function saveBasket(items) {
-  localStorage.setItem(KEY, JSON.stringify(items));
+function saveBasket(items = basket) {
+  basket = items;
+  localStorage.setItem(KEY, JSON.stringify(basket));
 }
 const RESERVE_MINS = 15;
 let reserveInterval;
@@ -54,7 +59,7 @@ export function addToBasket(item, opts = {}) {
   const expire = Date.now() + RESERVE_MINS * 60 * 1000;
   const entry = { ...item, auto: !!opts.auto, reserveUntil: expire };
   items.push(entry);
-  saveBasket(items);
+  saveBasket();
   const token = localStorage.getItem("token");
   if (token && item.jobId && typeof fetch === "function") {
     try {
@@ -71,9 +76,8 @@ export function addToBasket(item, opts = {}) {
           .then((r) => r.json())
           .then((d) => {
             if (d.id) {
-              const list = getBasket();
-              list[list.length - 1].serverId = d.id;
-              saveBasket(list);
+              entry.serverId = d.id;
+              saveBasket();
             }
           })
           .catch(() => {});
@@ -108,7 +112,7 @@ export function addAutoItem(item) {
     items.splice(idx, 1);
   }
   items.push({ ...item, auto: true });
-  saveBasket(items);
+  saveBasket();
   updateBadge();
   renderList();
   notifyBasketChange();
@@ -119,7 +123,7 @@ export function manualizeItem(predicate) {
   const idx = items.findIndex((it) => it.auto && predicate(it));
   if (idx !== -1) {
     items[idx].auto = false;
-    saveBasket(items);
+    saveBasket();
   }
   updateBadge();
   renderList();
@@ -128,7 +132,7 @@ export function manualizeItem(predicate) {
 export function removeFromBasket(index) {
   const items = getBasket();
   const [removed] = items.splice(index, 1);
-  saveBasket(items);
+  saveBasket();
   const token = localStorage.getItem("token");
   if (token && removed?.serverId && typeof fetch === "function") {
     try {


### PR DESCRIPTION
## Summary
- keep an in-memory basket array so object mutations persist across calls
- sync localStorage from the in-memory basket via saveBasket
- read latest serverId when removing items to send DELETE

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npx prettier js/basket.js -w`
- `npm run format` (backend) *(fails: 403 Forbidden - GET https://registry.npmjs.org/npm)*
- `npm test` *(fails: Cannot find module '../queue/printQueue')*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c2efb290f4832d9a897c478deae044