### PR TITLE
feat: persist checkout model

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1009,24 +1009,25 @@ async function init() {
 
   // Ensure checkout uses the model currently shown in the viewer
   refs.checkoutBtn?.addEventListener("click", () => {
-    if (refs.viewer.src) {
-      localStorage.setItem("print2Model", refs.viewer.src);
+    const modelUrl = refs.viewer.src;
+    if (modelUrl) {
+      localStorage.setItem("print2Model", modelUrl);
     }
     if (lastJobId) {
       localStorage.setItem("print2JobId", lastJobId);
     } else {
       localStorage.removeItem("print2JobId");
     }
+    const item = {
+      modelUrl,
+      jobId: lastJobId || "",
+      snapshot: lastSnapshot || "",
+    };
+    // Add the current viewer item to the basket and persist it for checkout
+    addBasketItem(item);
     try {
-      const items = [
-        {
-          modelUrl: refs.viewer.src,
-          jobId: lastJobId || "",
-          snapshot: lastSnapshot || "",
-        },
-      ];
+      const items = window.getBasket ? window.getBasket() : [item];
       localStorage.setItem("print2CheckoutItems", JSON.stringify(items));
-      localStorage.removeItem("print2Basket");
     } catch {}
     if (window.setWizardStage) window.setWizardStage("purchase");
   });


### PR DESCRIPTION
## Summary
- add current model to basket when clicking checkout
- store model info so payment page shows same GLB

## Testing
- `npm run validate-env`
- `npm run setup`
- `npm run format` *(fails: 403 Forbidden - GET https://registry.npmjs.org/npm)*
- `npm test` *(fails: Missing jest; run `npm run setup` before testing.)*
- `npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `npm run smoke` *(skipped: offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_68c3194831f0832d8cf03c896ccabefb