### PR TITLE
fix: hide payment viewer arrows for single model

### DIFF
--- a/js/payment.js
+++ b/js/payment.js
@@ -106,6 +106,7 @@ const TZ = "America/New_York";
 let flashTimerId = null;
 let flashSale = null;
 let checkoutItems = [];
+let storedModel = "";
 let currentIndex = 0;
 let suppressCheckoutReload = false;
 let suppressCheckoutReloadTimer = null;
@@ -1042,13 +1043,27 @@ async function initPaymentPage() {
     viewerCounter.textContent = `${currentIndex + 1}/${checkoutItems.length}`;
     viewerCounter.classList.remove("hidden");
   }
+  function getDisplayedModelKey(item) {
+    const sanitized = sanitizeUrl(item?.modelUrl);
+    if (sanitized) return sanitized;
+    if (storedModel) return storedModel;
+    return FALLBACK_GLB;
+  }
+  function shouldShowViewerNavigation() {
+    if (checkoutItems.length <= 1) return false;
+    const uniqueModels = new Set();
+    checkoutItems.forEach((entry) => {
+      uniqueModels.add(getDisplayedModelKey(entry));
+    });
+    return uniqueModels.size > 1;
+  }
   function showItem(idx) {
     if (!checkoutItems.length) {
       updateViewerCounter();
       return;
     }
     currentIndex = (idx + checkoutItems.length) % checkoutItems.length;
-    const hasMultiple = checkoutItems.length > 1;
+    const hasMultiple = shouldShowViewerNavigation();
     if (prevBtn) {
       prevBtn.hidden = !hasMultiple;
       prevBtn.disabled = !hasMultiple;
@@ -1242,7 +1257,7 @@ async function initPaymentPage() {
       // ignore if the element never upgrades
     }
   }
-  const storedModel = sanitizeUrl(localStorage.getItem("print2Model"));
+  storedModel = sanitizeUrl(localStorage.getItem("print2Model"));
 
   // Load saved basket items unless this is the Luckybox page
   if (!window.location.pathname.endsWith("luckybox-payment.html")) {


### PR DESCRIPTION
## Summary
- keep the stored model URL available across viewer updates
- suppress the payment viewer navigation when every checkout entry shows the same GLB

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da786e2058832db7eee2a5a6fd74db