### PR TITLE
fix: handle missing viewer src when adding to basket

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1051,7 +1051,11 @@ async function init() {
 
     refs.addBasketBtn.addEventListener("click", async () => {
       await viewerReadyPromise;
-      if (!refs.viewer.src) return;
+      if (!refs.viewer.src) {
+        const stored = localStorage.getItem("print2Model");
+        refs.viewer.src = stored || FALLBACK_GLB;
+      }
+      const modelUrl = refs.viewer.src;
       let snapshot = refs.previewImg?.src;
       const host = (() => {
         try {
@@ -1065,10 +1069,10 @@ async function init() {
         snapshot.includes("placehold.co") ||
         host === "images.unsplash.com"
       ) {
-        snapshot = await captureModelSnapshot(refs.viewer.src);
+        snapshot = await captureModelSnapshot(modelUrl);
       }
       lastSnapshot = snapshot;
-      const item = { jobId: lastJobId, modelUrl: refs.viewer.src, snapshot };
+      const item = { jobId: lastJobId, modelUrl, snapshot };
       if (
         window.manualizeItem &&
         window


### PR DESCRIPTION
## Summary
- ensure add-to-basket uses current model or fallback when viewer src is missing

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npx prettier js/index.js -w`
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: Cannot find module '../queue/printQueue')*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden from registry)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c2fc7d3414832dbca81d0ae69967cd