### PR TITLE
test: map yaml module for jest

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -24,6 +24,9 @@ try {
       ],
     },
     moduleFileExtensions: ["ts", "tsx", "js", "json", "mjs"],
+    moduleNameMapper: {
+      "^yaml$": "<rootDir>/node_modules/yaml/dist/index.js",
+    },
     testMatch: [
       "**/*.spec.ts",
       "**/*.spec.tsx",


### PR DESCRIPTION
## Summary
- add a moduleNameMapper entry so jest resolves the CommonJS yaml build

## Testing
- node scripts/run-jest.js tests/openapi

------
https://chatgpt.com/codex/tasks/task_e_68cf2849bc3c832db0a96f34f5d07b1e