### PR TITLE
test: add failing basket viewer src test

### DIFF
--- a/tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js
+++ b/tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js
@@ -117,6 +117,22 @@ test("loads index.html and clicking add button increments count", () => {
   expect(badge).toHaveTextContent("1");
 });
 
+test.failing("does not increment when viewer source is missing", () => {
+  const fs = require("fs");
+  const path = require("path");
+  const html = fs.readFileSync(
+    path.resolve(__dirname, "../../index.html"),
+    "utf8",
+  );
+  document.documentElement.innerHTML = html;
+  setupBasketUI();
+  document.getElementById("glb-viewer").src = "";
+  document.getElementById("add-basket-button").click();
+  const badge = document.getElementById("basket-count");
+  expect(badge).toHaveTextContent("");
+  expect(getBasket()).toHaveLength(0);
+});
+
 test("increments count for multiple added items", () => {
   const badge = document.getElementById("basket-count");
   for (let i = 1; i <= 3; i++) {


### PR DESCRIPTION
## Summary
- add failing test ensuring empty glb-viewer source doesn't increment basket count

## Testing
- `npx prettier --write tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js`
- `npm run format --prefix backend`
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup` *(fails: Skipping Playwright/apt deps)*
- `npm test --prefix backend` *(fails: Missing jest; run `npm run setup` before testing.)*
- `node scripts/run-jest.js tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js` *(fails: wait-on is not installed)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: lockfile mismatch; run 'npm install')*
- `SKIP_PW_DEPS=1 npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_68c3ee160128832d9a3b5df22e3e37cd