### PR TITLE
fix: show basket button with corrupted storage

### DIFF
--- a/js/basket.js
+++ b/js/basket.js
@@ -44,6 +44,10 @@ export function getBasket() {
     } catch {
       localStorage.removeItem(KEY);
       basket = [];
+      const btn = document.getElementById("basket-button");
+      if (btn) btn.hidden = false;
+      const badge = document.getElementById("basket-count");
+      if (badge) badge.hidden = true;
     }
   }
   return basket;

--- a/tests/e2e/basket-button.spec.r8k2m5n7b3v1c6x9.ts
+++ b/tests/e2e/basket-button.spec.r8k2m5n7b3v1c6x9.ts
@@ -1,8 +1,6 @@
 import { test, expect } from "@playwright/test";
 
-test("basket button remains visible with invalid localStorage", async ({
-  page,
-}) => {
+test("basket button visible with corrupted storage", async ({ page }) => {
   await page.addInitScript(() => {
     localStorage.setItem("print2Basket", "{oops");
   });


### PR DESCRIPTION
## Summary
- ensure corrupted basket storage clears invalid data but keeps the basket button visible
- verify basket button visibility and hidden count when storage is corrupted

## Testing
- `npm run validate-env`
- `npm run setup`
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c3fd4cfc4c832dad213aedbc856bba