### PR TITLE
fix: validate stripe webhook events in tests

### DIFF
--- a/backend/tests/utils/stripeMock.js
+++ b/backend/tests/utils/stripeMock.js
@@ -1,3 +1,5 @@
+const Stripe = require("stripe");
+
 const stripe = {
   checkout: {
     sessions: {
@@ -10,7 +12,13 @@ const stripe = {
     },
   },
   webhooks: {
-    constructEvent: () => ({}),
+    constructEvent: (payload, signature) => {
+      return Stripe.webhooks.constructEvent(
+        payload,
+        signature,
+        process.env.STRIPE_WEBHOOK_SECRET,
+      );
+    },
   },
 };
 


### PR DESCRIPTION
## Summary
- use real Stripe webhooks.constructEvent in test stripe mock

## Testing
- `npm run setup`
- `npm run format`
- `npx prettier backend/tests/utils/stripeMock.js --write`
- `npm test` *(fails: Missing jest; run `npm run setup` before testing)*
- `npm run ci` *(fails: Lockfile mismatch due to registry access)*
- `npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68c3fdaa7914832dbd50329ae4976857