### PR TITLE
fix: defer basket interactions until viewer ready

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1052,7 +1052,6 @@ async function init() {
   });
 
   if (refs.addBasketBtn) {
-    refs.addBasketBtn.disabled = true;
     const viewerReadyPromise = customElements.whenDefined("model-viewer").then(
       () =>
         new Promise((resolve) => {
@@ -1085,11 +1084,12 @@ async function init() {
         }),
     );
 
-    await viewerReadyPromise;
-    refs.addBasketBtn.disabled = false;
-
     refs.addBasketBtn.addEventListener("click", async () => {
-      await viewerReadyPromise;
+      try {
+        await viewerReadyPromise;
+      } catch {
+        return;
+      }
       let modelUrl = refs.viewer.src;
       if (!modelUrl) {
         modelUrl =


### PR DESCRIPTION
## Summary
- avoid disabling the add-to-basket button until the viewer is ready
- handle viewer load failures before updating the basket

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup`
- `npx prettier --write js/index.js`
- `npm test` *(fails: Unable to reach the npm registry)*
- `SKIP_PW_DEPS=1 npm run ci`
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c4b6f96b9c832d8fa332b23dec3804