### PR TITLE
fix: handle empty viewer src in basket

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1039,7 +1039,9 @@ async function init() {
         new Promise((resolve) => {
           if (!refs.viewer) return resolve();
           const onLoad = () => resolve();
-          if (refs.viewer.loaded || refs.viewer.modelIsVisible) {
+          if (!refs.viewer.src) {
+            onLoad();
+          } else if (refs.viewer.loaded || refs.viewer.modelIsVisible) {
             onLoad();
           } else {
             refs.viewer.addEventListener("load", onLoad, { once: true });

--- a/tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js
+++ b/tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js
@@ -271,9 +271,6 @@ test("index add-basket button adds to basket", async () => {
   window.customElements.whenDefined = () => Promise.resolve();
   await import("../../js/index.js");
   await window.initIndexPage();
-  const viewer = document.getElementById("glb-viewer");
-  viewer.src = "model.glb";
-  viewer.dispatchEvent(new Event("load"));
   await Promise.resolve();
   document.getElementById("add-basket-button").click();
   await waitFor(() => expect(getBasket()).toHaveLength(1));


### PR DESCRIPTION
## Summary
- ensure add-basket button waits for viewer or falls back when model source is missing
- test adding to basket without preloaded viewer source

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format`
- `npm test` *(fails: wait-on is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c3298e4714832d8907add3a1784ee3