### PR TITLE
test: add coverage for basket and index

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -1245,6 +1245,8 @@ if (typeof module !== "undefined") {
     updateStats,
     initDiscountDeliveryBanner,
     initIndexPage: initBasketUI,
+    // test seam: allow unit tests to call snapshot helper
+    captureModelSnapshot,
   };
 }
 
@@ -1253,5 +1255,7 @@ export {
   computeDailyPrintsSold,
   updateStats,
   initDiscountDeliveryBanner,
+  // test seam: allow unit tests to call snapshot helper
+  captureModelSnapshot,
   initBasketUI as initIndexPage,
 };

--- a/tests/basket.audio.spec.z0x9c8v7b6n5m4l3.js
+++ b/tests/basket.audio.spec.z0x9c8v7b6n5m4l3.js
@@ -1,0 +1,45 @@
+import { buildDOM } from "./helpers/dom.js";
+import { memoryStorage } from "./helpers/storage.js";
+
+describe("basket audio", () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  test("plays sound when available", async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2025-01-01T00:00:00Z"));
+    const dom = buildDOM(
+      '<button id="basket-button"></button><span id="basket-count"></span>',
+    );
+    global.window = dom.window;
+    global.document = dom.window.document;
+    const storage = memoryStorage();
+    const { createBasket } = await import("../js/basket.js");
+    const basket = createBasket(storage);
+    const play = jest.fn();
+    const audio = { currentTime: 5, play };
+    dom.window.__basketSound = audio;
+    await basket.addToBasket({ jobId: "j1" });
+    expect(audio.currentTime).toBe(0);
+    expect(play).toHaveBeenCalled();
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  test("no audio when sound missing", async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2025-01-01T00:00:00Z"));
+    const dom = buildDOM(
+      '<button id="basket-button"></button><span id="basket-count"></span>',
+    );
+    global.window = dom.window;
+    global.document = dom.window.document;
+    const { createBasket } = await import("../js/basket.js");
+    const basket = createBasket(memoryStorage());
+    await expect(basket.addToBasket({ jobId: "j2" })).resolves.toBeUndefined();
+    expect(dom.window.__basketSound).toBeUndefined();
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+});

--- a/tests/basket.sync.spec.a9s8d7f6g5h4j3k2.js
+++ b/tests/basket.sync.spec.a9s8d7f6g5h4j3k2.js
@@ -1,0 +1,53 @@
+import { buildDOM } from "./helpers/dom.js";
+import { memoryStorage } from "./helpers/storage.js";
+import { makeFetch } from "./helpers/fetch.js";
+
+describe("basket server sync", () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  test("maps server items", async () => {
+    const dom = buildDOM(
+      '<button id="basket-button"><span id="basket-count"></span></button><div id="basket-list"></div>',
+    );
+    global.window = dom.window;
+    global.document = dom.window.document;
+    const storage = memoryStorage({ token: "t" });
+    const fetch = makeFetch({
+      "http://localhost/api/cart": {
+        ok: true,
+        body: {
+          items: [
+            {
+              job_id: "j1",
+              quantity: 2,
+              id: "s1",
+              model_url: "m1",
+              snapshot: "snap1",
+            },
+          ],
+        },
+      },
+    });
+    const { createBasket } = await import("../js/basket.js");
+    const basket = createBasket(storage);
+    global.fetch = fetch;
+    await basket.syncServerCart();
+    expect(basket.getBasket()).toEqual([
+      {
+        jobId: "j1",
+        quantity: 2,
+        serverId: "s1",
+        modelUrl: "m1",
+        snapshot: "snap1",
+      },
+    ]);
+    expect(
+      dom.window.document.getElementById("basket-list").children.length,
+    ).toBe(1);
+    expect(dom.window.document.getElementById("basket-count").textContent).toBe(
+      "1",
+    );
+  });
+});

