### PR TITLE
test: add data testids for basket flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,6 +126,7 @@
           <!-- 🔑 Minimal, hard-coded astronaut -->
           <model-viewer
             id="glb-viewer"
+            data-testid="glb-viewer"
             src="https://modelviewer.dev/shared-assets/models/Astronaut.glb"
             environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr"
             camera-controls
@@ -141,7 +142,7 @@
           <div id="checkout-container" class="absolute bottom-4 right-4 flex flex-col items-end">
             <a id="checkout-button" href="payment.html" class="font-bold py-2 px-5 rounded-full shadow-md transition border-2 border-black" style="background-color: #30d5c8; color: #1a1a1d">Print from £29.99 →</a>
           </div>
-          <button id="add-basket-button" aria-label="Add to basket" class="absolute bottom-4 left-4 font-bold py-2 px-4 rounded-full shadow-md bg-[#30D5C8] text-[#1A1A1D] border-2 border-black">Add to Basket</button>
+          <button id="add-basket-button" data-testid="add-to-basket" aria-label="Add to basket" class="absolute bottom-4 left-4 font-bold py-2 px-4 rounded-full shadow-md bg-[#30D5C8] text-[#1A1A1D] border-2 border-black">Add to Basket</button>
         </section>
 
         <div id="gen-error" class="absolute top-2 left-2 w-fit text-left text-sm text-red-400 pointer-events-none" aria-live="assertive" style="opacity: 0"></div>
@@ -278,6 +279,15 @@
         window.addEventListener('load', apply, { once: true });
         window.addEventListener('resize', apply);
       })();
+    </script>
+
+    <script>
+      window.addEventListener('DOMContentLoaded', () => {
+        const basketBtn = document.getElementById('basket-button');
+        if (basketBtn) basketBtn.setAttribute('data-testid', 'basket-icon');
+        const basketCount = document.getElementById('basket-count');
+        if (basketCount) basketCount.setAttribute('data-testid', 'basket-count');
+      });
     </script>
 
     <!-- (removed) data-model-href mutator – not used anymore -->

--- a/js/basket.js
+++ b/js/basket.js
@@ -323,15 +323,27 @@ export function setupBasketUI() {
     audio.preload = "auto";
     window.__basketSound = audio;
   }
-  const btn = document.createElement("button");
-  btn.type = "button";
+  let btn = document.getElementById("basket-button");
+  if (!btn) {
+    btn = document.createElement("button");
+    btn.type = "button";
+    btn.className =
+      "fixed bottom-3 right-4 bg-[#30D5C8] text-black p-3 rounded-full shadow-lg z-50 border-2 border-black";
+    btn.innerHTML =
+      '<i class="fas fa-shopping-basket"></i> <span class="ml-1"></span>';
+    document.body.appendChild(btn);
+  }
   btn.id = "basket-button";
-  btn.className =
-    "fixed bottom-3 right-4 bg-[#30D5C8] text-black p-3 rounded-full shadow-lg z-50 border-2 border-black";
-  btn.innerHTML =
-    '<i class="fas fa-shopping-basket"></i> <span id="basket-count" class="ml-1"></span>';
+  btn.setAttribute("data-testid", "basket-icon");
   btn.addEventListener("click", openBasket);
-  document.body.appendChild(btn);
+  let count = btn.querySelector("#basket-count") || btn.querySelector("span");
+  if (!count) {
+    count = document.createElement("span");
+    count.className = "ml-1";
+    btn.appendChild(count);
+  }
+  count.id = "basket-count";
+  count.setAttribute("data-testid", "basket-count");
 
   const overlay = document.createElement("div");
   overlay.id = "basket-overlay";


### PR DESCRIPTION
## Summary
- add testing hooks for basket and viewer elements on the landing page
- ensure basket UI elements receive data-testid attributes after load
- set basket button and count ids/data-testid when constructing UI

## Testing
- `npm run validate-env`
- `cd backend && npm run format`
- `cd backend && npm test`
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68c46b063468832db0e768b0c739fea0