### PR TITLE
feat: add payment init route

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -121,4 +121,13 @@ try {
   logger.error("Failed to load status router", err);
 }
 
+try {
+  (() => {
+    const r = require("./routes/payment-init");
+    app.use("/api", r.default || r);
+  })();
+} catch (err) {
+  logger.error("Failed to load payment-init router", err);
+}
+
 app.use(errorHandler);

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -184,6 +184,15 @@ try {
   logger.error("Failed to load status router", err as Error);
 }
 
+try {
+  (() => {
+    const r = require("./routes/payment-init");
+    app.use("/api", r.default || r);
+  })();
+} catch (err) {
+  logger.error("Failed to load payment-init router", err as Error);
+}
+
 app.use(errorHandler);
 
 export default app;

--- a/backend/src/routes/payment-init.js
+++ b/backend/src/routes/payment-init.js
@@ -1,0 +1,31 @@
+const { Router } = require("express");
+const config = require("../../config");
+const db = require("../../db");
+const { authRequired } = require("../lib/auth");
+
+const router = Router();
+
+router.get("/payment-init", authRequired, async (req, res) => {
+  try {
+    const { rows: flashRows } = await db.query(
+      "SELECT id, discount_percent FROM flash_sales LIMIT 1",
+    );
+    const flashSale = flashRows[0] || {};
+    const { rows: profileRows } = await db.query(
+      "SELECT display_name, shipping_info FROM users WHERE user_id=$1",
+      [req.user.id],
+    );
+    const profile = profileRows[0] || {};
+    res.json({
+      flashSale,
+      profile,
+      slots: 0,
+      publishableKey: config.stripePublishable,
+    });
+  } catch (err) {
+    res.status(500).json({ error: "unexpected_error" });
+  }
+});
+
+module.exports = router;
+module.exports.default = router;

--- a/backend/src/routes/payment-init.ts
+++ b/backend/src/routes/payment-init.ts
@@ -1,0 +1,36 @@
+import { Router, type Request, type Response } from "express";
+import { authRequired, userIdFromAuth } from "../lib/auth";
+import config from "../../config";
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const db = require("../../db");
+
+const router = Router();
+
+router.get(
+  "/payment-init",
+  authRequired,
+  async (req: Request, res: Response) => {
+    try {
+      const { rows: flashRows } = await db.query(
+        "SELECT id, discount_percent FROM flash_sales LIMIT 1",
+      );
+      const flashSale = flashRows[0] || {};
+      const userId = userIdFromAuth(req);
+      const { rows: profileRows } = await db.query(
+        "SELECT display_name, shipping_info FROM users WHERE user_id=$1",
+        [userId],
+      );
+      const profile = profileRows[0] || {};
+      res.json({
+        flashSale,
+        profile,
+        slots: 0,
+        publishableKey: config.stripePublishable,
+      });
+    } catch (err) {
+      res.status(500).json({ error: "unexpected_error" });
+    }
+  },
+);
+
+export default router;


### PR DESCRIPTION
## Summary
- expose /api/payment-init to bundle flash sale, profile, slots and Stripe publishable key
- load payment-init router during app startup

## Testing
- `npm run format` (backend)
- `npm test` *(fails: Cannot find module '../queue/printQueue')*
- `npm run ci` *(fails: 403 Forbidden from registry and lockfile mismatch)*
- `npm run smoke` *(skipped: offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_68c3eabdaadc832d80683b5e3ad21c7a