### PR TITLE
fix: handle checkout session price or items

### DIFF
--- a/backend/src/routes/stripe/create-checkout-session.ts
+++ b/backend/src/routes/stripe/create-checkout-session.ts
@@ -13,6 +13,7 @@ interface Item {
 
 interface CheckoutBody {
   items?: Item[];
+  price?: number;
   allowPromotionCodes?: boolean;
   metadata?: Record<string, string>;
   customer_email?: string;
@@ -22,30 +23,13 @@ interface CheckoutBody {
 }
 
 const router = Router();
-let stripeKey: string;
-let successUrl: string;
-let cancelUrl: string;
-try {
-  stripeKey = getEnvVar("STRIPE_SECRET_KEY", { required: true })!;
-  successUrl = getEnvVar("FRONTEND_SUCCESS_URL", { required: true })!;
-  cancelUrl = getEnvVar("FRONTEND_CANCEL_URL", { required: true })!;
-} catch (err) {
-  logger.error((err as Error).message);
-  throw err;
-}
-
-const realStripe = new Stripe(stripeKey, {
-  apiVersion: "2022-11-15",
-});
-const stripe = isTest()
-  ? require("../../../tests/utils/stripeMock").stripe
-  : realStripe;
 
 router.post(
   "/api/checkout/create",
   async (req: Request<{}, any, CheckoutBody>, res: Response) => {
     const {
       items,
+      price,
       allowPromotionCodes,
       metadata,
       customer_email,
@@ -54,31 +38,59 @@ router.post(
       idempotencyKey,
     } = req.body;
 
-    if (!Array.isArray(items) || items.length === 0) {
-      return res.status(400).json({ error: "bad_request" });
+    const stripeKey = getEnvVar("STRIPE_SECRET_KEY");
+    const successUrl = getEnvVar("FRONTEND_SUCCESS_URL");
+    const cancelUrl = getEnvVar("FRONTEND_CANCEL_URL");
+
+    if (!stripeKey) {
+      return res.status(500).json({ error: "STRIPE_SECRET_KEY missing" });
+    }
+    if (!successUrl) {
+      return res.status(500).json({ error: "FRONTEND_SUCCESS_URL missing" });
+    }
+    if (!cancelUrl) {
+      return res.status(500).json({ error: "FRONTEND_CANCEL_URL missing" });
     }
 
-    for (const item of items) {
-      if (!item.price) {
+    const stripe = isTest()
+      ? require("../../../tests/utils/stripeMock").stripe
+      : new Stripe(stripeKey, { apiVersion: "2022-11-15" });
+
+    let lineItems: Stripe.Checkout.SessionCreateParams.LineItem[];
+
+    if (typeof price === "number") {
+      lineItems = [
+        {
+          price_data: { currency, unit_amount: price },
+          quantity: 1,
+        },
+      ];
+    } else {
+      if (!Array.isArray(items) || items.length === 0) {
         return res.status(400).json({ error: "bad_request" });
       }
-      if (
-        typeof item.quantity !== "number" ||
-        item.quantity < 1 ||
-        item.quantity > 99
-      ) {
-        return res.status(400).json({ error: "bad_request" });
+
+      for (const item of items) {
+        if (!item.price) {
+          return res.status(400).json({ error: "bad_request" });
+        }
+        if (
+          typeof item.quantity !== "number" ||
+          item.quantity < 1 ||
+          item.quantity > 99
+        ) {
+          return res.status(400).json({ error: "bad_request" });
+        }
       }
+
+      lineItems = items.map((i) => ({ price: i.price, quantity: i.quantity }));
     }
 
     const params: Stripe.Checkout.SessionCreateParams & { currency?: string } =
       {
         mode: "payment",
         payment_method_types: ["card"],
-        line_items: items.map((i) => ({
-          price: i.price,
-          quantity: i.quantity,
-        })),
+        line_items: lineItems,
         success_url: successUrl,
         cancel_url: cancelUrl,
         currency,
@@ -99,6 +111,7 @@ router.post(
 
     logger.info("create_checkout_session", {
       items,
+      price,
       allowPromotionCodes,
       metadata,
       customer_email,
@@ -116,7 +129,7 @@ router.post(
     } catch (err) {
       logger.error("create_checkout_session_failed", err as Error);
       capture(err);
-      res.status(502).json({ error: "stripe_error" });
+      res.status(500).json({ error: "stripe_error" });
     }
   },
 );

--- a/backend/tests/stripe/checkout.session.spec.ts
+++ b/backend/tests/stripe/checkout.session.spec.ts
@@ -112,10 +112,10 @@ describe("POST /api/checkout/create", () => {
     expect(opts.idempotencyKey).toBe("abc");
   });
 
-  test("maps Stripe create failure to 502 with {error:'stripe_error'}", async () => {
+  test("maps Stripe create failure to 500 with {error:'stripe_error'}", async () => {
     (Stripe as any).__mocks.createMock.mockRejectedValueOnce(new Error("boom"));
     const res = await request(app).post("/api/checkout/create").send(body);
-    expect(res.status).toBe(502);
+    expect(res.status).toBe(500);
     expect(res.body).toEqual({ error: "stripe_error" });
   });
 


### PR DESCRIPTION
## Summary
- allow creating Stripe checkout sessions from a raw `price` or an `items` array
- check for required Stripe env vars at request time
- surface Stripe SDK failures as HTTP 500

## Testing
- `npm run validate-env`
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Lockfile mismatch detected)*
- `SKIP_PW_DEPS=1 npm run smoke`

------
https://chatgpt.com/codex/tasks/task_e_68c3fdc479c8832d8d6707cc6ec1ebee