### PR TITLE
fix: support price field and handle stripe errors

### DIFF
--- a/backend/src/routes/stripe/create-checkout-session.ts
+++ b/backend/src/routes/stripe/create-checkout-session.ts
@@ -13,6 +13,7 @@ interface Item {
 
 interface CheckoutBody {
   items?: Item[];
+  price?: number;
   allowPromotionCodes?: boolean;
   metadata?: Record<string, string>;
   customer_email?: string;
@@ -22,30 +23,13 @@ interface CheckoutBody {
 }
 
 const router = Router();
-let stripeKey: string;
-let successUrl: string;
-let cancelUrl: string;
-try {
-  stripeKey = getEnvVar("STRIPE_SECRET_KEY", { required: true })!;
-  successUrl = getEnvVar("FRONTEND_SUCCESS_URL", { required: true })!;
-  cancelUrl = getEnvVar("FRONTEND_CANCEL_URL", { required: true })!;
-} catch (err) {
-  logger.error((err as Error).message);
-  throw err;
-}
-
-const realStripe = new Stripe(stripeKey, {
-  apiVersion: "2022-11-15",
-});
-const stripe = isTest()
-  ? require("../../../tests/utils/stripeMock").stripe
-  : realStripe;
 
 router.post(
   "/api/checkout/create",
   async (req: Request<{}, any, CheckoutBody>, res: Response) => {
     const {
       items,
+      price,
       allowPromotionCodes,
       metadata,
       customer_email,
@@ -54,31 +38,57 @@ router.post(
       idempotencyKey,
     } = req.body;
 
-    if (!Array.isArray(items) || items.length === 0) {
-      return res.status(400).json({ error: "bad_request" });
+    let stripeKey: string;
+    let successUrl: string;
+    let cancelUrl: string;
+    try {
+      stripeKey = getEnvVar("STRIPE_SECRET_KEY", { required: true })!;
+      successUrl = getEnvVar("FRONTEND_SUCCESS_URL", { required: true })!;
+      cancelUrl = getEnvVar("FRONTEND_CANCEL_URL", { required: true })!;
+    } catch (err) {
+      logger.error((err as Error).message);
+      return res.status(500).json({ error: "STRIPE_SECRET_KEY missing" });
     }
 
-    for (const item of items) {
-      if (!item.price) {
-        return res.status(400).json({ error: "bad_request" });
+    const stripe = isTest()
+      ? require("../../../tests/utils/stripeMock").stripe
+      : new Stripe(stripeKey, { apiVersion: "2022-11-15" });
+
+    let lineItems: Stripe.Checkout.SessionCreateParams.LineItem[];
+    if (typeof price === "number") {
+      lineItems = [
+        {
+          price_data: {
+            currency,
+            product_data: { name: "custom" },
+            unit_amount: price,
+          },
+          quantity: 1,
+        },
+      ];
+    } else if (Array.isArray(items) && items.length > 0) {
+      for (const item of items) {
+        if (!item.price) {
+          return res.status(400).json({ error: "bad_request" });
+        }
+        if (
+          typeof item.quantity !== "number" ||
+          item.quantity < 1 ||
+          item.quantity > 99
+        ) {
+          return res.status(400).json({ error: "bad_request" });
+        }
       }
-      if (
-        typeof item.quantity !== "number" ||
-        item.quantity < 1 ||
-        item.quantity > 99
-      ) {
-        return res.status(400).json({ error: "bad_request" });
-      }
+      lineItems = items.map((i) => ({ price: i.price, quantity: i.quantity }));
+    } else {
+      return res.status(400).json({ error: "bad_request" });
     }
 
     const params: Stripe.Checkout.SessionCreateParams & { currency?: string } =
       {
         mode: "payment",
         payment_method_types: ["card"],
-        line_items: items.map((i) => ({
-          price: i.price,
-          quantity: i.quantity,
-        })),
+        line_items: lineItems,
         success_url: successUrl,
         cancel_url: cancelUrl,
         currency,
@@ -99,6 +109,7 @@ router.post(
 
     logger.info("create_checkout_session", {
       items,
+      price,
       allowPromotionCodes,
       metadata,
       customer_email,
@@ -116,7 +127,7 @@ router.post(
     } catch (err) {
       logger.error("create_checkout_session_failed", err as Error);
       capture(err);
-      res.status(502).json({ error: "stripe_error" });
+      res.status(500).json({ error: "stripe_error" });
     }
   },
 );

--- a/backend/tests/stripe/checkout.session.spec.ts
+++ b/backend/tests/stripe/checkout.session.spec.ts
@@ -112,10 +112,10 @@ describe("POST /api/checkout/create", () => {
     expect(opts.idempotencyKey).toBe("abc");
   });
 
-  test("maps Stripe create failure to 502 with {error:'stripe_error'}", async () => {
+  test("maps Stripe create failure to 500 with {error:'stripe_error'}", async () => {
     (Stripe as any).__mocks.createMock.mockRejectedValueOnce(new Error("boom"));
     const res = await request(app).post("/api/checkout/create").send(body);
-    expect(res.status).toBe(502);
+    expect(res.status).toBe(500);
     expect(res.body).toEqual({ error: "stripe_error" });
   });
 


### PR DESCRIPTION
## Summary
- defer Stripe env lookup to POST handler with error response when missing
- allow specifying a numeric `price` for checkout sessions
- return HTTP 500 on Stripe SDK failures

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup` *(failed: process terminated)*
- `npm run format` (backend)
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: lockfile mismatch)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c4003348a8832da03407cb106cf141