### PR TITLE
fix: ensure npm registry defaults in setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ These guidelines apply to all automated agents (e.g. the Codex agent) working on
 
 1. **Go to the repository root** – run `cd "$(git rev-parse --show-toplevel)"` after opening a shell to ensure paths resolve correctly.
 2. **Trust mise config** – execute `mise trust` in the repository root to prevent repeated `"config files not trusted"` warnings.
-3. **Unset proxy variables** – before running any `npm` commands, **and whenever you start a new shell session**, execute `unset npm_config_http_proxy npm_config_https_proxy` to silence `http-proxy` warnings.
+3. **Unset proxy/registry variables** – before running any `npm` commands, **and whenever you start a new shell session**, execute `unset npm_config_http_proxy npm_config_https_proxy npm_config_registry` to silence `http-proxy` warnings and ensure the default npm registry is used.
 4. **Ensure Node 20** – run `mise use -g node@20` (or `mise install`) and then `eval \"$(mise activate bash)\"` so the required Node version is active before running setup.
 5. **Validate the environment** – run `npm run validate-env` to ensure required variables are set and proxy vars remain unset.
 6. **Check network access** – ensure the environment can reach both

--- a/scripts/check-env.sh
+++ b/scripts/check-env.sh
@@ -73,9 +73,18 @@ if [ "$current_major" -lt "$required_node_major" ]; then
   exit 1
 fi
 
-# Fail fast if npm-specific proxy variables are set. Other proxy variables may be required
+# Fail fast if npm-specific proxy or registry variables are set incorrectly.
 if [[ -n "${npm_config_http_proxy:-}" || -n "${npm_config_https_proxy:-}" ]]; then
   echo "npm proxy variables must be unset" >&2
+  exit 1
+fi
+if [[ -n "${npm_config_registry:-}" && "${npm_config_registry}" != "https://registry.npmjs.org/" ]]; then
+  echo "npm registry must be https://registry.npmjs.org/" >&2
+  exit 1
+fi
+actual_registry=$(npm config get registry 2>/dev/null || echo "")
+if [[ "$actual_registry" != "https://registry.npmjs.org/" ]]; then
+  echo "npm registry must be https://registry.npmjs.org/ (got $actual_registry)" >&2
   exit 1
 fi
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -84,7 +84,9 @@ if [ "$SKIP_MISE_TOOLS" -eq 0 ]; then
   eval "$(mise activate bash)"
 fi
 
-unset npm_config_http_proxy npm_config_https_proxy
+unset npm_config_http_proxy npm_config_https_proxy npm_config_registry
+export npm_config_registry="https://registry.npmjs.org/"
+npm config set registry "$npm_config_registry" >/dev/null 2>&1 || true
 export npm_config_fund=false
 
 # Validate required environment variables and network access
@@ -96,7 +98,10 @@ fi
 
 # Persist proxy removal so new shells start clean
 if ! grep -q "unset npm_config_http_proxy" ~/.bashrc 2>/dev/null; then
-  echo "unset npm_config_http_proxy npm_config_https_proxy" >> ~/.bashrc
+  echo "unset npm_config_http_proxy npm_config_https_proxy npm_config_registry" >> ~/.bashrc
+fi
+if ! grep -q "npm config set registry https://registry.npmjs.org/" ~/.bashrc 2>/dev/null; then
+  echo "npm config set registry https://registry.npmjs.org/ >/dev/null 2>&1 || true" >> ~/.bashrc
 fi
 
 # Silence mise warnings about idiomatic version files


### PR DESCRIPTION
## Summary
- document unsetting npm_config_registry alongside proxy vars
- force default npm registry in setup script and persist to new shells
- check npm registry in environment validation

## Testing
- `npm run setup` *(fails: 403 Forbidden - GET https://registry.npmjs.org/nyc)*
- `npm run format` *(fails: 403 Forbidden - GET https://registry.npmjs.org/npm)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c493105d40832d934d6700f8e9550b