### PR TITLE
fix: fallback model URL in add to basket

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1055,7 +1055,7 @@ async function init() {
     refs.addBasketBtn.addEventListener("click", async () => {
       await viewerReadyPromise;
       const modelUrl =
-        refs.viewer.src ||
+        refs.viewer?.src ||
         refs.previewImg?.dataset?.glb ||
         refs.previewImg?.src ||
         localStorage.getItem("print2Model") ||


### PR DESCRIPTION
## Summary
- ensure add-to-basket button uses alternative sources when viewer has no src

## Testing
- `npm run validate-env` *(fails: 403 Forbidden accessing npm registry)*
- `SKIP_PW_DEPS=1 npm run setup` *(no npm output; likely skipped)*
- `npm run format`
- `npm test` *(fails: Missing jest; run `npm run setup` before testing)*
- `node scripts/run-jest.js tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js` *(fails: wait-on is not installed)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke` *(skipped: offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_68c3428fa654832d853af09f8ee02e81