### PR TITLE
fix: add fallback URL for basket items

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1052,7 +1052,11 @@ async function init() {
     refs.addBasketBtn.addEventListener("click", async () => {
       await viewerReadyPromise;
       const modelUrl =
-        refs.viewer.src || localStorage.getItem("print2Model") || FALLBACK_GLB;
+        refs.viewer.src ||
+        refs.previewImg?.dataset?.glb ||
+        refs.previewImg?.src ||
+        localStorage.getItem("print2Model") ||
+        FALLBACK_GLB;
       let snapshot = refs.previewImg?.src;
       const host = (() => {
         try {


### PR DESCRIPTION
## Summary
- ensure add-basket handler falls back to preview image or stored model when viewer has no src

## Testing
- `npm run format`
- `node scripts/run-jest.js tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js -t "index"` *(fails: wait-on is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c31878d040832d8a3928b6ed8325a4