### PR TITLE
fix: add local test-all script without rimraf

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "prepare": "husky",
     "prepush": "echo \"(pre-push) no checks\"",
     "test:fresh": "npm test",
+    "test:all": "bash scripts/test-all.sh",
     "test:banner": "node scripts/run-jest.js tests/frontend/discount-delivery-banner*.test.js",
     "serve": "node scripts/serve.js"
   },

--- a/scripts/test-all.sh
+++ b/scripts/test-all.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+# Navigate to repository root
+cd "$(git rev-parse --show-toplevel)"
+
+# Silence npm proxy warnings and trust mise config
+unset npm_config_http_proxy npm_config_https_proxy
+mise trust >/dev/null 2>&1 || true
+
+# Clean previous test artefacts without relying on rimraf
+rm -rf coverage backend/coverage frontend/coverage test-dist >/dev/null 2>&1 || true
+
+# Run tests for backend and root
+npm test --prefix backend
+npm test


### PR DESCRIPTION
## Summary
- add test:all npm script
- run backend and root tests without rimraf; trust mise to avoid warnings

## Testing
- `npm run format --prefix backend`
- `npm run test:all`

------
https://chatgpt.com/codex/tasks/task_e_68c492f24730832daeeabad2b18a27bd