### PR TITLE
fix: centralize checkout persistence matching

### DIFF
--- a/js/basket.js
+++ b/js/basket.js
@@ -1,3 +1,10 @@
+import {
+  readCheckoutItems,
+  writeCheckoutItems,
+  createCheckoutMatcher,
+  clearCheckoutItems,
+} from "./checkout-storage.js";
+
 (() => {
   try {
     const map = {
@@ -160,20 +167,18 @@ export function removeFromBasket(index) {
       /* ignore network errors */
     }
   }
-  try {
-    const arr = JSON.parse(localStorage.getItem("print2CheckoutItems"));
-    if (Array.isArray(arr) && index >= 0 && index < arr.length) {
-      arr.splice(index, 1);
-      localStorage.setItem("print2CheckoutItems", JSON.stringify(arr));
-    }
-  } catch {}
+  const checkoutItems = readCheckoutItems();
+  if (index >= 0 && index < checkoutItems.length) {
+    checkoutItems.splice(index, 1);
+    writeCheckoutItems(checkoutItems);
+  }
   updateBadge();
   renderList();
   notifyBasketChange();
 }
 export function clearBasket() {
   saveBasket([]);
-  localStorage.removeItem("print2CheckoutItems");
+  clearCheckoutItems();
   const token = localStorage.getItem("token");
   if (token && typeof fetchFn === "function") {
     try {
@@ -395,10 +400,10 @@ export function setupBasketUI() {
     }
     // Save basket contents for payment page navigation
     try {
-      const existing =
-        JSON.parse(localStorage.getItem("print2CheckoutItems")) || [];
+      const existing = readCheckoutItems();
+      const findPrevForItem = createCheckoutMatcher(existing);
       const checkoutItems = items.map((it, idx) => {
-        const prev = existing[idx] || {};
+        const prev = findPrevForItem(it, idx);
         return {
           modelUrl: it.modelUrl,
           jobId: it.jobId,
@@ -411,10 +416,7 @@ export function setupBasketUI() {
             prev.etchName || localStorage.getItem("print2EtchName") || "",
         };
       });
-      localStorage.setItem(
-        "print2CheckoutItems",
-        JSON.stringify(checkoutItems),
-      );
+      writeCheckoutItems(checkoutItems);
     } catch {}
     closeBasket();
     if (location.pathname.endsWith("addons.html")) {

--- a/js/checkout-storage.js
+++ b/js/checkout-storage.js
@@ -1,0 +1,72 @@
+const CHECKOUT_KEY = "print2CheckoutItems";
+
+export function readCheckoutItems() {
+  try {
+    const raw = localStorage.getItem(CHECKOUT_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+export function writeCheckoutItems(items) {
+  try {
+    localStorage.setItem(CHECKOUT_KEY, JSON.stringify(items));
+  } catch {}
+}
+
+export function clearCheckoutItems() {
+  try {
+    localStorage.removeItem(CHECKOUT_KEY);
+  } catch {}
+}
+
+export function createCheckoutMatcher(existingItems) {
+  const prevEntries = (Array.isArray(existingItems) ? existingItems : []).map(
+    (prev, idx) => ({
+      prev,
+      idx,
+      used: false,
+    }),
+  );
+  const claimPrev = (predicate) => {
+    const entry = prevEntries.find(
+      (candidate) => !candidate.used && predicate(candidate),
+    );
+    if (!entry) return null;
+    entry.used = true;
+    return entry.prev && typeof entry.prev === "object" ? entry.prev : {};
+  };
+  return (item, index) => {
+    const byJob =
+      item?.jobId &&
+      claimPrev(
+        (candidate) =>
+          candidate.prev?.jobId && candidate.prev.jobId === item.jobId,
+      );
+    if (byJob) return byJob;
+    const byModel =
+      item?.modelUrl &&
+      claimPrev(
+        (candidate) =>
+          candidate.prev?.modelUrl && candidate.prev.modelUrl === item.modelUrl,
+      );
+    if (byModel) return byModel;
+    const sameIndex = claimPrev(
+      (candidate) =>
+        candidate.idx === index &&
+        candidate.prev &&
+        typeof candidate.prev === "object",
+    );
+    if (sameIndex) return sameIndex;
+    const anyWithData = claimPrev(
+      (candidate) => candidate.prev && typeof candidate.prev === "object",
+    );
+    if (anyWithData) return anyWithData;
+    const any = claimPrev(() => true);
+    if (any) return any;
+    return {};
+  };
+}

--- a/js/payment.js
+++ b/js/payment.js
@@ -1,5 +1,11 @@
 import { track } from "./analytics.js";
 import {
+  readCheckoutItems,
+  writeCheckoutItems,
+  createCheckoutMatcher,
+  clearCheckoutItems,
+} from "./checkout-storage.js";
+import {
   computeSlotsByTime,
   adjustedSlots,
   recordSlotPurchase,
@@ -1164,18 +1170,16 @@ async function initPaymentPage() {
 
   // Load saved basket items unless this is the Luckybox page
   if (!window.location.pathname.endsWith("luckybox-payment.html")) {
-    try {
-      const arr = JSON.parse(localStorage.getItem("print2CheckoutItems"));
-      if (Array.isArray(arr) && arr.length) {
-        checkoutItems = arr.map((it) => ({
-          ...it,
-          etchName: it.etchName || "",
-          qty: Math.max(1, parseInt(it.qty || "1", 10)),
-        }));
-      }
-    } catch {}
+    const stored = readCheckoutItems();
+    if (stored.length) {
+      checkoutItems = stored.map((it) => ({
+        ...it,
+        etchName: it.etchName || "",
+        qty: Math.max(1, parseInt(it.qty || "1", 10)),
+      }));
+    }
   } else {
-    localStorage.removeItem("print2CheckoutItems");
+    clearCheckoutItems();
   }
 
   if (viewer && viewer.tagName.toLowerCase() !== "img") {
@@ -1198,9 +1202,9 @@ async function initPaymentPage() {
             return !c || c.modelUrl !== it.modelUrl || c.jobId !== it.jobId;
           }))
       ) {
-        const existing = checkoutItems;
+        const findPrevForItem = createCheckoutMatcher(checkoutItems);
         checkoutItems = basket.map((it, idx) => {
-          const prev = existing[idx] || {};
+          const prev = findPrevForItem(it, idx);
           return {
             modelUrl: it.modelUrl,
             jobId: it.jobId,
@@ -1219,10 +1223,7 @@ async function initPaymentPage() {
             })(),
           };
         });
-        localStorage.setItem(
-          "print2CheckoutItems",
-          JSON.stringify(checkoutItems),
-        );
+        writeCheckoutItems(checkoutItems);
       }
     } catch {}
   }
@@ -1231,12 +1232,7 @@ async function initPaymentPage() {
     checkoutItems.forEach((it) => {
       it.qty = 1;
     });
-    try {
-      localStorage.setItem(
-        "print2CheckoutItems",
-        JSON.stringify(checkoutItems),
-      );
-    } catch {}
+    writeCheckoutItems(checkoutItems);
   }
   function normaliseQuantity(val) {
     const num = parseInt(val, 10);
@@ -1286,12 +1282,7 @@ async function initPaymentPage() {
     updateBasketBadgeCount();
   }
   function saveCheckoutItems() {
-    try {
-      localStorage.setItem(
-        "print2CheckoutItems",
-        JSON.stringify(checkoutItems),
-      );
-    } catch {}
+    writeCheckoutItems(checkoutItems);
     syncBasketQuantities();
   }
 


### PR DESCRIPTION
## Summary
- add a shared checkout-storage helper to read, write, and match stored checkout entries by job or model id
- update basket checkout handoff to reuse the helper so saved colour/material selections carry over when reopening payment
- streamline payment page initialisation to hydrate checkout items via the helper and persist updates through the shared writer

## Testing
- npm run validate-env
- SKIP_PW_DEPS=1 npm run setup *(fails with "npm error Exit handler never called!" in this environment)*
- npm test *(fails: Missing ts-jest because npm run setup cannot complete in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdd491cfd4832dad5a1937424bc03c