### PR TITLE
feat: add router for authenticated model listings

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -114,6 +114,15 @@ try {
 
 try {
   (() => {
+    const r = require("./routes/myModels");
+    app.use("/api/my/models", r.default || r);
+  })();
+} catch (err) {
+  logger.error("Failed to load my models router", err as Error);
+}
+
+try {
+  (() => {
     const r = require("./routes/rewards");
     app.use("/api", r.default || r);
   })();

--- a/backend/src/routes/myModels.ts
+++ b/backend/src/routes/myModels.ts
@@ -1,0 +1,80 @@
+import { Router, type Request, type Response } from "express";
+import { authRequired, userIdFromAuth } from "../lib/auth";
+import logger from "../logger";
+
+interface UserCreationRowRaw {
+  id: string;
+  title?: string | null;
+  category?: string | null;
+  job_id: string;
+  model_url: string;
+  snapshot?: string | null;
+  prompt?: string | null;
+}
+
+interface UserCreationResponse {
+  id: string;
+  title: string | null;
+  category: string | null;
+  job_id: string;
+  model_url: string;
+  snapshot: string | null;
+  prompt: string | null;
+}
+
+function parseNumericQuery(value: unknown, defaultValue: number): number {
+  if (Array.isArray(value)) {
+    return parseNumericQuery(value[0], defaultValue);
+  }
+  if (typeof value === "string") {
+    const parsed = Number.parseInt(value, 10);
+    if (!Number.isNaN(parsed) && parsed >= 0) {
+      return parsed;
+    }
+  }
+  return defaultValue;
+}
+
+const router = Router();
+
+const {
+  getUserCreations,
+}: {
+  getUserCreations: (
+    userId: string,
+    limit?: number,
+    offset?: number,
+  ) => Promise<UserCreationRowRaw[]>;
+} = require("../../db");
+
+router.get("/", authRequired, async (req: Request, res: Response) => {
+  const userId = userIdFromAuth(req);
+  if (!userId) {
+    res.status(401).json({ error: "unauthorized" });
+    return;
+  }
+
+  const query = req.query as { limit?: unknown; offset?: unknown };
+  const limit = parseNumericQuery(query.limit, 10);
+  const offset = parseNumericQuery(query.offset, 0);
+
+  try {
+    const rows = await getUserCreations(userId, limit, offset);
+    const models: UserCreationResponse[] = rows.map((row) => ({
+      id: row.id,
+      title: row.title ?? null,
+      category: row.category ?? null,
+      job_id: row.job_id,
+      model_url: row.model_url,
+      snapshot: row.snapshot ?? null,
+      prompt: row.prompt ?? row.title ?? null,
+    }));
+
+    res.json(models);
+  } catch (err) {
+    logger.error("my_models_fetch_failed", err as Error);
+    res.status(500).json({ error: "unexpected_error" });
+  }
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- add an authenticated router that returns the signed-in user’s models via the existing helper
- mount the router under `/api/my/models` so the frontend can load the list

## Testing
- `npm run format`
- `npm test` *(fails: unable to reach https://registry.npmjs.org/-/ping in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfbfa95e5c832da335b5015a6f6433