### PR TITLE
test: reset basket state in pipeline tests

### DIFF
--- a/tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js
+++ b/tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js
@@ -23,12 +23,19 @@ beforeAll(async () => {
 
 beforeEach(() => {
   localStorage.clear();
+  document.head.innerHTML = "";
   document.body.innerHTML = "";
+  delete window.__basketSound;
   global.Audio = function () {
     this.play = jest.fn();
   };
   global.fetch = jest.fn();
   setupBasketUI();
+});
+
+afterEach(() => {
+  jest.clearAllTimers();
+  jest.useRealTimers();
 });
 
 test("getBasket returns empty array when no data", () => {


### PR DESCRIPTION
## Summary
- reset basket pipeline test DOM and localStorage before each test
- clear timers after each basket pipeline test

## Testing
- `npm test` *(fails: Cannot find module '../queue/printQueue')*
- `node scripts/run-jest.js tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js` *(fails: wait-on is not installed)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: lockfile mismatch and npm 403)*
- `SKIP_PW_DEPS=1 npm run smoke`
- `npx prettier --write tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c2fc781850832db2304abb7bb4bb04