### PR TITLE
test: verify basket button increments

### DIFF
--- a/tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js
+++ b/tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js
@@ -39,7 +39,8 @@ beforeEach(() => {
   };
   window.removeEventListener = (type, listener, options) => {
     addedListeners = addedListeners.filter(
-      (l) => !(l.type === type && l.listener === listener && l.options === options),
+      (l) =>
+        !(l.type === type && l.listener === listener && l.options === options),
     );
     return originalRemoveEventListener.call(window, type, listener, options);
   };
@@ -95,6 +96,20 @@ test("adds item via UI shows basket and count", () => {
   const badge = document.getElementById("basket-count");
   expect(badge).toHaveTextContent("1");
   expect(badge.hidden).toBe(false);
+});
+
+test("loads index.html and clicking add button increments count", () => {
+  const fs = require("fs");
+  const path = require("path");
+  const html = fs.readFileSync(
+    path.resolve(__dirname, "../../index.html"),
+    "utf8",
+  );
+  document.documentElement.innerHTML = html;
+  setupBasketUI();
+  document.getElementById("add-basket-button").click();
+  const badge = document.getElementById("basket-count");
+  expect(badge).toHaveTextContent("1");
 });
 
 test("increments count for multiple added items", () => {


### PR DESCRIPTION
## Summary
- add test ensuring index.html's add basket button increments basket count

## Testing
- `npm run validate-env` *(fails: 403 Forbidden to registry)*
- `SKIP_PW_DEPS=1 npm run setup` *(fails: unable to install dependencies)*
- `npm run format --prefix backend`
- `cd backend && npm test` *(fails: Missing jest; run `npm run setup` before testing)*
- `node scripts/run-jest.js tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js` *(fails: wait-on is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c31695b2b8832d89c020935847f324