### PR TITLE
fix: clear corrupted basket storage

### DIFF
--- a/js/basket.js
+++ b/js/basket.js
@@ -38,18 +38,12 @@ let basket;
 export function getBasket() {
   if (!basket) {
     try {
-      basket = JSON.parse(localStorage.getItem(KEY)) || [];
-      if (!Array.isArray(basket)) {
-        basket = [];
-      }
+      const raw = localStorage.getItem(KEY);
+      const parsed = raw ? JSON.parse(raw) : [];
+      basket = Array.isArray(parsed) ? parsed : [];
     } catch {
       localStorage.removeItem(KEY);
       basket = [];
-      const badge = document.getElementById("basket-count");
-      if (badge) {
-        badge.textContent = "";
-        badge.hidden = true;
-      }
     }
   }
   return basket;
@@ -312,6 +306,8 @@ function closeBasket() {
   document.getElementById("basket-overlay")?.classList.add("hidden");
 }
 export function setupBasketUI() {
+  // Trigger basket loading to clear any corrupted storage before UI setup
+  getBasket();
   if (!document.getElementById("basket-bob-style")) {
     const style = document.createElement("style");
     style.id = "basket-bob-style";


### PR DESCRIPTION
## Summary
- safely reset basket on invalid JSON
- initialise UI with cleaned basket to keep button visible

## Testing
- `npm run format`
- `npm --prefix backend run format`
- `npm test` *(fails: wait-on is not installed. Run `npm run setup` to install dependencies.)*
- `npm --prefix backend test` *(fails: Cannot find module '../queue/printQueue' from 'tests/additionalApi.test.js')*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68c3417d0c64832db9d135f6c9df5768