--- a/tests/basket.timer.spec.p0o9i8u7y6t5r4e3.js
+++ b/tests/basket.timer.spec.p0o9i8u7y6t5r4e3.js
@@ -1,0 +1,65 @@
+import { buildDOM } from "./helpers/dom.js";
+import { memoryStorage } from "./helpers/storage.js";
+import { advanceSeconds } from "./helpers/clock.js";
+
+describe("basket reservation timer", () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  test("hides label when basket empty", async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2025-01-01T00:00:00Z"));
+    const dom = buildDOM();
+    global.window = dom.window;
+    global.document = dom.window.document;
+    const { createBasket } = await import("../js/basket.js");
+    const basket = createBasket(memoryStorage());
+    basket.setupBasketUI();
+    dom.window.document.getElementById("basket-button").click();
+    const label = dom.window.document.getElementById("basket-reserve");
+    expect(label.classList.contains("hidden")).toBe(true);
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  test("shows expired when diff <= 0", async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2025-01-01T00:00:00Z"));
+    const dom = buildDOM();
+    global.window = dom.window;
+    global.document = dom.window.document;
+    const storage = memoryStorage({
+      print2Basket: JSON.stringify([{ reserveUntil: Date.now() - 1000 }]),
+    });
+    const { createBasket } = await import("../js/basket.js");
+    const basket = createBasket(storage);
+    basket.setupBasketUI();
+    dom.window.document.getElementById("basket-button").click();
+    const label = dom.window.document.getElementById("basket-reserve");
+    expect(label.textContent).toBe("Queue slot expired");
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+
+  test("counts down and updates UI", async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2025-01-01T00:00:00Z"));
+    const dom = buildDOM();
+    global.window = dom.window;
+    global.document = dom.window.document;
+    const storage = memoryStorage({
+      print2Basket: JSON.stringify([{ reserveUntil: Date.now() + 5000 }]),
+    });
+    const { createBasket } = await import("../js/basket.js");
+    const basket = createBasket(storage);
+    basket.setupBasketUI();
+    dom.window.document.getElementById("basket-button").click();
+    const label = dom.window.document.getElementById("basket-reserve");
+    expect(label.textContent.includes("0:05")).toBe(true);
+    advanceSeconds(3);
+    expect(label.textContent.includes("0:02")).toBe(true);
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+});

--- a/tests/basket.ui.spec.q1w2e3r4t5y6u7i8.js
+++ b/tests/basket.ui.spec.q1w2e3r4t5y6u7i8.js
@@ -1,0 +1,35 @@
+import { buildDOM } from "./helpers/dom.js";
+import { memoryStorage } from "./helpers/storage.js";
+
+describe("basket ui interactions", () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  test("render list and open/close modal", async () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2025-01-01T00:00:00Z"));
+    const dom = buildDOM();
+    global.window = dom.window;
+    global.document = dom.window.document;
+    const { createBasket } = await import("../js/basket.js");
+    const storage = memoryStorage();
+    const basket = createBasket(storage);
+    basket.setupBasketUI();
+    await basket.addToBasket({ modelUrl: "m1" });
+    await basket.addToBasket({ modelUrl: "m2" });
+    dom.window.document.getElementById("basket-button").click();
+    const list = dom.window.document.getElementById("basket-list");
+    expect(list.children).toHaveLength(2);
+    list.querySelector("button.remove").click();
+    expect(list.children).toHaveLength(1);
+    dom.window.document.getElementById("basket-close").click();
+    expect(
+      dom.window.document
+        .getElementById("basket-overlay")
+        .classList.contains("hidden"),
+    ).toBe(true);
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+});

--- a/tests/helpers/clock.js
+++ b/tests/helpers/clock.js
@@ -1,0 +1,7 @@
+export function advanceBy(ms) {
+  jest.advanceTimersByTime(ms);
+}
+
+export function advanceSeconds(sec) {
+  advanceBy(sec * 1000);
+}

--- a/tests/helpers/fetch.js
+++ b/tests/helpers/fetch.js
@@ -1,0 +1,17 @@
+export function makeFetch(responses = {}) {
+  return jest.fn((url) => {
+    const key = String(url);
+    if (!(key in responses)) {
+      return Promise.reject(new Error(`Unhandled fetch: ${key}`));
+    }
+    const res = responses[key];
+    if (typeof res === "function") {
+      return res(url);
+    }
+    return Promise.resolve({
+      ok: res.ok !== undefined ? res.ok : true,
+      status: res.status || 200,
+      json: async () => res.body ?? res,
+    });
+  });
+}

--- a/tests/index.captureModelSnapshot.spec.v9b8n7m6l5k4j3h2.js
+++ b/tests/index.captureModelSnapshot.spec.v9b8n7m6l5k4j3h2.js
@@ -1,0 +1,71 @@
+import { buildDOM } from "./helpers/dom.js";
+
+describe("captureModelSnapshot", () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  test("returns data URL on success", async () => {
+    const dom = buildDOM();
+    global.document = dom.window.document;
+    const { captureModelSnapshot } = await import("../js/index.js");
+    const mv = {
+      setAttribute: jest.fn(),
+      style: {},
+      remove: jest.fn(),
+      updateComplete: Promise.resolve(),
+      toDataURL: jest.fn().mockResolvedValue("data:img"),
+    };
+    jest.spyOn(dom.window.document, "createElement").mockReturnValue(mv);
+    const res = await captureModelSnapshot("model.glb");
+    expect(res).toBe("data:img");
+    expect(mv.toDataURL).toHaveBeenCalled();
+  });
+
+  test("falls back to default model", async () => {
+    const dom = buildDOM();
+    global.document = dom.window.document;
+    const { captureModelSnapshot } = await import("../js/index.js");
+    const first = {
+      setAttribute: jest.fn(),
+      style: {},
+      remove: jest.fn(),
+      updateComplete: Promise.resolve(),
+      toDataURL: jest.fn().mockResolvedValue(null),
+    };
+    const second = {
+      setAttribute: jest.fn(),
+      style: {},
+      remove: jest.fn(),
+      updateComplete: Promise.resolve(),
+      toDataURL: jest.fn().mockResolvedValue("data:fallback"),
+    };
+    jest
+      .spyOn(dom.window.document, "createElement")
+      .mockImplementationOnce(() => first)
+      .mockImplementationOnce(() => second);
+    const res = await captureModelSnapshot("other.glb");
+    expect(res).toBe("data:fallback");
+    expect(first.toDataURL).toHaveBeenCalled();
+    expect(second.toDataURL).toHaveBeenCalled();
+  });
+
+  test("returns null on errors", async () => {
+    const dom = buildDOM();
+    global.document = dom.window.document;
+    const { captureModelSnapshot } = await import("../js/index.js");
+    const mv = {
+      setAttribute: jest.fn(),
+      style: {},
+      remove: jest.fn(),
+      updateComplete: Promise.resolve(),
+      toDataURL: jest.fn().mockRejectedValue(new Error("fail")),
+    };
+    jest.spyOn(dom.window.document, "createElement").mockReturnValue(mv);
+    const err = jest.spyOn(console, "error").mockImplementation(() => {});
+    const res = await captureModelSnapshot("model.glb");
+    expect(res).toBeNull();
+    expect(err).toHaveBeenCalled();
+    err.mockRestore();
+  });
+});

--- a/tests/index.computeDailyPrintsSold.spec.h1j2k3l4m5n6p7q8.js
+++ b/tests/index.computeDailyPrintsSold.spec.h1j2k3l4m5n6p7q8.js
@@ -1,0 +1,40 @@
+describe("computeDailyPrintsSold", () => {
+  let originalCrypto;
+  beforeEach(() => {
+    jest.resetModules();
+    originalCrypto = global.crypto;
+  });
+  afterEach(() => {
+    global.crypto = originalCrypto;
+  });
+
+  test("uses crypto digest when available", async () => {
+    const buffer = new ArrayBuffer(4);
+    new DataView(buffer).setUint32(0, 0x12345678);
+    global.crypto = { subtle: { digest: jest.fn().mockResolvedValue(buffer) } };
+    const { computeDailyPrintsSold } = await import("../js/index.js");
+    const date = new Date("2025-01-02T00:00:00Z");
+    const prints = await computeDailyPrintsSold(date);
+    const int = 0x12345678;
+    const expected = Math.floor((int / 0xffffffff) * (50 - 30 + 1)) + 30;
+    expect(prints).toBe(expected);
+  });
+
+  test("falls back when crypto digest missing", async () => {
+    global.crypto = {};
+    const { computeDailyPrintsSold } = await import("../js/index.js");
+    const date = new Date("2025-01-02T00:00:00Z");
+    const prints = await computeDailyPrintsSold(date);
+    const eastern = new Date(
+      date.toLocaleString("en-US", { timeZone: "America/New_York" }),
+    )
+      .toISOString()
+      .slice(0, 10);
+    let int = 0;
+    for (let i = 0; i < eastern.length; i++) {
+      int = (int * 31 + eastern.charCodeAt(i)) >>> 0;
+    }
+    const expected = Math.floor((int / 0xffffffff) * (50 - 30 + 1)) + 30;
+    expect(prints).toBe(expected);
+  });
+});

--- a/tests/index.updateStats.spec.l1k2j3h4g5f6d7s8.js
+++ b/tests/index.updateStats.spec.l1k2j3h4g5f6d7s8.js
@@ -1,0 +1,18 @@
+import { buildDOM } from "./helpers/dom.js";
+
+describe("updateStats", () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  test("updates ticker element", async () => {
+    const dom = buildDOM('<div id="stats-ticker"></div>');
+    global.document = dom.window.document;
+    const mod = await import("../js/index.js");
+    jest.spyOn(mod, "computeDailyPrintsSold").mockResolvedValueOnce(42);
+    await mod.updateStats();
+    const el = dom.window.document.getElementById("stats-ticker");
+    expect(el.textContent).toBe(" 42 prints soldin last 24 hrs");
+    expect(el.querySelector("i").className).toBe("fas fa-fire mr-1");
+  });
+});

