### PR TITLE
fix: defer basket animation until payment

### DIFF
--- a/js/basket.js
+++ b/js/basket.js
@@ -80,7 +80,8 @@ export async function addToBasket(item, opts = {}) {
   const items = getBasket();
   const expire = nowFn() + RESERVE_MINS * 60 * 1000;
   const entry = { ...item, auto: !!opts.auto, reserveUntil: expire };
-  const shouldAnimate = opts.animate !== false;
+  const shouldAnimate =
+    opts.animate !== false && !opts.deferAnimation;
   items.push(entry);
   saveBasket();
   const token = localStorage.getItem("token");

--- a/js/index.js
+++ b/js/index.js
@@ -60,7 +60,11 @@ const BASKET_ANIMATION_PENDING_KEY = "print2PendingBasketAnimation";
 
 function addBasketItem(item, opts = {}) {
   if (!window.addToBasket) return false;
-  if (opts.preventDuplicate && typeof window.getBasket === "function") {
+  const options = { ...opts };
+  if (
+    options.preventDuplicate &&
+    typeof window.getBasket === "function"
+  ) {
     try {
       const items = window.getBasket() || [];
       const alreadyExists = items.some((existing) => {
@@ -80,8 +84,8 @@ function addBasketItem(item, opts = {}) {
       // ignore duplicate detection errors
     }
   }
-  window.addToBasket(item, opts);
-  const shouldAnimate = opts.animate !== false;
+  window.addToBasket(item, options);
+  const shouldAnimate = options.animate !== false;
   if (!shouldAnimate) return true;
   const basketBtn = document.getElementById("basket-button");
   if (basketBtn) {
@@ -1091,6 +1095,7 @@ async function init() {
     const addedToBasket = addBasketItem(item, {
       animate: false,
       preventDuplicate: true,
+      deferAnimation: true,
     });
     if (addedToBasket) {
       try {


### PR DESCRIPTION
## Summary
- clone basket add options so they can carry a deferAnimation flag
- pass deferAnimation when navigating directly to checkout and honor it in the basket helper to avoid animating until payment

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf08262a34832da8bf6abd617c2098