### PR TITLE
fix: keep popular load more when using fallback

### DIFF
--- a/backend/tests/frontend/community.test.js
+++ b/backend/tests/frontend/community.test.js
@@ -18,15 +18,42 @@ function setup() {
 
   // Attach helpers to window BEFORE eval
   const mockGlobals = `
-    function getFallbackModels() {
-      return [
-        { model_url: 'url1' },
-        { model_url: 'url2' },
-        { model_url: 'url3' },
-        { model_url: 'url4' },
-        { model_url: 'url5' },
-        { model_url: 'url6' }
-      ];
+    const __local = new Map();
+    const __session = new Map();
+
+    const localStorage = {
+      getItem: (key) => (__local.has(key) ? __local.get(key) : null),
+      setItem: (key, value) => __local.set(key, String(value)),
+      removeItem: (key) => __local.delete(key),
+      clear: () => __local.clear(),
+    };
+
+    const sessionStorage = {
+      getItem: (key) => (__session.has(key) ? __session.get(key) : null),
+      setItem: (key, value) => __session.set(key, String(value)),
+      removeItem: (key) => __session.delete(key),
+      clear: () => __session.clear(),
+    };
+
+    window.localStorage = localStorage;
+    window.sessionStorage = sessionStorage;
+
+    async function captureSnapshots() {
+      return Promise.resolve();
+    }
+
+    window.captureSnapshots = captureSnapshots;
+
+    function getFallbackModels(count = 9, start = 0) {
+      return Array.from({ length: count }, (_, index) => {
+        const offset = start + index;
+        return {
+          model_url: 'url' + offset,
+          snapshot: 'snapshot' + offset,
+          job_id: 'job' + offset,
+          id: 'fallback-' + offset,
+        };
+      });
     }
 
     async function fetchCreations(category) {
@@ -51,7 +78,7 @@ function setup() {
 describe("community helpers", () => {
   test("getFallbackModels returns 6 items", () => {
     const dom = setup();
-    const list = dom.window.getFallbackModels();
+    const list = dom.window.getFallbackModels(6);
     expect(list).toHaveLength(6);
     expect(list[0]).toHaveProperty("model_url");
   });
@@ -61,5 +88,39 @@ describe("community helpers", () => {
     dom.window.fetch = jest.fn(() => Promise.reject(new Error("fail")));
     const data = await dom.window.fetchCreations("recent");
     expect(data).toEqual([]);
+  });
+
+  test("popular load more keeps button visible when using fallback data", async () => {
+    const dom = setup();
+    const { window } = dom;
+
+    window.communityState = { popular: {}, recent: {} };
+
+    window.fetch = jest.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve([]) }),
+    );
+
+    const { document } = window;
+    document.body.innerHTML = `
+      <select id="category"><option value="">All</option></select>
+      <input id="search" value="" />
+      <div id="popular-grid"></div>
+      <button id="popular-load" class="">More</button>
+    `;
+
+    const grid = document.getElementById("popular-grid");
+    grid.style.display = "grid";
+    grid.style.gridTemplateColumns = "repeat(3, 1fr)";
+
+    window.getComputedStyle = jest.fn(() => ({
+      gridTemplateColumns: "repeat(3, 1fr)",
+      gridRowEnd: "span 1",
+    }));
+
+    await window.loadMore("popular");
+
+    const btn = document.getElementById("popular-load");
+    expect(btn.classList.contains("hidden")).toBe(false);
+    expect(grid.querySelectorAll(".model-card").length).toBeGreaterThan(0);
   });
 });

--- a/js/community.js
+++ b/js/community.js
@@ -820,6 +820,7 @@ async function loadMore(type, filters = getFilters()) {
   let iterations = 0;
   let appended = 0;
   let reachedEnd = false;
+  let appendedFallback = false;
   while (iterations < 10) {
     let models = await fetchCreations(
       type,
@@ -830,13 +831,23 @@ async function loadMore(type, filters = getFilters()) {
       order,
     );
     const fetchedCount = models.length;
+    let usedFallbackThisIteration = false;
     if (fetchedCount === 0) {
-      reachedEnd = true;
-      models = getFallbackModels(limit, state.offset);
+      const fallback = getFallbackModels(limit, state.offset);
+      if (fallback.length) {
+        models = fallback;
+        usedFallbackThisIteration = true;
+      } else {
+        reachedEnd = true;
+        models = fallback;
+      }
     }
     models = models.filter(
       (m) => m && (m.placeholder || (m.model_url && m.snapshot)),
     );
+    if (usedFallbackThisIteration && models.length) {
+      appendedFallback = true;
+    }
     if (fetchedCount) state.offset += fetchedCount;
     if (models.length) {
       state.models = state.models.concat(models);
@@ -848,11 +859,15 @@ async function loadMore(type, filters = getFilters()) {
     const columns = getColumnCount(grid);
     const remainder = getPopularRemainder();
     if (!remainder) {
-      reachedEnd = fetchedCount < limit || reachedEnd;
+      if (fetchedCount < limit && !usedFallbackThisIteration) {
+        reachedEnd = true;
+      }
       break;
     }
     if (fetchedCount === 0 || fetchedCount < limit) {
-      reachedEnd = true;
+      if (!usedFallbackThisIteration) {
+        reachedEnd = true;
+      }
       balancePopularGrid(state, true);
       break;
     }
@@ -873,7 +888,7 @@ async function loadMore(type, filters = getFilters()) {
   }
   const btn = document.getElementById(`${type}-load`);
   if (btn) {
-    if (appended === 0 || reachedEnd) {
+    if (!appendedFallback && (appended === 0 || reachedEnd)) {
       btn.classList.add("hidden");
     } else {
       btn.classList.remove("hidden");


### PR DESCRIPTION
## Summary
- adjust the popular load more logic to record fallback usage without forcing the end state and keep the button visible when fallback models appear
- expand the community frontend test harness with storage/capture stubs and add a regression test covering fallback-only responses

## Testing
- npm run format (backend)
- npm test (backend) *(fails: cannot reach https://registry.npmjs.org/-/ping)*

------
https://chatgpt.com/codex/tasks/task_e_68dd3902073c832d98cf9ccabe9c6ca0