### PR TITLE
test: enable add-basket after viewer load

### DIFF
--- a/tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js
+++ b/tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js
@@ -682,3 +682,26 @@ test("index viewer load enables add-basket button", async () => {
   await Promise.resolve();
   expect(document.getElementById("add-basket-button").disabled).toBe(false);
 });
+
+test("index viewer load enables and adds to basket with minimal DOM", async () => {
+  document.body.innerHTML +=
+    '<button id="add-basket-button"></button>' +
+    '<div id="glb-viewer"></div>';
+  global.fetch = jest
+    .fn()
+    .mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+  const { webcrypto } = require("crypto");
+  global.crypto = webcrypto;
+  window.customElements.whenDefined = () => Promise.resolve();
+  const { initIndexPage } = await import("../../js/index.js");
+  await initIndexPage();
+  const button = document.getElementById("add-basket-button");
+  const viewer = document.getElementById("glb-viewer");
+  expect(button.disabled).toBe(true);
+  viewer.src = "model.glb";
+  viewer.dispatchEvent(new Event("load"));
+  await Promise.resolve();
+  expect(button.disabled).toBe(false);
+  button.click();
+  await waitFor(() => expect(getBasket()).toHaveLength(1));
+});


### PR DESCRIPTION
## Summary
- verify add-basket button remains disabled until viewer load and adds item to basket with minimal DOM

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format` (backend)
- `npm test` (backend) *(fails: wait-on is not installed)*
- `node scripts/run-jest.js tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js` *(fails: wait-on is not installed)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Lockfile mismatch and 403 from registry)*
- `SKIP_PW_DEPS=1 npm run smoke` *(skipped: offline mode)*

------
https://chatgpt.com/codex/tasks/task_e_68c429f2181c832db33036231d439c8f