### PR TITLE
test: stub navigation in index tests

### DIFF
--- a/tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js
+++ b/tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js
@@ -139,7 +139,12 @@ test("index add-basket button increments count", async () => {
 
   const loc = window.location;
   delete window.location;
-  window.location = { ...loc, assign: jest.fn(), replace: jest.fn(), href: loc.href };
+  window.location = {
+    ...loc,
+    assign: jest.fn(),
+    replace: jest.fn(),
+    href: "http://example.com",
+  };
   window.customElements.whenDefined = () => Promise.resolve();
   const { webcrypto } = require("crypto");
   global.crypto = webcrypto;
@@ -169,7 +174,12 @@ test("button does not increment when viewer source missing", async () => {
 
   const loc = window.location;
   delete window.location;
-  window.location = { ...loc, assign: jest.fn(), replace: jest.fn(), href: loc.href };
+  window.location = {
+    ...loc,
+    assign: jest.fn(),
+    replace: jest.fn(),
+    href: "http://example.com",
+  };
   window.customElements.whenDefined = () => Promise.resolve();
   const { webcrypto } = require("crypto");
   global.crypto = webcrypto;
@@ -194,22 +204,6 @@ test("button does not increment when viewer source missing", async () => {
 
 
 
-
-test.failing("does not increment when viewer source is missing", () => {
-  const fs = require("fs");
-  const path = require("path");
-  const html = fs.readFileSync(
-    path.resolve(__dirname, "../../index.html"),
-    "utf8",
-  );
-  document.documentElement.innerHTML = html;
-  setupBasketUI();
-  document.getElementById("glb-viewer").src = "";
-  document.getElementById("add-basket-button").click();
-  const badge = document.getElementById("basket-count");
-  expect(badge).toHaveTextContent("");
-  expect(getBasket()).toHaveLength(0);
-});
 
 test("increments count for multiple added items", () => {
   const badge = document.getElementById("basket-count");
@@ -482,11 +476,20 @@ test("index add-basket button adds to basket", async () => {
   const { webcrypto } = require("crypto");
   global.crypto = webcrypto;
   window.customElements.whenDefined = () => Promise.resolve();
+  const loc = window.location;
+  delete window.location;
+  window.location = {
+    ...loc,
+    assign: jest.fn(),
+    replace: jest.fn(),
+    href: "http://example.com",
+  };
   const { initIndexPage } = await import("../../js/index.js");
   await initIndexPage();
   await Promise.resolve();
   document.getElementById("add-basket-button").click();
   await waitFor(() => expect(getBasket()).toHaveLength(1));
+  window.location = loc;
 });
 
 test("index basket count increments without viewer src", async () => {
@@ -500,6 +503,14 @@ test("index basket count increments without viewer src", async () => {
   const { webcrypto } = require("crypto");
   global.crypto = webcrypto;
   window.customElements.whenDefined = () => Promise.resolve();
+  const loc = window.location;
+  delete window.location;
+  window.location = {
+    ...loc,
+    assign: jest.fn(),
+    replace: jest.fn(),
+    href: "http://example.com",
+  };
   await import("../../js/index.js");
   await window.initIndexPage();
   document.getElementById("add-basket-button").click();
@@ -507,6 +518,7 @@ test("index basket count increments without viewer src", async () => {
   const count = document.getElementById("basket-count");
   expect(count).toHaveTextContent("1");
   expect(count.hidden).toBe(false);
+  window.location = loc;
 });
 
 test("addToBasket skips server call without token", () => {
@@ -707,16 +719,14 @@ test("index viewer load enables add-basket button and increments count", async (
     '<button id="add-basket-button"></button>' +
     '<img id="preview-img" src="http://example.com/s.png" />' +
     '<model-viewer id="glb-viewer"></model-viewer>';
-  const originalLocation = window.location;
-  Object.defineProperty(window, "location", {
-    configurable: true,
-    writable: true,
-    value: {
-      ...originalLocation,
-      assign: jest.fn(),
-      href: "http://example.com",
-    },
-  });
+  const loc = window.location;
+  delete window.location;
+  window.location = {
+    ...loc,
+    assign: jest.fn(),
+    replace: jest.fn(),
+    href: "http://example.com",
+  };
   const { webcrypto } = require("crypto");
   global.crypto = webcrypto;
   window.customElements.whenDefined = () => Promise.resolve();
@@ -733,11 +743,7 @@ test("index viewer load enables add-basket button and increments count", async (
   expect(btn.disabled).toBe(false);
   btn.click();
   expect(badge).toHaveTextContent("1");
-  Object.defineProperty(window, "location", {
-    configurable: true,
-    writable: true,
-    value: originalLocation,
-  });
+  window.location = loc;
 });
 
 test("index viewer load enables and adds to basket with minimal DOM", async () => {
@@ -750,6 +756,14 @@ test("index viewer load enables and adds to basket with minimal DOM", async () =
   const { webcrypto } = require("crypto");
   global.crypto = webcrypto;
   window.customElements.whenDefined = () => Promise.resolve();
+  const loc = window.location;
+  delete window.location;
+  window.location = {
+    ...loc,
+    assign: jest.fn(),
+    replace: jest.fn(),
+    href: "http://example.com",
+  };
   const { initIndexPage } = await import("../../js/index.js");
   await initIndexPage();
   const button = document.getElementById("add-basket-button");
@@ -761,4 +775,5 @@ test("index viewer load enables and adds to basket with minimal DOM", async () =
   expect(button.disabled).toBe(false);
   button.click();
   await waitFor(() => expect(getBasket()).toHaveLength(1));
+  window.location = loc;
 });

--- a/tests/frontend/discount-delivery-banner.k1m2n3b4v5c6x7z8.test.js
+++ b/tests/frontend/discount-delivery-banner.k1m2n3b4v5c6x7z8.test.js
@@ -1,6 +1,23 @@
 /** @jest-environment jsdom */
 import "@testing-library/jest-dom";
-import { initDiscountDeliveryBanner } from "../../js/index.js";
+let initDiscountDeliveryBanner;
+let loc;
+
+beforeAll(async () => {
+  loc = window.location;
+  delete window.location;
+  window.location = {
+    ...loc,
+    assign: jest.fn(),
+    replace: jest.fn(),
+    href: "http://example.com",
+  };
+  ({ initDiscountDeliveryBanner } = await import("../../js/index.js"));
+});
+
+afterAll(() => {
+  window.location = loc;
+});
 
 describe("Discount/delivery banner", () => {
   let banner;

--- a/tests/frontend/print-run-info.4hb2oxnb2c7nx14by7.spec.js
+++ b/tests/frontend/print-run-info.4hb2oxnb2c7nx14by7.spec.js
@@ -1,10 +1,30 @@
 /** @jest-environment jsdom */
-import {
-  computeSlotsByTime,
-  computePrintRunHours,
-  adjustedSlots,
-  updatePrintRunInfo,
-} from "../../js/index.js";
+let computeSlotsByTime;
+let computePrintRunHours;
+let adjustedSlots;
+let updatePrintRunInfo;
+let loc;
+
+beforeAll(async () => {
+  loc = window.location;
+  delete window.location;
+  window.location = {
+    ...loc,
+    assign: jest.fn(),
+    replace: jest.fn(),
+    href: "http://example.com",
+  };
+  ({
+    computeSlotsByTime,
+    computePrintRunHours,
+    adjustedSlots,
+    updatePrintRunInfo,
+  } = await import("../../js/index.js"));
+});
+
+afterAll(() => {
+  window.location = loc;
+});
 
 describe("print run info", () => {
   let originalStorage;

--- a/tests/frontend/stats-ticker.heubfxn983x849byxn0.test.js
+++ b/tests/frontend/stats-ticker.heubfxn983x849byxn0.test.js
@@ -2,12 +2,25 @@
 import "@testing-library/jest-dom";
 
 let computeDailyPrintsSold;
+let loc;
 
 beforeAll(async () => {
   const { webcrypto } = require("crypto");
   global.crypto = webcrypto;
+  loc = window.location;
+  delete window.location;
+  window.location = {
+    ...loc,
+    assign: jest.fn(),
+    replace: jest.fn(),
+    href: "http://example.com",
+  };
   const mod = await import("../../js/index.js");
   computeDailyPrintsSold = mod.computeDailyPrintsSold;
+});
+
+afterAll(() => {
+  window.location = loc;
 });
 
 describe("computeDailyPrintsSold", () => {

--- a/tests/sdk/no-generateModel-export.spec.h7k3m2p9s4t8v6w1.ts
+++ b/tests/sdk/no-generateModel-export.spec.h7k3m2p9s4t8v6w1.ts
@@ -2,11 +2,23 @@ const entryPoints = ["../../js/api.js", "../../js/index.js"];
 
 describe("public SDK exports", () => {
   test("no generateModel symbol exported", () => {
-    for (const ep of entryPoints) {
-      const mod = require(ep);
-      for (const key of Object.keys(mod)) {
-        expect(/generateModel/i.test(key)).toBe(false);
+    const loc = window.location;
+    delete window.location;
+    window.location = {
+      ...loc,
+      assign: jest.fn(),
+      replace: jest.fn(),
+      href: "http://example.com",
+    };
+    try {
+      for (const ep of entryPoints) {
+        const mod = require(ep);
+        for (const key of Object.keys(mod)) {
+          expect(/generateModel/i.test(key)).toBe(false);
+        }
       }
+    } finally {
+      window.location = loc;
     }
   });
 });


### PR DESCRIPTION
### Summary
- stubbed `window.location` before importing `js/index.js` across tests
- removed obsolete failing basket test that read `index.html`

### Testing
- `npm run format`
- `node scripts/run-jest.js tests/frontend/discount-delivery-banner.k1m2n3b4v5c6x7z8.test.js tests/frontend/print-run-info.4hb2oxnb2c7nx14by7.spec.js tests/frontend/stats-ticker.heubfxn983x849byxn0.test.js tests/frontend/basket-pipeline.q7v4b8n2k6m1c3x9.test.js tests/sdk/no-generateModel-export.spec.h7k3m2p9s4t8v6w1.ts` *(fails: wait-on is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c44113e758832d8866af72d525ecbd