### PR TITLE
fix: ignore unused error variable in payment-init route

### DIFF
--- a/backend/src/routes/payment-init.js
+++ b/backend/src/routes/payment-init.js
@@ -22,7 +22,7 @@ router.get("/payment-init", authRequired, async (req, res) => {
       slots: 0,
       publishableKey: config.stripePublishable,
     });
-  } catch (err) {
+  } catch (_err) {
     res.status(500).json({ error: "unexpected_error" });
   }
 });


### PR DESCRIPTION
## Summary
- rename unused error variable in payment-init route

## Testing
- `npm run format --prefix backend`
- `npm test --prefix backend`
- `npm run lint --prefix backend`
- `npm run validate-env` *(failed: 403 Forbidden)*
- `SKIP_PW_DEPS=1 npm run setup` *(failed: command terminated early)*
- `SKIP_PW_DEPS=1 npm run ci` *(failed: 403 Forbidden - lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68c3fe1cfefc832db1d348185fb1fec1