### PR TITLE
fix: add colon to wizard slots

### DIFF
--- a/js/wizard.js
+++ b/js/wizard.js
@@ -52,7 +52,7 @@ window.setWizardStage = setWizardStage;
 export function setWizardSlotCount(n) {
   const el = document.getElementById("wizard-slots");
   if (el) {
-    el.textContent = `Only ${n} print slots left`;
+    el.textContent = `Only ${n} print slots left:`;
     const stage = localStorage.getItem(STAGE_KEY);
     if (stage === "building" || stage === "purchase" || stage === "print") {
       el.classList.remove("hidden");

--- a/tests/e2e/wizard-progress-bar.spec.x3h7p9k2d6s4f8l0.ts
+++ b/tests/e2e/wizard-progress-bar.spec.x3h7p9k2d6s4f8l0.ts
@@ -23,6 +23,6 @@ for (const path of ["/index.html", "/payment.html"]) {
     );
     const slots = page.locator("#wizard-slots");
     await expect(slots).toBeVisible();
-    await expect(slots).toHaveText("Only 2 print slots left");
+    await expect(slots).toHaveText("Only 2 print slots left:");
   });
 }


### PR DESCRIPTION
## Summary
- add a trailing colon to the wizard slot counter text so the third step reads with a separator
- update the wizard progress bar e2e test to expect the new colonized copy

## Testing
- `npm run validate-env`
- `npm run setup` *(fails: npm error Exit handler never called!)*
- `npm test` *(fails: Missing ts-jest; run npm run setup before testing.)*
- `npm run ci` *(terminated: command hung while running npm ci in offline environment)*
- `npm run smoke` *(fails: Missing ts-jest; run npm run setup before testing.)*

------
https://chatgpt.com/codex/tasks/task_e_68cbd07c3b10832db9f808143f90d31b