### PR TITLE
Add viewer navigation arrows to payment flow

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -458,6 +458,8 @@ async function initPaymentPage() {
   }
 
   const viewer = document.getElementById("viewer");
+  const prevBtn = document.getElementById("viewer-prev");
+  const nextBtn = document.getElementById("viewer-next");
   const optOut = document.getElementById("opt-out");
   const emailEl = document.getElementById("checkout-email");
   const successMsg = document.getElementById("success");
@@ -938,6 +940,15 @@ async function initPaymentPage() {
   function showItem(idx) {
     if (!checkoutItems.length) return;
     currentIndex = (idx + checkoutItems.length) % checkoutItems.length;
+    const hasMultiple = checkoutItems.length > 1;
+    if (prevBtn) {
+      prevBtn.hidden = !hasMultiple;
+      prevBtn.disabled = !hasMultiple;
+    }
+    if (nextBtn) {
+      nextBtn.hidden = !hasMultiple;
+      nextBtn.disabled = !hasMultiple;
+    }
     const item = checkoutItems[currentIndex];
     if (viewer) {
       const tag = viewer.tagName.toLowerCase();
@@ -998,6 +1009,14 @@ async function initPaymentPage() {
     updatePayButton();
     updateFlashSaleBanner();
   }
+  prevBtn?.addEventListener("click", () => {
+    if (!checkoutItems.length) return;
+    showItem(currentIndex - 1);
+  });
+  nextBtn?.addEventListener("click", () => {
+    if (!checkoutItems.length) return;
+    showItem(currentIndex + 1);
+  });
   const sessionId = qs("session_id");
   if (sessionId) {
     recordPurchase();

--- a/payment.html
+++ b/payment.html
@@ -78,6 +78,24 @@
               alt="3D astronaut"
               style="width: 100%; height: 100%; display: block"
             ></model-viewer>
+            <button
+              type="button"
+              id="viewer-prev"
+              aria-label="View previous item"
+              hidden
+              class="absolute left-3 top-1/2 -translate-y-1/2 z-10 w-10 h-10 rounded-full bg-black/60 text-white flex items-center justify-center transition hover:bg-black/80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+            >
+              <span aria-hidden="true" class="text-2xl leading-none">&#8592;</span>
+            </button>
+            <button
+              type="button"
+              id="viewer-next"
+              aria-label="View next item"
+              hidden
+              class="absolute right-3 top-1/2 -translate-y-1/2 z-10 w-10 h-10 rounded-full bg-black/60 text-white flex items-center justify-center transition hover:bg-black/80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+            >
+              <span aria-hidden="true" class="text-2xl leading-none">&#8594;</span>
+            </button>
             <div
               id="print-run-info"
               class="absolute top-2 left-3 text-left text-sm text-red-400 leading-snug invisible"


### PR DESCRIPTION
## Summary
- add left/right controls to the payment page model viewer so shoppers can page through basket items
- hook the new buttons into the existing checkout item state to update the viewer and material selections while hiding the controls when only one item exists

## Testing
- npm run lint --prefix frontend

------
https://chatgpt.com/codex/tasks/task_e_68cc758a1688832daa529c8680c2b595