### PR TITLE
test: add coverage for basket and index

### DIFF
--- a/js/basket.js
+++ b/js/basket.js
@@ -35,6 +35,15 @@
 const KEY = "print2Basket";
 const API_BASE = (window.API_ORIGIN || "") + "/api";
 let basket;
+let fetchFn = typeof fetch !== "undefined" ? fetch : undefined;
+let setTimeoutFn = typeof setTimeout !== "undefined" ? setTimeout : undefined;
+let clearTimeoutFn =
+  typeof clearTimeout !== "undefined" ? clearTimeout : undefined;
+let setIntervalFn =
+  typeof setInterval !== "undefined" ? setInterval : undefined;
+let clearIntervalFn =
+  typeof clearInterval !== "undefined" ? clearInterval : undefined;
+let nowFn = () => Date.now();
 export function getBasket() {
   try {
     const raw = localStorage.getItem(KEY);
@@ -62,14 +71,14 @@ function notifyBasketChange() {
 }
 export async function addToBasket(item, opts = {}) {
   const items = getBasket();
-  const expire = Date.now() + RESERVE_MINS * 60 * 1000;
+  const expire = nowFn() + RESERVE_MINS * 60 * 1000;
   const entry = { ...item, auto: !!opts.auto, reserveUntil: expire };
   items.push(entry);
   saveBasket();
   const token = localStorage.getItem("token");
-  if (token && item.jobId && typeof fetch === "function") {
+  if (token && item.jobId && typeof fetchFn === "function") {
     try {
-      const res = await fetch(`${API_BASE}/cart/items`, {
+      const res = await fetchFn(`${API_BASE}/cart/items`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -92,7 +101,7 @@ export async function addToBasket(item, opts = {}) {
   const basketBtn = document.getElementById("basket-button");
   if (basketBtn) {
     basketBtn.classList.add("basket-bob");
-    setTimeout(() => basketBtn.classList.remove("basket-bob"), 800);
+    setTimeoutFn(() => basketBtn.classList.remove("basket-bob"), 800);
     if (window.__basketSound) {
       try {
         window.__basketSound.currentTime = 0;
@@ -135,9 +144,9 @@ export function removeFromBasket(index) {
   const [removed] = items.splice(index, 1);
   saveBasket();
   const token = localStorage.getItem("token");
-  if (token && removed?.serverId && typeof fetch === "function") {
+  if (token && removed?.serverId && typeof fetchFn === "function") {
     try {
-      const res = fetch(`${API_BASE}/cart/items/${removed.serverId}`, {
+      const res = fetchFn(`${API_BASE}/cart/items/${removed.serverId}`, {
         method: "DELETE",
         headers: { Authorization: `Bearer ${token}` },
       });
@@ -163,9 +172,9 @@ export function clearBasket() {
   saveBasket([]);
   localStorage.removeItem("print2CheckoutItems");
   const token = localStorage.getItem("token");
-  if (token && typeof fetch === "function") {
+  if (token && typeof fetchFn === "function") {
     try {
-      const res = fetch(`${API_BASE}/cart`, {
+      const res = fetchFn(`${API_BASE}/cart`, {
         method: "DELETE",
         headers: { Authorization: `Bearer ${token}` },
       });
@@ -193,7 +202,7 @@ async function syncServerCart() {
   const token = localStorage.getItem("token");
   if (!token) return;
   try {
-    const res = await fetch(`${API_BASE}/cart`, {
+    const res = await fetchFn(`${API_BASE}/cart`, {
       headers: { Authorization: `Bearer ${token}` },
     });
     const data = await res.json();
@@ -213,21 +222,21 @@ async function syncServerCart() {
 }
 
 function startReservationTimer() {
-  clearInterval(reserveInterval);
+  clearIntervalFn(reserveInterval);
   const label = document.getElementById("basket-reserve");
   if (!label) return;
   function tick() {
     const items = getBasket();
     if (!items.length) {
       label.classList.add("hidden");
-      clearInterval(reserveInterval);
+      clearIntervalFn(reserveInterval);
       return;
     }
     const expire = Math.min(...items.map((i) => i.reserveUntil || 0));
-    const diff = expire - Date.now();
+    const diff = expire - nowFn();
     if (diff <= 0) {
       label.textContent = "Queue slot expired";
-      clearInterval(reserveInterval);
+      clearIntervalFn(reserveInterval);
       return;
     }
     const mins = Math.floor(diff / 60000);
@@ -237,7 +246,7 @@ function startReservationTimer() {
     label.classList.remove("hidden");
   }
   tick();
-  reserveInterval = setInterval(tick, 1000);
+  reserveInterval = setIntervalFn(tick, 1000);
 }
 let viewerModal;
 let viewerEl;
@@ -490,6 +499,7 @@ export function setupBasketUI() {
 }
 export function createBasket(
   storage = typeof window !== "undefined" ? window.localStorage : undefined,
+  opts = {},
 ) {
   try {
     const map = {
@@ -520,18 +530,58 @@ export function createBasket(
       }
     }
   } catch {}
+  const {
+    fetchFn: fetchOverride = typeof fetch !== "undefined" ? fetch : undefined,
+    setTimeoutFn: setTimeoutOverride = typeof setTimeout !== "undefined"
+      ? setTimeout
+      : undefined,
+    clearTimeoutFn: clearTimeoutOverride = typeof clearTimeout !== "undefined"
+      ? clearTimeout
+      : undefined,
+    setIntervalFn: setIntervalOverride = typeof setInterval !== "undefined"
+      ? setInterval
+      : undefined,
+    clearIntervalFn: clearIntervalOverride = typeof clearInterval !==
+    "undefined"
+      ? clearInterval
+      : undefined,
+    nowFn: nowOverride = () => Date.now(),
+  } = opts;
   const bind =
     (fn) =>
     (...args) => {
-      const original = globalThis.localStorage;
+      const originalStorage = globalThis.localStorage;
+      const originals = {
+        fetchFn,
+        setTimeoutFn,
+        clearTimeoutFn,
+        setIntervalFn,
+        clearIntervalFn,
+        nowFn,
+      };
       globalThis.localStorage = storage;
+      fetchFn = fetchOverride;
+      setTimeoutFn = setTimeoutOverride;
+      clearTimeoutFn = clearTimeoutOverride;
+      setIntervalFn = setIntervalOverride;
+      clearIntervalFn = clearIntervalOverride;
+      nowFn = nowOverride;
       const result = fn(...args);
+      const restore = () => {
+        globalThis.localStorage = originalStorage;
+        ({
+          fetchFn,
+          setTimeoutFn,
+          clearTimeoutFn,
+          setIntervalFn,
+          clearIntervalFn,
+          nowFn,
+        } = originals);
+      };
       if (result && typeof result.then === "function") {
-        return result.finally(() => {
-          globalThis.localStorage = original;
-        });
+        return result.finally(restore);
       }
-      globalThis.localStorage = original;
+      restore();
       return result;
     };
   return {

--- a/js/index.js
+++ b/js/index.js
@@ -49,6 +49,8 @@ const FALLBACK_GLB_LOW =
 const FALLBACK_GLB_HIGH = FALLBACK_GLB_LOW;
 const FALLBACK_GLB = FALLBACK_GLB_LOW;
 const LOW_POLY_GLB = FALLBACK_GLB_LOW;
+let setIntervalFn = setInterval;
+let clearIntervalFn = clearInterval;
 
 function addBasketItem(item) {
   if (!window.addToBasket) return;
@@ -854,7 +856,7 @@ function initDiscountDeliveryBanner(bannerEl) {
   }
 
   refresh();
-  setInterval(refresh, 1000);
+  setIntervalFn(refresh, 1000);
   scheduleCycle();
 }
 
@@ -892,7 +894,7 @@ async function init() {
     }
     await updateStats();
     updatePrintRunInfo();
-    setInterval(updatePrintRunInfo, 60000);
+    setIntervalFn(updatePrintRunInfo, 60000);
   } else {
     updateWizardSlotCount();
     fetchProfile().then(() => {
@@ -903,7 +905,7 @@ async function init() {
     });
     await updateStats();
     updatePrintRunInfo();
-    setInterval(updatePrintRunInfo, 60000);
+    setIntervalFn(updatePrintRunInfo, 60000);
   }
   const sr = new URLSearchParams(window.location.search).get("sr");
   if (!sr) {
@@ -1093,7 +1095,7 @@ async function init() {
     });
   }
 
-  setInterval(updateStats, 3600000);
+  setIntervalFn(updateStats, 3600000);
 
   // Keep the wizard UI in sync with the payment page
   updateWizardSlotCount();
@@ -1111,7 +1113,7 @@ async function init() {
     cutoffEl.textContent = `Order in ${hrs}h ${String(mins).padStart(2, "0")}m for same-day processing`;
   }
   updateCutoff();
-  setInterval(updateCutoff, 60000);
+  setIntervalFn(updateCutoff, 60000);
 
   const popupEl = document.getElementById("purchase-popups");
   let popupMsgs = [
@@ -1185,7 +1187,7 @@ async function init() {
     }, 8000);
     popupIdx++;
   }
-  setInterval(showPopup, 15000);
+  setIntervalFn(showPopup, 15000);
 
   const banner = document.getElementById("theme-banner");
   if (banner) {
@@ -1206,19 +1208,28 @@ export function initBasketUI({
   doc = document,
   storage = window.localStorage,
   fetchFn = globalThis.fetch,
+  timers,
 } = {}) {
   const origDoc = globalThis.document;
   const origStorage = globalThis.localStorage;
   const origFetch = globalThis.fetch;
+  const origSetInterval = setIntervalFn;
+  const origClearInterval = clearIntervalFn;
   globalThis.document = doc;
   globalThis.localStorage = storage;
   globalThis.fetch = fetchFn;
+  if (timers) {
+    if (timers.setIntervalFn) setIntervalFn = timers.setIntervalFn;
+    if (timers.clearIntervalFn) clearIntervalFn = timers.clearIntervalFn;
+  }
   try {
     return init();
   } finally {
     globalThis.document = origDoc;
     globalThis.localStorage = origStorage;
     globalThis.fetch = origFetch;
+    setIntervalFn = origSetInterval;
+    clearIntervalFn = origClearInterval;
   }
 }
 
@@ -1247,6 +1258,8 @@ if (typeof module !== "undefined") {
     initIndexPage: initBasketUI,
     // test seam: allow unit tests to call snapshot helper
     captureModelSnapshot,
+    updateWizardSlotCount,
+    updateWizardFromInputs,
   };
 }
 
@@ -1258,4 +1271,6 @@ export {
   // test seam: allow unit tests to call snapshot helper
   captureModelSnapshot,
   initBasketUI as initIndexPage,
+  updateWizardSlotCount,
+  updateWizardFromInputs,
 };

--- a/tests/basket.modal.spec.r8s7t6y5u4i3o2p1.js
+++ b/tests/basket.modal.spec.r8s7t6y5u4i3o2p1.js
@@ -1,0 +1,47 @@
+import { buildDOM } from "./helpers/dom.js";
+import { memoryStorage } from "./helpers/storage.js";
+
+describe("basket viewer modal", () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  test("show and hide modal", async () => {
+    jest.useFakeTimers();
+    const dom = buildDOM();
+    dom.window.Audio = function () {
+      return { play: jest.fn() };
+    };
+    global.window = dom.window;
+    global.document = dom.window.document;
+    const storage = memoryStorage();
+    const { createBasket } = await import("../js/basket.js");
+    const basket = createBasket(storage);
+    basket.setupBasketUI();
+    await basket.addToBasket({
+      modelUrl: "model.glb",
+      snapshot: "poster.png",
+      jobId: "j1",
+    });
+    dom.window.document.getElementById("basket-button").click();
+    dom.window.document.querySelector("#basket-list img").click();
+    const modal = dom.window.document.getElementById("basket-model-modal");
+    const viewer = modal.querySelector("model-viewer");
+    const btn = dom.window.document.getElementById("basket-model-checkout");
+    expect(modal.classList.contains("hidden")).toBe(false);
+    expect(viewer.src).toBe("model.glb");
+    expect(viewer.getAttribute("poster")).toBe("poster.png");
+    expect(btn.dataset.model).toBe("model.glb");
+    expect(btn.dataset.job).toBe("j1");
+    btn.click();
+    expect(storage.getItem("print2Model")).toBe("model.glb");
+    expect(storage.getItem("print2JobId")).toBe("j1");
+    dom.window.document.getElementById("basket-model-close").click();
+    expect(modal.classList.contains("hidden")).toBe(true);
+    expect(dom.window.document.body.classList.contains("overflow-hidden")).toBe(
+      false,
+    );
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
+  });
+});

--- a/tests/basket.sync.spec.a9s8d7f6g5h4j3k2.js
+++ b/tests/basket.sync.spec.a9s8d7f6g5h4j3k2.js
@@ -7,14 +7,17 @@ describe("basket server sync", () => {
     jest.resetModules();
   });
 
-  test("maps server items", async () => {
+  test("maps and merges server items", async () => {
     const dom = buildDOM(
       '<button id="basket-button"><span id="basket-count"></span></button><div id="basket-list"></div>',
     );
     global.window = dom.window;
     global.document = dom.window.document;
-    const storage = memoryStorage({ token: "t" });
-    const fetch = makeFetch({
+    const storage = memoryStorage({
+      token: "t",
+      print2Basket: JSON.stringify([{ jobId: "local", serverId: "s0" }]),
+    });
+    const fetchFn = makeFetch({
       "http://localhost/api/cart": {
         ok: true,
         body: {
@@ -31,8 +34,7 @@ describe("basket server sync", () => {
       },
     });
     const { createBasket } = await import("../js/basket.js");
-    const basket = createBasket(storage);
-    global.fetch = fetch;
+    const basket = createBasket(storage, { fetchFn });
     await basket.syncServerCart();
     expect(basket.getBasket()).toEqual([
       {
@@ -43,11 +45,12 @@ describe("basket server sync", () => {
         snapshot: "snap1",
       },
     ]);
-    expect(
-      dom.window.document.getElementById("basket-list").children.length,
-    ).toBe(1);
+    const list = dom.window.document.getElementById("basket-list");
+    expect(list.children.length).toBe(1);
     expect(dom.window.document.getElementById("basket-count").textContent).toBe(
       "1",
     );
+    expect(storage.getItem("print2Basket")).toContain("j1");
+    expect(storage.getItem("print2Basket")).not.toContain("local");
   });
 });

--- a/tests/basket.ui.spec.q1w2e3r4t5y6u7i8.js
+++ b/tests/basket.ui.spec.q1w2e3r4t5y6u7i8.js
@@ -18,11 +18,15 @@ describe("basket ui interactions", () => {
     basket.setupBasketUI();
     await basket.addToBasket({ modelUrl: "m1" });
     await basket.addToBasket({ modelUrl: "m2" });
+    const badge = dom.window.document.getElementById("basket-count");
+    expect(badge.textContent).toBe("2");
     dom.window.document.getElementById("basket-button").click();
     const list = dom.window.document.getElementById("basket-list");
     expect(list.children).toHaveLength(2);
     list.querySelector("button.remove").click();
     expect(list.children).toHaveLength(1);
+    expect(JSON.parse(storage.getItem("print2Basket")).length).toBe(1);
+    expect(badge.textContent).toBe("1");
     dom.window.document.getElementById("basket-close").click();
     expect(
       dom.window.document

--- a/tests/index.wiring.timers.spec.g7h8j9k0l1m2n3b4.js
+++ b/tests/index.wiring.timers.spec.g7h8j9k0l1m2n3b4.js
@@ -1,0 +1,31 @@
+import { buildDOM } from "./helpers/dom.js";
+import { memoryStorage } from "./helpers/storage.js";
+
+describe("index timer wiring", () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  test("uses injected interval timers", async () => {
+    jest.useFakeTimers();
+    const spy = jest.spyOn(global, "setInterval");
+    const timers = {
+      setIntervalFn: setInterval,
+      clearIntervalFn: clearInterval,
+    };
+    const dom = buildDOM(
+      '<button id="basket-button"><span id="basket-count"></span></button>',
+    );
+    global.window = dom.window;
+    global.document = dom.window.document;
+    const storage = memoryStorage();
+    const fetchFn = () =>
+      Promise.resolve({ ok: false, json: async () => ({}) });
+    const { initBasketUI } = await import("../js/index.js");
+    await initBasketUI({ doc: dom.window.document, storage, fetchFn, timers });
+    expect(spy).toHaveBeenCalled();
+    jest.runOnlyPendingTimers();
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+});

--- a/tests/index.wizard.spec.s4d5f6g7h8j9k0l1.js
+++ b/tests/index.wizard.spec.s4d5f6g7h8j9k0l1.js
@@ -1,0 +1,28 @@
+import { adjustedSlots } from "../js/print-slots.js";
+
+describe("index wizard helpers", () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  test("updateWizardSlotCount fetches and updates", async () => {
+    const fetchFn = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ slots: 10 }),
+    });
+    global.fetch = fetchFn;
+    const setWizardSlotCount = jest.fn();
+    global.window = { setWizardSlotCount };
+    const { updateWizardSlotCount } = await import("../js/index.js");
+    await updateWizardSlotCount();
+    expect(setWizardSlotCount).toHaveBeenCalledWith(adjustedSlots(10));
+  });
+
+  test("updateWizardFromInputs sets stage", async () => {
+    const setWizardStage = jest.fn();
+    global.window = { setWizardStage };
+    const { updateWizardFromInputs } = await import("../js/index.js");
+    updateWizardFromInputs();
+    expect(setWizardStage).toHaveBeenCalledWith("prompt");
+  });
+});


### PR DESCRIPTION
## Summary
- add optional dependency injection in basket utilities and index wiring for deterministic timers
- expand basket and index tests to exercise audio, modal, server sync, wizard helpers and timer seams

## Testing
- `SKIP_NET_CHECKS=1 npm run test -- --coverage` *(fails: Missing ts-jest; run `npm run setup` before testing.)*
- `SKIP_NET_CHECKS=1 npm run test:all` *(fails: request to https://registry.npmjs.org/nyc failed)*


------
https://chatgpt.com/codex/tasks/task_e_68c5a5e139a4832dbe1b29e7e0e73a05