### PR TITLE
test: add viewer load enables basket button

### DIFF
--- a/tests/frontend/add-basket-viewer.r3n8p5k1v6t2m9q4.test.js
+++ b/tests/frontend/add-basket-viewer.r3n8p5k1v6t2m9q4.test.js
@@ -1,0 +1,42 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+
+describe("add basket button", () => {
+  test("enables after viewer load and adds to basket", async () => {
+    document.body.innerHTML = `
+      <img id="preview-img" src="snapshot.png" data-glb="model.glb" />
+      <model-viewer id="viewer" src="model.glb"></model-viewer>
+      <button id="add-basket-button" disabled></button>
+    `;
+
+    global.customElements = {
+      get: () => undefined,
+      define: jest.fn(),
+      whenDefined: jest.fn(() => Promise.resolve()),
+    };
+
+    window.addToBasket = jest.fn();
+    window.getBasket = jest.fn(() => []);
+
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ ok: true, json: async () => ({ slots: 0 }) }),
+    );
+
+    const { initIndexPage } = await import("../../js/index.js");
+
+    const initPromise = initIndexPage();
+    await new Promise((r) => setTimeout(r, 0));
+
+    const btn = document.getElementById("add-basket-button");
+    expect(btn).toBeDisabled();
+
+    const viewer = document.getElementById("viewer");
+    viewer.dispatchEvent(new Event("load"));
+
+    await initPromise;
+    expect(btn).not.toBeDisabled();
+
+    btn.click();
+    expect(window.addToBasket).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add test ensuring add-to-basket button enables after model viewer load and triggers basket addition

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke`
- `node scripts/run-jest.js tests/frontend/add-basket-viewer.r3n8p5k1v6t2m9q4.test.js` *(fails: wait-on is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c44127f0d0832db642ae13189a40f2