### PR TITLE
test: enable basket button after model viewer load

### DIFF
--- a/tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js
+++ b/tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js
@@ -653,32 +653,40 @@ test("checkout button saves model and job id", () => {
   expect(localStorage.getItem("print2JobId")).toBe("j");
 });
 
-test("index add-basket button disabled until viewer ready", async () => {
+test("index viewer load enables add-basket button and increments count", async () => {
   document.body.innerHTML +=
     '<button id="add-basket-button"></button>' +
     '<img id="preview-img" src="http://example.com/s.png" />' +
-    '<div id="glb-viewer"></div>';
+    '<model-viewer id="glb-viewer"></model-viewer>';
+  const originalLocation = window.location;
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    writable: true,
+    value: {
+      ...originalLocation,
+      assign: jest.fn(),
+      href: "http://example.com",
+    },
+  });
   const { webcrypto } = require("crypto");
   global.crypto = webcrypto;
   window.customElements.whenDefined = () => Promise.resolve();
+  jest.resetModules();
   const { initIndexPage } = await import("../../js/index.js");
   await initIndexPage();
-  expect(document.getElementById("add-basket-button").disabled).toBe(true);
-});
-
-test("index viewer load enables add-basket button", async () => {
-  document.body.innerHTML +=
-    '<button id="add-basket-button"></button>' +
-    '<img id="preview-img" src="http://example.com/s.png" />' +
-    '<div id="glb-viewer"></div>';
-  const { webcrypto } = require("crypto");
-  global.crypto = webcrypto;
-  window.customElements.whenDefined = () => Promise.resolve();
-  const { initIndexPage } = await import("../../js/index.js");
-  await initIndexPage();
+  const btn = document.getElementById("add-basket-button");
+  const badge = document.getElementById("basket-count");
+  expect(btn.disabled).toBe(true);
   const viewer = document.getElementById("glb-viewer");
   viewer.src = "model.glb";
   viewer.dispatchEvent(new Event("load"));
   await Promise.resolve();
-  expect(document.getElementById("add-basket-button").disabled).toBe(false);
+  expect(btn.disabled).toBe(false);
+  btn.click();
+  expect(badge).toHaveTextContent("1");
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    writable: true,
+    value: originalLocation,
+  });
 });


### PR DESCRIPTION
## Summary
- stub `window.location` in basket pipeline test to avoid jsdom navigation
- mimic `<model-viewer>` readiness and assert basket button enables and increments count

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` (backend)
- `npx prettier tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js --write`
- `npm test` (backend)
- `node scripts/run-jest.js tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js` *(fails: wait-on is not installed)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: lockfile mismatch)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c429ed3f68832da0c1720bebb94e1d