### PR TITLE
fix: adjust marketplace layout

### DIFF
--- a/marketplace.html
+++ b/marketplace.html
@@ -123,7 +123,7 @@
         class="grid grid-cols-1 md:grid-cols-2 gap-6 h-full mt-auto mb-6"
       >
         <div
-          class="bg-[#2A2A2E] p-4 rounded-xl border border-white/10 flex flex-col h-[40vh]"
+          class="bg-[#2A2A2E] p-4 rounded-xl border border-white/10 flex flex-col h-[48vh]"
         >
           <h2 class="text-xl font-semibold mb-2">Your Marketplace</h2>
           <p>
@@ -160,7 +160,7 @@
           </script>
         </div>
         <div
-          class="bg-[#2A2A2E] p-4 rounded-xl border border-white/10 flex flex-col h-[40vh]"
+          class="bg-[#2A2A2E] p-4 rounded-xl border border-white/10 flex flex-col h-[48vh]"
         >
           <h2 class="text-xl font-semibold mb-2">Their Marketplace</h2>
           <p>
@@ -177,23 +177,6 @@
         >
           <h2 class="text-xl font-semibold mb-2">Featured Deals</h2>
         </div>
-      </section>
-      <section class="bg-[#2A2A2E] p-4 rounded-xl border border-white/10 mb-6">
-        <p class="text-center">
-          Purchase items here to get
-          <span class="text-[#30D5C8]">£7 off</span>
-          your 2nd and
-          <span class="text-[#30D5C8]">£15 off</span>
-          your 3rd print. Add them to your
-          <a
-            href="#"
-            class="font-bold text-[#30D5C8]"
-            onclick="document.getElementById('basket-button')?.click(); return false;"
-            >Basket</a
-          >
-          and
-          <a href="payment.html" class="font-bold text-[#30D5C8]">Buy Here</a>.
-        </p>
       </section>
     </main>
     <script type="module">


### PR DESCRIPTION
## Summary
- remove the duplicate purchase promotion block from the bottom of marketplace.html
- increase the heights of the marketplace cards so the featured deals card retains its original baseline alignment

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da785a86b0832d8f10430d704acea5