### PR TITLE
fix: skip lockfile check in offline mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ These guidelines apply to all automated agents (e.g. the Codex agent) working on
 
 1. **Go to the repository root** – run `cd "$(git rev-parse --show-toplevel)"` after opening a shell to ensure paths resolve correctly.
 2. **Trust mise config** – execute `mise trust` in the repository root to prevent repeated `"config files not trusted"` warnings.
-3. **Unset proxy variables** – before running any `npm` commands, **and whenever you start a new shell session**, execute `unset npm_config_http_proxy npm_config_https_proxy` to silence `http-proxy` warnings.
+3. **Unset proxy variables** – before running any `npm` commands, and whenever you start a new shell session, execute `unset npm_config_http_proxy npm_config_https_proxy http_proxy https_proxy HTTP_PROXY HTTPS_PROXY` to silence `http-proxy` warnings.
 4. **Ensure Node 20** – run `mise use -g node@20` (or `mise install`) and then `eval \"$(mise activate bash)\"` so the required Node version is active before running setup.
 5. **Validate the environment** – run `npm run validate-env` to ensure required variables are set and proxy vars remain unset.
 6. **Check network access** – ensure the environment can reach both

--- a/scripts/ci.mjs
+++ b/scripts/ci.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { execSync } from "child_process";
-import { isOfflineEnv } from "./net-mode.mjs";
+import { isOfflineEnv, logOfflineSkip } from "./net-mode.mjs";
 
 const offline = isOfflineEnv();
 
@@ -21,7 +21,11 @@ if (offline) {
 }
 
 try {
-  execSync("npm run check:lockfile", { stdio: "inherit" });
+  if (offline) {
+    logOfflineSkip("lockfile check");
+  } else {
+    execSync("npm run check:lockfile", { stdio: "inherit" });
+  }
 } catch (err) {
   console.error(
     "Lockfile mismatch detected. Run 'npm install' to regenerate package-lock.json.",


### PR DESCRIPTION
## Summary
- skip lockfile check when running CI offline to avoid failing network lookups
- document clearing all proxy variables in AGENTS guidelines

## Testing
- `npm --prefix /workspace/MVP-website/backend run format`
- `npm --prefix /workspace-MVP-website/backend test`
- `SKIP_PW_DEPS=1 npm --prefix /workspace/MVP-website run ci` *(fails: wait-on is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68c4936f393c832d8ce07bdcf45db98d