### PR TITLE
fix: recompute print run overlays when loading more cards

### DIFF
--- a/js/community.js
+++ b/js/community.js
@@ -813,6 +813,7 @@ async function loadMore(type, filters = getFilters()) {
       }
     }
     saveState();
+    applyPrintRunHighlights();
     return;
   }
 


### PR DESCRIPTION
## Summary
- ensure the print run highlights are recalculated when loading additional non-popular community cards

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e29bbf3d10832d86e6ef7054e07003