### PR TITLE
fix: import isTest in payments route

### DIFF
--- a/backend/src/routes/payments.ts
+++ b/backend/src/routes/payments.ts
@@ -1,6 +1,6 @@
 import { Router, type Request, type Response } from "express";
 import Stripe from "stripe";
-import { getEnv } from "../env";
+import { getEnv, isTest } from "../env";
 import logger from "../logger";
 import { capture } from "../lib/logger";
 


### PR DESCRIPTION
## Summary
- correctly import `isTest` helper in payments route to allow Stripe mocking during tests

## Testing
- `node backend/node_modules/prettier/bin/prettier.cjs backend/src/routes/payments.ts -w`
- `npm run validate-env`
- `npm test --prefix backend` *(fails: Cannot find module '../queue/printQueue')*
- `npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68c3eac9fe90832dad21501c207ddaa1