### PR TITLE
test: ensure basket tests reset state

### DIFF
--- a/tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js
+++ b/tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js
@@ -9,6 +9,8 @@ let manualizeItem;
 let removeFromBasket;
 let clearBasket;
 let setupBasketUI;
+let leftoverListener;
+let leftoverFlag;
 
 const originalAddEventListener = window.addEventListener;
 const originalRemoveEventListener = window.removeEventListener;
@@ -67,6 +69,33 @@ afterEach(() => {
     delete global.fetch;
   }
   jest.clearAllTimers();
+  jest.useRealTimers();
+});
+
+test("creates listener, timer and DOM node for cleanup", () => {
+  document.body.innerHTML += '<div id="temp"></div>';
+  leftoverListener = jest.fn();
+  window.addEventListener("cleanup-test", leftoverListener);
+  addToBasket({ modelUrl: "m" });
+  leftoverFlag = false;
+  jest.useFakeTimers();
+  setTimeout(() => {
+    leftoverFlag = true;
+  }, 1000);
+});
+
+test("beforeEach/afterEach reset DOM, timers and listeners", () => {
+  expect(document.getElementById("temp")).toBeNull();
+  window.dispatchEvent(new Event("cleanup-test"));
+  expect(leftoverListener).not.toHaveBeenCalled();
+  jest.useFakeTimers();
+  jest.runOnlyPendingTimers();
+  expect(leftoverFlag).toBe(false);
+  jest.useRealTimers();
+  const badge = document.getElementById("basket-count");
+  expect(getBasket()).toHaveLength(0);
+  expect(badge).toHaveTextContent("");
+  expect(badge.hidden).toBe(true);
 });
 
 test("getBasket returns empty array when no data", () => {


### PR DESCRIPTION
## Summary
- add regression tests ensuring basket state, event listeners, and timers reset between runs
- clean up timers with `jest.useRealTimers`

## Testing
- `npm run format` (backend) *(fails: 403 Forbidden to npm registry)*
- `npm test` (backend) *(fails: Missing jest; run npm run setup)*
- `node scripts/run-jest.js tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js` *(fails: wait-on is not installed)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden to npm registry)*
- `SKIP_PW_DEPS=1 npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_68c3fd5f008c832db85e2a26f21cb5da