### PR TITLE
fix: export index init function for tests

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1231,6 +1231,7 @@ if (typeof module !== "undefined") {
     computeDailyPrintsSold,
     updateStats,
     initDiscountDeliveryBanner,
+    initIndexPage: init,
   };
 }
 
@@ -1239,4 +1240,5 @@ export {
   computeDailyPrintsSold,
   updateStats,
   initDiscountDeliveryBanner,
+  init as initIndexPage,
 };

--- a/tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js
+++ b/tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js
@@ -407,8 +407,8 @@ test("index add-basket button adds to basket", async () => {
   const { webcrypto } = require("crypto");
   global.crypto = webcrypto;
   window.customElements.whenDefined = () => Promise.resolve();
-  await import("../../js/index.js");
-  await window.initIndexPage();
+  const { initIndexPage } = await import("../../js/index.js");
+  await initIndexPage();
   await Promise.resolve();
   document.getElementById("add-basket-button").click();
   await waitFor(() => expect(getBasket()).toHaveLength(1));
@@ -612,8 +612,8 @@ test("index add-basket button disabled until viewer ready", async () => {
   const { webcrypto } = require("crypto");
   global.crypto = webcrypto;
   window.customElements.whenDefined = () => Promise.resolve();
-  await import("../../js/index.js");
-  await window.initIndexPage();
+  const { initIndexPage } = await import("../../js/index.js");
+  await initIndexPage();
   expect(document.getElementById("add-basket-button").disabled).toBe(true);
 });
 
@@ -625,8 +625,8 @@ test("index viewer load enables add-basket button", async () => {
   const { webcrypto } = require("crypto");
   global.crypto = webcrypto;
   window.customElements.whenDefined = () => Promise.resolve();
-  await import("../../js/index.js");
-  await window.initIndexPage();
+  const { initIndexPage } = await import("../../js/index.js");
+  await initIndexPage();
   const viewer = document.getElementById("glb-viewer");
   viewer.src = "model.glb";
   viewer.dispatchEvent(new Event("load"));


### PR DESCRIPTION
## Summary
- export `initIndexPage` from `js/index.js`
- update basket pipeline tests to import and run `initIndexPage`

## Testing
- `npx prettier --log-level debug --write js/index.js tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js`
- `node scripts/run-jest.js tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js` *(fails: wait-on is not installed)*
- `npm run format` *(fails: 403 Forbidden - GET https://registry.npmjs.org/npm)*


------
https://chatgpt.com/codex/tasks/task_e_68c341876d20832da5eff37de3827790