### PR TITLE
test: add index basket button tests

### DIFF
--- a/tests/frontend/index-basket.v0t2s4y6q8e1r3p5.test.js
+++ b/tests/frontend/index-basket.v0t2s4y6q8e1r3p5.test.js
@@ -1,0 +1,66 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+
+describe("index page add-basket", () => {
+  beforeEach(() => {
+    Object.defineProperty(window.HTMLMediaElement.prototype, "play", {
+      configurable: true,
+      writable: true,
+      value: jest.fn().mockResolvedValue(undefined),
+    });
+  });
+
+  async function setupDom() {
+    document.body.innerHTML = `
+      <img id="preview-img" src="snapshot.png" data-glb="model.glb" />
+      <model-viewer id="glb-viewer"></model-viewer>
+      <button id="add-basket-button" disabled></button>
+    `;
+    const loc = window.location;
+    delete window.location;
+    window.location = Object.assign(new URL("http://example.com"), {
+      assign: jest.fn(),
+      replace: jest.fn(),
+    });
+    window.customElements.whenDefined = () => Promise.resolve();
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve({}) }),
+    );
+    const { webcrypto } = require("crypto");
+    global.crypto = webcrypto;
+    jest.resetModules();
+    await import("../../js/basket.js");
+    const { initIndexPage } = await import("../../js/index.js");
+    await initIndexPage();
+    return { loc };
+  }
+
+  test("enables after viewer load and adds to basket", async () => {
+    const { loc } = await setupDom();
+    const btn = document.getElementById("add-basket-button");
+    const badge = document.getElementById("basket-count");
+    expect(btn).toBeDisabled();
+    const viewer = document.getElementById("glb-viewer");
+    viewer.src = "model.glb";
+    viewer.dispatchEvent(new Event("load"));
+    await Promise.resolve();
+    expect(btn).not.toBeDisabled();
+    btn.click();
+    expect(badge).toHaveTextContent("1");
+    window.location = loc;
+  });
+
+  test("remains disabled if viewer src missing", async () => {
+    const { loc } = await setupDom();
+    const btn = document.getElementById("add-basket-button");
+    const badge = document.getElementById("basket-count");
+    expect(btn).toBeDisabled();
+    const viewer = document.getElementById("glb-viewer");
+    viewer.dispatchEvent(new Event("load"));
+    await Promise.resolve();
+    expect(btn).toBeDisabled();
+    btn.click();
+    expect(badge).toHaveTextContent("");
+    window.location = loc;
+  });
+});


### PR DESCRIPTION
## Summary
- add diagnostic tests for index add-basket button lifecycle

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `cd backend && npm run format`
- `node scripts/run-jest.js tests/frontend/index-basket.v0t2s4y6q8e1r3p5.test.js --runInBand --verbose` *(fails: wait-on is not installed)*
- `cd backend && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c42663f880832d8c0f619081d57351