### PR TITLE
fix: align community banner messaging

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -67,6 +67,13 @@
     </style>
   </head>
   <body class="bg-[#1A1A1D] text-white font-sans flex flex-col min-h-screen">
+    <div
+      id="theme-banner"
+      class="bg-[#30D5C8] text-black text-center py-1 hidden sticky top-0 z-50 w-full"
+      data-discount-message="24% off when you order 3 prints – when you buy from this community page"
+    >
+      24% off when you order 3 prints – when you buy from this community page
+    </div>
     <!-- Header -->
     <header class="relative flex items-center py-4 px-6">
       <div class="flex items-center flex-1">
@@ -468,6 +475,7 @@
         loadReferralLink,
         copyReferralLink,
       } from "./js/community.js";
+      import { initDiscountDeliveryBanner } from "./js/index.js";
       window.shareOn = shareOn;
       window.copyReferralLink = copyReferralLink;
 
@@ -477,6 +485,10 @@
         const addBasketBtn = document.getElementById("modal-add-basket");
         const closeBtn = document.getElementById("close-modal");
         const tierToggle = document.getElementById("tier-toggle");
+        const banner = document.getElementById("theme-banner");
+        if (banner) {
+          initDiscountDeliveryBanner(banner);
+        }
         document
           .querySelectorAll('a[href="login.html"], a[href="signup.html"]')
           .forEach((el) => {

--- a/js/index.js
+++ b/js/index.js
@@ -838,9 +838,12 @@ if (refs.submitBtn && refs.promptInput && refs.viewer) {
   });
 }
 
-function initDiscountDeliveryBanner(bannerEl) {
+function initDiscountDeliveryBanner(bannerEl, options = {}) {
   if (!bannerEl) return;
-  const discountMsg = "24% off when you order 3 prints";
+  const discountMsg =
+    options.discountMessage ||
+    bannerEl.dataset.discountMessage ||
+    "24% off when you order 3 prints";
   let countdownText = "";
   let showDiscount = true;
   bannerEl.style.opacity = "1";

--- a/tests/frontend/discount-delivery-banner.k1m2n3b4v5c6x7z8.test.js
+++ b/tests/frontend/discount-delivery-banner.k1m2n3b4v5c6x7z8.test.js
@@ -71,6 +71,14 @@ describe("Discount/delivery banner", () => {
     expect(banner.style.opacity).toBe("1");
   });
 
+  test("respects a custom discount message supplied via dataset", () => {
+    document.body.innerHTML =
+      '<div id="theme-banner" data-discount-message="Community deal"></div>';
+    const customBanner = document.getElementById("theme-banner");
+    initDiscountDeliveryBanner(customBanner);
+    expect(customBanner.textContent).toBe("Community deal");
+  });
+
   test("opacity resets after transition", () => {
     advance(7000);
     advance(1000);


### PR DESCRIPTION
## Summary
- make the community creations discount banner sticky and reuse the homepage copy with a community-specific override
- allow the shared discount/weekend delivery helper to respect per-page discount messaging and cover it with a unit test

## Testing
- node scripts/run-jest.js tests/frontend/discount-delivery-banner.k1m2n3b4v5c6x7z8.test.js *(fails: Missing ts-jest; run `npm run setup` before testing)*

------
https://chatgpt.com/codex/tasks/task_e_68da79d20870832dbbc46447cd5283ca