### PR TITLE
fix: cover profile and my models apis

### DIFF
--- a/backend/__tests__/auth.test.js
+++ b/backend/__tests__/auth.test.js
@@ -73,16 +73,44 @@ test("/api/me rejects invalid token", async () => {
 });
 
 test("/api/me returns user for valid token", async () => {
-  db.query
-    .mockResolvedValueOnce({
-      rows: [{ id: "u1", username: "alice", email: "a@a.com" }],
-    })
-    .mockResolvedValueOnce({ rows: [{ display_name: "Alice" }] });
+  db.query.mockResolvedValueOnce({
+    rows: [
+      {
+        id: "u1",
+        username: "alice",
+        email: "a@a.com",
+        display_name: "Alice",
+        avatar_url: "https://cdn.test/avatar.png",
+        avatar_glb: "model.glb",
+        shipping_info: { city: "Seattle" },
+        payment_info: { brand: "visa" },
+        competition_notify: true,
+      },
+    ],
+  });
   const token = jwt.sign({ id: "u1" }, AUTH_SECRET);
   const res = await request(app)
     .get("/api/me")
     .set("Authorization", `Bearer ${token}`);
+
   expect(res.status).toBe(200);
-  expect(res.body.username).toBe("alice");
-  expect(res.body.email).toBe("a@a.com");
+  expect(db.query).toHaveBeenCalledWith(
+    expect.stringContaining("LEFT JOIN user_profiles"),
+    ["u1"],
+  );
+  expect(res.body).toMatchObject({
+    id: "u1",
+    username: "alice",
+    email: "a@a.com",
+    avatarUrl: "https://cdn.test/avatar.png",
+    profile: {
+      user_id: "u1",
+      display_name: "Alice",
+      avatar_url: "https://cdn.test/avatar.png",
+      avatar_glb: "model.glb",
+      shipping_info: { city: "Seattle" },
+      payment_info: { brand: "visa" },
+      competition_notify: true,
+    },
+  });
 });

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -54,6 +54,13 @@ try {
 }
 
 try {
+  const r = require("./routes/myModels");
+  app.use("/api/my/models", r.default || r);
+} catch (err) {
+  logger.error("Failed to load my models router", err);
+}
+
+try {
   (() => {
     const r = require("./routes/auth");
     app.use("/api", r.default || r);

--- a/backend/src/lib/auth.js
+++ b/backend/src/lib/auth.js
@@ -1,8 +1,11 @@
 const jwt = require("jsonwebtoken");
+
 const AUTH_SECRET = process.env.AUTH_SECRET || "secret";
+
 function authOptional(req, _res, next) {
   const authHeader = req.headers.authorization;
   const adminHeader = req.headers["x-admin-token"];
+
   if (adminHeader === "admin") {
     req.user = { user_id: "u1", isAdmin: true };
   } else if (authHeader === "***") {
@@ -12,11 +15,13 @@ function authOptional(req, _res, next) {
     try {
       req.user = jwt.verify(token, AUTH_SECRET);
     } catch {
-      /* TODO: handle auth verification errors */
+      // ignore invalid token
     }
   }
+
   next();
 }
+
 function authRequired(req, res, next) {
   authOptional(req, res, () => {
     if (!req.user) {
@@ -26,4 +31,11 @@ function authRequired(req, res, next) {
     next();
   });
 }
-module.exports = { authOptional, authRequired };
+
+function userIdFromAuth(req) {
+  const user = req.user;
+  if (!user) return undefined;
+  return user.id || user.user_id;
+}
+
+module.exports = { authOptional, authRequired, userIdFromAuth };

--- a/backend/src/routes/myModels.js
+++ b/backend/src/routes/myModels.js
@@ -1,0 +1,53 @@
+const { Router } = require("express");
+const { authRequired, userIdFromAuth } = require("../lib/auth");
+const logger = require("../logger.js");
+
+const { getUserCreations } = require("../../db");
+
+function parseNumericQuery(value, defaultValue) {
+  if (Array.isArray(value)) {
+    return parseNumericQuery(value[0], defaultValue);
+  }
+  if (typeof value === "string") {
+    const parsed = parseInt(value, 10);
+    if (!Number.isNaN(parsed) && parsed >= 0) {
+      return parsed;
+    }
+  }
+  return defaultValue;
+}
+
+const router = Router();
+
+router.get("/", authRequired, async (req, res) => {
+  const userId = userIdFromAuth(req);
+  if (!userId) {
+    res.status(401).json({ error: "unauthorized" });
+    return;
+  }
+
+  const query = req.query || {};
+  const limit = parseNumericQuery(query.limit, 10);
+  const offset = parseNumericQuery(query.offset, 0);
+
+  try {
+    const rows = await getUserCreations(userId, limit, offset);
+    const models = (rows || []).map((row) => ({
+      id: row.id,
+      title: row.title ?? null,
+      category: row.category ?? null,
+      job_id: row.job_id,
+      model_url: row.model_url,
+      snapshot: row.snapshot ?? null,
+      prompt: row.prompt ?? row.title ?? null,
+    }));
+
+    res.json(models);
+  } catch (err) {
+    logger.error("my_models_fetch_failed", err);
+    res.status(500).json({ error: "unexpected_error" });
+  }
+});
+
+module.exports = router;
+module.exports.default = router;

--- a/backend/tests/__mocks__/db.js
+++ b/backend/tests/__mocks__/db.js
@@ -1,0 +1,28 @@
+const noopResolved = async () => ({ rows: [] });
+
+const db = {
+  query: jest.fn(noopResolved),
+  insertCommission: jest.fn().mockResolvedValue({}),
+  upsertSubscription: jest.fn(),
+  cancelSubscription: jest.fn(),
+  getSubscription: jest.fn(),
+  ensureCurrentWeekCredits: jest.fn(),
+  getCurrentWeekCredits: jest.fn(),
+  incrementCreditsUsed: jest.fn(),
+  upsertMailingListEntry: jest.fn(),
+  confirmMailingListEntry: jest.fn(),
+  unsubscribeMailingListEntry: jest.fn(),
+  getUserCreations: jest.fn(),
+  insertCommunityComment: jest.fn(),
+  getCommunityComments: jest.fn(),
+  insertSocialShare: jest.fn(),
+  verifySocialShare: jest.fn(),
+  getUserIdForReferral: jest.fn(),
+  getOrCreateOrderReferralLink: jest.fn(),
+  insertReferredOrder: jest.fn(),
+  updateWeeklyOrderStreak: jest.fn(),
+  insertGenerationLog: jest.fn(),
+};
+
+module.exports = db;
+module.exports.default = db;

--- a/backend/tests/additionalApi.test.js
+++ b/backend/tests/additionalApi.test.js
@@ -1,16 +1,13 @@
+process.env.NODE_ENV = "test";
 process.env.STRIPE_SECRET_KEY = "test";
 process.env.STRIPE_WEBHOOK_SECRET = "whsec";
 process.env.DB_URL = "postgres://user:pass@localhost/db";
+process.env.S3_BUCKET = "test-bucket";
+process.env.CLOUDFRONT_MODEL_DOMAIN = "cdn.test";
 
-jest.mock("../db", () => ({
-  query: jest.fn().mockResolvedValue({ rows: [] }),
-  insertCommission: jest.fn().mockResolvedValue({}),
-  getUserCreations: jest.fn(),
-  insertCommunityComment: jest.fn(),
-  getCommunityComments: jest.fn(),
-  getOrCreateOrderReferralLink: jest.fn(),
-  insertReferredOrder: jest.fn(),
-}));
+const dbMock = require("./__mocks__/db.js");
+jest.mock("../db", () => dbMock);
+jest.mock("../../db", () => dbMock);
 const db = require("../db");
 
 jest.mock("../mail", () => ({ sendMail: jest.fn() }));
@@ -39,12 +36,10 @@ const { shouldSkipSuite } = require("./utils/shouldSkipSuite");
 
 const skipCommunity = shouldSkipSuite("/api/community");
 const communityTest = skipCommunity ? test.skip : test;
-const skipProfile = shouldSkipSuite("/api/profile");
-const profileTest = skipProfile ? test.skip : test;
+const profileTest = test;
 const skipCompetitions = shouldSkipSuite("/api/competitions");
 const competitionsTest = skipCompetitions ? test.skip : test;
-const skipMyModels = shouldSkipSuite("/api/my/models");
-const myModelsTest = skipMyModels ? test.skip : test;
+const myModelsTest = test;
 const skipUserModels = shouldSkipSuite("/api/users");
 const userModelsTest = skipUserModels ? test.skip : test;
 const skipModels = shouldSkipSuite("/api/models");
@@ -85,6 +80,7 @@ beforeAll(() => {
 beforeEach(() => {
   db.query.mockClear();
   db.insertCommission.mockClear();
+  db.getUserCreations.mockClear();
   axios.post.mockClear();
   sendMail.mockClear();
   stripeMock.checkout.sessions.create.mockResolvedValue({
@@ -94,78 +90,113 @@ beforeEach(() => {
 });
 
 myModelsTest("GET /api/my/models returns models", async () => {
-  db.query.mockResolvedValueOnce({ rows: [{ job_id: "j1" }] });
+  db.getUserCreations.mockResolvedValueOnce([
+    {
+      id: "m1",
+      job_id: "j1",
+      model_url: "https://cdn.test/models/j1.glb",
+      title: "Robot",
+      category: "scifi",
+      snapshot: "https://cdn.test/snap.png",
+      prompt: "make a robot",
+    },
+  ]);
   const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .get("/api/my/models")
     .set("authorization", `Bearer ${token}`);
   expect(res.status).toBe(200);
-  expect(res.body[0].job_id).toBe("j1");
+  expect(db.getUserCreations).toHaveBeenCalledWith("u1", 10, 0);
+  expect(res.body).toEqual([
+    {
+      id: "m1",
+      job_id: "j1",
+      model_url: "https://cdn.test/models/j1.glb",
+      title: "Robot",
+      category: "scifi",
+      snapshot: "https://cdn.test/snap.png",
+      prompt: "make a robot",
+    },
+  ]);
 });
 
-myModelsTest("GET /api/my/models includes snapshot", async () => {
-  db.query.mockResolvedValueOnce({
-    rows: [{ job_id: "j1", snapshot: "snap.png" }],
-  });
-  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
-  const res = await request(app)
-    .get("/api/my/models")
-    .set("authorization", `Bearer ${token}`);
-  expect(res.status).toBe(200);
-  expect(res.body[0].snapshot).toBeDefined();
-});
+myModelsTest(
+  "GET /api/my/models derives prompt from title when missing",
+  async () => {
+    db.getUserCreations.mockResolvedValueOnce([
+      {
+        id: "m2",
+        job_id: "j2",
+        model_url: "https://cdn.test/models/j2.glb",
+        title: "Dragon",
+        category: null,
+        snapshot: null,
+        prompt: null,
+      },
+    ]);
+    const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
+    const res = await request(app)
+      .get("/api/my/models")
+      .set("authorization", `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body[0]).toEqual({
+      id: "m2",
+      job_id: "j2",
+      model_url: "https://cdn.test/models/j2.glb",
+      title: "Dragon",
+      category: null,
+      snapshot: null,
+      prompt: "Dragon",
+    });
+  },
+);
 
 myModelsTest("GET /api/my/models requires auth", async () => {
   const res = await request(app).get("/api/my/models");
   expect(res.status).toBe(401);
 });
 
-myModelsTest("GET /api/my/models ordered by date", async () => {
-  db.query.mockResolvedValueOnce({ rows: [] });
+myModelsTest("GET /api/my/models uses default pagination", async () => {
+  db.getUserCreations.mockResolvedValueOnce([]);
   const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   await request(app)
     .get("/api/my/models")
     .set("authorization", `Bearer ${token}`);
-  expect(db.query).toHaveBeenCalledWith(
-    expect.stringContaining("ORDER BY created_at DESC"),
-    ["u1", 10, 0],
-  );
+  expect(db.getUserCreations).toHaveBeenCalledWith("u1", 10, 0);
 });
 
 myModelsTest("GET /api/my/models supports pagination", async () => {
-  db.query.mockResolvedValueOnce({ rows: [] });
+  db.getUserCreations.mockResolvedValueOnce([]);
   const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   await request(app)
     .get("/api/my/models?limit=5&offset=2")
     .set("authorization", `Bearer ${token}`);
-  expect(db.query).toHaveBeenCalledWith(
-    expect.stringContaining("ORDER BY created_at DESC"),
-    ["u1", 5, 2],
-  );
-});
-
-myModelsTest("GET /api/my/models returns models sorted by date", async () => {
-  const rows = [
-    { job_id: "j2", created_at: "2024-01-02" },
-    { job_id: "j1", created_at: "2024-01-01" },
-  ];
-  db.query.mockResolvedValueOnce({ rows });
-  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
-  const res = await request(app)
-    .get("/api/my/models")
-    .set("authorization", `Bearer ${token}`);
-  expect(res.status).toBe(200);
-  expect(res.body.map((r) => r.job_id)).toEqual(["j2", "j1"]);
+  expect(db.getUserCreations).toHaveBeenCalledWith("u1", 5, 2);
 });
 
 profileTest("GET /api/profile returns profile", async () => {
-  db.query.mockResolvedValueOnce({ rows: [{ display_name: "A" }] });
+  const row = {
+    user_id: "u1",
+    email: "user@example.com",
+    username: "alice",
+    display_name: "Alice",
+    avatar_url: "https://cdn.test/avatar.png",
+    avatar_glb: "model.glb",
+    shipping_info: { city: "Seattle" },
+    payment_info: { brand: "visa" },
+    competition_notify: true,
+  };
+  db.query.mockResolvedValueOnce({ rows: [row] });
   const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   const res = await request(app)
     .get("/api/profile")
     .set("authorization", `Bearer ${token}`);
   expect(res.status).toBe(200);
-  expect(res.body.display_name).toBe("A");
+  expect(db.query).toHaveBeenCalledWith(
+    expect.stringContaining("FROM user_profiles p"),
+    ["u1"],
+  );
+  expect(res.body).toEqual(row);
 });
 
 profileTest("GET /api/profile 404 when missing", async () => {
@@ -189,25 +220,31 @@ userModelsTest("GET /api/users/:username/models returns models", async () => {
   expect(call[1]).toEqual(["u1", 10, 0]);
 });
 
-userModelsTest("GET /api/users/:username/models includes snapshot", async () => {
-  db.query
-    .mockResolvedValueOnce({ rows: [{ id: "u1" }] })
-    .mockResolvedValueOnce({
-      rows: [{ job_id: "j1", likes: 0, snapshot: "s.png" }],
-    });
-  const res = await request(app).get("/api/users/alice/models");
-  expect(res.status).toBe(200);
-  expect(res.body[0].snapshot).toBeDefined();
-});
+userModelsTest(
+  "GET /api/users/:username/models includes snapshot",
+  async () => {
+    db.query
+      .mockResolvedValueOnce({ rows: [{ id: "u1" }] })
+      .mockResolvedValueOnce({
+        rows: [{ job_id: "j1", likes: 0, snapshot: "s.png" }],
+      });
+    const res = await request(app).get("/api/users/alice/models");
+    expect(res.status).toBe(200);
+    expect(res.body[0].snapshot).toBeDefined();
+  },
+);
 
-userModelsTest("GET /api/users/:username/models supports pagination", async () => {
-  db.query
-    .mockResolvedValueOnce({ rows: [{ id: "u1" }] })
-    .mockResolvedValueOnce({ rows: [] });
-  await request(app).get("/api/users/alice/models?limit=3&offset=1");
-  const call = db.query.mock.calls.find((c) => c[0].includes("FROM jobs"));
-  expect(call[1]).toEqual(["u1", 3, 1]);
-});
+userModelsTest(
+  "GET /api/users/:username/models supports pagination",
+  async () => {
+    db.query
+      .mockResolvedValueOnce({ rows: [{ id: "u1" }] })
+      .mockResolvedValueOnce({ rows: [] });
+    await request(app).get("/api/users/alice/models?limit=3&offset=1");
+    const call = db.query.mock.calls.find((c) => c[0].includes("FROM jobs"));
+    expect(call[1]).toEqual(["u1", 3, 1]);
+  },
+);
 
 userModelsTest("GET /api/users/:username/models 404 when missing", async () => {
   db.query.mockResolvedValueOnce({ rows: [] });
@@ -750,19 +787,22 @@ staticTest("static assets send cache headers", async () => {
   );
 });
 
-initDataTest("GET /api/init-data returns slots, stats, and profile", async () => {
-  const { _setDailyPrintsSold } = require("../utils/dailyPrints");
-  _setDailyPrintsSold(10);
-  db.query.mockResolvedValueOnce({ rows: [{ display_name: "A" }] });
-  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
-  const res = await request(app)
-    .get("/api/init-data")
-    .set("authorization", `Bearer ${token}`);
-  expect(res.status).toBe(200);
-  expect(typeof res.body.slots).toBe("number");
-  expect(res.body.stats.printsSold).toBe(10);
-  expect(res.body.profile.display_name).toBe("A");
-});
+initDataTest(
+  "GET /api/init-data returns slots, stats, and profile",
+  async () => {
+    const { _setDailyPrintsSold } = require("../utils/dailyPrints");
+    _setDailyPrintsSold(10);
+    db.query.mockResolvedValueOnce({ rows: [{ display_name: "A" }] });
+    const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
+    const res = await request(app)
+      .get("/api/init-data")
+      .set("authorization", `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(typeof res.body.slots).toBe("number");
+    expect(res.body.stats.printsSold).toBe(10);
+    expect(res.body.profile.display_name).toBe("A");
+  },
+);
 
 paymentInitTest("GET /api/payment-init bundles payment data", async () => {
   db.query

--- a/backend/tests/api.test.ts
+++ b/backend/tests/api.test.ts
@@ -1,6 +1,9 @@
+process.env.NODE_ENV = "test";
 process.env.STRIPE_SECRET_KEY = "test";
 process.env.STRIPE_WEBHOOK_SECRET = "whsec";
 process.env.DB_URL = "postgres://user:pass@localhost/db";
+process.env.S3_BUCKET = "test-bucket";
+process.env.CLOUDFRONT_MODEL_DOMAIN = "cdn.test";
 
 // mock the database module using the same relative path as the app code
 jest.mock("../../db", () => ({
@@ -77,6 +80,12 @@ jest.mock("../shipping", () => ({
 }));
 const { getShippingEstimate } = require("../shipping");
 
+jest.mock("../src/lib/uploadS3", () => ({
+  uploadFile: jest.fn(),
+}));
+const uploadS3 = require("../src/lib/uploadS3") as { uploadFile: jest.Mock };
+const uploadFile = uploadS3.uploadFile;
+
 jest.mock(
   "../utils/captionService",
   () => ({
@@ -91,8 +100,7 @@ const { shouldSkipSuite } = require("./utils/shouldSkipSuite");
 
 const skipCommunity = shouldSkipSuite("/api/community");
 const communityTest = skipCommunity ? test.skip : test;
-const skipProfile = shouldSkipSuite("/api/profile");
-const profileTest = skipProfile ? test.skip : test;
+const profileTest = test;
 const fs = require("fs");
 const stream = require("stream");
 
@@ -113,6 +121,7 @@ beforeEach(() => {
   db.ensureCurrentWeekCredits.mockClear();
   db.getCurrentWeekCredits.mockClear();
   db.getUserIdForReferral.mockClear();
+  uploadFile.mockClear();
 });
 
 afterEach(() => {
@@ -248,9 +257,7 @@ test("create-order grants free print after three referrals", async () => {
 
 test("create-order rejects unknown job", async () => {
   db.query.mockResolvedValueOnce({ rows: [] });
-  const res = await req()
-    .post("/api/create-order")
-    .send({ jobId: "bad" });
+  const res = await req().post("/api/create-order").send({ jobId: "bad" });
   expect(res.status).toBe(404);
 });
 
@@ -508,9 +515,7 @@ communityTest("GET /api/community/mine returns creations", async () => {
 });
 
 communityTest("POST /api/community/:id/comment requires auth", async () => {
-  const res = await req()
-    .post("/api/community/5/comment")
-    .send({ text: "hi" });
+  const res = await req().post("/api/community/5/comment").send({ text: "hi" });
   expect(res.status).toBe(401);
 });
 
@@ -682,40 +687,88 @@ test("GET /api/users/:username/profile 404 when missing", async () => {
 
 profileTest("GET /api/profile returns profile", async () => {
   const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
-  db.query.mockResolvedValueOnce({
-    rows: [
-      {
-        user_id: "u1",
-        shipping_info: {},
-        payment_info: {},
-        avatar_glb: "model.glb",
-      },
-    ],
-  });
+  const row = {
+    user_id: "u1",
+    email: "user@example.com",
+    username: "alice",
+    display_name: "Alice",
+    avatar_url: "https://cdn.test/avatar.png",
+    avatar_glb: "model.glb",
+    shipping_info: { city: "Seattle" },
+    payment_info: { brand: "visa" },
+    competition_notify: false,
+  };
+  db.query.mockResolvedValueOnce({ rows: [row] });
   const res = await req()
     .get("/api/profile")
     .set("authorization", `Bearer ${token}`);
   expect(res.status).toBe(200);
-  expect(res.body.user_id).toBe("u1");
-  expect(res.body.avatar_glb).toBe("model.glb");
+  expect(db.query).toHaveBeenCalledWith(
+    expect.stringContaining("FROM user_profiles p"),
+    ["u1"],
+  );
+  expect(res.body).toEqual(row);
 });
 
 profileTest("POST /api/profile saves details", async () => {
   const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
   db.query.mockResolvedValueOnce({});
+  const payload = {
+    displayName: "Alice",
+    avatarUrl: "https://cdn.test/avatar.png",
+    avatarGlb: "model.glb",
+    shippingInfo: { city: "Seattle" },
+    paymentInfo: { brand: "visa" },
+    competitionNotify: false,
+  };
   const res = await req()
     .post("/api/profile")
     .set("authorization", `Bearer ${token}`)
-    .send({
-      shippingInfo: { a: 1 },
-      paymentInfo: { b: 2 },
-      avatarGlb: "model.glb",
-    });
+    .send(payload);
+
   expect(res.status).toBe(204);
   const call = db.query.mock.calls.find((c) =>
     c[0].includes("INSERT INTO user_profiles"),
   );
   expect(call).toBeTruthy();
+  expect(call?.[1]).toEqual([
+    "u1",
+    payload.displayName,
+    payload.avatarUrl,
+    payload.avatarGlb,
+    payload.shippingInfo,
+    payload.paymentInfo,
+    payload.competitionNotify,
+    true,
+    true,
+    true,
+    true,
+    true,
+    true,
+  ]);
+});
+
+profileTest("POST /api/profile/avatar uploads avatar", async () => {
+  const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");
+  uploadFile.mockResolvedValueOnce("https://cdn.test/avatar.png");
+  db.query.mockResolvedValueOnce({});
+
+  const res = await req()
+    .post("/api/profile/avatar")
+    .set("authorization", `Bearer ${token}`)
+    .attach("avatar", Buffer.from("data"), "avatar.png");
+
+  expect(res.status).toBe(200);
+  expect(uploadFile).toHaveBeenCalledTimes(1);
+  const [uploadedPath, contentType] = uploadFile.mock.calls[0];
+  expect(typeof uploadedPath).toBe("string");
+  expect(typeof contentType).toBe("string");
+  expect((contentType as string).length).toBeGreaterThan(0);
+  const queryCall = db.query.mock.calls.find((c) =>
+    c[0].includes("INSERT INTO user_profiles (user_id, avatar_url)"),
+  );
+  expect(queryCall?.[1]).toEqual(["u1", "https://cdn.test/avatar.png"]);
+  expect(res.body).toEqual({ avatarUrl: "https://cdn.test/avatar.png" });
 });
 
 test("POST /api/create-order saves user id", async () => {
@@ -876,9 +929,7 @@ test("POST /api/discount-code returns discount", async () => {
   db.query.mockResolvedValueOnce({
     rows: [{ id: 1, code: "SAVE5", amount_cents: 500 }],
   });
-  const res = await req()
-    .post("/api/discount-code")
-    .send({ code: "SAVE5" });
+  const res = await req().post("/api/discount-code").send({ code: "SAVE5" });
   expect(res.status).toBe(200);
   expect(res.body.discount).toBe(500);
   expect(db.query).toHaveBeenCalledWith(
@@ -889,9 +940,7 @@ test("POST /api/discount-code returns discount", async () => {
 
 test("POST /api/discount-code invalid", async () => {
   db.query.mockResolvedValueOnce({ rows: [] });
-  const res = await req()
-    .post("/api/discount-code")
-    .send({ code: "BAD" });
+  const res = await req().post("/api/discount-code").send({ code: "BAD" });
   expect(res.status).toBe(404);
 });
 
@@ -925,7 +974,6 @@ test("POST /api/dalle requires prompt", async () => {
   const res = await req().post("/api/dalle").send({});
   expect(res.status).toBe(400);
 });
-
 
 test("GET /api/dashboard returns aggregated info", async () => {
   const token = jwt.sign({ id: "u1" }, process.env.AUTH_SECRET || "secret");

--- a/backend/tests/stripe/__mocks__/stripe.js
+++ b/backend/tests/stripe/__mocks__/stripe.js
@@ -1,0 +1,18 @@
+const createMock = jest.fn(async (_args, _opts) => ({
+  id: "cs_test_123",
+}));
+
+const Stripe = jest.fn().mockImplementation((_key, _opts) => ({
+  checkout: { sessions: { create: createMock } },
+  webhooks: {
+    constructEvent: jest.fn(),
+    generateTestHeaderString: jest.fn(() => "test"),
+  },
+}));
+
+Stripe.__mocks = { createMock };
+Stripe.webhooks = {
+  generateTestHeaderString: jest.fn(() => "test"),
+};
+
+module.exports = Stripe;


### PR DESCRIPTION
## Summary
- export the userId helper for Express routes and load the /api/my/models router in the CommonJS app build
- add a CommonJS implementation of the my models router plus shared database/stripe test mocks
- expand auth, profile, and additional API Jest suites to cover the new /api/me, /api/profile, and /api/my/models behaviours

## Testing
- npm run format
- SKIP_NET_CHECKS=1 SKIP_ROOT_DEPS_CHECK=1 SKIP_BACKEND_DEPS_CHECK=1 npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1af6f2268832db05e3e0ef951ae1e