### PR TITLE
fix: keep basket button visible on invalid storage

### DIFF
--- a/js/basket.js
+++ b/js/basket.js
@@ -45,8 +45,6 @@ export function getBasket() {
     } catch {
       localStorage.removeItem(KEY);
       basket = [];
-      const btn = document.getElementById("basket-button");
-      if (btn) btn.hidden = false;
       const badge = document.getElementById("basket-count");
       if (badge) {
         badge.textContent = "";

--- a/tests/e2e/basket-button.spec.r8k2m5n7b3v1c6x9.ts
+++ b/tests/e2e/basket-button.spec.r8k2m5n7b3v1c6x9.ts
@@ -1,0 +1,12 @@
+import { test, expect } from "@playwright/test";
+
+test("basket button remains visible with invalid localStorage", async ({
+  page,
+}) => {
+  await page.addInitScript(() => {
+    localStorage.setItem("print2Basket", "{oops");
+  });
+  await page.goto("/index.html");
+  await expect(page.locator("#basket-button")).toBeVisible();
+  await expect(page.locator("#basket-count")).toBeHidden();
+});


### PR DESCRIPTION
## Summary
- clear invalid basket data without toggling the button
- test that basket button stays visible while badge hides on bad JSON

## Testing
- `npm run validate-env`
- `npm test` *(fails: Cannot find module '../queue/printQueue')*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: lockfile-diff 403 Forbidden)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68c3299310e0832daac7814df1d212ed