### PR TITLE
fix: drop nyc config to avoid forbidden downloads

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -1,8 +1,0 @@
-{
-  "check-coverage": true,
-  "branches": 70,
-  "functions": 75,
-  "lines": 80,
-  "statements": 80,
-  "reporter": ["lcov", "text", "json-summary"]
-}

--- a/backend/tests/checkCoverageScript.test.js
+++ b/backend/tests/checkCoverageScript.test.js
@@ -8,7 +8,10 @@ const script = path.join(__dirname, "..", "..", "scripts", "check-coverage.js");
 describe("check-coverage script", () => {
   test("fails when coverage summary is missing", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "cov-"));
-    fs.writeFileSync(path.join(tmp, ".nycrc"), "{}");
+    fs.writeFileSync(
+      path.join(tmp, "package.json"),
+      JSON.stringify({ coverageThreshold: {} }, null, 2),
+    );
     const result = spawnSync(process.execPath, [script], {
       cwd: tmp,
       encoding: "utf8",

--- a/package.json
+++ b/package.json
@@ -2,19 +2,6 @@
   "name": "mvp-website",
   "version": "1.0.0",
   "private": true,
-  "nyc": {
-    "reporter": [
-      "lcov",
-      "text",
-      "json-summary"
-    ],
-    "report-dir": "coverage",
-    "check-coverage": true,
-    "branches": 70,
-    "functions": 75,
-    "lines": 80,
-    "statements": 80
-  },
   "coverageThreshold": {
     "branches": 70,
     "functions": 75,

--- a/scripts/check-coverage.js
+++ b/scripts/check-coverage.js
@@ -1,6 +1,7 @@
 const fs = require("fs");
 
-const config = JSON.parse(fs.readFileSync(".nycrc", "utf8"));
+const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+const config = pkg.coverageThreshold || {};
 
 const summaryPath = "coverage/coverage-summary.json";
 if (!fs.existsSync(summaryPath)) {


### PR DESCRIPTION
## Summary
- remove unused nyc config and .nycrc file
- load coverage settings from package.json in check-coverage script
- update coverage script test to use package.json

## Testing
- `npm run validate-env` *(fails: 403 Forbidden - GET https://registry.npmjs.org/npm)*
- `npm run format --prefix backend`
- `npm test` *(fails: wait-on is not installed. Run `npm run setup` to install dependencies.)*


------
https://chatgpt.com/codex/tasks/task_e_68c4928bc7ec832da4ba1ea6d53e5968