### PR TITLE
fix: keep basket button visible on storage error

### DIFF
--- a/js/basket.js
+++ b/js/basket.js
@@ -45,6 +45,13 @@ export function getBasket() {
     } catch {
       localStorage.removeItem(KEY);
       basket = [];
+      const btn = document.getElementById("basket-button");
+      if (btn) btn.hidden = false;
+      const badge = document.getElementById("basket-count");
+      if (badge) {
+        badge.textContent = "";
+        badge.hidden = true;
+      }
     }
   }
   return basket;

--- a/tests/e2e/basket-button.spec.r8k2m5n7b3v1c6x9.ts
+++ b/tests/e2e/basket-button.spec.r8k2m5n7b3v1c6x9.ts
@@ -146,10 +146,15 @@ for (const file of basketPages) {
         page.locator("#basket-button"),
         "Basket button should be visible when localStorage is corrupted",
       ).toBeVisible();
+      const count = page.locator("#basket-count");
       await expect(
-        page.locator("#basket-count"),
+        count,
         "Basket count should be hidden when localStorage is corrupted",
       ).toBeHidden();
+      await expect(
+        count,
+        "Basket count text should be cleared when storage is corrupted",
+      ).toHaveText("");
       const stored = await page.evaluate(() =>
         localStorage.getItem("print2Basket"),
       );


### PR DESCRIPTION
## Summary
- ensure basket button stays visible and count clears when localStorage is corrupted
- adjust corrupted-storage test to expect visible button and cleared count

## Testing
- `npm run validate-env`
- `npm run format`
- `npm test` *(fails: Cannot find module '../queue/printQueue')*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68c30a77a348832db72d3bc121a330f2