### PR TITLE
fix: fill popular grid remainder using column complement

### DIFF
--- a/js/community.js
+++ b/js/community.js
@@ -817,6 +817,7 @@ async function loadMore(type, filters = getFilters()) {
     }
 
     applyPopularViewer();
+    const columns = getColumnCount(grid);
     const remainder = getPopularRemainder();
     if (!remainder) {
       reachedEnd = fetchedCount < limit || reachedEnd;
@@ -827,7 +828,12 @@ async function loadMore(type, filters = getFilters()) {
       balancePopularGrid(state, true);
       break;
     }
-    limit = remainder;
+    const complement = columns - remainder;
+    if (complement <= 0) {
+      iterations += 1;
+      continue;
+    }
+    limit = complement;
     iterations += 1;
   }
 


### PR DESCRIPTION
## Summary
- compute the current column count before checking the popular grid remainder so the fetch logic can react to layout changes
- request the column complement instead of the raw remainder to backfill empty slots while preserving the reached-end behavior

## Testing
- Manual: Served the site with `python3 -m http.server 8000` and used Playwright to stub `fetchCreations`, confirming the first popular load showed a full grid with the More button still visible.

------
https://chatgpt.com/codex/tasks/task_e_68da9f4538bc832d883154d599785841