### PR TITLE
test: add basket and index wiring tests

### DIFF
--- a/tests/basket.spec.p9d4f7g2h3j6k8l0.js
+++ b/tests/basket.spec.p9d4f7g2h3j6k8l0.js
@@ -1,0 +1,110 @@
+import { buildDOM } from "./helpers/dom.js";
+import { memoryStorage } from "./helpers/storage.js";
+
+describe("basket storage", () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  test("fresh store: add increments and persists", async () => {
+    const dom = buildDOM(
+      '<button id="basket-button"></button><span id="basket-count"></span>',
+    );
+    global.window = dom.window;
+    global.document = dom.window.document;
+    const storage = memoryStorage();
+    const { createBasket } = await import("../js/basket.js");
+    const basket = createBasket(storage);
+    expect(basket.getBasket()).toHaveLength(0);
+    await basket.addToBasket({ modelUrl: "x" });
+    expect(basket.getBasket()).toHaveLength(1);
+    expect(JSON.parse(storage.getItem("print2Basket")).length).toBe(1);
+  });
+
+  test("prefilled store loads existing items", async () => {
+    const dom = buildDOM();
+    global.window = dom.window;
+    global.document = dom.window.document;
+    const storage = memoryStorage({
+      print2Basket: JSON.stringify([{ id: 1 }, { id: 2 }]),
+    });
+    const { createBasket } = await import("../js/basket.js");
+    const basket = createBasket(storage);
+    expect(basket.getBasket()).toHaveLength(2);
+  });
+
+  test("invalid storage resets basket", async () => {
+    const dom = buildDOM(
+      '<button id="basket-button" hidden></button><span id="basket-count"></span>',
+    );
+    global.window = dom.window;
+    global.document = dom.window.document;
+    const storage = memoryStorage({ print2Basket: "not json" });
+    const { createBasket } = await import("../js/basket.js");
+    const basket = createBasket(storage);
+    expect(basket.getBasket()).toEqual([]);
+    expect(storage.getItem("print2Basket")).toBe(null);
+    const btn = dom.window.document.getElementById("basket-button");
+    const badge = dom.window.document.getElementById("basket-count");
+    expect(btn.hidden).toBe(false);
+    expect(badge.hidden).toBe(true);
+  });
+
+  test("remove and clear basket with fetch paths", async () => {
+    const dom = buildDOM(
+      '<button id="basket-button"></button><span id="basket-count"></span>',
+    );
+    global.window = dom.window;
+    global.document = dom.window.document;
+    const storage = memoryStorage();
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce({ json: async () => ({ id: "s1" }) })
+      .mockRejectedValueOnce(new Error("fail"))
+      .mockResolvedValue({ catch: jest.fn() });
+    global.fetch = fetchMock;
+    storage.setItem("token", "t");
+    const { createBasket } = await import("../js/basket.js");
+    const basket = createBasket(storage);
+    await basket.addToBasket({ jobId: "j1" });
+    await basket.addToBasket({ jobId: "j2" });
+    expect(basket.getBasket()).toHaveLength(2);
+    storage.setItem(
+      "print2CheckoutItems",
+      JSON.stringify([{ a: 1 }, { a: 2 }]),
+    );
+    await basket.removeFromBasket(0);
+    await basket.removeFromBasket(5);
+    expect(JSON.parse(storage.getItem("print2CheckoutItems")).length).toBe(1);
+    await basket.clearBasket();
+    expect(basket.getBasket()).toHaveLength(0);
+    expect(storage.getItem("print2CheckoutItems")).toBe(null);
+  });
+
+  test("add and manualize auto items", async () => {
+    const dom = buildDOM();
+    global.window = dom.window;
+    global.document = dom.window.document;
+    const storage = memoryStorage();
+    const { createBasket } = await import("../js/basket.js");
+    const basket = createBasket(storage);
+    basket.addAutoItem({ jobId: "a" });
+    basket.addAutoItem({ jobId: "b" });
+    expect(basket.getBasket()).toHaveLength(1);
+    basket.manualizeItem(() => true);
+    expect(basket.getBasket()[0].auto).toBe(false);
+  });
+
+  test("migration handles storage errors", async () => {
+    const storage = {
+      getItem: (k) => (k === "print3Basket" ? "[]" : null),
+      setItem: () => {
+        throw new Error("fail");
+      },
+      removeItem: () => {},
+      clear: () => {},
+    };
+    const mod = await import("../js/basket.js");
+    expect(() => mod.createBasket(storage)).not.toThrow();
+  });
+});

--- a/tests/helpers/dom.js
+++ b/tests/helpers/dom.js
@@ -1,0 +1,8 @@
+import { JSDOM } from "jsdom";
+
+export function buildDOM(html = "") {
+  const dom = new JSDOM(`<!doctype html><html><body>${html}</body></html>`, {
+    url: "http://localhost/",
+  });
+  return dom;
+}

--- a/tests/helpers/storage.js
+++ b/tests/helpers/storage.js
@@ -1,0 +1,18 @@
+export function memoryStorage(initial = {}) {
+  const map = new Map(Object.entries(initial));
+  return {
+    getItem: (k) => (map.has(k) ? map.get(k) : null),
+    setItem: (k, v) => {
+      map.set(k, String(v));
+    },
+    removeItem: (k) => {
+      map.delete(k);
+    },
+    clear: () => map.clear(),
+    key: (i) => Array.from(map.keys())[i] ?? null,
+    get length() {
+      return map.size;
+    },
+    _map: map,
+  };
+}

