### PR TITLE
test: reset basket pipeline test state

### DIFF
--- a/tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js
+++ b/tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js
@@ -10,6 +10,10 @@ let removeFromBasket;
 let clearBasket;
 let setupBasketUI;
 
+const originalAddEventListener = window.addEventListener;
+const originalRemoveEventListener = window.removeEventListener;
+let addedListeners = [];
+
 beforeAll(async () => {
   const mod = await import("../../js/basket.js");
   getBasket = mod.getBasket;
@@ -22,10 +26,23 @@ beforeAll(async () => {
 });
 
 beforeEach(() => {
+  jest.clearAllTimers();
+  jest.useRealTimers();
   localStorage.clear();
   document.head.innerHTML = "";
   document.body.innerHTML = "";
   delete window.__basketSound;
+  addedListeners = [];
+  window.addEventListener = (type, listener, options) => {
+    addedListeners.push({ type, listener, options });
+    return originalAddEventListener.call(window, type, listener, options);
+  };
+  window.removeEventListener = (type, listener, options) => {
+    addedListeners = addedListeners.filter(
+      (l) => !(l.type === type && l.listener === listener && l.options === options),
+    );
+    return originalRemoveEventListener.call(window, type, listener, options);
+  };
   global.Audio = function () {
     this.play = jest.fn();
   };
@@ -34,6 +51,15 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  addedListeners.forEach(({ type, listener, options }) => {
+    originalRemoveEventListener.call(window, type, listener, options);
+  });
+  addedListeners = [];
+  window.addEventListener = originalAddEventListener;
+  window.removeEventListener = originalRemoveEventListener;
+  document.head.innerHTML = "";
+  document.body.innerHTML = "";
+  jest.clearAllMocks();
   jest.clearAllTimers();
   jest.useRealTimers();
 });


### PR DESCRIPTION
## Summary
- clean up basket pipeline tests by tracking event listeners and removing them after each test
- reset timers and DOM in setup and teardown to ensure isolation

## Testing
- `npm run validate-env`
- `npm run setup` *(fails: Skipping Playwright/apt deps; dependencies missing)*
- `npm run format`
- `node scripts/run-jest.js tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js` *(fails: wait-on is not installed)*
- `npm test` *(fails: Cannot find module '../queue/printQueue')*
- `npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c30a81b600832d8692075bef6aca0a