### PR TITLE
test: reset DOM and globals after basket tests

### DIFF
--- a/tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js
+++ b/tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js
@@ -12,6 +12,10 @@ let setupBasketUI;
 
 const originalAddEventListener = window.addEventListener;
 const originalRemoveEventListener = window.removeEventListener;
+const originalAudio = global.Audio;
+const originalFetch = global.fetch;
+const originalCrypto = global.crypto;
+const originalWhenDefined = window.customElements?.whenDefined;
 let addedListeners = [];
 
 beforeAll(async () => {
@@ -56,6 +60,27 @@ afterEach(() => {
   addedListeners = [];
   window.addEventListener = originalAddEventListener;
   window.removeEventListener = originalRemoveEventListener;
+  if (originalAudio) {
+    global.Audio = originalAudio;
+  } else {
+    delete global.Audio;
+  }
+  if (originalFetch) {
+    global.fetch = originalFetch;
+  } else {
+    delete global.fetch;
+  }
+  if (originalCrypto) {
+    global.crypto = originalCrypto;
+  } else {
+    delete global.crypto;
+  }
+  if (window.customElements) {
+    window.customElements.whenDefined = originalWhenDefined;
+  }
+  delete window.__basketSound;
+  delete window.initIndexPage;
+  localStorage.clear();
   document.head.innerHTML = "";
   document.body.innerHTML = "";
   jest.clearAllMocks();


### PR DESCRIPTION
## Summary
- isolate basket pipeline tests by restoring globals
- clear storage, DOM, and timers after each test

## Testing
- `npx prettier tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js -w`
- `node scripts/run-jest.js tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js` *(fails: wait-on is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c3298a929c832d925445e25417b0d4