### PR TITLE
fix: preserve checkout checkout metadata

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -2,6 +2,11 @@
 import { shareOn } from "./share.js";
 import { track } from "./analytics.js";
 import {
+  readCheckoutItems,
+  writeCheckoutItems,
+  createCheckoutMatcher,
+} from "./checkout-storage.js";
+import {
   computeSlotsByTime,
   adjustedSlots,
   updatePrintRunInfo,
@@ -1087,8 +1092,20 @@ async function init() {
       sessionStorage.setItem(BASKET_ANIMATION_PENDING_KEY, "1");
     } catch {}
     try {
-      const items = window.getBasket ? window.getBasket() : [item];
-      localStorage.setItem("print2CheckoutItems", JSON.stringify(items));
+      const basketItems = window.getBasket ? window.getBasket() : null;
+      const items = Array.isArray(basketItems) && basketItems.length
+        ? basketItems
+        : [item];
+      const previous = readCheckoutItems();
+      const findPrevForItem = createCheckoutMatcher(previous);
+      const checkoutItems = items.map((basketItem, index) => {
+        const prev = findPrevForItem(basketItem, index);
+        return {
+          ...prev,
+          ...basketItem,
+        };
+      });
+      writeCheckoutItems(checkoutItems);
     } catch {}
     if (window.setWizardStage) window.setWizardStage("purchase");
   });


### PR DESCRIPTION
## Summary
- import the checkout storage helpers into the homepage script
- merge basket entries with previously saved checkout data before persisting so metadata is preserved

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce62b3e394832da2a74513de96c24a