### PR TITLE
fix: handle empty viewer src on checkout

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1008,8 +1008,24 @@ async function init() {
   }
 
   // Ensure checkout uses the model currently shown in the viewer
-  refs.checkoutBtn?.addEventListener("click", () => {
-    const modelUrl = refs.viewer.src;
+  refs.checkoutBtn?.addEventListener("click", async () => {
+    let modelUrl = refs.viewer?.src;
+    if (!modelUrl) {
+      await customElements.whenDefined("model-viewer");
+      if (refs.viewer && !refs.viewer.src) {
+        try {
+          await refs.viewer.updateComplete;
+        } catch {}
+      }
+    }
+    if (!modelUrl) {
+      modelUrl =
+        refs.viewer?.src ||
+        refs.previewImg?.dataset?.glb ||
+        refs.previewImg?.src ||
+        localStorage.getItem("print2Model") ||
+        FALLBACK_GLB;
+    }
     if (modelUrl) {
       localStorage.setItem("print2Model", modelUrl);
     }


### PR DESCRIPTION
## Summary
- ensure checkout falls back to a model URL when the viewer source is missing

## Testing
- `npm run validate-env`
- `npm run setup`
- `npm run format` (backend)
- `npm test` (backend) *(fails: Cannot find module '../queue/printQueue' from 'tests/additionalApi.test.js')*
- `npm run ci` *(fails: Lockfile mismatch detected. Run 'npm install' to regenerate package-lock.json.)*
- `node scripts/run-jest.js tests/e2e/basket-button.spec.r8k2m5n7b3v1c6x9.ts` *(fails: wait-on is not installed. Run `npm run setup` to install dependencies.)*

------
https://chatgpt.com/codex/tasks/task_e_68c3ee21ab60832d9fa5ae67b86e901d