### PR TITLE
fix: clear proxy env vars before setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ These guidelines apply to all automated agents (e.g. the Codex agent) working on
 
 1. **Go to the repository root** – run `cd "$(git rev-parse --show-toplevel)"` after opening a shell to ensure paths resolve correctly.
 2. **Trust mise config** – execute `mise trust` in the repository root to prevent repeated `"config files not trusted"` warnings.
-3. **Unset proxy/registry variables** – before running any `npm` commands, **and whenever you start a new shell session**, execute `unset npm_config_http_proxy npm_config_https_proxy npm_config_registry` to silence `http-proxy` warnings and ensure the default npm registry is used.
+3. **Unset proxy/registry variables** – before running any `npm` commands, **and whenever you start a new shell session**, execute `unset npm_config_http_proxy npm_config_https_proxy npm_config_registry http_proxy https_proxy HTTP_PROXY HTTPS_PROXY` to silence proxy warnings and ensure the default npm registry is used.
 4. **Ensure Node 20** – run `mise use -g node@20` (or `mise install`) and then `eval \"$(mise activate bash)\"` so the required Node version is active before running setup.
 5. **Validate the environment** – run `npm run validate-env` to ensure required variables are set and proxy vars remain unset.
 6. **Check network access** – ensure the environment can reach both

--- a/scripts/install-mise.sh
+++ b/scripts/install-mise.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+unset npm_config_http_proxy npm_config_https_proxy npm_config_registry http_proxy https_proxy HTTP_PROXY HTTPS_PROXY
+
 if ! command -v mise >/dev/null 2>&1; then
   curl -fsSL https://mise.jdx.dev/install.sh -o /tmp/install-mise.sh
   bash /tmp/install-mise.sh

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -84,7 +84,7 @@ if [ "$SKIP_MISE_TOOLS" -eq 0 ]; then
   eval "$(mise activate bash)"
 fi
 
-unset npm_config_http_proxy npm_config_https_proxy npm_config_registry
+unset npm_config_http_proxy npm_config_https_proxy npm_config_registry http_proxy https_proxy HTTP_PROXY HTTPS_PROXY
 export npm_config_registry="https://registry.npmjs.org/"
 npm config set registry "$npm_config_registry" >/dev/null 2>&1 || true
 export npm_config_fund=false
@@ -98,7 +98,7 @@ fi
 
 # Persist proxy removal so new shells start clean
 if ! grep -q "unset npm_config_http_proxy" ~/.bashrc 2>/dev/null; then
-  echo "unset npm_config_http_proxy npm_config_https_proxy npm_config_registry" >> ~/.bashrc
+  echo "unset npm_config_http_proxy npm_config_https_proxy npm_config_registry http_proxy https_proxy HTTP_PROXY HTTPS_PROXY" >> ~/.bashrc
 fi
 if ! grep -q "npm config set registry https://registry.npmjs.org/" ~/.bashrc 2>/dev/null; then
   echo "npm config set registry https://registry.npmjs.org/ >/dev/null 2>&1 || true" >> ~/.bashrc


### PR DESCRIPTION
## Summary
- ensure proxy env vars are cleared before installing and using Node
- document unsetting proxy variables in agent guidelines

## Testing
- `npx prettier -w AGENTS.md`
- `npx prettier -w scripts/install-mise.sh scripts/setup.sh` *(fails: No parser could be inferred)*
- `npm run format` *(backend)*
- `npm test` *(fails: Unable to reach the npm registry. Check network connectivity or proxy settings.)*
- `SKIP_PW_DEPS=1 npm run ci` *(terminated: engine check and build start, then stopped due to environment)*
- `SKIP_PW_DEPS=1 npm run smoke`


------
https://chatgpt.com/codex/tasks/task_e_68c585a61ad8832da25b700e7acea863