### PR TITLE
fix: delay basket animation until payment

### DIFF
--- a/js/basket.js
+++ b/js/basket.js
@@ -73,6 +73,7 @@ export async function addToBasket(item, opts = {}) {
   const items = getBasket();
   const expire = nowFn() + RESERVE_MINS * 60 * 1000;
   const entry = { ...item, auto: !!opts.auto, reserveUntil: expire };
+  const shouldAnimate = opts.animate !== false;
   items.push(entry);
   saveBasket();
   const token = localStorage.getItem("token");
@@ -100,8 +101,10 @@ export async function addToBasket(item, opts = {}) {
   startReservationTimer();
   const basketBtn = document.getElementById("basket-button");
   if (basketBtn) {
-    basketBtn.classList.add("basket-bob");
-    setTimeoutFn(() => basketBtn.classList.remove("basket-bob"), 800);
+    if (shouldAnimate) {
+      basketBtn.classList.add("basket-bob");
+      setTimeoutFn(() => basketBtn.classList.remove("basket-bob"), 800);
+    }
     if (window.__basketSound) {
       try {
         window.__basketSound.currentTime = 0;

--- a/js/index.js
+++ b/js/index.js
@@ -51,10 +51,13 @@ const FALLBACK_GLB = FALLBACK_GLB_LOW;
 const LOW_POLY_GLB = FALLBACK_GLB_LOW;
 let setIntervalFn = setInterval;
 let clearIntervalFn = clearInterval;
+const BASKET_ANIMATION_PENDING_KEY = "print2PendingBasketAnimation";
 
-function addBasketItem(item) {
+function addBasketItem(item, opts = {}) {
   if (!window.addToBasket) return;
-  window.addToBasket(item);
+  window.addToBasket(item, opts);
+  const shouldAnimate = opts.animate !== false;
+  if (!shouldAnimate) return;
   const basketBtn = document.getElementById("basket-button");
   if (basketBtn) {
     basketBtn.classList.add("basket-bob");
@@ -1059,7 +1062,10 @@ async function init() {
       snapshot: lastSnapshot || "",
     };
     // Add the current viewer item to the basket and persist it for checkout
-    addBasketItem(item);
+    addBasketItem(item, { animate: false });
+    try {
+      sessionStorage.setItem(BASKET_ANIMATION_PENDING_KEY, "1");
+    } catch {}
     try {
       const items = window.getBasket ? window.getBasket() : [item];
       localStorage.setItem("print2CheckoutItems", JSON.stringify(items));

--- a/js/payment.js
+++ b/js/payment.js
@@ -59,6 +59,7 @@ const PRICES = {
   multi: 3999,
   premium: 5999,
 };
+const BASKET_ANIMATION_PENDING_KEY = "print2PendingBasketAnimation";
 
 // Override prices for Luckybox checkout
 if (window.location.pathname.endsWith("luckybox-payment.html")) {
@@ -475,6 +476,24 @@ async function initPaymentPage() {
   const promoToggle = document.querySelector(".promo-toggle");
   const promoBox = document.querySelector(".promo-input");
   const surpriseToggle = document.getElementById("surprise-toggle");
+  try {
+    if (sessionStorage.getItem(BASKET_ANIMATION_PENDING_KEY) === "1") {
+      sessionStorage.removeItem(BASKET_ANIMATION_PENDING_KEY);
+      let attempts = 0;
+      const triggerBasketAnimation = () => {
+        const basketBtn = document.getElementById("basket-button");
+        if (!basketBtn) {
+          if (attempts++ < 10) {
+            setTimeout(triggerBasketAnimation, 50);
+          }
+          return;
+        }
+        basketBtn.classList.add("basket-bob");
+        setTimeout(() => basketBtn.classList.remove("basket-bob"), 800);
+      };
+      setTimeout(triggerBasketAnimation, 0);
+    }
+  } catch {}
   viewer?.addEventListener("error", () => {
     const img = document.getElementById("preview-img");
     if (img) {


### PR DESCRIPTION
## Summary
- allow basket additions to opt out of the immediate animation so the checkout button can defer it
- mark the checkout button navigation with a session flag and play the basket bob animation on the payment page after load

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc783e7b94832da736e44b668644c8