### PR TITLE
feat: expose stripe publishable key config

### DIFF
--- a/backend/queue/printQueue.js
+++ b/backend/queue/printQueue.js
@@ -1,0 +1,1 @@
+module.exports = require("../src/queue/printQueue.js");

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -24,6 +24,15 @@ try {
 
 try {
   (() => {
+    const r = require("./routes/stripe/config");
+    app.use("/api/config/stripe", r.default || r);
+  })();
+} catch (err) {
+  logger.error("Failed to load stripe config router", err as Error);
+}
+
+try {
+  (() => {
     const r = require("./routes/health");
     app.use(r.default || r);
   })();

--- a/backend/src/routes/stripe/config.ts
+++ b/backend/src/routes/stripe/config.ts
@@ -1,0 +1,10 @@
+import { Router } from "express";
+import config from "../../../config";
+
+const router = Router();
+
+router.get("/", (_req, res) => {
+  res.json({ publishableKey: config.stripePublishable });
+});
+
+export default router;

--- a/tests/api/smoke/basic.n7p3f9d2k6h4q1v5.spec.ts
+++ b/tests/api/smoke/basic.n7p3f9d2k6h4q1v5.spec.ts
@@ -1,6 +1,7 @@
 import request from "supertest";
 
 process.env.NODE_ENV = "test";
+process.env.STRIPE_PUBLISHABLE_KEY = "pk_test";
 const app = require("../../../backend/server");
 
 const EXPECT = Number(process.env.EXPECT_REMOVED_STATUS || 410);


### PR DESCRIPTION
## Summary
- add `/api/config/stripe` endpoint returning the Stripe publishable key
- mount new stripe config route in app
- provide publishable key in API smoke test

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npx prettier backend/src/app.ts backend/src/routes/stripe/config.ts backend/queue/printQueue.js tests/api/smoke/basic.n7p3f9d2k6h4q1v5.spec.ts --write`
- `npm test` *(fails: Missing jest; run `npm run setup` before testing)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c3eac37814832da7c60e86c7194c71