### PR TITLE
feat: add sticky banner to community page

### DIFF
--- a/CommunityCreations.html
+++ b/CommunityCreations.html
@@ -68,6 +68,12 @@
   </head>
   <body class="bg-[#1A1A1D] text-white font-sans flex flex-col min-h-screen">
     <div
+      id="theme-banner"
+      class="bg-[#30D5C8] text-black text-center py-1 hidden sticky top-0 z-50"
+    >
+      24% off when you buy from this community page
+    </div>
+    <div
       aria-hidden="true"
       style="position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); border: 0;"
     >
@@ -641,5 +647,13 @@
     <script type="module" src="js/publicGalleries.js"></script>
     <script type="module" src="js/carousel.js"></script>
     <script type="module" src="js/trackingPixel.js"></script>
+    <script type="module">
+      import { initDiscountDeliveryBanner } from "./js/discountDeliveryBanner.js";
+
+      const banner = document.getElementById("theme-banner");
+      initDiscountDeliveryBanner(banner, {
+        discountMessage: "24% off when you buy from this community page",
+      });
+    </script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -78,7 +78,12 @@
   </head>
 
   <body class="bg-[#1A1A1D] text-white font-sans flex flex-col">
-    <div id="theme-banner" class="bg-[#30D5C8] text-black text-center py-1 hidden">24% off when you order 3 prints</div>
+    <div
+      id="theme-banner"
+      class="bg-[#30D5C8] text-black text-center py-1 hidden sticky top-0 z-50"
+    >
+      24% off when you order 3 prints
+    </div>
 
     <!-- HEADER (unchanged UI) -->
     <header class="relative flex items-center justify-between py-4 px-6">

--- a/js/discountDeliveryBanner.js
+++ b/js/discountDeliveryBanner.js
@@ -1,0 +1,83 @@
+"use strict";
+
+function initDiscountDeliveryBanner(
+  bannerEl,
+  {
+    discountMessage = "24% off when you order 3 prints",
+    getNow = () => new Date(),
+    scheduleInterval = (fn, interval) => setInterval(fn, interval),
+    scheduleTimeout = (fn, delay) => setTimeout(fn, delay),
+  } = {},
+) {
+  if (!bannerEl) return;
+
+  let countdownText = "";
+  let showDiscount = true;
+
+  if (!bannerEl.style.opacity) bannerEl.style.opacity = "1";
+  if (!bannerEl.style.transition) bannerEl.style.transition = "opacity 1s";
+  if (!bannerEl.style.position) bannerEl.style.position = "sticky";
+  if (!bannerEl.style.top) bannerEl.style.top = "0";
+  if (!bannerEl.style.zIndex) bannerEl.style.zIndex = "50";
+  if (!bannerEl.classList.contains("w-full")) bannerEl.classList.add("w-full");
+
+  bannerEl.textContent = discountMessage;
+
+  function getCountdownText() {
+    const now = getNow();
+    const day = now.getDay();
+    const friday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    friday.setDate(friday.getDate() + ((5 - day + 7) % 7));
+    const diff = friday - now;
+    if (day !== 0 && day !== 6 && diff > 0 && diff < 7 * 86400000) {
+      const hoursTotal = Math.floor(diff / 3600000);
+      const days = Math.floor(hoursTotal / 24);
+      const hours = hoursTotal % 24;
+      const minutes = Math.floor((diff % 3600000) / 60000);
+      const seconds = Math.floor((diff % 60000) / 1000);
+      const parts = [];
+      if (days > 0) parts.push(`${days}d`);
+      parts.push(`${hours.toString().padStart(2, "0")}h`);
+      parts.push(`${minutes.toString().padStart(2, "0")}m`);
+      parts.push(`${seconds.toString().padStart(2, "0")}s`);
+      return `${parts.join(" ")} left for weekend delivery`;
+    }
+    return "";
+  }
+
+  function refresh() {
+    countdownText = getCountdownText();
+    bannerEl.classList.remove("hidden");
+    if (!countdownText) {
+      showDiscount = true;
+      bannerEl.textContent = discountMessage;
+    } else if (!showDiscount) {
+      bannerEl.textContent = countdownText;
+    }
+  }
+
+  function scheduleCycle() {
+    scheduleTimeout(cycle, 7000);
+  }
+
+  function cycle() {
+    if (!countdownText) {
+      scheduleCycle();
+      return;
+    }
+    bannerEl.style.opacity = "0";
+    scheduleTimeout(() => {
+      showDiscount = !showDiscount;
+      bannerEl.textContent = showDiscount ? discountMessage : countdownText;
+      bannerEl.style.opacity = "1";
+    }, 1000);
+    scheduleCycle();
+  }
+
+  refresh();
+  scheduleInterval(refresh, 1000);
+  scheduleCycle();
+}
+
+export { initDiscountDeliveryBanner };
+export default initDiscountDeliveryBanner;

