### PR TITLE
feat: deduplicate stripe webhook events

### DIFF
--- a/backend/src/routes/stripe/webhook.ts
+++ b/backend/src/routes/stripe/webhook.ts
@@ -9,6 +9,7 @@ import { isTest } from "../../env";
 import { getEnv as getEnvVar } from "../../../utils/getEnv";
 
 const router = Router();
+const processedEvents = new Set<string>();
 let stripeKey: string;
 let stripeWebhookSecret: string;
 try {
@@ -54,6 +55,13 @@ router.post(
     }
 
     logger.info("stripe_webhook_received", { type: event.type });
+    if (processedEvents.has(event.id)) {
+      logger.info("stripe_webhook_duplicate_event", { eventId: event.id });
+      res.status(200).json({ received: true });
+      return;
+    }
+
+    processedEvents.add(event.id);
 
     if (event.type === "checkout.session.completed") {
       const session = event.data.object as Stripe.Checkout.Session;
@@ -74,6 +82,7 @@ router.post(
           });
         }
       } catch (err) {
+        processedEvents.delete(event.id);
         logger.error("stripe_webhook_processing_failed", {
           sessionId: session.id,
         });


### PR DESCRIPTION
## Summary
- avoid duplicate processing of Stripe webhook events by tracking processed IDs
- skip webhook processing if an event ID was already handled

## Testing
- `npm run format`
- `npm test`
- `npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68c400313928832d8179c76fea19a9bd