### PR TITLE
test: rewrite fetch-assets test using jest

### DIFF
--- a/tests/fetch-assets.test.h3k9f2s8p1t6w4y5.js
+++ b/tests/fetch-assets.test.h3k9f2s8p1t6w4y5.js
@@ -1,9 +1,7 @@
-const test = require("node:test");
-const assert = require("node:assert/strict");
 const { resolve } = require("node:path");
 const fs = require("node:fs");
 
 test("fetch-assets script exists", () => {
   const script = resolve(__dirname, "../scripts/fetch-assets.cjs");
-  assert.ok(fs.existsSync(script), "fetch-assets.cjs should exist");
+  expect(fs.existsSync(script)).toBe(true);
 });


### PR DESCRIPTION
## Summary
- rewrite fetch-assets test to use Jest's `test` and `expect`

## Testing
- `npx prettier tests/fetch-assets.test.h3k9f2s8p1t6w4y5.js -w`
- `node scripts/run-jest.js tests/fetch-assets.test.h3k9f2s8p1t6w4y5.js` *(fails: wait-on is not installed)*


------
https://chatgpt.com/codex/tasks/task_e_68c3fdf5f394832db2f663a1626c04b7