--- a/js/index.js
+++ b/js/index.js
@@ -11,6 +11,7 @@ import {
   adjustedSlots,
   updatePrintRunInfo,
 } from "./print-slots.js";
+import { initDiscountDeliveryBanner as initDiscountDeliveryBannerCore } from "./discountDeliveryBanner.js";
 
 (() => {
   try {
@@ -838,69 +839,16 @@ if (refs.submitBtn && refs.promptInput && refs.viewer) {
   });
 }
 
-function initDiscountDeliveryBanner(bannerEl) {
-  if (!bannerEl) return;
-  const discountMsg = "24% off when you order 3 prints";
-  let countdownText = "";
-  let showDiscount = true;
-  bannerEl.style.opacity = "1";
-  bannerEl.style.transition = "opacity 1s";
-  bannerEl.textContent = discountMsg;
-
-  function getCountdownText() {
-    const now = new Date();
-    const day = now.getDay();
-    const friday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-    friday.setDate(friday.getDate() + ((5 - day + 7) % 7));
-    const diff = friday - now;
-    if (day !== 0 && day !== 6 && diff > 0 && diff < 7 * 86400000) {
-      const hoursTotal = Math.floor(diff / 3600000);
-      const days = Math.floor(hoursTotal / 24);
-      const hours = hoursTotal % 24;
-      const minutes = Math.floor((diff % 3600000) / 60000);
-      const seconds = Math.floor((diff % 60000) / 1000);
-      const parts = [];
-      if (days > 0) parts.push(`${days}d`);
-      parts.push(`${hours.toString().padStart(2, "0")}h`);
-      parts.push(`${minutes.toString().padStart(2, "0")}m`);
-      parts.push(`${seconds.toString().padStart(2, "0")}s`);
-      return `${parts.join(" ")} left for weekend delivery`;
-    }
-    return "";
-  }
-
-  function refresh() {
-    countdownText = getCountdownText();
-    bannerEl.classList.remove("hidden");
-    if (!countdownText) {
-      showDiscount = true;
-      bannerEl.textContent = discountMsg;
-    } else if (!showDiscount) {
-      bannerEl.textContent = countdownText;
-    }
-  }
-
-  function scheduleCycle() {
-    setTimeout(cycle, 7000);
-  }
-
-  function cycle() {
-    if (!countdownText) {
-      scheduleCycle();
-      return;
-    }
-    bannerEl.style.opacity = "0";
-    setTimeout(() => {
-      showDiscount = !showDiscount;
-      bannerEl.textContent = showDiscount ? discountMsg : countdownText;
-      bannerEl.style.opacity = "1";
-    }, 1000);
-    scheduleCycle();
-  }
-
-  refresh();
-  setIntervalFn(refresh, 1000);
-  scheduleCycle();
+function initDiscountDeliveryBanner(bannerEl, options = {}) {
+  initDiscountDeliveryBannerCore(
+    bannerEl,
+    Object.assign(
+      {
+        scheduleInterval: (fn, interval) => setIntervalFn(fn, interval),
+      },
+      options,
+    ),
+  );
 }
 
 async function init() {


### PR DESCRIPTION
## Summary
- share the rotating discount/weekend banner logic in a dedicated module that enforces sticky positioning
- add the banner to CommunityCreations with community-specific copy and initialize it on load
- update the index banner markup to match the sticky styling

## Testing
- npm test -- tests/frontend/discount-delivery-banner.k1m2n3b4v5c6x7z8.test.js *(fails: Missing ts-jest; run `npm run setup` to install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68da94fdbb4c832dae4b92ea0d380a64