### PR TITLE
fix: add fallback viewer model

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1051,11 +1051,8 @@ async function init() {
 
     refs.addBasketBtn.addEventListener("click", async () => {
       await viewerReadyPromise;
-      if (!refs.viewer.src) {
-        const stored = localStorage.getItem("print2Model");
-        refs.viewer.src = stored || FALLBACK_GLB;
-      }
-      const modelUrl = refs.viewer.src;
+      const modelUrl =
+        refs.viewer.src || localStorage.getItem("print2Model") || FALLBACK_GLB;
       let snapshot = refs.previewImg?.src;
       const host = (() => {
         try {


### PR DESCRIPTION
## Summary
- ensure basket button uses stored or fallback model when viewer src is missing

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup` *(fails: registry access forbidden)*
- `npm run format` *(fails: registry access forbidden)*
- `npm test` *(fails: Cannot find module '../queue/printQueue')*
- `node scripts/run-jest.js tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js -t "index add-basket button adds to basket"` *(fails: wait-on is not installed)*
- `npx playwright test tests/e2e/basket-button.spec.r8k2m5n7b3v1c6x9.ts -g "adds item via UI shows basket and count"` *(fails: registry access forbidden)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: registry access forbidden)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68c30a7b7f4c832d932ff6403a5466e1