### PR TITLE
fix: use preview fallback when viewer empty

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1054,12 +1054,14 @@ async function init() {
 
     refs.addBasketBtn.addEventListener("click", async () => {
       await viewerReadyPromise;
-      const modelUrl =
-        refs.viewer.src ||
-        refs.previewImg?.dataset?.glb ||
-        refs.previewImg?.src ||
-        localStorage.getItem("print2Model") ||
-        FALLBACK_GLB;
+      let modelUrl = refs.viewer.src;
+      if (!modelUrl) {
+        modelUrl =
+          refs.previewImg?.dataset?.glb ||
+          refs.previewImg?.src ||
+          localStorage.getItem("print2Model") ||
+          FALLBACK_GLB;
+      }
       let snapshot = refs.previewImg?.src;
       const host = (() => {
         try {

--- a/tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js
+++ b/tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js
@@ -414,6 +414,26 @@ test("index add-basket button adds to basket", async () => {
   await waitFor(() => expect(getBasket()).toHaveLength(1));
 });
 
+test("index basket count increments without viewer src", async () => {
+  document.body.innerHTML +=
+    '<button id="add-basket-button"></button>' +
+    '<img id="preview-img" src="http://example.com/fallback.png" />' +
+    '<div id="glb-viewer"></div>';
+  global.fetch = jest
+    .fn()
+    .mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+  const { webcrypto } = require("crypto");
+  global.crypto = webcrypto;
+  window.customElements.whenDefined = () => Promise.resolve();
+  await import("../../js/index.js");
+  await window.initIndexPage();
+  document.getElementById("add-basket-button").click();
+  await waitFor(() => expect(getBasket()).toHaveLength(1));
+  const count = document.getElementById("basket-count");
+  expect(count).toHaveTextContent("1");
+  expect(count.hidden).toBe(false);
+});
+
 test("addToBasket skips server call without token", () => {
   addToBasket({ modelUrl: "m", jobId: "j" });
   expect(global.fetch).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- ensure add-basket fallback uses preview image when viewer source missing
- add regression test for basket count increment with no viewer src

## Testing
- `npm run validate-env`
- `npm run setup`
- `npx prettier js/index.js tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js --write`
- `node scripts/run-jest.js tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js` *(fails: wait-on is not installed)*
- `(cd backend && npm test)` *(fails: Cannot find module '../queue/printQueue')*
- `npm run ci` *(fails: Lockfile mismatch / npm 403)*
- `npm run smoke` *(offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_68c341823bc0832db7d38e2b5ebaddd3