### PR TITLE
fix: run backend tests through run-jest

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -3,10 +3,10 @@
   "version": "1.0.0",
   "main": "src/server.js",
   "scripts": {
-    "test": "NODE_ENV=test node scripts/ensure-tests-exist.js && PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 jest --runInBand --passWithNoTests=false tests/additionalApi.test.js tests/getEnv.test.p7q8r9s0t1u2v3w4.js tests/users.test.z9x8c7v6b5n4m3l2.js",
-    "test-ci": "node scripts/ensure-tests-exist.js && jest --ci --passWithNoTests=false",
+    "test": "NODE_ENV=test node scripts/ensure-tests-exist.js && PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 node ../scripts/run-jest.js --runInBand --passWithNoTests=false tests/additionalApi.test.js tests/getEnv.test.p7q8r9s0t1u2v3w4.js tests/users.test.z9x8c7v6b5n4m3l2.js",
+    "test-ci": "node scripts/ensure-tests-exist.js && node ../scripts/run-jest.js --ci --passWithNoTests=false",
     "test:unit": "npm test",
-    "test:backend": "jest --runInBand",
+    "test:backend": "node ../scripts/run-jest.js --runInBand",
     "ci": "npm run validate-env && SKIP_PW_DEPS=1 PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npm test",
     "validate-env": "npm run validate-env --prefix ..",
     "start": "node src/server.js",
@@ -43,7 +43,7 @@
     "send-ops-report": "node scripts/send-ops-report.js",
     "flag-overdue-printers": "node scripts/flag-overdue-procurement-orders.js",
     "format:check": "prettier --log-level warn --check \"**/*.{ts,tsx,js,jsx,json,md}\"",
-    "test:db": "jest --runInBand --env=node --passWithNoTests=false tests/db/**/*.spec.{ts,js}"
+    "test:db": "node ../scripts/run-jest.js --runInBand --env=node --passWithNoTests=false tests/db/**/*.spec.{ts,js}"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- route backend test scripts through shared run-jest helper

## Testing
- `npm run format` (failed: 403 Forbidden - GET https://registry.npmjs.org/npm)
- `npm test` (failed: wait-on is not installed. Run `npm run setup` to install dependencies.)

------
https://chatgpt.com/codex/tasks/task_e_68c492da9d3c832dba76ed31797b619a