### PR TITLE
fix: add fallback when viewer src missing

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1056,7 +1056,24 @@ async function init() {
           if (!refs.viewer) return resolve();
           const onLoad = () => resolve();
           if (!refs.viewer.src) {
-            onLoad();
+            const timer = setTimeout(() => {
+              if (!refs.viewer.src) {
+                refs.viewer.src =
+                  refs.previewImg?.dataset?.glb ||
+                  refs.previewImg?.src ||
+                  localStorage.getItem("print2Model") ||
+                  FALLBACK_GLB;
+              }
+              onLoad();
+            }, 0);
+            refs.viewer.addEventListener(
+              "load",
+              () => {
+                clearTimeout(timer);
+                onLoad();
+              },
+              { once: true },
+            );
           } else if (refs.viewer.loaded || refs.viewer.modelIsVisible) {
             onLoad();
           } else {


### PR DESCRIPTION
## Summary
- handle empty model-viewer elements by loading a fallback model and waiting for a load event

## Testing
- `npm run format` *(fails: bash: command not found: npm)*
- `node scripts/run-jest.js tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js` *(fails: bash: command not found: node)*

------
https://chatgpt.com/codex/tasks/task_e_68c3fd5818f0832d9cc8e2d7003ac086