### PR TITLE
fix: sync basket quantity with checkout

### DIFF
--- a/js/basket.js
+++ b/js/basket.js
@@ -192,9 +192,15 @@ export function clearBasket() {
 function updateBadge() {
   const badge = document.getElementById("basket-count");
   if (badge) {
-    const n = getBasket().length;
-    badge.textContent = n > 0 ? String(n) : "";
-    badge.hidden = n === 0;
+    const items = getBasket();
+    const total = items.reduce((acc, item) => {
+      const raw = item?.quantity ?? item?.qty ?? 1;
+      const parsed = parseInt(raw, 10);
+      const qty = Number.isFinite(parsed) && parsed > 0 ? parsed : 1;
+      return acc + qty;
+    }, 0);
+    badge.textContent = total > 0 ? String(total) : "";
+    badge.hidden = total === 0;
   }
 }
 

--- a/js/payment.js
+++ b/js/payment.js
@@ -460,6 +460,7 @@ async function initPaymentPage() {
   const viewer = document.getElementById("viewer");
   const prevBtn = document.getElementById("viewer-prev");
   const nextBtn = document.getElementById("viewer-next");
+  const viewerCounter = document.getElementById("viewer-counter");
   const optOut = document.getElementById("opt-out");
   const emailEl = document.getElementById("checkout-email");
   const successMsg = document.getElementById("success");
@@ -937,8 +938,21 @@ async function initPaymentPage() {
   }
   updatePayButton();
   updatePopularMessage();
+  function updateViewerCounter() {
+    if (!viewerCounter) return;
+    if (checkoutItems.length <= 1) {
+      viewerCounter.textContent = "";
+      viewerCounter.classList.add("hidden");
+      return;
+    }
+    viewerCounter.textContent = `${currentIndex + 1}/${checkoutItems.length}`;
+    viewerCounter.classList.remove("hidden");
+  }
   function showItem(idx) {
-    if (!checkoutItems.length) return;
+    if (!checkoutItems.length) {
+      updateViewerCounter();
+      return;
+    }
     currentIndex = (idx + checkoutItems.length) % checkoutItems.length;
     const hasMultiple = checkoutItems.length > 1;
     if (prevBtn) {
@@ -1008,6 +1022,7 @@ async function initPaymentPage() {
     applyStoredColorIfNeeded();
     updatePayButton();
     updateFlashSaleBanner();
+    updateViewerCounter();
   }
   prevBtn?.addEventListener("click", () => {
     if (!checkoutItems.length) return;
@@ -1204,6 +1219,53 @@ async function initPaymentPage() {
       );
     } catch {}
   }
+  function normaliseQuantity(val) {
+    const num = parseInt(val, 10);
+    return Number.isFinite(num) && num > 0 ? num : 1;
+  }
+  function getItemQuantity(item) {
+    if (!item) return 1;
+    if (item.qty != null) return normaliseQuantity(item.qty);
+    if (item.quantity != null) return normaliseQuantity(item.quantity);
+    return 1;
+  }
+  function updateBasketBadgeCount() {
+    const badge = document.getElementById("basket-count");
+    if (!badge) return;
+    let total = 0;
+    if (checkoutItems.length) {
+      checkoutItems.forEach((it) => {
+        total += getItemQuantity(it);
+      });
+    } else {
+      try {
+        const stored = JSON.parse(localStorage.getItem("print2Basket"));
+        if (Array.isArray(stored)) {
+          stored.forEach((entry) => {
+            total += getItemQuantity(entry);
+          });
+        }
+      } catch {}
+    }
+    badge.textContent = total > 0 ? String(total) : "";
+    badge.hidden = total === 0;
+  }
+  function syncBasketQuantities() {
+    let stored = null;
+    try {
+      stored = JSON.parse(localStorage.getItem("print2Basket"));
+    } catch {}
+    if (Array.isArray(stored) && stored.length) {
+      const updated = stored.map((entry, idx) => ({
+        ...entry,
+        quantity: getItemQuantity(checkoutItems[idx] || entry),
+      }));
+      try {
+        localStorage.setItem("print2Basket", JSON.stringify(updated));
+      } catch {}
+    }
+    updateBasketBadgeCount();
+  }
   function saveCheckoutItems() {
     try {
       localStorage.setItem(
@@ -1211,12 +1273,19 @@ async function initPaymentPage() {
         JSON.stringify(checkoutItems),
       );
     } catch {}
+    syncBasketQuantities();
   }
 
   // Ensure a minimum quantity of 2 when arriving on the payment page
   if (checkoutItems.length === 1 && checkoutItems[0].qty === 1) {
     checkoutItems[0].qty = 2;
     saveCheckoutItems();
+  }
+
+  if (checkoutItems.length > 1) {
+    syncBasketQuantities();
+  } else {
+    updateBasketBadgeCount();
   }
 
   if (!checkoutItems.length) {

--- a/payment.html
+++ b/payment.html
@@ -97,6 +97,10 @@
               <span aria-hidden="true" class="text-2xl leading-none">&#8594;</span>
             </button>
             <div
+              id="viewer-counter"
+              class="absolute top-3 right-3 bg-black/60 text-white text-xs font-semibold tracking-wide px-3 py-1 rounded-full hidden"
+            ></div>
+            <div
               id="print-run-info"
               class="absolute top-2 left-3 text-left text-sm text-red-400 leading-snug invisible"
             >


### PR DESCRIPTION
## Summary
- keep the payment page basket badge in sync with per-model quantities and persist the counts back to local storage
- surface the current model position (e.g. 1/3) when cycling through saved models on the payment page viewer
- update the shared basket badge logic to total item quantities instead of just counting unique entries

## Testing
- npm test *(fails: Missing ts-jest; run `npm run setup` before testing.)*


------
https://chatgpt.com/codex/tasks/task_e_68cdc9ef0a98832da9c291462598ae32