### PR TITLE
fix: show wizard slots on payment stage

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -1016,27 +1016,33 @@ async function initPaymentPage() {
       }
     } catch {}
   }
-  let baseSlots = null;
+  // Compute a client-side slot count first so we have a reasonable value even
+  // if the API fails or returns stale data.
+  let baseSlots = computeSlotsByTime();
+  if (typeof initData.slots === "number") {
+    baseSlots = initData.slots;
+  }
+
+  const adjustedSlotCount = adjustedSlots(baseSlots);
 
   if (slotEl) {
     slotEl.style.visibility = "hidden";
-    if (bulkSlotEl) {
-      bulkSlotEl.style.visibility = "hidden";
-    }
-    // Compute a client-side slot count first so we have a reasonable value even
-    // if the API fails or returns stale data.
-    baseSlots = computeSlotsByTime();
-    if (typeof initData.slots === "number") {
-      baseSlots = initData.slots;
-    }
-    slotEl.textContent = adjustedSlots(baseSlots);
+  }
+  if (bulkSlotEl) {
+    bulkSlotEl.style.visibility = "hidden";
+  }
+
+  if (window.setWizardSlotCount) {
+    window.setWizardSlotCount(adjustedSlotCount);
+  }
+
+  if (slotEl) {
+    slotEl.textContent = adjustedSlotCount;
     slotEl.style.visibility = "visible";
-    if (window.setWizardSlotCount)
-      window.setWizardSlotCount(adjustedSlots(baseSlots));
-    if (bulkSlotEl) {
-      bulkSlotEl.textContent = adjustedSlots(baseSlots);
-      bulkSlotEl.style.visibility = "visible";
-    }
+  }
+  if (bulkSlotEl) {
+    bulkSlotEl.textContent = adjustedSlotCount;
+    bulkSlotEl.style.visibility = "visible";
   }
 
   if (colorSlotEl) {


### PR DESCRIPTION
## Summary
- ensure the payment checkout always computes a base slot count so the wizard banner can display remaining slots even without the page-level counter
- hide/show the slot and bulk slot indicators after the shared count is available while keeping the wizard text in sync

## Testing
- `npx prettier --write js/payment.js`
- `SKIP_NET_CHECKS=1 npm test -- backend/tests/frontend/slotCount.test.js` *(fails: Unable to reach the npm registry in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbce775228832d9a42e084cc4b7404