### PR TITLE
fix: run tests with nyc to satisfy coverage check

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "test": "node scripts/run-jest.js --passWithNoTests",
     "check:cov": "npx nyc check-coverage",
-    "test:all": "npm run test -- --coverage && npm run check:cov",
+    "test:all": "npx nyc npm test && npm run check:cov",
     "test:image-pipeline": "node scripts/test-image-pipeline.js",
     "preinstall": "corepack enable && node scripts/check-node-version.js",
     "preformat": "true",


### PR DESCRIPTION
## Summary
- run Jest under nyc so `nyc check-coverage` finds `.nyc_output`

## Testing
- `npm run validate-env`
- `SKIP_PW_DEPS=1 npm run setup` *(fails: Exit handler never called)*
- `npm test` *(fails: Missing jest; run `npm run setup` before testing)*
- `SKIP_PW_DEPS=1 npm run ci` *(fails: Exit handler never called)*
- `SKIP_PW_DEPS=1 npm run smoke` *(fails: Missing jest core)*
- `npm run test:all` *(fails: request to https://registry.npmjs.org/nyc failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a60794c0832d8a099e8686af321b