### PR TITLE
refactor: rely on .nycrc for coverage thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,14 +464,12 @@ Run coverage after installing dependencies:
 
 ```bash
 npm run setup
-npm run coverage
-
+npm run test:all
 cat coverage/lcov.info | npx coveralls
 ```
 
-The `check-coverage` script writes a baseline to `tests/coverageBaseline.json`
-the first time coverage falls below the required thresholds. Commit this file
-after the initial run so future merges will fail when coverage regresses.
+`npm run test:all` runs Jest with coverage and then `nyc check-coverage`.
+NYC's configuration in `.nycrc` is the single source of coverage thresholds.
 
 Using `npx coveralls` ensures the CLI runs even if it's not installed globally.
 By piping the generated `lcov.info` file instead of test output we avoid

--- a/ci/generated/full-ci.jobs.json
+++ b/ci/generated/full-ci.jobs.json
@@ -48,12 +48,6 @@
     "needs": []
   },
   {
-    "name": "root:test:update-threshold",
-    "command": "npm run test:update-threshold",
-    "paths": ["."],
-    "needs": []
-  },
-  {
     "name": "root:test:cf-readiness",
     "command": "npm run test:cf-readiness",
     "paths": ["."],

--- a/ci/generated/full-ci.yml
+++ b/ci/generated/full-ci.yml
@@ -27,8 +27,6 @@ jobs:
             command: npm run test
           - name: root:test:ci
             command: npm run test:ci
-          - name: root:test:update-threshold
-            command: npm run test:update-threshold
           - name: root:test:cf-readiness
             command: npm run test:cf-readiness
           - name: root:test:stability

--- a/scripts/coverage-inspector.js
+++ b/scripts/coverage-inspector.js
@@ -38,11 +38,29 @@ const linesPct = pct(linesHit, linesFound);
 const funcsPct = pct(funcsHit, funcsFound);
 const branchesPct = pct(branchesHit, branchesFound);
 
+const nycrcPath = path.join(__dirname, "..", ".nycrc");
+if (!fs.existsSync(nycrcPath)) {
+  console.error(`Coverage config not found: ${nycrcPath}`);
+  process.exit(1);
+}
+
+let cfg;
+try {
+  cfg = JSON.parse(fs.readFileSync(nycrcPath, "utf8"));
+} catch (err) {
+  console.error(`Failed to parse ${nycrcPath}: ${err.message}`);
+  process.exit(1);
+}
+
 console.log(`Lines: ${linesPct.toFixed(2)}%`);
 console.log(`Functions: ${funcsPct.toFixed(2)}%`);
 console.log(`Branches: ${branchesPct.toFixed(2)}%`);
 
-if (linesPct >= 80 && funcsPct >= 80 && branchesPct >= 80) {
+if (
+  linesPct >= cfg.lines &&
+  funcsPct >= cfg.functions &&
+  branchesPct >= cfg.branches
+) {
   console.log("✅");
 } else {
   console.log("❌");

--- a/scripts/find-branch-coverage-gaps.js
+++ b/scripts/find-branch-coverage-gaps.js
@@ -1,15 +1,31 @@
 #!/usr/bin/env node
 const fs = require("fs");
+const path = require("path");
 
 // Parse CLI args
 const args = process.argv.slice(2);
 let reportPath = "./coverage/coverage-final.json";
-let min = 90;
+let min;
 for (const arg of args) {
   if (arg.startsWith("--report=")) {
     reportPath = arg.split("=")[1];
   } else if (arg.startsWith("--min=")) {
     min = Number(arg.split("=")[1]);
+  }
+}
+
+if (min === undefined) {
+  const configPath = path.join(__dirname, "..", ".nycrc");
+  if (!fs.existsSync(configPath)) {
+    console.error(`Coverage config not found: ${configPath}`);
+    process.exit(1);
+  }
+  try {
+    const cfg = JSON.parse(fs.readFileSync(configPath, "utf8"));
+    min = cfg.branches;
+  } catch (err) {
+    console.error(`Failed to parse ${configPath}: ${err.message}`);
+    process.exit(1);
   }
 }
 


### PR DESCRIPTION
## Summary
- refactor coverage scripts to read thresholds from .nycrc
- remove deprecated test:update-threshold from CI
- clarify `.nycrc` as sole coverage threshold source in docs

## Testing
- `npx prettier -w README.md scripts/coverage-inspector.js scripts/find-branch-coverage-gaps.js ci/generated/full-ci.yml ci/generated/full-ci.jobs.json`
- `npm run format --prefix backend`
- `npm test --prefix backend` *(fails: Unable to reach npm registry)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: network/connectivity issues)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c583cb27e0832d9acfcc4d336c578d