### PR TITLE
fix: verify stripe webhook events

### DIFF
--- a/backend/tests/utils/stripeMock.js
+++ b/backend/tests/utils/stripeMock.js
@@ -1,3 +1,5 @@
+const Stripe = require("stripe");
+
 const stripe = {
   checkout: {
     sessions: {
@@ -10,7 +12,10 @@ const stripe = {
     },
   },
   webhooks: {
-    constructEvent: () => ({}),
+    constructEvent: (payload, signature) => {
+      const secret = process.env.STRIPE_WEBHOOK_SECRET;
+      return Stripe.webhooks.constructEvent(payload, signature, secret);
+    },
   },
 };
 


### PR DESCRIPTION
## Summary
- use real Stripe webhook parsing in test stripeMock

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format -- tests/utils/stripeMock.js`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Lockfile mismatch detected. Run 'npm install' to regenerate package-lock.json.)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c4002d4a1c832d92a3476bb0d2f290