### PR TITLE
test: cover basket count when glb src missing

### DIFF
--- a/tests/e2e/basket-button.spec.r8k2m5n7b3v1c6x9.ts
+++ b/tests/e2e/basket-button.spec.r8k2m5n7b3v1c6x9.ts
@@ -10,3 +10,18 @@ test("basket button remains visible with invalid localStorage", async ({
   await expect(page.locator("#basket-button")).toBeVisible();
   await expect(page.locator("#basket-count")).toBeHidden();
 });
+
+test("basket count stays at 0 when glb-viewer src cleared", async ({
+  page,
+}) => {
+  test.fail(true, "FIXME: basket increments when glb-viewer src is missing");
+  await page.goto("/index.html");
+  await page.evaluate(() => {
+    const viewer = document.querySelector<HTMLImageElement>("#glb-viewer");
+    if (viewer) viewer.src = "";
+  });
+  const count = page.locator("#basket-count");
+  await expect(count).toHaveText("0");
+  await page.locator("#add-basket-button").click();
+  await expect(count).toHaveText("0");
+});


### PR DESCRIPTION
## Summary
- add failing e2e to ensure basket count doesn't increment if glb-viewer src is empty

## Testing
- `npm run format` (backend) *(fails: 403 Forbidden - GET https://registry.npmjs.org/npm)*
- `npm test` (backend) *(fails: Cannot find module '../queue/printQueue')*
- `npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68c3428b18f4832d95855669d053279e