### PR TITLE
fix: run smoke tests when offline

### DIFF
--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 import { EventEmitter } from "events";
 import { execSync } from "child_process";
-import { createRequire } from "module";
 import { isOfflineEnv, logOfflineSkip } from "./net-mode.mjs";
 
 EventEmitter.defaultMaxListeners = Math.max(
@@ -21,14 +20,6 @@ if (
   !process.env.SKIP_NET_CHECKS
 ) {
   process.env.SKIP_NET_CHECKS = "1";
-}
-
-const require = createRequire(import.meta.url);
-try {
-  require.resolve("jest");
-} catch {
-  logOfflineSkip("smoke");
-  process.exit(0);
 }
 
 if (offline) {


### PR DESCRIPTION
## Summary
- run smoke tests even when offline by dropping Jest dependency check

## Testing
- `npm run format`
- `npm test`
- `SKIP_PW_DEPS=1 npm run smoke`
- `SKIP_PW_DEPS=1 npm run ci`


------
https://chatgpt.com/codex/tasks/task_e_68c4938e6b40832db1a157e9d3f000c5