### PR TITLE
fix: refresh basket list after item removal

### DIFF
--- a/js/basket.js
+++ b/js/basket.js
@@ -296,6 +296,7 @@ function renderList() {
     btn.addEventListener("click", (e) => {
       e.stopPropagation();
       removeFromBasket(idx);
+      renderList();
     });
 
     div.appendChild(img);

--- a/tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js
+++ b/tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js
@@ -521,6 +521,7 @@ test("badge shows when items exist", () => {
 });
 
 test("renderList populates basket list", () => {
+  clearBasket();
   addToBasket({ modelUrl: "a" });
   document.getElementById("basket-button").click();
   const list = document.querySelectorAll("#basket-list .remove");
@@ -528,10 +529,12 @@ test("renderList populates basket list", () => {
 });
 
 test("renderList remove button deletes item", () => {
+  clearBasket();
   addToBasket({ modelUrl: "a" });
   document.getElementById("basket-button").click();
   document.querySelector("#basket-list .remove").click();
   expect(getBasket()).toHaveLength(0);
+  expect(document.querySelectorAll("#basket-list .remove")).toHaveLength(0);
 });
 
 test("basket button opens overlay", () => {


### PR DESCRIPTION
## Summary
- clear basket before renderList tests and verify DOM updates after removing items
- re-render basket list after item removal so the overlay reflects current basket

## Testing
- `npm run format`
```
> backend@1.0.0 format
> prettier --log-level warn --write "**/*.{ts,tsx,js,jsx,json,md}"
```
- `npm test`
```
PASS tests/getEnv.test.p7q8r9s0t1u2v3w4.js
PASS tests/users.test.z9x8c7v6b5n4m3l2.js
FAIL tests/additionalApi.test.js
  ● Test suite failed to run
    Cannot find module '../queue/printQueue' from 'tests/additionalApi.test.js'
```
- `node scripts/run-jest.js tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js`
```
wait-on is not installed. Run `npm run setup` to install dependencies.
```
- `SKIP_PW_DEPS=1 npm run ci`
```
npm error 403 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff
Lockfile mismatch detected. Run 'npm install' to regenerate package-lock.json.
```
- `SKIP_PW_DEPS=1 npm run smoke`
```
offline mode: skipping smoke
```

------
https://chatgpt.com/codex/tasks/task_e_68c3418c439c832d8300492efeb2e7f2