### PR TITLE
fix: avoid duplicate checkout basket items

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -55,6 +55,26 @@ const BASKET_ANIMATION_PENDING_KEY = "print2PendingBasketAnimation";
 
 function addBasketItem(item, opts = {}) {
   if (!window.addToBasket) return;
+  if (opts.preventDuplicate && typeof window.getBasket === "function") {
+    try {
+      const items = window.getBasket() || [];
+      const alreadyExists = items.some((existing) => {
+        if (!existing) return false;
+        if (item.jobId && existing.jobId) {
+          return existing.jobId === item.jobId;
+        }
+        if (item.modelUrl && existing.modelUrl) {
+          return existing.modelUrl === item.modelUrl;
+        }
+        return false;
+      });
+      if (alreadyExists) {
+        return;
+      }
+    } catch {
+      // ignore duplicate detection errors
+    }
+  }
   window.addToBasket(item, opts);
   const shouldAnimate = opts.animate !== false;
   if (!shouldAnimate) return;
@@ -1062,7 +1082,7 @@ async function init() {
       snapshot: lastSnapshot || "",
     };
     // Add the current viewer item to the basket and persist it for checkout
-    addBasketItem(item, { animate: false });
+    addBasketItem(item, { animate: false, preventDuplicate: true });
     try {
       sessionStorage.setItem(BASKET_ANIMATION_PENDING_KEY, "1");
     } catch {}

--- a/tests/index.wiring.spec.m1n2b3v4c5x6z7l8.js
+++ b/tests/index.wiring.spec.m1n2b3v4c5x6z7l8.js
@@ -64,6 +64,71 @@ describe("index wiring", () => {
     ).toBe("1");
   });
 
+  test("checkout button skips duplicate entries", async () => {
+    const html = `
+      <model-viewer id="glb-viewer" src="https://example.com/model.glb"></model-viewer>
+      <img id="preview-img" src="https://example.com/img.png" />
+      <a id="checkout-button" href="#"></a>
+      <button id="basket-button"><span id="basket-count"></span></button>
+      <div id="theme-banner" class="hidden"></div>
+    `;
+    const dom = buildDOM(html);
+    const storage = memoryStorage();
+    const session = memoryStorage();
+    const fetchFn = () =>
+      Promise.resolve({ ok: false, json: async () => ({}) });
+
+    global.window = dom.window;
+    global.document = dom.window.document;
+    global.localStorage = storage;
+    global.sessionStorage = session;
+    global.navigator = dom.window.navigator;
+
+    dom.window.localStorage = storage;
+    dom.window.sessionStorage = session;
+
+    const originalCustomElements = global.customElements;
+    const customElementsStub = {
+      get: () => undefined,
+      whenDefined: () => Promise.resolve(),
+      define: () => {},
+    };
+    dom.window.customElements = customElementsStub;
+    global.customElements = customElementsStub;
+
+    const { createBasket } = await import("../js/basket.js");
+    const basket = createBasket(storage, { fetchFn });
+
+    dom.window.addToBasket = basket.addToBasket;
+    dom.window.getBasket = basket.getBasket;
+    global.addToBasket = basket.addToBasket;
+    global.getBasket = basket.getBasket;
+
+    await basket.addToBasket({
+      modelUrl: "https://example.com/model.glb",
+      jobId: "job-1",
+    });
+
+    const { initBasketUI } = await import("../js/index.js");
+    await initBasketUI({ doc: dom.window.document, storage, fetchFn });
+
+    expect(dom.window.getBasket().length).toBe(1);
+
+    const checkoutBtn = dom.window.document.getElementById("checkout-button");
+    checkoutBtn.dispatchEvent(
+      new dom.window.Event("click", { bubbles: true }),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(dom.window.getBasket().length).toBe(1);
+    const storedItemsRaw = storage.getItem("print2CheckoutItems");
+    expect(storedItemsRaw).not.toBeNull();
+    expect(JSON.parse(storedItemsRaw)).toHaveLength(1);
+
+    global.customElements = originalCustomElements;
+  });
+
   test("graceful when elements missing", async () => {
     const dom = buildDOM("<div></div>");
     global.window = dom.window;


### PR DESCRIPTION
## Summary
- prevent duplicate basket entries when the checkout button is used repeatedly on the same model
- add a regression test covering the checkout path to ensure existing items are not duplicated

## Testing
- npm run setup *(fails: npm error "Exit handler never called!")*
- npm test -- tests/index.wiring.spec.m1n2b3v4c5x6z7l8.js *(fails: Missing ts-jest; setup could not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68cdd747f2a8832dadae13a13fc83056