### PR TITLE
fix: align community creations viewer

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -182,8 +182,8 @@
         <h2 class="text-xl font-semibold mb-4">Bestselling</h2>
         <div
           id="popular-grid"
-          class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4"
-          style="grid-auto-rows: 8rem"
+          class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 grid-flow-row-dense gap-4"
+          style="grid-auto-rows: 8rem;"
         ></div>
         <div id="popular-sentinel" class="h-8"></div>
         <button
@@ -328,8 +328,8 @@
         <h2 class="text-xl font-semibold mb-4">Recent</h2>
         <div
           id="recent-grid"
-          class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4"
-          style="grid-auto-rows: 8rem"
+          class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 grid-flow-row-dense gap-4"
+          style="grid-auto-rows: 8rem;"
         ></div>
         <div id="recent-sentinel" class="h-8"></div>
         <button

--- a/js/community.js
+++ b/js/community.js
@@ -399,10 +399,10 @@ function createCard(model) {
 function createViewerCard(modelUrl) {
   const div = document.createElement("div");
   div.className =
-    "viewer-card model-card relative bg-[#2A2A2E] border border-white/10 rounded-xl flex items-center justify-center cursor-pointer";
+    "viewer-card model-card relative bg-[#2A2A2E] border border-white/10 rounded-xl flex items-stretch justify-center cursor-pointer h-full row-span-1 sm:row-span-2 sm:col-start-2 md:row-span-3 md:col-start-3";
 
   div.dataset.model = modelUrl;
-  div.innerHTML = `<model-viewer src="${modelUrl}" alt="3D model preview" poster="images/box logo.png" environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr" camera-controls auto-rotate loading="lazy" class="w-full h-full bg-[#2A2A2E] rounded-xl"></model-viewer>\n    <button class="purchase absolute bottom-1 right-1 font-bold text-lg py-1.5 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]" style="transform: scale(0.78); transform-origin: right bottom;">Buy from £29.99</button>`;
+  div.innerHTML = `<model-viewer src="${modelUrl}" alt="3D model preview" poster="images/box logo.png" environment-image="https://modelviewer.dev/shared-assets/environments/neutral.hdr" camera-controls auto-rotate loading="lazy" class="w-full h-full min-h-0 flex-1 bg-[#2A2A2E] rounded-xl"></model-viewer>\n    <button class="purchase absolute bottom-1 right-1 font-bold text-lg py-1.5 px-4 rounded-full shadow-md transition border-2 border-black bg-[#30D5C8] text-[#1A1A1D]" style="transform: scale(0.78); transform-origin: right bottom;">Buy from £29.99</button>`;
   const viewer = div.querySelector("model-viewer");
   viewer.addEventListener("error", handleModelError);
   div.addEventListener("pointerenter", () => prefetchModel(modelUrl));
@@ -449,7 +449,6 @@ function applyPopularViewer() {
   toRemove.forEach((el) => el.remove());
 
   const viewer = createViewerCard(modelUrl);
-  viewer.classList.add("row-span-3", "h-[24rem]");
 
   const insertBefore = grid.children[2];
   if (insertBefore) grid.insertBefore(viewer, insertBefore);
@@ -469,10 +468,6 @@ function applyRecentViewer() {
   const modelUrl = firstModel.dataset.model;
 
   const viewer = createViewerCard(modelUrl);
-
-  // Let the grid determine the final height so alignment matches
-
-  viewer.classList.add("row-span-3");
 
   const insertBefore = firstModel;
   if (insertBefore) grid.insertBefore(viewer, insertBefore);


### PR DESCRIPTION
## Summary
- enable dense packing on the Community Creations grids so cards backfill instead of leaving blank slots
- update the viewer card to span the correct rows/columns at each breakpoint and stretch its wrapper/content instead of using the fixed 24rem height that left a bottom gap

## Testing
- npm run lint --prefix frontend
- Manual verification: `python -m http.server 3000` + Playwright snapshots of CommunityCreations.html

------
https://chatgpt.com/codex/tasks/task_e_68ce5fe284d8832dadbd0f30a3d40c5d