--- a/tests/index.wiring.addToBasket.spec.c3v4b5n6m7x8z9l0.js
+++ b/tests/index.wiring.addToBasket.spec.c3v4b5n6m7x8z9l0.js
@@ -1,0 +1,45 @@
+import { buildDOM } from "./helpers/dom.js";
+import { memoryStorage } from "./helpers/storage.js";
+
+describe("index add-to-basket wiring", () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  test("click adds item and persists across reload", async () => {
+    const html = `
+      <model-viewer id="viewer" src="https://example.com/m.glb"></model-viewer>
+      <img id="preview-img" src="https://example.com/i.png" />
+      <button id="add-basket-button"></button>
+      <button id="basket-button"><span id="basket-count"></span></button>
+    `;
+    const storage = memoryStorage();
+    const fetchFn = () =>
+      Promise.resolve({ ok: false, json: async () => ({}) });
+
+    const dom = buildDOM(html);
+    global.window = dom.window;
+    global.document = dom.window.document;
+    const basket = (await import("../js/basket.js")).createBasket(storage);
+    global.addToBasket = basket.addToBasket;
+    global.getBasket = basket.getBasket;
+    const { initBasketUI } = await import("../js/index.js");
+    await initBasketUI({ doc: dom.window.document, storage, fetchFn });
+    dom.window.document.getElementById("add-basket-button").click();
+    expect(JSON.parse(storage.getItem("print2Basket")).length).toBe(1);
+    expect(dom.window.document.getElementById("basket-count").textContent).toBe(
+      "1",
+    );
+
+    const dom2 = buildDOM(html);
+    global.window = dom2.window;
+    global.document = dom2.window.document;
+    const basket2 = (await import("../js/basket.js")).createBasket(storage);
+    global.addToBasket = basket2.addToBasket;
+    global.getBasket = basket2.getBasket;
+    await initBasketUI({ doc: dom2.window.document, storage, fetchFn });
+    expect(
+      dom2.window.document.getElementById("basket-count").textContent,
+    ).toBe("1");
+  });
+});


### PR DESCRIPTION
## Summary
- add basket tests for audio cues, server sync, reservation timer, and UI flows
- exercise index helpers including computeDailyPrintsSold, updateStats, and captureModelSnapshot
- expose captureModelSnapshot for unit testing

## Testing
- `npm run format`
- `npm run test -- --coverage` *(fails: Missing ts-jest; run `npm run setup` before testing.)*
- `npm run check:cov` *(fails: request to https://registry.npmjs.org/nyc failed, reason: Network is unreachable)*
- `npm run test:all` *(fails: Missing ts-jest; run `npm run setup` before testing.)*

------
https://chatgpt.com/codex/tasks/task_e_68c59df75c84832dbb177810de2afd1e