--- a/tests/index.wiring.spec.m1n2b3v4c5x6z7l8.js
+++ b/tests/index.wiring.spec.m1n2b3v4c5x6z7l8.js
@@ -1,0 +1,107 @@
+import { buildDOM } from "./helpers/dom.js";
+import { memoryStorage } from "./helpers/storage.js";
+
+describe("index wiring", () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  test("button wiring persists count", async () => {
+    const html = `
+      <model-viewer id="viewer" src="https://example.com/model.glb"></model-viewer>
+      <img id="preview-img" src="https://example.com/img.png" />
+      <button id="add-basket-button" data-testid="add"></button>
+      <button id="basket-button"><span id="basket-count" data-testid="basket-count"></span></button>
+      <div id="theme-banner" class="hidden"></div>
+    `;
+    const dom = buildDOM(html);
+    global.window = dom.window;
+    global.document = dom.window.document;
+    const storage = memoryStorage();
+    const basket = (await import("../js/basket.js")).createBasket(storage);
+    global.addToBasket = basket.addToBasket;
+    global.getBasket = basket.getBasket;
+    const fetchFn = (url) => {
+      if (String(url).endsWith("/campaign")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ theme: "Sale" }),
+        });
+      }
+      return Promise.resolve({ ok: false, json: async () => ({}) });
+    };
+    const { initBasketUI } = await import("../js/index.js");
+    await initBasketUI({ doc: dom.window.document, storage, fetchFn });
+    global.window = dom.window;
+    global.document = dom.window.document;
+    global.localStorage = storage;
+    dom.window.document.getElementById("add-basket-button").click();
+    expect(dom.window.document.getElementById("basket-count").textContent).toBe(
+      "1",
+    );
+    expect(dom.window.document.getElementById("theme-banner").textContent).toBe(
+      "Sale",
+    );
+
+    const dom2 = buildDOM(`
+      <model-viewer id="viewer" src="https://example.com/model.glb"></model-viewer>
+      <img id="preview-img" src="https://example.com/img.png" />
+      <button id="add-basket-button"></button>
+      <button id="basket-button"><span id="basket-count"></span></button>
+    `);
+    global.window = dom2.window;
+    global.document = dom2.window.document;
+    global.localStorage = storage;
+    const basket2 = (await import("../js/basket.js")).createBasket(storage);
+    global.addToBasket = basket2.addToBasket;
+    global.getBasket = basket2.getBasket;
+    await initBasketUI({ doc: dom2.window.document, storage, fetchFn });
+    global.window = dom2.window;
+    global.document = dom2.window.document;
+    global.localStorage = storage;
+    expect(
+      dom2.window.document.getElementById("basket-count").textContent,
+    ).toBe("1");
+  });
+
+  test("graceful when elements missing", async () => {
+    const dom = buildDOM("<div></div>");
+    global.window = dom.window;
+    global.document = dom.window.document;
+    const storage = memoryStorage();
+    const basket = (await import("../js/basket.js")).createBasket(storage);
+    global.addToBasket = basket.addToBasket;
+    global.getBasket = basket.getBasket;
+    const fetchFn = () =>
+      Promise.resolve({ ok: false, json: async () => ({}) });
+    const { initBasketUI } = await import("../js/index.js");
+    await expect(
+      initBasketUI({ doc: dom.window.document, storage, fetchFn }),
+    ).resolves.not.toThrow();
+  });
+
+  test("campaign fetch failure keeps banner hidden", async () => {
+    const dom = buildDOM(`
+      <model-viewer id="viewer" src="https://example.com/model.glb"></model-viewer>
+      <img id="preview-img" src="https://example.com/img.png" />
+      <button id="add-basket-button"></button>
+      <button id="basket-button"><span id="basket-count"></span></button>
+      <div id="theme-banner" class="hidden"></div>
+    `);
+    global.window = dom.window;
+    global.document = dom.window.document;
+    const storage = memoryStorage();
+    const basket = (await import("../js/basket.js")).createBasket(storage);
+    global.addToBasket = basket.addToBasket;
+    global.getBasket = basket.getBasket;
+    const fetchFn = () =>
+      Promise.resolve({ ok: false, json: async () => ({}) });
+    const { initBasketUI } = await import("../js/index.js");
+    await initBasketUI({ doc: dom.window.document, storage, fetchFn });
+    expect(
+      dom.window.document
+        .getElementById("theme-banner")
+        .classList.contains("hidden"),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add memoryStorage and buildDOM helpers for isolated DOM tests
- cover basket state transitions, error paths, and storage migration
- verify index wiring with injected fetch and persistent basket count

## Testing
- `npm run format` (fails: modifies many files but reverted to keep repository clean)
- `npm test -- --coverage` (fails: Missing jest core; run `npm run setup` before testing.)

## Coverage
```
File         | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
js/basket.js |    N/A  |    N/A   |   N/A   |   N/A   |
js/index.js  |    N/A  |    N/A   |   N/A   |   N/A   |
```


------
https://chatgpt.com/codex/tasks/task_e_68c598091634832dbff89fbe94401090