### PR TITLE
fix: add composite test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "prepush": "echo \"(pre-push) no checks\"",
     "test:fresh": "npm test",
     "test:banner": "node scripts/run-jest.js tests/frontend/discount-delivery-banner*.test.js",
+    "test:all": "npm test && npm test --prefix backend",
     "serve": "node scripts/serve.js"
   },
   "babel": {


### PR DESCRIPTION
## Summary
- add `test:all` script to invoke root and backend tests without relying on external rimraf

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npm run format --prefix backend`
- `npm run test:all` *(fails: wait-on is not installed. Run `npm run setup` to install dependencies.)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lockfile-diff)*
- `SKIP_PW_DEPS=1 npm run smoke` *(offline mode: skipping smoke)*

------
https://chatgpt.com/codex/tasks/task_e_68c49327caac832db69337fed78fbe95