### PR TITLE
fix: align viewer error text offset

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,7 +145,12 @@
           <button id="add-basket-button" data-testid="add-to-basket" aria-label="Add to basket" class="absolute bottom-4 left-4 font-bold py-2 px-4 rounded-full shadow-md bg-[#30D5C8] text-[#1A1A1D] border-2 border-black">Add to Basket</button>
         </section>
 
-        <div id="gen-error" class="absolute top-2 left-2 w-fit text-left text-sm text-red-400 pointer-events-none" aria-live="assertive" style="opacity: 0"></div>
+        <div
+          id="gen-error"
+          class="absolute top-2 left-[0.7rem] w-fit text-left text-sm text-red-400 pointer-events-none"
+          aria-live="assertive"
+          style="opacity: 0"
+        ></div>
 
         <!-- (kept) quote + info UI -->
         <div id="subreddit-quote" class="absolute text-left text-sm text-gray-400 leading-snug invisible">


### PR DESCRIPTION
## Summary
- move the GLB viewer error message slightly to the right so its spacing matches the top margin

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cdd7f15220832da20c3d1ffbb4c4e4