### PR TITLE
test: stub navigation in payment flow tests

### DIFF
--- a/tests/frontend/payment-flow.a1b2c3d4e5f6g7h8.spec.js
+++ b/tests/frontend/payment-flow.a1b2c3d4e5f6g7h8.spec.js
@@ -41,6 +41,21 @@ jest.mock(
 const { GeneratorApp } = require("../../js/modelGenerator.js");
 
 describe("payment flow", () => {
+  const originalLocation = window.location;
+
+  beforeAll(() => {
+    const href = originalLocation.href;
+    delete window.location;
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { href, assign: jest.fn(), replace: jest.fn() },
+    });
+  });
+
+  afterAll(() => {
+    window.location = originalLocation;
+  });
+
   beforeEach(() => {
     jest.clearAllMocks();
     confirmCardPaymentMock.mockReset();


### PR DESCRIPTION
## Summary
- mock `window.location` in payment flow tests to prevent jsdom navigation attempts

## Testing
- `npm run format`
- `npm test` *(fails: wait-on is not installed)*
- `npm test` in `backend/` *(fails: Cannot find module '../queue/printQueue')*


------
https://chatgpt.com/codex/tasks/task_e_68c31895bc70832da36b567c74a2a113