### PR TITLE
fix: clear basket count on parse error

### DIFF
--- a/js/basket.js
+++ b/js/basket.js
@@ -189,7 +189,7 @@ function updateBadge() {
   const badge = document.getElementById("basket-count");
   if (badge) {
     const n = getBasket().length;
-    badge.textContent = String(n);
+    badge.textContent = n > 0 ? String(n) : "";
     badge.hidden = n === 0;
   }
 }

--- a/tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js
+++ b/tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js
@@ -39,7 +39,8 @@ beforeEach(() => {
   };
   window.removeEventListener = (type, listener, options) => {
     addedListeners = addedListeners.filter(
-      (l) => !(l.type === type && l.listener === listener && l.options === options),
+      (l) =>
+        !(l.type === type && l.listener === listener && l.options === options),
     );
     return originalRemoveEventListener.call(window, type, listener, options);
   };
@@ -84,6 +85,7 @@ test("basket button visible and count hidden when empty", () => {
   const badge = document.getElementById("basket-count");
   expect(btn.hidden).toBe(false);
   expect(badge.hidden).toBe(true);
+  expect(badge).toHaveTextContent("");
 });
 
 test("adds item via UI shows basket and count", () => {
@@ -122,6 +124,7 @@ test("clearing basket keeps button visible", () => {
   const badge = document.getElementById("basket-count");
   expect(btn.hidden).toBe(false);
   expect(badge.hidden).toBe(true);
+  expect(badge).toHaveTextContent("");
 });
 
 test("handles corrupted localStorage gracefully", () => {
@@ -214,9 +217,11 @@ test("removeFromBasket removes item", () => {
 test("badge hides when basket empty", () => {
   const badge = document.getElementById("basket-count");
   expect(badge.hidden).toBe(true);
+  expect(badge).toHaveTextContent("");
   addToBasket({ modelUrl: "a" });
   removeFromBasket(0);
   expect(badge.hidden).toBe(true);
+  expect(badge).toHaveTextContent("");
 });
 
 test("clearBasket empties localStorage", () => {


### PR DESCRIPTION
## Summary
- hide basket count and clear text when localStorage parsing fails
- initialize basket badge with empty string when count is zero
- update basket tests for blank count handling

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup` *(fails: tunnel error; interrupted)*
- `npx prettier -w js/basket.js tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js`
- `cd backend && npm run format`
- `cd backend && npm test` *(fails: Cannot find module '../queue/printQueue')*
- `node scripts/run-jest.js tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js` *(fails: wait-on is not installed)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_68c318818890832db44ee0cca0949588